### PR TITLE
add bevy dynamic linking project test

### DIFF
--- a/wild/tests/build_projects.rs
+++ b/wild/tests/build_projects.rs
@@ -1,0 +1,55 @@
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+const PROJECTS_ROOT: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/projects");
+const WILD_TEST_DIR: &str = "wild_project_tests";
+const RUSTFLAGS_LINK_WITH_WILD: &str = concat!(
+    "-Clinker=clang -Clink-args=--ld-path=",
+    env!("CARGO_BIN_EXE_wild")
+);
+
+#[test]
+fn run_bevy_dynamic() {
+    let proj_name = "bevy_dynamic";
+
+    let proj_root = PathBuf::from(PROJECTS_ROOT).join(proj_name);
+
+    let temp_dir = std::env::temp_dir().join(WILD_TEST_DIR).join(proj_name);
+
+    force_copy_dir(proj_root, &temp_dir).unwrap();
+
+    let mut cargo_cmd = Command::new("cargo");
+    cargo_cmd
+        .env("RUSTFLAGS", RUSTFLAGS_LINK_WITH_WILD)
+        .current_dir(&temp_dir)
+        .arg("run");
+
+    let status_code = cargo_cmd.status().unwrap().code().unwrap();
+
+    assert_eq!(status_code, 42);
+}
+
+fn force_copy_dir(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
+    // TODO: uncomment remove_dir_all. Currently commented to improve iteration speed of setting up the test
+    // TODO: use incremental=false once the test is stable to cut down compile time
+
+    // let _ = fs::remove_dir_all(&dst);
+
+    fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
+        fs::create_dir_all(&dst)?;
+        for entry in fs::read_dir(src)? {
+            let entry = entry?;
+            if entry.file_type()?.is_dir() {
+                copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
+            } else {
+                fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
+            }
+        }
+        Ok(())
+    }
+
+    copy_dir_all(src, dst)
+}

--- a/wild/tests/projects/bevy_dynamic/Cargo.toml
+++ b/wild/tests/projects/bevy_dynamic/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "bevy_dynamic"
+version = "0.1.0"
+edition = "2021"
+
+[profile.dev]
+# incremental = false
+
+[workspace]
+
+[dependencies]
+bevy = { version = "0.13.2", features = ["dynamic_linking"] }

--- a/wild/tests/projects/bevy_dynamic/src/main.rs
+++ b/wild/tests/projects/bevy_dynamic/src/main.rs
@@ -1,0 +1,12 @@
+use bevy::{app::ScheduleRunnerPlugin, prelude::*};
+
+fn main() {
+    App::new()
+        .add_plugins(MinimalPlugins.set(ScheduleRunnerPlugin::run_once()))
+        .add_systems(Update, exit_with_success_code)
+        .run();
+}
+
+fn exit_with_success_code() {
+    std::process::exit(42);
+}


### PR DESCRIPTION
Conceptualising what more involved testing might look like, probably don't merge this as is :) ?

Runs with `cargo test run_bevy_dynamic`

- Tests using wild through cargo (arguably the most common scenario)
- Tests with cargo dependencies
- This particular test is with a dependency that relies upon dynamic linking
- Tests the actual program can run, this example currently compiles using dynamic linking, but errors when running

I'm not sure if bigger tests like this should live in the repo or not. This example is small, but if we wanted to add tests for something like ripgrep it seems clumsy to bring that in.

Bigger tests _could_ live in a separate repo that is dedicated to integration testing wild with larger projects. Then it wouldn't feel as hacky to have lots of git submodules. It would also make it more straight forward to develop integration testing tooling for running lots of cargo compiles.