### PR TITLE
Make error reporting when forking consistent with not forking

### DIFF
--- a/wild_lib/src/subprocess.rs
+++ b/wild_lib/src/subprocess.rs
@@ -21,7 +21,7 @@ pub unsafe fn run_in_subprocess(linker: &Linker) -> ! {
     let exit_code = match subprocess_result(linker) {
         Ok(code) => code,
         Err(error) => {
-            eprintln!("{error}");
+            eprintln!("Error: {error:?}");
             -1
         }
     };


### PR DESCRIPTION
When we don't fork, we display the full trace of the error, which gives more context. Now we show that when forking too.