### PR TITLE
Fix error when running integration tests

### DIFF
--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -521,8 +521,7 @@ fn build_obj(filename: &str, variant: &Variant, placement: FilePlacement) -> Res
                 .env("WILD_SAVE_SKIP_LINKING", "1")
                 .arg("+nightly")
                 .args(["-C", "linker=clang"])
-                .args(["-C", &format!("link-arg=--ld-path={wild}")])
-                .args(["-o", "/dev/null"]);
+                .args(["-C", &format!("link-arg=--ld-path={wild}")]);
         }
     }
     command.arg(&src_path);


### PR DESCRIPTION
rustc doesn't appear to support using /dev/null as the output. This error occurs even when running rustc manually.

error: couldn't create a temp dir: Permission denied (os error 13) at path "/dev/rmetayXAwWn"
