### PR TITLE
Come up with `SymbolInfo` type and use it

### DIFF
--- a/wild_lib/src/layout.rs
+++ b/wild_lib/src/layout.rs
@@ -2296,6 +2296,15 @@ fn process_relocation(
         }
 
         if previous_flags.is_empty() {
+            let symbol_info = resources.symbol_db.symbol_info(symbol_id)?;
+            let source_section_name =
+                String::from_utf8_lossy(object.object.section_name(section).unwrap()).to_string();
+            println!(
+                "{} {} -> {}",
+                object.input.file.filename.to_str().unwrap(),
+                source_section_name,
+                symbol_info
+            );
             queue.send_symbol_request(symbol_id, resources);
         }
 


### PR DESCRIPTION
I'm still working on the Debug info support and I think I'll need filtering in `process_relocation` where a debug info section should be able to "load" only another debug info section. Otherwise, I'm going to end up with all symbols (and sections) linked by debug info. As mentioned, the garbage collected sections linked by debug info should be relocated by a tombstone value.

So the question is: Are you happy with the introduction of `symbol_info`, which I can use for the aforementioned filtering?

I'm also thinking about the possibility to use tracing in a classical way:

```rust
info!(
  object = object.input.file.filename.to_str().unwrap(),
  source_section = source_section_name,
  symbol = format!("{}", symbol_info),
  "send_symbol_request"
);
```

```
2024-09-03T11:56:56.053953Z  INFO wild_lib::layout: send_symbol_request object="/usr/lib64/gcc/x86_64-suse-linux/14/../../../../lib64/crt1.o" source_section=".debug_info" symbol="section `.debug_abbrev`"
2024-09-03T11:56:56.053964Z  INFO wild_lib::layout: send_symbol_request object="/usr/lib64/gcc/x86_64-suse-linux/14/../../../../lib64/crt1.o" source_section=".debug_info" symbol="section `.debug_line`"
2024-09-03T11:56:56.053969Z  INFO wild_lib::layout: send_symbol_request object="/usr/lib64/gcc/x86_64-suse-linux/14/../../../../lib64/crt1.o" source_section=".debug_info" symbol="section `.text`"
2024-09-03T11:56:56.053973Z  INFO wild_lib::layout: send_symbol_request object="/usr/lib64/gcc/x86_64-suse-linux/14/../../../../lib64/crt1.o" source_section=".debug_info" symbol="section `.debug_str`"
2024-09-03T11:56:56.053977Z  INFO wild_lib::layout: send_symbol_request object="/usr/lib64/gcc/x86_64-suse-linux/14/../../../../lib64/crt1.o" source_section=".debug_info" symbol="section `.debug_line_str`"
2024-09-03T11:56:56.053983Z  INFO wild_lib::layout: send_symbol_request object="/usr/lib64/gcc/x86_64-suse-linux/14/../../../../lib64/crt1.o" source_section=".debug_info" symbol="section `.note.ABI-tag`"
2024-09-03T11:56:56.053987Z  INFO wild_lib::layout: send_symbol_request object="/usr/lib64/gcc/x86_64-suse-linux/14/../../../../lib64/crt1.o" source_section=".debug_info" symbol="symbol `_IO_stdin_used`"
2024-09-03T11:56:56.053992Z  INFO wild_lib::layout: send_symbol_request object="/usr/lib64/gcc/x86_64-suse-linux/14/../../../../lib64/crti.o" source_section=".debug_info" symbol="section `.debug_abbrev`"
2024-09-03T11:56:56.053996Z  INFO wild_lib::layout: send_symbol_request object="/usr/lib64/gcc/x86_64-suse-linux/14/../../../../lib64/crti.o" source_section=".debug_info" symbol="section `.debug_line`"
2024-09-03T11:56:56.053999Z  INFO wild_lib::layout: send_symbol_request object="/usr/lib64/gcc/x86_64-suse-linux/14/../../../../lib64/crti.o" source_section=".debug_info" symbol="section `.debug_rnglists`"
2024-09-03T11:56:56.054003Z  INFO wild_lib::layout: send_symbol_request object="/usr/lib64/gcc/x86_64-suse-linux/14/../../../../lib64/crti.o" source_section=".debug_info" symbol="section `.debug_str`"
2024-09-03T11:56:56.054007Z  INFO wild_lib::layout: send_symbol_request object="/usr/lib64/gcc/x86_64-suse-linux/14/../../../../lib64/crti.o" source_section=".init" symbol="symbol `__gmon_start__`"
2024-09-03T11:56:56.054011Z  INFO wild_lib::layout: send_symbol_request object="/usr/lib64/gcc/x86_64-suse-linux/14/crtbegin.o" source_section=".init_array" symbol="section `.text`"
2024-09-03T11:56:56.054017Z  INFO wild_lib::layout: send_symbol_request object="a-main.o" source_section=".debug_info" symbol="section `.debug_abbrev`"
2024-09-03T11:56:56.054020Z  INFO wild_lib::layout: send_symbol_request object="a-main.o" source_section=".debug_info" symbol="section `.debug_str`"
2024-09-03T11:56:56.054024Z  INFO wild_lib::layout: send_symbol_request object="a-main.o" source_section=".debug_info" symbol="section `.debug_line_str`"
2024-09-03T11:56:56.054027Z  INFO wild_lib::layout: send_symbol_request object="a-main.o" source_section=".debug_info" symbol="section `.text`"
2024-09-03T11:56:56.054031Z  INFO wild_lib::layout: send_symbol_request object="a-main.o" source_section=".debug_info" symbol="section `.debug_line`"
2024-09-03T11:56:56.054041Z  INFO wild_lib::layout: send_symbol_request object="/usr/lib64/gcc/x86_64-suse-linux/14/../../../../lib64/crtn.o" source_section=".debug_info" symbol="section `.debug_abbrev`"
2024-09-03T11:56:56.054045Z  INFO wild_lib::layout: send_symbol_request object="/usr/lib64/gcc/x86_64-suse-linux/14/../../../../lib64/crtn.o" source_section=".debug_info" symbol="section `.debug_line`"
```

Can we add another subscribed that will be of type https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html? Or is it going to collide with the custom subscriber used in the `--time` option?