### PR TITLE
Do string merging in batches

### DIFF
--- a/wild_lib/src/output_section_map.rs
+++ b/wild_lib/src/output_section_map.rs
@@ -1,3 +1,4 @@
+use crate::error::Result;
 use crate::output_section_id::OutputSectionId;
 
 /// A map from output section IDs to something.
@@ -37,6 +38,13 @@ impl<T> OutputSectionMap<T> {
             .iter()
             .enumerate()
             .for_each(|(k, v)| cb(OutputSectionId::from_usize(k), v));
+    }
+
+    pub(crate) fn try_for_each(&self, mut cb: impl FnMut(OutputSectionId, &T) -> Result) -> Result {
+        self.values
+            .iter()
+            .enumerate()
+            .try_for_each(|(k, v)| cb(OutputSectionId::from_usize(k), v))
     }
 
     pub(crate) fn len(&self) -> usize {


### PR DESCRIPTION
This allows us to reuse some heap allocations, rather than needing 32 heap allocations for each input string-merge section.

Before we did all splitting and hashing during section resolution, then deduplication later in the string merging phase.

Now, we do multiple batches where we alternate between splitting/hashing and deduplication. This allows us to reuse the bucket allocations for each batch.

This also makes timing output more meaningful, since all the string merging is now done in the string merging phase rather than some of it being done during section resolution.