### PR TITLE
Support for object crate not returning null symbol/section

### DIFF
--- a/wild_lib/src/symbol.rs
+++ b/wild_lib/src/symbol.rs
@@ -45,7 +45,6 @@ impl<'data, 'file> Display for SymDebug<'data, 'file> {
         };
         let kind = if sym.is_definition() {
             match sym.kind() {
-                object::SymbolKind::Null => "Null",
                 object::SymbolKind::Text => "Text",
                 object::SymbolKind::Data => "Data",
                 object::SymbolKind::Section => "Section",


### PR DESCRIPTION
The current git version of `object` no longer returns the null symbol or section at index 0.

For sections, check for this and add an extra section slot if needed.

For symbols, there are multiple places where we iterate over the input symbols, and adding an extra symbol every time is a bit ugly. Instead, add `SymbolIdRange` to recording the starting index and add methods to convert between id, vec index, and ELF index. These methods also include debug assertions to validate the values are in the correct range.