### PR TITLE
Remove string-merge caching

### DIFF
--- a/wild_lib/src/elf_writer.rs
+++ b/wild_lib/src/elf_writer.rs
@@ -48,7 +48,6 @@ use crate::sharding::ShardKey;
 use crate::slice::slice_take_prefix_mut;
 use crate::slice::take_first_mut;
 use crate::string_merging::get_merged_string_output_address;
-use crate::string_merging::StringOffsetCache;
 use crate::symbol_db::SymbolDb;
 use crate::threading::prelude::*;
 use ahash::AHashMap;
@@ -1114,14 +1113,13 @@ impl<'out> ObjectLayout<'out> {
     ) -> Result {
         let _span = debug_span!("write_file", filename = ?self.input.file.filename).entered();
         let _file_span = layout.args().trace_span_for_file(self.file_id);
-        let mut string_offset_cache = StringOffsetCache::new();
         for sec in &self.sections {
             match sec {
                 SectionSlot::Loaded(sec) => {
                     self.write_section(layout, sec, buffers, table_writer)?
                 }
                 SectionSlot::LoadedDebugInfo(sec) => {
-                    self.write_debug_section(layout, sec, buffers, &mut string_offset_cache)?;
+                    self.write_debug_section(layout, sec, buffers)?;
                 }
                 SectionSlot::EhFrameData(section_index) => {
                     self.write_eh_frame_data(*section_index, layout, table_writer)?;
@@ -1194,10 +1192,9 @@ impl<'out> ObjectLayout<'out> {
         layout: &Layout,
         sec: &Section,
         buffers: &mut OutputSectionPartMap<&mut [u8]>,
-        string_offset_cache: &mut StringOffsetCache,
     ) -> Result {
         let out = self.write_section_raw(layout, sec, buffers)?;
-        self.apply_debug_relocations(out, sec, layout, string_offset_cache)
+        self.apply_debug_relocations(out, sec, layout)
             .with_context(|| {
                 format!(
                     "Failed to apply relocations in section `{}` of {}",
@@ -1339,7 +1336,6 @@ impl<'out> ObjectLayout<'out> {
                 layout,
                 out,
                 table_writer,
-                &mut StringOffsetCache::no_caching(),
             )
             .with_context(|| {
                 format!(
@@ -1356,7 +1352,6 @@ impl<'out> ObjectLayout<'out> {
         out: &mut [u8],
         section: &Section,
         layout: &Layout,
-        string_offset_cache: &mut StringOffsetCache,
     ) -> Result {
         let object_section = self.object.section(section.index)?;
         let section_name = self.object.section_name(object_section)?;
@@ -1380,21 +1375,13 @@ impl<'out> ObjectLayout<'out> {
             .fetch_add(relocations.len() as u64, Relaxed);
         for rel in relocations {
             let offset_in_section = rel.r_offset.get(LittleEndian);
-            apply_debug_relocation(
-                self,
-                offset_in_section,
-                rel,
-                layout,
-                tombstone_value,
-                out,
-                string_offset_cache,
-            )
-            .with_context(|| {
-                format!(
-                    "Failed to apply {} at offset 0x{offset_in_section:x}",
-                    self.display_relocation(rel, layout)
-                )
-            })?;
+            apply_debug_relocation(self, offset_in_section, rel, layout, tombstone_value, out)
+                .with_context(|| {
+                    format!(
+                        "Failed to apply {} at offset 0x{offset_in_section:x}",
+                        self.display_relocation(rel, layout)
+                    )
+                })?;
         }
         Ok(())
     }
@@ -1519,7 +1506,6 @@ impl<'out> ObjectLayout<'out> {
                         layout,
                         entry_out,
                         table_writer,
-                        &mut StringOffsetCache::no_caching(),
                     )
                     .with_context(|| {
                         format!(
@@ -1614,7 +1600,6 @@ fn apply_relocation(
     layout: &Layout,
     out: &mut [u8],
     table_writer: &mut TableWriter,
-    string_offset_cache: &mut StringOffsetCache,
 ) -> Result<RelocationModifier> {
     let section_address = section_info.section_address;
     let place = section_address + offset_in_section;
@@ -1674,7 +1659,6 @@ fn apply_relocation(
                 object_layout,
                 &layout.merged_strings,
                 &layout.merged_string_start_addresses,
-                string_offset_cache,
             )?
             .wrapping_sub(place)
             .wrapping_sub(rel_info.byte_size as u64),
@@ -1737,7 +1721,6 @@ fn apply_debug_relocation(
     layout: &Layout,
     section_tombstone_value: u64,
     out: &mut [u8],
-    string_offset_cache: &mut StringOffsetCache,
 ) -> Result<()> {
     let e = LittleEndian;
     let symbol_index = rel
@@ -1766,7 +1749,6 @@ fn apply_debug_relocation(
                 object_layout,
                 &layout.merged_strings,
                 &layout.merged_string_start_addresses,
-                string_offset_cache,
             )?,
             RelocationKind::DtpOff => resolution
                 .value()
@@ -1784,7 +1766,6 @@ fn apply_debug_relocation(
                 &layout.merged_strings,
                 &layout.merged_string_start_addresses,
                 false,
-                string_offset_cache,
             )?
             .context("Cannot get merged string offset for a debug info section")?,
             SectionSlot::Discard | SectionSlot::Unloaded(..) => section_tombstone_value,
@@ -1833,7 +1814,6 @@ fn write_absolute_relocation(
             object_layout,
             &layout.merged_strings,
             &layout.merged_string_start_addresses,
-            &mut StringOffsetCache::no_caching(),
         )
     }
 }

--- a/wild_lib/src/layout.rs
+++ b/wild_lib/src/layout.rs
@@ -47,7 +47,6 @@ use crate::sharding::ShardKey;
 use crate::string_merging::get_merged_string_output_address;
 use crate::string_merging::MergeStringsSection;
 use crate::string_merging::MergedStringStartAddresses;
-use crate::string_merging::StringOffsetCache;
 use crate::symbol::SymbolName;
 use crate::symbol_db::SymbolDb;
 use crate::symbol_db::SymbolDebug;
@@ -3248,7 +3247,6 @@ impl<'data> ObjectLayoutState<'data> {
                     resources.merged_strings,
                     resources.merged_string_start_addresses,
                     true,
-                    &mut StringOffsetCache::no_caching(),
                 )?
                 .ok_or_else(|| {
                     anyhow!(
@@ -3676,7 +3674,6 @@ impl Resolution {
         object_layout: &ObjectLayout,
         merged_strings: &OutputSectionMap<MergeStringsSection>,
         merged_string_start_addresses: &MergedStringStartAddresses,
-        string_offset_cache: &mut StringOffsetCache,
     ) -> Result<u64> {
         // For most symbols, `raw_value` won't be zero, so we can save ourselves from looking up the
         // section to see if it's a string-merge section. For string-merge symbols with names,
@@ -3690,7 +3687,6 @@ impl Resolution {
                 merged_strings,
                 merged_string_start_addresses,
                 false,
-                string_offset_cache,
             )? {
                 if self.raw_value != 0 {
                     bail!("Merged string resolution has value 0x{}", self.raw_value);


### PR DESCRIPTION
When it was added, it appeared to speed up string merging, however it was buggy and once the bug(s) were fixed, it turns out that it actually makes things slower.

Issue #117