### PR TITLE
Support .note.gnu.property

### DIFF
--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -120,7 +120,6 @@ impl Config {
                 "section.debug*",
                 "section.stapsdt.base",
                 "section.note.gnu.build-id",
-                "section.note.gnu.property",
                 "section.note.stapsdt",
                 "section.hash",
                 // We set this to 8. GNU ld sometimes does too, but sometimes to 0.

--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -120,6 +120,7 @@ impl Config {
                 "section.debug*",
                 "section.stapsdt.base",
                 "section.note.gnu.build-id",
+                "section.note.gnu.property",
                 "section.note.stapsdt",
                 "section.hash",
                 // We set this to 8. GNU ld sometimes does too, but sometimes to 0.

--- a/wild_lib/src/alignment.rs
+++ b/wild_lib/src/alignment.rs
@@ -44,6 +44,7 @@ pub(crate) const VERSYM: Alignment = Alignment { exponent: 1 };
 pub(crate) const USIZE: Alignment = Alignment { exponent: 3 };
 
 pub(crate) const EH_FRAME_HDR: Alignment = Alignment { exponent: 2 };
+pub(crate) const NOTE_GNU_PROPERTY: Alignment = Alignment { exponent: 3 };
 
 impl Alignment {
     pub(crate) fn new(raw: u64) -> Result<Self> {

--- a/wild_lib/src/elf.rs
+++ b/wild_lib/src/elf.rs
@@ -374,6 +374,7 @@ const _ASSERTS: () = {
 };
 
 pub(crate) const GNU_NOTE_NAME: &[u8] = b"GNU\0";
+pub(crate) const GNU_NOTE_PROPERTY_ENTRY_SIZE: usize = 16;
 
 /// For additional information on ELF relocation types, see "ELF-64 Object File Format" -
 /// https://uclibc.org/docs/elf-64-gen.pdf. For information on the TLS related relocations, see "ELF

--- a/wild_lib/src/elf.rs
+++ b/wild_lib/src/elf.rs
@@ -376,6 +376,28 @@ const _ASSERTS: () = {
 pub(crate) const GNU_NOTE_NAME: &[u8] = b"GNU\0";
 pub(crate) const GNU_NOTE_PROPERTY_ENTRY_SIZE: usize = 16;
 
+/// For additional information on Elf_Prop, see
+/// Linux Extensions to gABI at https://gitlab.com/x86-psABIs/Linux-ABI.
+///
+/// Right now, all properties that pr_datasz equal to 4 and so the pr_padding is always
+/// 4 bytes!
+///
+/// typedef struct {
+/// Elf_Word pr_type;
+/// Elf_Word pr_datasz;
+/// unsigned char pr_data[PR_DATASZ];
+/// unsigned char pr_padding[PR_PADDING];
+/// } Elf_Prop;
+
+#[derive(Zeroable, Pod, Clone, Copy)]
+#[repr(C)]
+pub(crate) struct NoteProperty {
+    pub(crate) pr_type: u32,
+    pub(crate) pr_datasz: u32,
+    pub(crate) pr_data: u32,
+    pub(crate) pr_padding: u32,
+}
+
 /// For additional information on ELF relocation types, see "ELF-64 Object File Format" -
 /// https://uclibc.org/docs/elf-64-gen.pdf. For information on the TLS related relocations, see "ELF
 /// Handling For Thread-Local Storage" - https://www.uclibc.org/docs/tls.pdf.

--- a/wild_lib/src/elf.rs
+++ b/wild_lib/src/elf.rs
@@ -36,6 +36,7 @@ pub(crate) type Verneed = object::elf::Verneed<LittleEndian>;
 pub(crate) type Vernaux = object::elf::Vernaux<LittleEndian>;
 pub(crate) type Versym = object::elf::Versym<LittleEndian>;
 pub(crate) type VerdefIterator<'data> = object::read::elf::VerdefIterator<'data, FileHeader>;
+pub(crate) type NoteHeader = object::elf::NoteHeader64<LittleEndian>;
 
 type SectionTable<'data> = object::read::elf::SectionTable<'data, FileHeader>;
 type SymbolTable<'data> = object::read::elf::SymbolTable<'data, FileHeader>;
@@ -371,6 +372,8 @@ const _ASSERTS: () = {
     assert!(PROGRAM_HEADER_SIZE as usize == size_of::<ProgramHeader>());
     assert!(SECTION_HEADER_SIZE as usize == size_of::<SectionHeader>());
 };
+
+pub(crate) const GNU_NOTE_NAME: &[u8] = b"GNU\0";
 
 /// For additional information on ELF relocation types, see "ELF-64 Object File Format" -
 /// https://uclibc.org/docs/elf-64-gen.pdf. For information on the TLS related relocations, see "ELF

--- a/wild_lib/src/elf_writer.rs
+++ b/wild_lib/src/elf_writer.rs
@@ -1,3 +1,4 @@
+use self::elf::NoteHeader;
 use crate::alignment;
 use crate::arch::Arch;
 use crate::arch::Relaxation as _;
@@ -19,6 +20,7 @@ use crate::elf::SymtabEntry;
 use crate::elf::Vernaux;
 use crate::elf::Verneed;
 use crate::elf::Versym;
+use crate::elf::GNU_NOTE_NAME;
 use crate::error::Result;
 use crate::layout::compute_allocations;
 use crate::layout::DynamicLayout;
@@ -62,9 +64,12 @@ use anyhow::Context;
 use linker_utils::elf::rel_type_to_string;
 use linker_utils::elf::shf;
 use linker_utils::elf::sht;
+use linker_utils::elf::sht::NOTE;
 use linker_utils::elf::SectionFlags;
 use memmap2::MmapOptions;
+use object::elf::NT_GNU_PROPERTY_TYPE_0;
 use object::from_bytes_mut;
+use object::read::elf::GnuProperty;
 use object::read::elf::Rela;
 use object::read::elf::Sym as _;
 use object::LittleEndian;
@@ -2037,8 +2042,43 @@ impl EpilogueLayout<'_> {
 
         write_dynamic_symbol_definitions(self, table_writer, layout)?;
 
+        if !dbg!(&self.gnu_property_notes).is_empty() {
+            write_gnu_property_notes(self, buffers)?;
+        }
+
         Ok(())
     }
+}
+
+fn write_gnu_property_notes(
+    epilogue: &EpilogueLayout,
+    buffers: &mut OutputSectionPartMap<&mut [u8]>,
+) -> Result {
+    dbg!("called");
+    let e = LittleEndian;
+    let (note_header, mut rest) =
+        from_bytes_mut::<NoteHeader>(buffers.get_mut(part_id::NOTE_GNU_PROPERTY))
+            .map_err(|_| anyhow!("Insufficient .note.gnu.property allocation"))?;
+    dbg!(&note_header);
+    dbg!(&rest.len());
+    note_header.n_namesz.set(e, GNU_NOTE_NAME.len() as u32);
+    note_header
+        .n_descsz
+        .set(e, (epilogue.gnu_property_notes.len() * 16) as u32);
+    note_header.n_type.set(e, NT_GNU_PROPERTY_TYPE_0);
+
+    let name_out = crate::slice::slice_take_prefix_mut(&mut rest, GNU_NOTE_NAME.len());
+    name_out.copy_from_slice(GNU_NOTE_NAME);
+
+    for note in &epilogue.gnu_property_notes {
+        let note_out = crate::slice::slice_take_prefix_mut(&mut rest, 16);
+        note_out[..4].copy_from_slice(&note.r#type.to_le_bytes());
+        note_out[4..8].copy_from_slice(&4u32.to_le_bytes());
+        note_out[8..12].copy_from_slice(&note.data.to_le_bytes());
+        note_out[12..].copy_from_slice(&0u32.to_le_bytes());
+    }
+
+    Ok(())
 }
 
 fn write_gnu_hash_tables(

--- a/wild_lib/src/layout.rs
+++ b/wild_lib/src/layout.rs
@@ -326,14 +326,7 @@ fn merge_gnu_property_notes(group_states: &mut [GroupState]) -> Result {
                 })
                 .or_insert_with(|| {
                     type_index += 1;
-                    (
-                        type_index,
-                        if matches!(property_class, PropertyClass::And) {
-                            u32::MAX
-                        } else {
-                            0
-                        },
-                    )
+                    (type_index, prop.data)
                 });
         }
     }
@@ -349,7 +342,8 @@ fn merge_gnu_property_notes(group_states: &mut [GroupState]) -> Result {
                     .any(|prop| prop.ptype == property_type)
             });
             if match property_class {
-                PropertyClass::Or | PropertyClass::And => property_value != 0,
+                PropertyClass::Or => property_value != 0,
+                PropertyClass::And => type_present_in_all && property_value != 0,
                 PropertyClass::AndOr => type_present_in_all,
             } {
                 Some(GnuProperty {

--- a/wild_lib/src/layout.rs
+++ b/wild_lib/src/layout.rs
@@ -305,6 +305,8 @@ fn merge_gnu_property_notes(group_states: &mut [GroupState]) -> Result {
         })
         .collect_vec();
 
+    // Merge bits of each property type based on type: OR or AND operation. When a property type
+    // is newly added to the map, we start either with zero or all bits-set (PropertyClass::And).
     let mut type_index = 0usize;
     let mut property_map = HashMap::new();
     for file_props in &properties_per_file {

--- a/wild_lib/src/layout.rs
+++ b/wild_lib/src/layout.rs
@@ -311,10 +311,9 @@ fn merge_gnu_property_notes(group_states: &mut [GroupState]) -> Result {
     let mut property_map = HashMap::new();
     for file_props in &properties_per_file {
         for prop in *file_props {
-            let property_class = get_property_class(prop.ptype).ok_or(anyhow::anyhow!(format!(
-                "unclassified property type {}",
-                prop.ptype
-            )))?;
+            let property_class = get_property_class(prop.ptype).ok_or_else(|| {
+                anyhow::anyhow!(format!("unclassified property type {}", prop.ptype))
+            })?;
             property_map
                 .entry(prop.ptype)
                 .and_modify(|e: &mut (usize, u32)| {

--- a/wild_lib/src/output_section_id.rs
+++ b/wild_lib/src/output_section_id.rs
@@ -378,6 +378,7 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = [
         name: SectionName(b".note.gnu.property"),
         ty: sht::NOTE,
         section_flags: shf::ALLOC,
+        min_alignment: alignment::NOTE_GNU_PROPERTY,
         ..DEFAULT_DEFS
     },
     // Multi-part generated sections

--- a/wild_lib/src/output_section_id.rs
+++ b/wild_lib/src/output_section_id.rs
@@ -83,6 +83,8 @@ pub(crate) const INTERP: OutputSectionId = part_id::INTERP.output_section_id();
 pub(crate) const GNU_VERSION: OutputSectionId = part_id::GNU_VERSION.output_section_id();
 pub(crate) const GNU_VERSION_R: OutputSectionId = part_id::GNU_VERSION_R.output_section_id();
 pub(crate) const PLT_GOT: OutputSectionId = part_id::PLT_GOT.output_section_id();
+pub(crate) const NOTE_GNU_PROPERTY: OutputSectionId =
+    part_id::NOTE_GNU_PROPERTY.output_section_id();
 
 // These two are multi-part sections, but we can pick any part we wish in order to get the section
 // ID.
@@ -370,6 +372,12 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = [
         info_fn: Some(version_r_info),
         min_alignment: alignment::VERSION_R,
         link: &[DYNSTR],
+        ..DEFAULT_DEFS
+    },
+    BuiltInSectionDetails {
+        name: SectionName(b".note.gnu.property"),
+        ty: sht::NOTE,
+        section_flags: shf::ALLOC,
         ..DEFAULT_DEFS
     },
     // Multi-part generated sections
@@ -730,6 +738,7 @@ impl CustomSectionIds {
         events.push(INTERP.event());
         events.push(OrderEvent::SegmentEnd(crate::program_segments::INTERP));
         events.push(OrderEvent::SegmentStart(crate::program_segments::NOTE));
+        events.push(NOTE_GNU_PROPERTY.event());
         events.push(NOTE_ABI_TAG.event());
         events.push(OrderEvent::SegmentEnd(crate::program_segments::NOTE));
         events.push(GNU_HASH.event());
@@ -923,6 +932,7 @@ fn test_constant_ids() {
         (GNU_HASH, ".gnu.hash"),
         (PLT_GOT, ".plt.got"),
         (NOTE_ABI_TAG, ".note.ABI-tag"),
+        (NOTE_GNU_PROPERTY, ".note.gnu.property"),
     ];
     for (id, name) in check {
         assert_eq!(

--- a/wild_lib/src/part_id.rs
+++ b/wild_lib/src/part_id.rs
@@ -142,19 +142,6 @@ impl<'data> UnresolvedSection<'data> {
         } else if args.strip_debug && section_name.starts_with(b".debug_") {
             // Drop soon string merge debug info section.
             None
-            /*
-            } else if section_name == b".note.gnu.property" {
-                dbg!("sec: {}", String::from_utf8_lossy(section_name));
-                if let Ok(Some(notes)) = section.notes(LittleEndian, object.data) {
-                    for note in notes {
-                        dbg!(&note);
-                        for gnu_property in note.unwrap().gnu_properties(LittleEndian).unwrap() {
-                            dbg!(gnu_property);
-                        }
-                    }
-                };
-                None
-                */
         } else {
             let sh_type = SectionType::from_header(section);
             if !section_name.is_empty() {

--- a/wild_lib/src/part_id.rs
+++ b/wild_lib/src/part_id.rs
@@ -58,8 +58,9 @@ pub(crate) const DYNSTR: PartId = PartId(13);
 pub(crate) const INTERP: PartId = PartId(14);
 pub(crate) const GNU_VERSION: PartId = PartId(15);
 pub(crate) const GNU_VERSION_R: PartId = PartId(16);
+pub(crate) const NOTE_GNU_PROPERTY: PartId = PartId(17);
 
-pub(crate) const NUM_SINGLE_PART_SECTIONS: u32 = 17;
+pub(crate) const NUM_SINGLE_PART_SECTIONS: u32 = 18;
 
 // Generated sections that have more than one part. Fortunately they all have exactly 2 parts.
 pub(crate) const SYMTAB_LOCAL: PartId = PartId::multi(0);
@@ -141,6 +142,19 @@ impl<'data> UnresolvedSection<'data> {
         } else if args.strip_debug && section_name.starts_with(b".debug_") {
             // Drop soon string merge debug info section.
             None
+            /*
+            } else if section_name == b".note.gnu.property" {
+                dbg!("sec: {}", String::from_utf8_lossy(section_name));
+                if let Ok(Some(notes)) = section.notes(LittleEndian, object.data) {
+                    for note in notes {
+                        dbg!(&note);
+                        for gnu_property in note.unwrap().gnu_properties(LittleEndian).unwrap() {
+                            dbg!(gnu_property);
+                        }
+                    }
+                };
+                None
+                */
         } else {
             let sh_type = SectionType::from_header(section);
             if !section_name.is_empty() {

--- a/wild_lib/src/part_id.rs
+++ b/wild_lib/src/part_id.rs
@@ -20,7 +20,6 @@ pub(crate) enum TemporaryPartId<'data> {
     BuiltIn(PartId),
     Custom(CustomSectionId<'data>, Alignment),
     EhFrameData,
-    NoteGnuProperty,
 }
 
 /// An ID for a part of an output section. Parts IDs are ordered with generated
@@ -145,7 +144,7 @@ impl<'data> UnresolvedSection<'data> {
             None
         } else if section_name == b".note.gnu.property" {
             return Ok(Some(UnresolvedSection {
-                part_id: TemporaryPartId::NoteGnuProperty,
+                part_id: TemporaryPartId::BuiltIn(NOTE_GNU_PROPERTY),
                 is_string_merge: false,
             }));
         } else {
@@ -288,7 +287,6 @@ impl<'data> TemporaryPartId<'data> {
             TemporaryPartId::BuiltIn(id) => id.built_in_details().name,
             TemporaryPartId::Custom(id, _) => id.name,
             TemporaryPartId::EhFrameData => EH_FRAME.built_in_details().name,
-            TemporaryPartId::NoteGnuProperty => NOTE_GNU_PROPERTY.built_in_details().name,
         }
     }
 }
@@ -320,7 +318,6 @@ impl std::fmt::Display for TemporaryPartId<'_> {
                 write!(f, "custom section `{}`", custom.name)
             }
             TemporaryPartId::EhFrameData => write!(f, "eh_frame data"),
-            TemporaryPartId::NoteGnuProperty => write!(f, "GNU note"),
         }
     }
 }

--- a/wild_lib/src/part_id.rs
+++ b/wild_lib/src/part_id.rs
@@ -20,6 +20,7 @@ pub(crate) enum TemporaryPartId<'data> {
     BuiltIn(PartId),
     Custom(CustomSectionId<'data>, Alignment),
     EhFrameData,
+    NoteGnuProperty,
 }
 
 /// An ID for a part of an output section. Parts IDs are ordered with generated
@@ -142,6 +143,11 @@ impl<'data> UnresolvedSection<'data> {
         } else if args.strip_debug && section_name.starts_with(b".debug_") {
             // Drop soon string merge debug info section.
             None
+        } else if section_name == b".note.gnu.property" {
+            return Ok(Some(UnresolvedSection {
+                part_id: TemporaryPartId::NoteGnuProperty,
+                is_string_merge: false,
+            }));
         } else {
             let sh_type = SectionType::from_header(section);
             if !section_name.is_empty() {
@@ -282,6 +288,7 @@ impl<'data> TemporaryPartId<'data> {
             TemporaryPartId::BuiltIn(id) => id.built_in_details().name,
             TemporaryPartId::Custom(id, _) => id.name,
             TemporaryPartId::EhFrameData => EH_FRAME.built_in_details().name,
+            TemporaryPartId::NoteGnuProperty => NOTE_GNU_PROPERTY.built_in_details().name,
         }
     }
 }
@@ -313,6 +320,7 @@ impl std::fmt::Display for TemporaryPartId<'_> {
                 write!(f, "custom section `{}`", custom.name)
             }
             TemporaryPartId::EhFrameData => write!(f, "eh_frame data"),
+            TemporaryPartId::NoteGnuProperty => write!(f, "GNU note"),
         }
     }
 }

--- a/wild_lib/src/resolution.rs
+++ b/wild_lib/src/resolution.rs
@@ -2,6 +2,7 @@
 //! entries are needed. We also resolve which output section, if any, each input section should be
 //! assigned to.
 
+use self::part_id::NOTE_GNU_PROPERTY;
 use crate::args::Args;
 use crate::debug_assert_bail;
 use crate::elf::File;
@@ -744,7 +745,7 @@ fn resolve_sections_for_object<'data>(
                         });
                     }
                     TemporaryPartId::BuiltIn(p) => part_id = p,
-                    TemporaryPartId::EhFrameData | TemporaryPartId::NoteGnuProperty => (),
+                    TemporaryPartId::EhFrameData => (),
                 }
                 let slot = if unloaded.is_string_merge {
                     let section_data =
@@ -760,6 +761,9 @@ fn resolve_sections_for_object<'data>(
                     })
                 } else {
                     match unloaded.part_id {
+                        TemporaryPartId::BuiltIn(id) if id == NOTE_GNU_PROPERTY => {
+                            SectionSlot::NoteGnuProperty(input_section_index)
+                        }
                         TemporaryPartId::BuiltIn(id)
                             if id
                                 .output_section_id()
@@ -793,9 +797,6 @@ fn resolve_sections_for_object<'data>(
                         }
                         TemporaryPartId::EhFrameData => {
                             SectionSlot::EhFrameData(input_section_index)
-                        }
-                        TemporaryPartId::NoteGnuProperty => {
-                            SectionSlot::NoteGnuProperty(input_section_index)
                         }
                     }
                 };

