### PR TITLE
Simplify `RelocationKind::Relative` calculation

### DIFF
--- a/wild_lib/src/elf_writer.rs
+++ b/wild_lib/src/elf_writer.rs
@@ -1734,14 +1734,13 @@ fn apply_relocation<S: StorageModel, A: Arch>(
         )?,
         RelocationKind::Relative => resolution
             .value_with_addend(
-                addend.wrapping_add(rel_info.byte_size as u64),
+                addend,
                 symbol_index,
                 object_layout,
                 &layout.merged_strings,
                 &layout.merged_string_start_addresses,
             )?
-            .wrapping_sub(place)
-            .wrapping_sub(rel_info.byte_size as u64),
+            .wrapping_sub(place),
         RelocationKind::GotRelative => resolution
             .got_address()?
             .wrapping_add(addend)


### PR DESCRIPTION
> I guess adding, then later subtracting can give a different result if the relocation references a merged string. Adding the byte size of the relocation is likely assuming that the relocation is at the end of the instruction and thus the instruction pointer when the instruction is being evaluated will be pointing to the byte immediately after the relocation. Removing it, does appear to still pass the tests. So maybe we should remove it. If it turns out that it is needed, we can then add additional tests when we add it back again. Might be best to remove it in a separate commit though.

I can confirm there is not change for tests, mold's test-suite and also Clang binary when it comes to the `RelocationKind::Relative` relocation calculation. Tested with:

```patch
 wild_lib/src/elf_writer.rs | 33 +++++++++++++++++++++++----------
 1 file changed, 23 insertions(+), 10 deletions(-)

diff --git a/wild_lib/src/elf_writer.rs b/wild_lib/src/elf_writer.rs
index 62f0545..1c4a6dd 100644
--- a/wild_lib/src/elf_writer.rs
+++ b/wild_lib/src/elf_writer.rs
@@ -1732,16 +1732,29 @@ fn apply_relocation<S: StorageModel, A: Arch>(
             object_layout,
             layout,
         )?,
-        RelocationKind::Relative => resolution
-            .value_with_addend(
-                addend.wrapping_add(rel_info.byte_size as u64),
-                symbol_index,
-                object_layout,
-                &layout.merged_strings,
-                &layout.merged_string_start_addresses,
-            )?
-            .wrapping_sub(place)
-            .wrapping_sub(rel_info.byte_size as u64),
+        RelocationKind::Relative => {
+            let expected = resolution
+                .value_with_addend(
+                    addend.wrapping_add(rel_info.byte_size as u64),
+                    symbol_index,
+                    object_layout,
+                    &layout.merged_strings,
+                    &layout.merged_string_start_addresses,
+                )?
+                .wrapping_sub(place)
+                .wrapping_sub(rel_info.byte_size as u64);
+            let value = resolution
+                .value_with_addend(
+                    addend,
+                    symbol_index,
+                    object_layout,
+                    &layout.merged_strings,
+                    &layout.merged_string_start_addresses,
+                )?
+                .wrapping_sub(place);
+            assert_eq!(value, expected);
+            value
+        }
         RelocationKind::GotRelative => resolution
             .got_address()?
             .wrapping_add(addend)
```