### PR TITLE
Use Rela instead of object::Relocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
  "clap",
  "iced-x86",
  "linker-layout",
- "object",
+ "object 0.34.0",
  "rayon",
  "symbolic-demangle",
 ]
@@ -366,6 +366,14 @@ name = "object"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7090bae93f8585aad99e595b7073c5de9ba89fbd6b4e9f0cdd7a10177273ac8"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.35.0"
+source = "git+https://github.com/gimli-rs/object?rev=017624aa70a1a52e36dbb61e693ba3c7f3bf010e#017624aa70a1a52e36dbb61e693ba3c7f3bf010e"
 dependencies = [
  "memchr",
 ]
@@ -642,7 +650,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "linker-diff",
- "object",
+ "object 0.35.0",
  "tracing",
  "wait-timeout",
  "wild_lib",
@@ -661,7 +669,7 @@ dependencies = [
  "linker-layout",
  "memchr",
  "memmap2",
- "object",
+ "object 0.35.0",
  "rayon",
  "smallvec",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ debug = false
 [profile.opt-debug]
 inherits = "release"
 debug = true
+
+[patch.crates-io]
+# TODO: Remove patch once version newer than 0.35.0 is released.
+object = { git = "https://github.com/gimli-rs/object", rev = "017624aa70a1a52e36dbb61e693ba3c7f3bf010e" }

--- a/wild/Cargo.toml
+++ b/wild/Cargo.toml
@@ -10,7 +10,7 @@ tracing = "0.1.40"
 
 [dev-dependencies]
 wait-timeout = "0.2.0"
-object = { version = "0.34.0", default-features = false, features = [
+object = { version = "0.35.0", default-features = false, features = [
     "elf",
     "read_core",
     "std",

--- a/wild_lib/Cargo.toml
+++ b/wild_lib/Cargo.toml
@@ -12,7 +12,7 @@ crossbeam-utils = "0.8.18"
 linker-layout = { path = "../linker-layout" }
 memchr = "2.7.1"
 memmap2 = "0.9.0"
-object = { version = "0.34.0", default-features = false, features = [
+object = { version = "0.35.0", default-features = false, features = [
     "elf",
     "read_core",
     "std",

--- a/wild_lib/src/symbol_db.rs
+++ b/wild_lib/src/symbol_db.rs
@@ -366,7 +366,7 @@ fn load_symbols_from_file<'data>(
                     |sym| match sym.section() {
                         object::SymbolSection::Absolute => ValueKind::Absolute,
                         _ => {
-                            if sym.raw_symbol().st_info & crate::elf::SYMBOL_TYPE_MASK
+                            if sym.elf_symbol().st_info & crate::elf::SYMBOL_TYPE_MASK
                                 == crate::elf::SYMBOL_TYPE_IFUNC
                             {
                                 ValueKind::IFunc


### PR DESCRIPTION
This is a draft for #4. It needs some small helpers in `object` first.

In doing this I've been merrily deleting all the support for `RelocationTarget::Section` because [`object` never returns that for ELF](https://github.com/gimli-rs/object/blob/9650d6429667938a01b41a19e6de32f8f36b1aab/src/read/elf/relocation.rs#L474-L478), instead returning a `RelocationTarget::Symbol` that may refer to a section symbol. However, maybe I shouldn't be deleting this, and instead fixing it to handle section symbols, even though it previously didn't? I don't understand enough of the code to know.