### PR TITLE
Fix and enhance `DisplaySection`

### DIFF
--- a/linker-diff/src/section_map.rs
+++ b/linker-diff/src/section_map.rs
@@ -139,7 +139,7 @@ impl<'data> DisplaySection<'data> {
     fn new(info: &SectionInfo, files: &'data [InputFile]) -> Self {
         Self {
             info: info.clone(),
-            file: &files[info.section_index],
+            file: &files[info.file_index],
         }
     }
 }
@@ -157,8 +157,10 @@ impl Display for DisplaySection<'_> {
         {
             write!(
                 f,
-                "section `{section_name}` (0x{:x}..0x{:x})",
-                self.info.addresses.start, self.info.addresses.end
+                "section `{section_name}` (0x{:x}..0x{:x}) ({})",
+                self.info.addresses.start,
+                self.info.addresses.end,
+                self.file.filename.to_string_lossy()
             )?;
         }
         Ok(())


### PR DESCRIPTION
I noticed that while debugging another issue:

```
thread 'integration_test::program_name_02___trivial_main_c__' panicked at linker-diff/src/section_map.rs:142:20:
index out of bounds: the len is 6 but the index is 18
```

It's fixed and I added also info about which file is affected.

Now I face the following issue:
```
Error: section `.debug_rnglists` (0x0..0x21) (/usr/lib64/gcc/x86_64-suse-linux/14/../../../../lib64/crti.o) overlaps with section `.debug_line` (0x0..0x13d) (/usr/lib64/gcc/x86_64-suse-linux/14/../../../../lib64/crt1.o)
```

and I am curious why is `validate_no_overlaps` called for a collection of object files. They theoretically cannot overlap as they are not linked together yet, right?