### PR TITLE
Add license field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 
 [workspace.package]
 repository = "https://github.com/davidlattimore/wild"
+license = "MIT OR Apache-2.0"
 version = "0.3.0"
 readme = "README.md"
 

--- a/linker-diff/Cargo.toml
+++ b/linker-diff/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "linker-diff"
 version.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "Diffs and validates ELF binaries"
 edition = "2021"
-repository.workspace = true
 
 [dependencies]
 linker-layout = { path = "../linker-layout" }

--- a/linker-layout/Cargo.toml
+++ b/linker-layout/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "linker-layout"
 version.workspace = true
-edition = "2021"
+license.workspace = true
 repository.workspace = true
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0.94"

--- a/linker-trace/Cargo.toml
+++ b/linker-trace/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "linker-trace"
 version.workspace = true
-edition = "2021"
+license.workspace = true
 repository.workspace = true
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0.94"

--- a/linker-utils/Cargo.toml
+++ b/linker-utils/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "linker-utils"
 version.workspace = true
-edition = "2021"
+license.workspace = true
 repository.workspace = true
+edition = "2021"
 
 [dependencies]
 object = { version = "0.36.5", default-features = false, features = [

--- a/wild/Cargo.toml
+++ b/wild/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "wild"
 version.workspace = true
-edition = "2021"
+license.workspace = true
 repository.workspace = true
+edition = "2021"
 
 [dependencies]
 wild_lib = { path = "../wild_lib" }

--- a/wild_lib/Cargo.toml
+++ b/wild_lib/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "wild_lib"
 version.workspace = true
-edition = "2021"
+license.workspace = true
 repository.workspace = true
+edition = "2021"
 
 [dependencies]
 ahash = { version = "0.8.11", default-features = false, features = ["std"] }


### PR DESCRIPTION
The value, "MIT or Apache-2.0" matches the pre-existing LICENSE files in this repository.