### PR TITLE
Address new clippy warning:

### DIFF
--- a/wild_lib/src/args.rs
+++ b/wild_lib/src/args.rs
@@ -1,4 +1,6 @@
-//! A hand-written parser for our arguments. We don't currently use a 3rd party library because
+//! A hand-written parser for our arguments.
+//!
+//! We don't currently use a 3rd party library because
 //! order is important for some arguments and it's not clear how easy it would be to get that
 //! correct with something like clap.
 

--- a/wild_lib/src/error.rs
+++ b/wild_lib/src/error.rs
@@ -2,7 +2,9 @@ pub(crate) use anyhow::Error;
 
 pub type Result<T = (), E = Error> = core::result::Result<T, E>;
 
-/// Like debug_assert, but bails instead of panicking. Returning an error often allows us to give
+/// Like debug_assert, but bails instead of panicking.
+///
+/// Returning an error often allows us to give
 /// more context as to what we were trying to do, e.g. which file / symbol we were processing,
 /// whereas a panic just gives us a function backtrace, which is less useful.
 #[macro_export]


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#/too_long_first_doc_paragraph