### PR TITLE
Use itertools Crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,6 +319,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +347,7 @@ dependencies = [
  "bytemuck",
  "clap",
  "iced-x86",
+ "itertools",
  "linker-layout",
  "linker-trace",
  "object",
@@ -714,6 +724,7 @@ name = "wild"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "itertools",
  "linker-diff",
  "object",
  "tracing",
@@ -733,6 +744,7 @@ dependencies = [
  "bytemuck",
  "crossbeam-queue",
  "crossbeam-utils",
+ "itertools",
  "linker-layout",
  "linker-trace",
  "memchr",

--- a/linker-diff/Cargo.toml
+++ b/linker-diff/Cargo.toml
@@ -23,3 +23,4 @@ anyhow = "1.0.80"
 clap = { version = "4.5.4", features = ["derive"] }
 rayon = "1.8.0"
 bytemuck = { version = "1.14.0", features = ["derive"] }
+itertools = "0.13.0"

--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -17,6 +17,7 @@ use anyhow::bail;
 use anyhow::Context as _;
 use asm_diff::AddressIndex;
 use clap::Parser;
+use itertools::Itertools;
 use object::read::elf::ElfSection64;
 use object::read::elf::ProgramHeader as _;
 use object::LittleEndian;
@@ -165,7 +166,7 @@ impl Config {
                 .equiv
                 .iter()
                 .map(|(k, v)| format!("{k}={v}"))
-                .collect::<Vec<_>>();
+                .collect_vec();
             out.push_str(&parts.join(","));
             out.push_str("' ");
         }
@@ -299,7 +300,7 @@ fn validate_objects(
             Ok(_) => "OK".to_owned(),
             Err(e) => e.to_string(),
         })
-        .collect::<Vec<_>>();
+        .collect_vec();
     if first_equals_any(values.iter()) {
         return;
     }
@@ -571,7 +572,7 @@ fn short_file_display_names(config: &Config) -> Result<Vec<String>> {
     let mut names = paths
         .iter()
         .map(|p| p.to_string_lossy().into_owned())
-        .collect::<Vec<_>>();
+        .collect_vec();
     if names.iter().all(|name| name.ends_with(".so")) {
         names = names
             .into_iter()
@@ -580,7 +581,7 @@ fn short_file_display_names(config: &Config) -> Result<Vec<String>> {
     }
     // This is not quite right, since we might split in the middle of a multibyte character.
     // But this is a dev tool, so we'll punt on that for now.
-    let mut iterators = names.iter().map(|n| n.bytes()).collect::<Vec<_>>();
+    let mut iterators = names.iter().map(|n| n.bytes()).collect_vec();
     let mut n = 0;
     while first_equals_all(iterators.iter_mut().map(|i| i.next())) {
         n += 1;
@@ -590,7 +591,7 @@ fn short_file_display_names(config: &Config) -> Result<Vec<String>> {
         .map(|name| {
             String::from_utf8_lossy(&name.bytes().skip(n).collect::<Vec<u8>>()).into_owned()
         })
-        .collect::<Vec<_>>();
+        .collect_vec();
     Ok(names)
 }
 

--- a/wild/Cargo.toml
+++ b/wild/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 wild_lib = { version = "0.2.0", path = "../wild_lib" }
 anyhow = "1.0.75"
 tracing = "0.1.40"
+itertools = "0.13.0"
 
 [dev-dependencies]
 wait-timeout = "0.2.0"

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -16,6 +16,7 @@
 use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Context;
+use itertools::Itertools;
 use object::LittleEndian;
 use object::Object;
 use object::ObjectSection;
@@ -372,7 +373,7 @@ fn parse_configs(src_filename: &Path) -> Result<Vec<Config>> {
     let mut configs = config_by_name
         .into_values()
         .filter(|c| !c.is_abstract)
-        .collect::<Vec<_>>();
+        .collect_vec();
     configs.push(config);
     Ok(configs)
 }
@@ -656,7 +657,7 @@ fn command_as_str(command: &Command) -> String {
         command
             .get_args()
             .map(|arg| arg.to_string_lossy())
-            .collect::<Vec<_>>()
+            .collect_vec()
             .join(" ")
     )
 }
@@ -1118,7 +1119,7 @@ fn diff_shared_objects(instructions: &Config, programs: &[Program]) -> Result {
         }
     }
     for so_group in so_groups {
-        let filenames = so_group.iter().map(|i| i.path.clone()).collect::<Vec<_>>();
+        let filenames = so_group.iter().map(|i| i.path.clone()).collect_vec();
         diff_files(
             instructions,
             filenames,
@@ -1133,7 +1134,7 @@ fn diff_executables(instructions: &Config, programs: &[Program]) -> Result {
     let filenames = programs
         .iter()
         .map(|p| p.link_output.binary.clone())
-        .collect::<Vec<_>>();
+        .collect_vec();
     diff_files(instructions, filenames, programs.last().unwrap())
 }
 

--- a/wild_lib/Cargo.toml
+++ b/wild_lib/Cargo.toml
@@ -32,6 +32,7 @@ tracing-subscriber = { version = "0.3.18", default-features = false, features = 
     "registry",
 ] }
 sharded-vec-writer = "0.1.0"
+itertools = "0.13.0"
 
 [dev-dependencies]
 ar = "0.9.0"

--- a/wild_lib/src/gc_stats.rs
+++ b/wild_lib/src/gc_stats.rs
@@ -27,6 +27,7 @@ use crate::output_section_id;
 use crate::output_section_id::TemporaryOutputSectionId;
 use crate::resolution::SectionSlot;
 use anyhow::Context as _;
+use itertools::Itertools;
 use object::LittleEndian;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -123,7 +124,7 @@ fn write_gc_stats(
         }
     }
 
-    let mut files = files.values().collect::<Vec<_>>();
+    let mut files = files.values().collect_vec();
     files.sort_by_key(|f| f.discarded);
 
     let mut out = std::io::BufWriter::new(

--- a/wild_lib/src/layout.rs
+++ b/wild_lib/src/layout.rs
@@ -53,6 +53,7 @@ use anyhow::bail;
 use anyhow::Context;
 use bitflags::bitflags;
 use crossbeam_queue::ArrayQueue;
+use itertools::Itertools;
 use object::elf::gnu_hash;
 use object::elf::Rela64;
 use object::read::elf::Dyn;
@@ -142,7 +143,7 @@ pub fn compute<'data>(
     let mut per_group_res_writers = group_states
         .iter()
         .map(|group| res_writer.take_shard(group.num_symbols))
-        .collect::<Vec<_>>();
+        .collect_vec();
 
     let resources = FinaliseLayoutResources {
         symbol_db,
@@ -1258,7 +1259,7 @@ fn compute_start_offsets_by_group(
             mem_offsets.merge(&group.common.mem_sizes);
             group_mem_starts
         })
-        .collect::<Vec<_>>()
+        .collect_vec()
 }
 
 #[tracing::instrument(skip_all, name = "Assign symbol addresses")]

--- a/wild_lib/src/linker_script.rs
+++ b/wild_lib/src/linker_script.rs
@@ -353,6 +353,7 @@ fn take_up_to<'a>(input: &mut &'a str, pattern: &str) -> Result<&'a str> {
 mod tests {
     use super::*;
     use crate::args::InputSpec;
+    use itertools::assert_equal;
 
     #[test]
     fn test_tokenisation() {
@@ -383,18 +384,18 @@ mod tests {
             Modifiers::default(),
         )
         .unwrap();
-        assert_eq!(
-            inputs.into_iter().map(|i| i.spec).collect::<Vec<_>>(),
-            vec![
+        assert_equal(
+            inputs.into_iter().map(|i| i.spec),
+            [
                 InputSpec::File(Box::from(Path::new("libgcc_s.so.1"))),
-                InputSpec::Lib(Box::from("gcc"))
-            ]
+                InputSpec::Lib(Box::from("gcc")),
+            ],
         );
 
         let inputs = inputs_from_script("INPUT(libfoo.so)", Modifiers::default()).unwrap();
-        assert_eq!(
-            inputs.into_iter().map(|i| i.spec).collect::<Vec<_>>(),
-            vec![InputSpec::File(Box::from(Path::new("libfoo.so"))),]
+        assert_equal(
+            inputs.into_iter().map(|i| i.spec),
+            [InputSpec::File(Box::from(Path::new("libfoo.so")))],
         );
     }
 
@@ -407,15 +408,15 @@ mod tests {
         Modifiers::default(),
         )
         .unwrap();
-        assert_eq!(
-            inputs.into_iter().map(|i| i.spec).collect::<Vec<_>>(),
-            vec![
+        assert_equal(
+            inputs.into_iter().map(|i| i.spec),
+            [
                 InputSpec::File(Box::from(Path::new("/lib/x86_64-linux-gnu/libc.so.6"))),
                 InputSpec::File(Box::from(Path::new(
-                    "/usr/lib/x86_64-linux-gnu/libc_nonshared.a"
+                    "/usr/lib/x86_64-linux-gnu/libc_nonshared.a",
                 ))),
                 InputSpec::File(Box::from(Path::new("/lib64/ld-linux-x86-64.so.2"))),
-            ]
+            ],
         )
     }
 
@@ -435,23 +436,21 @@ mod tests {
         };
         let script = VersionScript::parse(&data).unwrap();
         let version = script.version.unwrap();
-        assert_eq!(
+        assert_equal(
             version
                 .globals
                 .exact
                 .iter()
-                .map(|s| std::str::from_utf8(s.bytes()).unwrap())
-                .collect::<Vec<_>>(),
-            &["foo"]
+                .map(|s| std::str::from_utf8(s.bytes()).unwrap()),
+            ["foo"],
         );
-        assert_eq!(
+        assert_equal(
             version
                 .globals
                 .prefixes
                 .iter()
-                .map(|s| std::str::from_utf8(s).unwrap())
-                .collect::<Vec<_>>(),
-            &["bar"]
+                .map(|s| std::str::from_utf8(s).unwrap()),
+            ["bar"],
         );
         assert!(version.locals.matches_all);
     }

--- a/wild_lib/src/output_section_part_map.rs
+++ b/wild_lib/src/output_section_part_map.rs
@@ -526,6 +526,8 @@ fn test_merge_with_custom_sections() {
 /// that they iterate through the sections in the same order.
 #[test]
 fn test_output_order_map_consistent() {
+    use itertools::Itertools;
+
     let output_sections = output_section_id::OutputSections::for_testing();
     let mut part_map = OutputSectionPartMap::<u32>::with_size(output_sections.len());
     part_map.resize(output_sections.len());
@@ -543,7 +545,7 @@ fn test_output_order_map_consistent() {
         missing
             .iter()
             .map(|id| output_sections.display_name(*id))
-            .collect::<Vec<_>>()
+            .collect_vec()
             .join(", ")
     );
 

--- a/wild_lib/src/resolution.rs
+++ b/wild_lib/src/resolution.rs
@@ -36,6 +36,7 @@ use bitflags::bitflags;
 use crossbeam_queue::ArrayQueue;
 use crossbeam_queue::SegQueue;
 use crossbeam_utils::atomic::AtomicCell;
+use itertools::Itertools;
 use object::read::elf::Sym as _;
 use object::LittleEndian;
 use std::fmt::Display;
@@ -106,9 +107,9 @@ pub(crate) fn resolve_symbols_in_files<'data>(
                         file.num_symbols(),
                     ))))
                 })
-                .collect::<Vec<_>>()
+                .collect_vec()
         })
