### PR TITLE
Enable debug info for dev mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,6 @@ members = ["linker-diff", "linker-layout", "linker-trace", "linker-utils", "wild
 
 resolver = "2"
 
-[profile.dev]
-debug = false
-
 [profile.opt-debug]
 inherits = "release"
 debug = true


### PR DESCRIPTION
It took me a while to realize that VS Code cannot put a breakpoint when debugging because I was missing the debug info.