### PR TITLE
Add metrics about relocations

### DIFF
--- a/wild_lib/src/elf_writer.rs
+++ b/wild_lib/src/elf_writer.rs
@@ -69,6 +69,7 @@ use std::ops::DerefMut;
 use std::ops::Range;
 use std::ops::Sub;
 use std::path::Path;
+use std::sync::atomic::Ordering::Relaxed;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
 use std::sync::Arc;
@@ -305,6 +306,16 @@ impl SizedOutput {
                     .with_context(|| format!("validate_empty failed for {group}"))?;
                 Ok(())
             })?;
+
+        for (output_section_id, section) in layout.output_sections.ids_with_info() {
+            let relocations = layout
+                .relocation_statistics
+                .get(output_section_id)
+                .load(Relaxed);
+            if relocations > 0 {
+                tracing::debug!(target: "metrics", section = %section.name, relocations, "resolved relocations");
+            }
+        }
         Ok(())
     }
 }
@@ -1392,7 +1403,12 @@ impl<'out> ObjectLayout<'out> {
         let object_section = self.object.section(section.index)?;
         let section_flags = SectionFlags::from_header(object_section);
         let mut modifier = RelocationModifier::Normal;
-        for rel in self.object.relocations(section.index)? {
+        let relocations = self.object.relocations(section.index)?;
+        layout
+            .relocation_statistics
+            .get(section.part_id.output_section_id())
+            .fetch_add(relocations.len() as u64, Relaxed);
+        for rel in relocations {
             if modifier == RelocationModifier::SkipNextRelocation {
                 modifier = RelocationModifier::Normal;
                 continue;
@@ -1448,7 +1464,12 @@ impl<'out> ObjectLayout<'out> {
                 0
             };
 
-        for rel in self.object.relocations(section.index)? {
+        let relocations = self.object.relocations(section.index)?;
+        layout
+            .relocation_statistics
+            .get(section.part_id.output_section_id())
+            .fetch_add(relocations.len() as u64, Relaxed);
+        for rel in relocations {
             let offset_in_section = rel.r_offset.get(LittleEndian);
             apply_debug_relocation(
                 self,

--- a/wild_lib/src/elf_writer.rs
+++ b/wild_lib/src/elf_writer.rs
@@ -1443,14 +1443,8 @@ impl<'out> ObjectLayout<'out> {
         section: &Section,
         layout: &Layout,
     ) -> Result {
-        let section_address = self.section_resolutions[section.index.0]
-            .as_ref()
-            .unwrap()
-            .address()?;
-
         let object_section = self.object.section(section.index)?;
         let section_name = self.object.section_name(object_section)?;
-        let section_flags = SectionFlags::from_header(object_section);
         let tombstone_value: u64 =
             // TODO: Starting with DWARF 6, the tombstone value will be defined as -1 and -2.
             // However, the change is premature as consumers of the DWARF format don't fully support
@@ -1471,25 +1465,13 @@ impl<'out> ObjectLayout<'out> {
             .fetch_add(relocations.len() as u64, Relaxed);
         for rel in relocations {
             let offset_in_section = rel.r_offset.get(LittleEndian);
-            apply_debug_relocation(
-                self,
-                offset_in_section,
-                rel,
-                SectionInfo {
-                    section_address,
-                    is_writable: section.is_writable,
-                    section_flags,
-                },
-                layout,
-                tombstone_value,
-                out,
-            )
-            .with_context(|| {
-                format!(
-                    "Failed to apply {} at offset 0x{offset_in_section:x}",
-                    self.display_relocation(rel, layout)
-                )
-            })?;
+            apply_debug_relocation(self, offset_in_section, rel, layout, tombstone_value, out)
+                .with_context(|| {
+                    format!(
+                        "Failed to apply {} at offset 0x{offset_in_section:x}",
+                        self.display_relocation(rel, layout)
+                    )
+                })?;
         }
         Ok(())
     }
@@ -1822,15 +1804,10 @@ fn apply_debug_relocation(
     object_layout: &ObjectLayout,
     offset_in_section: u64,
     rel: &elf::Rela,
-    section_info: SectionInfo,
     layout: &Layout,
     section_tombstone_value: u64,
     out: &mut [u8],
 ) -> Result<()> {
-    let section_address = section_info.section_address;
-    let place = section_address + offset_in_section;
-    let _span = tracing::trace_span!("debug relocation", address = place).entered();
-
     let e = LittleEndian;
     let symbol_index = rel
         .symbol(e, false)

--- a/wild_lib/src/layout.rs
+++ b/wild_lib/src/layout.rs
@@ -74,6 +74,7 @@ use std::num::NonZeroU32;
 use std::num::NonZeroU64;
 use std::sync::atomic;
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU64;
 use std::sync::atomic::AtomicU8;
 use std::sync::Mutex;
 
@@ -169,6 +170,8 @@ pub fn compute<'data>(
     update_dynamic_symbol_resolutions(&group_layouts, &mut symbol_resolutions.resolutions);
     crate::gc_stats::maybe_write_gc_stats(&group_layouts, symbol_db.args)?;
 
+    let relocation_statistics = OutputSectionMap::with_size(section_layouts.len());
+
     Ok(Layout {
         symbol_db,
         symbol_resolutions,
@@ -182,6 +185,7 @@ pub fn compute<'data>(
         merged_strings,
         merged_string_start_addresses,
         has_static_tls: gc_outputs.has_static_tls,
+        relocation_statistics,
     })
 }
 
@@ -250,6 +254,7 @@ pub struct Layout<'data> {
     pub(crate) symbol_resolution_flags: Vec<ResolutionFlags>,
     pub(crate) merged_strings: OutputSectionMap<MergeStringsSection<'data>>,
     pub(crate) merged_string_start_addresses: MergedStringStartAddresses,
+    pub(crate) relocation_statistics: OutputSectionMap<AtomicU64>,
     pub(crate) has_static_tls: bool,
 }
 


### PR DESCRIPTION
I decided to use a new target: metrics that can be nicely used for even filtering:

```
RUST_LOG=metrics=debug ...
2024-09-11T07:52:08.059135Z DEBUG metrics: merge_strings section=.rodata size=1899588 totally_added=2365762 strings=112764 totally_added_strings=155595 input_sections=15981
2024-09-11T07:52:08.059155Z DEBUG metrics: merge_strings section=.comment size=26 totally_added=73710 strings=2 totally_added_strings=5670 input_sections=2835
2024-09-11T07:52:08.059159Z DEBUG metrics: merge_strings section=.debug_str size=242491445 totally_added=6249233166 strings=2600883 totally_added_strings=95110530 input_sections=2842
2024-09-11T07:52:08.059162Z DEBUG metrics: merge_strings section=.debug_line_str size=374266 totally_added=11731603 strings=9274 totally_added_strings=676002 input_sections=2842
2024-09-11T07:52:11.039014Z DEBUG metrics: resolved relocations section=.rodata relocations=543425
2024-09-11T07:52:11.039034Z DEBUG metrics: resolved relocations section=.init_array relocations=642
2024-09-11T07:52:11.039037Z DEBUG metrics: resolved relocations section=.fini_array relocations=1
2024-09-11T07:52:11.039039Z DEBUG metrics: resolved relocations section=.text relocations=1878004
2024-09-11T07:52:11.039042Z DEBUG metrics: resolved relocations section=.init relocations=1
2024-09-11T07:52:11.039045Z DEBUG metrics: resolved relocations section=.data relocations=325345
2024-09-11T07:52:11.039047Z DEBUG metrics: resolved relocations section=.debug_aranges relocations=235925
2024-09-11T07:52:11.039050Z DEBUG metrics: resolved relocations section=.debug_info relocations=229911308
2024-09-11T07:52:11.039051Z DEBUG metrics: resolved relocations section=.debug_line relocations=903224
2024-09-11T07:52:11.039054Z DEBUG metrics: resolved relocations section=.debug_rnglists relocations=4203183
2024-09-11T07:52:11.039056Z DEBUG metrics: resolved relocations section=.debug_loclists relocations=21125879
```