--- a/wild_lib/src/resolution.rs
+++ b/wild_lib/src/resolution.rs
@@ -744,7 +744,7 @@ fn resolve_sections_for_object<'data>(
                         });
                     }
                     TemporaryPartId::BuiltIn(p) => part_id = p,
-                    TemporaryPartId::EhFrameData => (),
+                    TemporaryPartId::EhFrameData | TemporaryPartId::NoteGnuProperty => (),
                 }
                 let slot = if unloaded.is_string_merge {
                     let section_data =
@@ -774,9 +774,7 @@ fn resolve_sections_for_object<'data>(
                         }
                         TemporaryPartId::Custom(custom_section_id, _alignment) => {
                             let section_name = custom_section_id.name.bytes();
-                            if section_name == b".note.gnu.property" {
-                                SectionSlot::NoteGnuProperty(input_section_index)
-                            } else if section_name.starts_with(b".debug_") {
+                            if section_name.starts_with(b".debug_") {
                                 if args.strip_debug {
                                     custom_section = None;
                                     SectionSlot::Discard
@@ -795,6 +793,9 @@ fn resolve_sections_for_object<'data>(
                         }
                         TemporaryPartId::EhFrameData => {
                             SectionSlot::EhFrameData(input_section_index)
+                        }
+                        TemporaryPartId::NoteGnuProperty => {
+                            SectionSlot::NoteGnuProperty(input_section_index)
                         }
                     }
                 };


### PR DESCRIPTION
The PR implements the feature where I would like to discuss the following things:

1. The merging of the sections happens for all object files where the output section is present just once and should be synthesized. That's why I chose to implement it in `EpilogueLayout`, where the corresponding sections are identified based on the newly added `SectionSlot` value. Is it a good design choice?
2. The implementation supports (similarly to Mold) only properties with 4B property data. Do you have a hint on how to do a smarter serialization in elf_writer.rs? Theoretically, `GnuProperty` [^1] from _object_ create can be converted to not only read mode.
3. I face an issue in testing:
```
Error: Unexpected memory offsets:
Part #17 (section `.note.gnu.property` alignment: 8) expected: 0x400408 actual: 0x4003d8 bumped by: 0x0 requested size: 0x30
```

Can you help me with that?

4. The output (`.gnu.note.property`) should be binary equal to what other linkers do. That said, will we need any special handling in linker-diff`, or is the binary diff the default one?

Thanks for review in advance!

Implements: #38

[^1]: https://docs.rs/object/latest/object/read/elf/struct.GnuProperty.html