### PR TITLE
Fix incorrect caching of string-merge offsets

### DIFF
--- a/wild_lib/src/elf_writer.rs
+++ b/wild_lib/src/elf_writer.rs
@@ -1114,7 +1114,7 @@ impl<'out> ObjectLayout<'out> {
     ) -> Result {
         let _span = debug_span!("write_file", filename = ?self.input.file.filename).entered();
         let _file_span = layout.args().trace_span_for_file(self.file_id);
-        let mut string_offset_cache = StringOffsetCache::new(&layout.output_sections);
+        let mut string_offset_cache = StringOffsetCache::new();
         for sec in &self.sections {
             match sec {
                 SectionSlot::Loaded(sec) => {


### PR DESCRIPTION
Previously we cached by OutputSectionId and offset within the input section, however multiple input sections can be mapped to a single OutputSectionId / PartId, so we were getting incorrect results from the cache.

Now we use the offset within the input file as a key instead.

Fixes #158