### PR TITLE
Extend supported cmdline arguments from file

### DIFF
--- a/wild_lib/src/args.rs
+++ b/wild_lib/src/args.rs
@@ -575,8 +575,8 @@ fn arguments_from_string(input: &str) -> Result<Vec<String>> {
                     // close the argument
                     if let Some(arg) = heap.take() {
                         out.push(arg);
-                        quote = None;
                     }
+                    quote = None;
                     expect_whitespace = true;
                 }
             } else {
@@ -725,6 +725,8 @@ mod tests {
         use super::arguments_from_string;
 
         assert!(arguments_from_string("").unwrap().is_empty());
+        assert!(arguments_from_string("''").unwrap().is_empty());
+        assert!(arguments_from_string("\"\"").unwrap().is_empty());
         assert_eq!(
             arguments_from_string(r#""foo" "bar""#).unwrap(),
             ["foo", "bar"]


### PR DESCRIPTION
The goal of the pull request is to support rules specified by BFD:

```
       @file
           Options  in  file  are  separated  by  whitespace.   A whitespace character may be included in an option by surrounding the entire option in either single or double quotes.  Any character (including a backslash) may be included by prefixing the character to be included with a backslash.  The file may itself contain additional @file options; any such
           options will be processed recursively.
```

My changes don't utilize `Cow`; they use a normal string. Hopefully, it's something hard to spot in the performance stats. What do you think?