### PR TITLE
Support compressed input sections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "ahash"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,6 +222,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +280,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +316,16 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -551,6 +587,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "msvc-demangler"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,7 +610,9 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
 dependencies = [
+ "flate2",
  "memchr",
+ "ruzstd",
 ]
 
 [[package]]
@@ -739,6 +786,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruzstd"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5174a470eeb535a721ae9fdd6e291c2411a906b96592182d05217591d5c5cf7b"
+dependencies = [
+ "byteorder",
+ "derive_more",
+ "twox-hash",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,6 +872,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -924,6 +988,16 @@ dependencies = [
  "sharded-slab",
  "thread_local",
  "tracing-core",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
 ]
 
 [[package]]

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -73,6 +73,7 @@ pub mod shf {
     pub const OS_NONCONFORMING: u64 = object::elf::SHF_OS_NONCONFORMING as u64;
     pub const GROUP: u64 = object::elf::SHF_GROUP as u64;
     pub const TLS: u64 = object::elf::SHF_TLS as u64;
+    pub const COMPRESSED: u64 = object::elf::SHF_COMPRESSED as u64;
     // TODO: add with the new release of object crate (https://github.com/gimli-rs/object/pull/720)
     pub const GNU_RETAIN: u64 = 0x200_000;
 
@@ -107,6 +108,9 @@ pub mod shf {
         }
         if value & TLS != 0 {
             flags.push('T');
+        }
+        if value & COMPRESSED != 0 {
+            flags.push('C');
         }
         flags
     }

--- a/wild_lib/Cargo.toml
+++ b/wild_lib/Cargo.toml
@@ -16,6 +16,7 @@ linker-utils = { path = "../linker-utils" }
 memchr = "2.7.1"
 memmap2 = "0.9.0"
 object = { version = "0.36.0", default-features = false, features = [
+    "compression",
     "elf",
     "read_core",
     "std",

--- a/wild_lib/src/elf.rs
+++ b/wild_lib/src/elf.rs
@@ -125,7 +125,7 @@ impl<'data> File<'data> {
     pub(crate) fn section_data(&self, section: &SectionHeader) -> Result<&'data [u8]> {
         let data = section.data(LittleEndian, self.data)?;
 
-        if let Some((compression, offset, _)) = section.compression(LittleEndian, self.data)? {
+        if let Some((compression, _, _)) = section.compression(LittleEndian, self.data)? {
             let format = match compression.ch_type.get(LittleEndian) {
                 object::elf::ELFCOMPRESS_ZLIB => object::CompressionFormat::Zlib,
                 object::elf::ELFCOMPRESS_ZSTD => object::CompressionFormat::Zstandard,
@@ -134,7 +134,8 @@ impl<'data> File<'data> {
 
             let decompressed = CompressedData {
                 format,
-                data: &data[(offset as usize)..],
+                data: &data
+                    [core::mem::size_of::<object::elf::CompressionHeader64<LittleEndian>>()..],
                 uncompressed_size: compression.ch_size.get(LittleEndian),
             }
             .decompress()?;

--- a/wild_lib/src/elf_writer.rs
+++ b/wild_lib/src/elf_writer.rs
@@ -53,6 +53,7 @@ use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Context;
 use linker_utils::elf::rel_type_to_string;
+use linker_utils::elf::shf;
 use memmap2::MmapOptions;
 use object::from_bytes_mut;
 use object::read::elf::Rela;
@@ -2271,7 +2272,10 @@ fn write_section_headers(out: &mut [u8], layout: &Layout) {
         let e = LittleEndian;
         entry.sh_name.set(e, name_offset);
         entry.sh_type.set(e, section_details.ty);
-        entry.sh_flags.set(e, section_details.section_flags.0);
+        // TODO: Section are always uncompressed and the output compression is not supported yet.
+        entry
+            .sh_flags
+            .set(e, section_details.section_flags.0 & !shf::COMPRESSED);
         entry.sh_addr.set(e, section_layout.mem_offset);
         entry.sh_offset.set(e, section_layout.file_offset as u64);
         entry.sh_size.set(e, size);

--- a/wild_lib/src/gc_stats.rs
+++ b/wild_lib/src/gc_stats.rs
@@ -25,7 +25,6 @@ use crate::part_id::TemporaryPartId;
 use crate::resolution::SectionSlot;
 use anyhow::Context as _;
 use itertools::Itertools;
-use object::LittleEndian;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -87,7 +86,7 @@ fn write_gc_stats(
                     SectionSlot::Unloaded(s) => match s.part_id {
                         TemporaryPartId::BuiltIn(id) => {
                             if id.output_section_id() == output_section_id::TEXT {
-                                file_discarded += section.sh_size.get(LittleEndian);
+                                file_discarded += obj.object.section_size(section)?;
                                 if args.verbose_gc_stats {
                                     file_record
                                         .discarded_names
@@ -101,7 +100,7 @@ fn write_gc_stats(
                         if s.output_part_id.is_some_and(|part_id| {
                             part_id.output_section_id() == output_section_id::TEXT
                         }) {
-                            file_kept += section.sh_size.get(LittleEndian);
+                            file_kept += obj.object.section_size(section)?;
                         }
                     }
                     _ => {}


### PR DESCRIPTION
This is a foundation for supporting of the ELF compressed sections. The ergonomics is not ideal as one needs to go from `SectionHeader::sh_size` to `obj.object.section_size(section)` to get the correct section size, similarly for the alignment.
Do we have any other option?

For the actual uncompressed data, there is an existing [`object`'s `decompression` function](https://docs.rs/object/0.36.3/object/read/struct.CompressedData.html#method.decompress), but it comes from the unused `object::read` API. Do you know if we can use the function? If not, then we will need to do the decompression ourselves.

Partially implements #37 (part 1).