### PR TITLE
Use a separate type for section resolutions

### DIFF
--- a/wild_lib/src/validation.rs
+++ b/wild_lib/src/validation.rs
@@ -57,7 +57,9 @@ fn validate_object(object: &crate::elf::File, layout: &Layout) -> Result {
                 crate::layout::FileLayout::Prelude(_) => {}
                 crate::layout::FileLayout::Object(obj) => {
                     for (sec_index, sec) in obj.object.sections.enumerate() {
-                        if let Some(resolution) = obj.section_resolutions[sec_index.0] {
+                        if let Some(resolution) =
+                            obj.section_resolutions[sec_index.0].full_resolution()
+                        {
                             validate_resolution(
                                 obj.object.section_name(sec)?,
                                 &resolution,


### PR DESCRIPTION
This reduces the per-section resolution size from 40 bytes to 8.