### PR TITLE
Use the default gcc, ld.lld when running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   test-nightly:
     name: Test x86_64-linux nightly
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
@@ -31,13 +31,13 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
-      - run: sudo apt install bubblewrap
+      - run: sudo apt install bubblewrap lld
       - run: cargo build --no-default-features
       - run: cargo test
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
@@ -57,7 +57,7 @@ jobs:
 
   rustfmt:
     name: Check formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -535,8 +535,8 @@ impl ToolPaths {
 
         match compiler {
             "gcc" => Some(GCC_INSTANCE.get_or_init(|| ToolPaths {
-                cc: select_bin(&["gcc-13", "gcc"]),
-                cpp: select_bin(&["g++-13", "g++"]),
+                cc: select_bin(&["gcc"]),
+                cpp: select_bin(&["g++"]),
             })),
             "clang" => Some(CLANG_INSTANCE.get_or_init(|| ToolPaths {
                 cc: select_bin(&["clang"]),
@@ -1279,7 +1279,7 @@ fn integration_test(
         Linker::ThirdParty(ThirdPartyLinker {
             name: "lld",
             gcc_name: "lld",
-            path: find_bin(&["ld.lld-18", "ld.lld-17", "ld.lld-16", "ld.lld-15"])?,
+            path: find_bin(&["ld.lld"])?,
             enabled_by_default: false,
         }),
     ];


### PR DESCRIPTION
I think all distros support a symlink of `ld.lld`. The `gcc-13` is probably a leftover from times when you tests `opensuse:leap` Docker container, right?