### PR TITLE
Switch to zstd Rust library (C binding of the official libzstd)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,11 @@ name = "cc"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
+dependencies = [
+ "jobserver",
+ "libc",
+ "once_cell",
+]
 
 [[package]]
 name = "cfg-if"
@@ -506,6 +511,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,6 +679,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "postcard"
@@ -834,16 +854,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ruzstd"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8b8f3d26bd9f945e5cbae77f7cdfbf37af9a66956f1115eb4516e45df519f4"
-dependencies = [
- "byteorder",
- "twox-hash",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,12 +929,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1057,16 +1061,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "twox-hash"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "static_assertions",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,11 +1149,11 @@ dependencies = [
  "memmap2",
  "object",
  "rayon",
- "ruzstd",
  "sharded-vec-writer",
  "smallvec",
  "tracing",
  "tracing-subscriber",
+ "zstd",
 ]
 
 [[package]]
@@ -1290,4 +1284,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/cackle.toml
+++ b/cackle.toml
@@ -93,9 +93,6 @@ from.test.allow_apis = [
 [pkg.crossbeam-deque]
 allow_unsafe = true
 
-[pkg.ruzstd]
-allow_unsafe = true
-
 [pkg.rayon-core]
 allow_unsafe = true
 

--- a/wild_lib/Cargo.toml
+++ b/wild_lib/Cargo.toml
@@ -32,8 +32,8 @@ sharded-vec-writer = "0.1.0"
 itertools = "0.13.0"
 bytesize = "1.3.0"
 flate2 = "1.0.33"
-ruzstd = "0.7.1"
 bumpalo-herd = "0.1.2"
+zstd = "0.13.2"
 
 [dev-dependencies]
 ar = "0.9.0"

--- a/wild_lib/src/elf.rs
+++ b/wild_lib/src/elf.rs
@@ -229,8 +229,12 @@ fn decompress_into(
                 flate2::FlushDecompress::Finish,
             )?;
         }
+        // We might use pure Rust implementation for the decompression (ruzstd), however the decompression
+        // speed is not on par with the official C library.
+        // With the official library, the linking time of Clang binary (contains 1GB of debug info sections)
+        // shrinks by 30%!
         object::elf::ELFCOMPRESS_ZSTD => {
-            ruzstd::StreamingDecoder::new(input)?.read_exact(out)?;
+            zstd::stream::Decoder::new(input)?.read_exact(out)?;
         }
         c => bail!("Unsupported compression format: {}", c),
     };


### PR DESCRIPTION
The linking for Clang binary is now 30% faster!

Before:
```
  Time (mean ± σ):      6.132 s ±  0.092 s    [User: 109.349 s, System: 13.627 s]
  Range (min … max):    5.994 s …  6.292 s    10 runs
```

After:
```
  Time (mean ± σ):      4.736 s ±  0.144 s    [User: 74.308 s, System: 13.071 s]
  Range (min … max):    4.494 s …  4.971 s    10 runs
```