### PR TITLE
Support compressed sections and reports stats about merged string sections

### DIFF
--- a/wild_lib/src/part_id.rs
+++ b/wild_lib/src/part_id.rs
@@ -205,8 +205,6 @@ fn should_merge_strings(section: &SectionHeader, section_alignment: u64, args: &
     section_flags.contains(shf::MERGE)
         && section_flags.contains(shf::STRINGS)
         && section_alignment <= 1
-        // TODO: support also debug info sections?
-        && !section_flags.contains(shf::COMPRESSED)
 }
 
 impl PartId {


### PR DESCRIPTION
The compressed sections are supported right now as `File::section_data` properly returns the uncompressed content of sections.