### PR TITLE
Mention "now" as it is a supported option right now

### DIFF
--- a/wild_lib/src/args.rs
+++ b/wild_lib/src/args.rs
@@ -204,6 +204,7 @@ pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(mut input: I) -> Resul
         };
         let mut handle_z_option = |arg: &str| {
             match arg {
+                "now" => {}
                 "lazy" => {
                     warning!("wild doesn't support -z lazy");
                 }


### PR DESCRIPTION
If we'll recent unknown `-z` options in the future, "now" should be mentioned in the match statement.