-        .collect::<Vec<_>>();
+        .collect_vec();
 
     let mut prelude = None;
     let mut resolved: Vec<ResolvedGroup<'_>> = groups

--- a/wild_lib/src/symbol_db.rs
+++ b/wild_lib/src/symbol_db.rs
@@ -21,6 +21,7 @@ use crate::sharding::ShardKey;
 use crate::symbol::SymbolName;
 use crate::threading::prelude::*;
 use anyhow::Context;
+use itertools::Itertools;
 use object::read::elf::Sym as _;
 use object::LittleEndian;
 use std::collections::hash_map;
@@ -238,7 +239,7 @@ impl<'data> SymbolDb<'data> {
                     symbol_file_ids_writer.take_shard(num_symbols),
                 )
             })
-            .collect::<Vec<_>>();
+            .collect_vec();
 
         let symbol_per_file = read_symbols(groups, &version_script, &mut per_group_writers, args)?;
 

--- a/wild_lib/src/verification.rs
+++ b/wild_lib/src/verification.rs
@@ -8,6 +8,7 @@ use crate::output_section_id::OutputSectionId;
 use crate::output_section_id::OutputSections;
 use crate::output_section_part_map::OutputSectionPartMap;
 use anyhow::bail;
+use itertools::Itertools;
 
 pub(crate) struct OffsetVerifier {
     expected: OutputSectionPartMap<u64>,
@@ -53,7 +54,7 @@ impl OffsetVerifier {
                 ));
             }
         }
-        let files = files.iter().map(|f| f.to_string()).collect::<Vec<_>>();
+        let files = files.iter().map(|f| f.to_string()).collect_vec();
         bail!(
             "Unexpected memory offsets:\n{}\nfor files:\n{}",
             problems.join(""),


### PR DESCRIPTION
The change utilizes the crate where `::collect<Vec<_>>` is replaced with `collect_vec `and `assert_equal` is used for equality of iterable collections.
