### PR TITLE
Add a basic merged-string offset cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,6 +1164,7 @@ dependencies = [
  "crossbeam-queue",
  "crossbeam-utils",
  "flate2",
+ "fxhash",
  "itertools",
  "linker-layout",
  "linker-trace",

--- a/wild_lib/Cargo.toml
+++ b/wild_lib/Cargo.toml
@@ -34,6 +34,7 @@ bytesize = "1.3.0"
 flate2 = "1.0.33"
 bumpalo-herd = "0.1.2"
 zstd = "0.13.2"
+fxhash = "0.2.1"
 
 [dev-dependencies]
 ar = "0.9.0"


### PR DESCRIPTION
On my laptop, this reduces the time to link clang with debug info by about 39%.

Issue #117