### PR TITLE
Come up with `RelocationSize` for future use for AArch64

### DIFF
--- a/wild_lib/src/elf.rs
+++ b/wild_lib/src/elf.rs
@@ -454,6 +454,7 @@ pub(crate) enum RelocationKind {
 #[derive(Clone, Debug)]
 pub(crate) enum RelocationSize {
     ByteSize(usize),
+    #[allow(dead_code)]
     BitRange(Range<usize>),
 }
 

--- a/wild_lib/src/x86_64.rs
+++ b/wild_lib/src/x86_64.rs
@@ -16,7 +16,7 @@ impl crate::arch::Arch for X86_64 {
     type Relaxation = Relaxation;
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(crate) struct Relaxation {
     kind: RelaxationKind,
     rel_info: RelocationKindInfo,
@@ -336,7 +336,7 @@ impl crate::arch::Relaxation for Relaxation {
     }
 
     fn rel_info(&self) -> crate::elf::RelocationKindInfo {
-        self.rel_info
+        self.rel_info.clone()
     }
 
     fn debug_kind(&self) -> impl std::fmt::Debug {


### PR DESCRIPTION
This is a preparation change for AArch64 where various relocation values are stored partially:
https://github.com/ARM-software/abi-aa/blob/main/aaelf64/aaelf64.rst#id53

```
285	15	R_<CLS>_ LDST32_ABS_LO12_NC	S + A	Set the LD/ST immediate value to bits [11:2] of X. No overflow check
```

and so I introduce `RelocationSize::BitRange`. I wish the `write_to_buffer` implementation would be simpler, but it seems Rust is quite strict when it comes to overflow of the shift operations and thus I combine masking with SHR.

Plus, I would like to ask why do you add and subtract `rel_info.byte_size` for `RelocationKind::Relative` relocation value calculation? That would make it more complicated for `BitRange` type.