### PR TITLE
Support any alignment for string merge sections

### DIFF
--- a/wild_lib/src/elf_writer.rs
+++ b/wild_lib/src/elf_writer.rs
@@ -1758,8 +1758,7 @@ impl PreludeLayout {
     fn write_merged_strings(&self, buffers: &mut OutputSectionPartMap<&mut [u8]>, layout: &Layout) {
         layout.merged_strings.for_each(|section_id, merged| {
             if merged.len() > 0 {
-                let buffer =
-                    buffers.get_mut(section_id.part_id_with_alignment(crate::alignment::MIN));
+                let buffer = buffers.get_mut(section_id.part_id_with_alignment(merged.alignment));
                 for string in &merged.strings {
                     let dest = crate::slice::slice_take_prefix_mut(buffer, string.len());
                     dest.copy_from_slice(string)

--- a/wild_lib/src/layout.rs
+++ b/wild_lib/src/layout.rs
@@ -2366,7 +2366,7 @@ impl<'data> PreludeLayoutState {
         resources.merged_strings.for_each(|section_id, merged| {
             if merged.len() > 0 {
                 common.allocate(
-                    section_id.part_id_with_alignment(alignment::MIN),
+                    section_id.part_id_with_alignment(merged.alignment),
                     merged.len(),
                 );
             }
@@ -2644,7 +2644,7 @@ impl<'data> PreludeLayoutState {
         resources.merged_strings.for_each(|section_id, merged| {
             if merged.len() > 0 {
                 memory_offsets.increment(
-                    section_id.part_id_with_alignment(alignment::MIN),
+                    section_id.part_id_with_alignment(merged.alignment),
                     merged.len(),
                 );
             }

--- a/wild_lib/src/part_id.rs
+++ b/wild_lib/src/part_id.rs
@@ -146,11 +146,7 @@ impl<'data> UnloadedSection<'data> {
                 };
                 return Ok(Some(UnloadedSection {
                     part_id: TemporaryPartId::Custom(custom_section_id, alignment),
-                    is_string_merge: should_merge_strings(
-                        section,
-                        object.section_alignment(section)?,
-                        args,
-                    ),
+                    is_string_merge: should_merge_strings(section, args),
                 }));
             }
             if !section_flags.contains(shf::ALLOC) {
@@ -181,11 +177,7 @@ impl<'data> UnloadedSection<'data> {
         let part_id = built_in_section_id.part_id_with_alignment(alignment);
         Ok(Some(UnloadedSection {
             part_id: TemporaryPartId::BuiltIn(part_id),
-            is_string_merge: should_merge_strings(
-                section,
-                object.section_alignment(section)?,
-                args,
-            ),
+            is_string_merge: should_merge_strings(section, args),
         }))
     }
 
@@ -195,16 +187,13 @@ impl<'data> UnloadedSection<'data> {
 }
 
 /// Returns whether the supplied section meets our criteria for string merging. String merging is
-/// optional, so there are cases where we might be able to merge, but don't currently. For example
-/// if alignment is > 1.
-fn should_merge_strings(section: &SectionHeader, section_alignment: u64, args: &Args) -> bool {
+/// optional, so there are cases where we might be able to merge, but don't currently.
+fn should_merge_strings(section: &SectionHeader, args: &Args) -> bool {
     if !args.merge_strings {
         return false;
     }
     let section_flags = SectionFlags::from_header(section);
-    section_flags.contains(shf::MERGE)
-        && section_flags.contains(shf::STRINGS)
-        && section_alignment <= 1
+    section_flags.contains(shf::MERGE) && section_flags.contains(shf::STRINGS)
 }
 
 impl PartId {


### PR DESCRIPTION
This is probably a naive implementation, but still something we can discuss. I noticed the `clang` binary contains a string section `Wild` can't deal with right now: `0.7%  1.51Mi   0.9%  1.51Mi    .rodata.str1.8`. As the name suggests, the section's alignment is equal to 8. My patch causes crashes for various binaries.

Why is the non-one alignment used for strings as the strings have variadic lengths and so you don't have any guarantees about an alignment of a reference string in such a section? Or am I wrong?

