### PR TITLE
Reduce Dependabot interval and group PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,8 @@ updates:
   - package-ecosystem: cargo
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+    groups:
+      weekly-updates:
+        patterns:
+          - "*"


### PR DESCRIPTION
Reduces dependabot schedule to weekly and groups PRs made by Dependabot into a single PR.

Example grouped PR: https://github.com/tbillington/kondo/pull/137