### PR TITLE
gc-stats: Do not filter out input files by cwd

### DIFF
--- a/wild_lib/src/gc_stats.rs
+++ b/wild_lib/src/gc_stats.rs
@@ -1,17 +1,14 @@
 //! Optionally writes garbage collection statistics to a text file. To use this, pass
 //! `--write-gc-stats=/path/to/file.txt`
 //!
-//! Only input files under the current working directory will be included in the GC stats. This is
-//! because the purpose of writing these stats is to see how much of the code we just compiled is
-//! actually being used. We assume that the code we just compiled is somewhere in a subdirectory of
-//! the current directory.
-//!
-//! You can also ignore selected files even if they're under the current directory by passing
-//! `--gc-stats-ignore=some-string`. Any files that contain `some-string` in their filename will be
-//! ignored.
+//! You can also ignore selected files by passing `--gc-stats-ignore=some-string`.
+//! Any files that contain `some-string` in their filename will be ignored.
 //!
 //! By default, only the stats per input file and the totals for all input files are shown. If you'd
 //! like to also see what sections are discarded, you can run with `--verbose-gc-stats`.
+//!
+//! Note that only .text sections are reported, the other sections like .data, .rodata and .bss
+//! are commonly garbage collected, but ignored for the purpose of this report.
 //!
 //! Example usage:
 //!

--- a/wild_lib/src/gc_stats.rs
+++ b/wild_lib/src/gc_stats.rs
@@ -63,13 +63,6 @@ fn write_gc_stats(
             let FileLayout::Object(obj) = file else {
                 continue;
             };
-            // Ignore files outside of our current working directory. Our use-case for GC stats is to
-            // see how much code we compiled, but then discarded at link time. Code outside of our
-            // current directory is code that we didn't just compile.
-            let filename = std::fs::canonicalize(&obj.input.file.filename)?;
-            if !filename.starts_with(&current_dir) {
-                continue;
-            }
             let file_display_name = obj.input.file.filename.to_string_lossy();
             if args
                 .gc_stats_ignore
@@ -125,7 +118,7 @@ fn write_gc_stats(
     }
 
     let mut files = files.values().collect_vec();
-    files.sort_by_key(|f| f.discarded);
+    files.sort_by_key(|f| (f.discarded, &f.path));
 
     let mut out = std::io::BufWriter::new(
         std::fs::OpenOptions::new()


### PR DESCRIPTION
The output file is made stable.

Fixes: #34