### PR TITLE
Use low level API from object crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,7 +364,7 @@ dependencies = [
 [[package]]
 name = "object"
 version = "0.35.0"
-source = "git+https://github.com/gimli-rs/object?rev=017624aa70a1a52e36dbb61e693ba3c7f3bf010e#017624aa70a1a52e36dbb61e693ba3c7f3bf010e"
+source = "git+https://github.com/gimli-rs/object?rev=aa2f5adc8badeac3dadaf26e9dacb66784d5d643#aa2f5adc8badeac3dadaf26e9dacb66784d5d643"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ debug = true
 
 [patch.crates-io]
 # TODO: Remove patch once version newer than 0.35.0 is released.
-object = { git = "https://github.com/gimli-rs/object", rev = "017624aa70a1a52e36dbb61e693ba3c7f3bf010e" }
+object = { git = "https://github.com/gimli-rs/object", rev = "aa2f5adc8badeac3dadaf26e9dacb66784d5d643" }


### PR DESCRIPTION
I think this is worth doing because the code is closely tied to the ELF format, and using the lower level API removes possibilities for ambiguity due to the abstractions in the unified API in `object`. Other than the need to define our own `File` and sometimes pass an extra parameter, it doesn't add any significant complexity.

Closes #4 
