### PR TITLE
Support .note.gnu.build-id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d67af77d68a931ecd5cbd8a3b5987d63a1d1d1278f7f6a60ae33db485cdebb69"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,12 +124,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
+name = "blake3"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "b8ee0c1824c4dea5b5f81736aff91bae041d2c07ee1192bec91054e10e3e601e"
 dependencies = [
- "generic-array",
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -237,21 +253,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "cpp_demangle"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96e58d342ad113c2b878f16d5d034c03be492ae460cdbc02b7f0f2284d310c7d"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -304,32 +317,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
 ]
 
 [[package]]
@@ -484,16 +477,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -948,17 +931,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,12 +1097,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,6 +1164,7 @@ dependencies = [
  "anyhow",
  "ar",
  "bitflags",
+ "blake3",
  "bumpalo-herd",
  "bytemuck",
  "bytesize",
@@ -1213,7 +1180,6 @@ dependencies = [
  "memmap2",
  "object",
  "rayon",
- "sha2",
  "sharded-vec-writer",
  "smallvec",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,6 +480,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,9 +1121,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "version_check"
@@ -1128,6 +1142,12 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "which"
@@ -1184,6 +1204,7 @@ dependencies = [
  "smallvec",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "zstd",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,6 +543,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "home"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,6 +1198,7 @@ dependencies = [
  "crossbeam-utils",
  "flate2",
  "fxhash",
+ "hex",
  "itertools",
  "linker-layout",
  "linker-trace",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +246,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,12 +304,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -446,6 +484,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -900,6 +948,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,6 +1125,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,6 +1213,7 @@ dependencies = [
  "memmap2",
  "object",
  "rayon",
+ "sha2",
  "sharded-vec-writer",
  "smallvec",
  "tracing",

--- a/wild_lib/Cargo.toml
+++ b/wild_lib/Cargo.toml
@@ -36,7 +36,7 @@ flate2 = "1.0.35"
 bumpalo-herd = "0.1.2"
 zstd = "0.13.2"
 fxhash = "0.2.1"
-sha2 = "0.10.8"
+blake3 = "1.5.5"
 
 [dev-dependencies]
 ar = "0.9.0"

--- a/wild_lib/Cargo.toml
+++ b/wild_lib/Cargo.toml
@@ -37,6 +37,7 @@ bumpalo-herd = "0.1.2"
 zstd = "0.13.2"
 fxhash = "0.2.1"
 blake3 = "1.5.5"
+uuid = { version = "1.11.0", features = ["v4"] }
 
 [dev-dependencies]
 ar = "0.9.0"

--- a/wild_lib/Cargo.toml
+++ b/wild_lib/Cargo.toml
@@ -36,6 +36,7 @@ flate2 = "1.0.35"
 bumpalo-herd = "0.1.2"
 zstd = "0.13.2"
 fxhash = "0.2.1"
+sha2 = "0.10.8"
 
 [dev-dependencies]
 ar = "0.9.0"

--- a/wild_lib/Cargo.toml
+++ b/wild_lib/Cargo.toml
@@ -38,6 +38,7 @@ zstd = "0.13.2"
 fxhash = "0.2.1"
 blake3 = "1.5.5"
 uuid = { version = "1.11.0", features = ["v4"] }
+hex = "0.4.3"
 
 [dev-dependencies]
 ar = "0.9.0"

--- a/wild_lib/src/alignment.rs
+++ b/wild_lib/src/alignment.rs
@@ -45,6 +45,7 @@ pub(crate) const USIZE: Alignment = Alignment { exponent: 3 };
 
 pub(crate) const EH_FRAME_HDR: Alignment = Alignment { exponent: 2 };
 pub(crate) const NOTE_GNU_PROPERTY: Alignment = Alignment { exponent: 3 };
+pub(crate) const NOTE_GNU_BUILD_ID: Alignment = Alignment { exponent: 2 };
 
 impl Alignment {
     pub(crate) fn new(raw: u64) -> Result<Self> {

--- a/wild_lib/src/args.rs
+++ b/wild_lib/src/args.rs
@@ -268,7 +268,7 @@ pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(mut input: I) -> Resul
                 "fast" | "md5"| "sha1" => BuildIdOption::Fast,
                 "uuid" => BuildIdOption::Uuid,
                 s if s.starts_with("0x") || s.starts_with("0X")=> {
-                    let hex_string = s.strip_prefix("0x").unwrap_or_else(|| s.strip_prefix("0X").unwrap());
+                    let hex_string = &s[2..];
                     let decoded_bytes = hex::decode(hex_string).with_context(|| format!("Invalid Hex Build Id `0x{hex_string}`"))?;
                     BuildIdOption::Hex(decoded_bytes)
                 }

--- a/wild_lib/src/args.rs
+++ b/wild_lib/src/args.rs
@@ -174,7 +174,7 @@ pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(mut input: I) -> Resul
     let mut soname = None;
     let mut execstack = false;
     let mut should_fork = true;
-    let mut build_id = true;
+    let mut build_id = false;
     let max_files_per_group = std::env::var(FILES_PER_GROUP_ENV)
         .ok()
         .map(|s| s.parse())

--- a/wild_lib/src/elf.rs
+++ b/wild_lib/src/elf.rs
@@ -398,6 +398,19 @@ pub(crate) struct NoteProperty {
     pub(crate) pr_padding: u32,
 }
 
+#[derive(Zeroable, Pod, Clone, Copy, Default)]
+#[repr(C)]
+pub(crate) struct GnuBuildId([u8; 32]);
+
+impl GnuBuildId {
+    pub(crate) fn new(id: [u8; 32]) -> Self {    
+        Self(id)
+    }
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+}
+
 /// For additional information on ELF relocation types, see "ELF-64 Object File Format" -
 /// https://uclibc.org/docs/elf-64-gen.pdf. For information on the TLS related relocations, see "ELF
 /// Handling For Thread-Local Storage" - https://www.uclibc.org/docs/tls.pdf.

--- a/wild_lib/src/elf.rs
+++ b/wild_lib/src/elf.rs
@@ -398,19 +398,6 @@ pub(crate) struct NoteProperty {
     pub(crate) pr_padding: u32,
 }
 
-#[derive(Zeroable, Pod, Clone, Copy, Default)]
-#[repr(C)]
-pub(crate) struct GnuBuildId([u8; 32]);
-
-impl GnuBuildId {
-    pub(crate) fn new(id: [u8; 32]) -> Self {    
-        Self(id)
-    }
-    pub(crate) fn as_slice(&self) -> &[u8] {
-        self.0.as_slice()
-    }
-}
-
 /// For additional information on ELF relocation types, see "ELF-64 Object File Format" -
 /// https://uclibc.org/docs/elf-64-gen.pdf. For information on the TLS related relocations, see "ELF
 /// Handling For Thread-Local Storage" - https://www.uclibc.org/docs/tls.pdf.

--- a/wild_lib/src/output_section_id.rs
+++ b/wild_lib/src/output_section_id.rs
@@ -946,8 +946,6 @@ fn test_constant_ids() {
         (NOTE_GNU_BUILD_ID, ".note.gnu.build-id"),
     ];
     for (id, name) in check {
-        dbg!(std::str::from_utf8(id.built_in_details().name.bytes()).unwrap());
-        dbg!(*name);
         assert_eq!(
             std::str::from_utf8(id.built_in_details().name.bytes()).unwrap(),
             *name

--- a/wild_lib/src/output_section_id.rs
+++ b/wild_lib/src/output_section_id.rs
@@ -85,7 +85,8 @@ pub(crate) const GNU_VERSION_R: OutputSectionId = part_id::GNU_VERSION_R.output_
 pub(crate) const PLT_GOT: OutputSectionId = part_id::PLT_GOT.output_section_id();
 pub(crate) const NOTE_GNU_PROPERTY: OutputSectionId =
     part_id::NOTE_GNU_PROPERTY.output_section_id();
-pub(crate) const NOTE_GNU_BUILD_ID: OutputSectionId = part_id::NOTE_GNU_BUILD_ID.output_section_id();
+pub(crate) const NOTE_GNU_BUILD_ID: OutputSectionId =
+    part_id::NOTE_GNU_BUILD_ID.output_section_id();
 
 // These two are multi-part sections, but we can pick any part we wish in order to get the section
 // ID.

--- a/wild_lib/src/output_section_id.rs
+++ b/wild_lib/src/output_section_id.rs
@@ -85,6 +85,7 @@ pub(crate) const GNU_VERSION_R: OutputSectionId = part_id::GNU_VERSION_R.output_
 pub(crate) const PLT_GOT: OutputSectionId = part_id::PLT_GOT.output_section_id();
 pub(crate) const NOTE_GNU_PROPERTY: OutputSectionId =
     part_id::NOTE_GNU_PROPERTY.output_section_id();
+pub(crate) const NOTE_GNU_BUILD_ID: OutputSectionId = part_id::NOTE_GNU_BUILD_ID.output_section_id();
 
 // These two are multi-part sections, but we can pick any part we wish in order to get the section
 // ID.
@@ -379,6 +380,13 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = [
         ty: sht::NOTE,
         section_flags: shf::ALLOC,
         min_alignment: alignment::NOTE_GNU_PROPERTY,
+        ..DEFAULT_DEFS
+    },
+    BuiltInSectionDetails {
+        name: SectionName(b".note.gnu.build-id"),
+        ty: sht::NOTE,
+        section_flags: shf::ALLOC,
+        min_alignment: alignment::NOTE_GNU_BUILD_ID,
         ..DEFAULT_DEFS
     },
     // Multi-part generated sections
@@ -740,6 +748,7 @@ impl CustomSectionIds {
         events.push(OrderEvent::SegmentEnd(crate::program_segments::INTERP));
         events.push(OrderEvent::SegmentStart(crate::program_segments::NOTE));
         events.push(NOTE_GNU_PROPERTY.event());
+        events.push(NOTE_GNU_BUILD_ID.event());
         events.push(NOTE_ABI_TAG.event());
         events.push(OrderEvent::SegmentEnd(crate::program_segments::NOTE));
         events.push(GNU_HASH.event());
@@ -934,8 +943,11 @@ fn test_constant_ids() {
         (PLT_GOT, ".plt.got"),
         (NOTE_ABI_TAG, ".note.ABI-tag"),
         (NOTE_GNU_PROPERTY, ".note.gnu.property"),
+        (NOTE_GNU_BUILD_ID, ".note.gnu.build-id"),
     ];
     for (id, name) in check {
+        dbg!(std::str::from_utf8(id.built_in_details().name.bytes()).unwrap());
+        dbg!(*name);
         assert_eq!(
             std::str::from_utf8(id.built_in_details().name.bytes()).unwrap(),
             *name

--- a/wild_lib/src/part_id.rs
+++ b/wild_lib/src/part_id.rs
@@ -59,8 +59,9 @@ pub(crate) const INTERP: PartId = PartId(14);
 pub(crate) const GNU_VERSION: PartId = PartId(15);
 pub(crate) const GNU_VERSION_R: PartId = PartId(16);
 pub(crate) const NOTE_GNU_PROPERTY: PartId = PartId(17);
+pub(crate) const NOTE_GNU_BUILD_ID: PartId = PartId(18);
 
-pub(crate) const NUM_SINGLE_PART_SECTIONS: u32 = 18;
+pub(crate) const NUM_SINGLE_PART_SECTIONS: u32 = 19;
 
 // Generated sections that have more than one part. Fortunately they all have exactly 2 parts.
 pub(crate) const SYMTAB_LOCAL: PartId = PartId::multi(0);
@@ -130,6 +131,8 @@ impl<'data> UnresolvedSection<'data> {
             Some(output_section_id::GCC_EXCEPT_TABLE)
         } else if section_name == b".note.ABI-tag" {
             Some(output_section_id::NOTE_ABI_TAG)
+        } else if section_name == b".note.gnu.build-id" {
+            Some(output_section_id::NOTE_GNU_BUILD_ID)
         } else if section_name.starts_with(b".rela")
             || b".strtab" == section_name
             || b".symtab" == section_name


### PR DESCRIPTION
Implements the --build-id flag to generate GNU build IDs in ELF files.

The build ID is enabled by default (matching GNU ld behavior) and can be disabled with --build-id=none. The implementation uses SHA256 to generate a 32-byte build ID stored in the .note.gnu.build-id section.

Note: The current implementation computes the hash serially over the entire output file which can be slow for large outputs. A future optimization could follow mold's parallel approach as described in their [design doc](https://github.com/rui314/mold/blob/5bb914553fc0d0dcfe2b87204e06ebd1a9eff9b7/docs/design.md?plain=1#L152C1-L163C1)