### PR TITLE
Rudimentary AArch64 architecture support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,5 @@
 {
     "rust-analyzer.linkedProjects": [
         "Cargo.toml",
-    ],
-    "files.associations": {
-        "*.dbclient-js": "javascript",
-        "*.tcc": "c"
-    }
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,9 @@
 {
     "rust-analyzer.linkedProjects": [
         "Cargo.toml",
-    ]
+    ],
+    "files.associations": {
+        "*.dbclient-js": "javascript",
+        "*.tcc": "c"
+    }
 }

--- a/linker-diff/src/asm_diff.rs
+++ b/linker-diff/src/asm_diff.rs
@@ -49,6 +49,7 @@ const RESOLVE_SECTION_NAMES: bool = false;
 /// or more instructions equivalent.
 const PLACEHOLDER: u64 = 0xaaa;
 
+#[allow(dead_code)]
 pub(crate) fn report_function_diffs(report: &mut Report, objects: &[Object]) {
     let mut all_symbols = BTreeSet::new();
     for o in objects {

--- a/linker-diff/src/asm_diff.rs
+++ b/linker-diff/src/asm_diff.rs
@@ -17,9 +17,9 @@ use iced_x86::Mnemonic;
 use iced_x86::OpKind;
 use iced_x86::Register;
 use itertools::Itertools;
-use linker_utils::elf::rel_type_to_string;
 #[allow(clippy::wildcard_imports)]
 use linker_utils::elf::secnames::*;
+use linker_utils::elf::x86_64_rel_type_to_string;
 use object::read::elf::FileHeader;
 use object::read::elf::ProgramHeader as _;
 use object::read::elf::Rela;
@@ -709,7 +709,7 @@ impl Display for RelocationDisplay<'_, '_> {
         let object::RelocationFlags::Elf { r_type } = self.rel.flags() else {
             unreachable!();
         };
-        rel_type_to_string(r_type).fmt(f)?;
+        x86_64_rel_type_to_string(r_type).fmt(f)?;
         " -> ".fmt(f)?;
         match self.rel.target() {
             RelocationTarget::Symbol(symbol_index) => {
@@ -2415,7 +2415,7 @@ impl Display for Relocation<'_> {
         write!(
             f,
             "{} at 0x{:x} for `{}` {:+}",
-            rel_type_to_string(self.r_type),
+            x86_64_rel_type_to_string(self.r_type),
             self.offset_in_instruction,
             String::from_utf8_lossy(self.symbol_name),
             self.addend,

--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -416,7 +416,11 @@ impl Report {
         );
         header_diff::check_dynamic_headers(self, objects);
         header_diff::check_file_headers(self, objects);
-        asm_diff::report_function_diffs(self, objects);
+        // TODO: add support for aarch64 target
+        #[cfg(target_arch = "x86_64")]
+        {
+            asm_diff::report_function_diffs(self, objects);
+        }
         header_diff::report_section_diffs(self, objects);
         eh_frame_diff::report_diffs(self, objects);
         debug_info_diff::check_debug_info(self, objects);

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -12,7 +12,7 @@ macro_rules! const_name_by_value {
 }
 
 #[must_use]
-pub fn rel_type_to_string(r_type: u32) -> Cow<'static, str> {
+pub fn x86_64_rel_type_to_string(r_type: u32) -> Cow<'static, str> {
     if let Some(name) = const_name_by_value![
         r_type,
         R_X86_64_NONE,
@@ -59,7 +59,7 @@ pub fn rel_type_to_string(r_type: u32) -> Cow<'static, str> {
     ] {
         Cow::Borrowed(name)
     } else {
-        Cow::Owned(format!("Unknown relocation type 0x{r_type:x}"))
+        Cow::Owned(format!("Unknown x86_64 relocation type 0x{r_type:x}"))
     }
 }
 
@@ -252,12 +252,18 @@ mod tests {
 
     #[test]
     fn test_rel_type_to_string() {
-        assert_eq!(&rel_type_to_string(R_X86_64_32), stringify!(R_X86_64_32));
         assert_eq!(
-            &rel_type_to_string(R_X86_64_GOTPC32_TLSDESC),
+            &x86_64_rel_type_to_string(R_X86_64_32),
+            stringify!(R_X86_64_32)
+        );
+        assert_eq!(
+            &x86_64_rel_type_to_string(R_X86_64_GOTPC32_TLSDESC),
             stringify!(R_X86_64_GOTPC32_TLSDESC)
         );
-        assert_eq!(&rel_type_to_string(64), "Unknown relocation type 0x40");
+        assert_eq!(
+            &x86_64_rel_type_to_string(64),
+            "Unknown relocation type 0x40"
+        );
     }
 }
 

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -262,7 +262,7 @@ mod tests {
         );
         assert_eq!(
             &x86_64_rel_type_to_string(64),
-            "Unknown relocation type 0x40"
+            "Unknown x86_64 relocation type 0x40"
         );
     }
 }

--- a/wild/tests/sources/exit.c
+++ b/wild/tests/sources/exit.c
@@ -3,6 +3,7 @@
 #include <inttypes.h>
 #include <sys/types.h>
 
+#if defined(__x86_64__)
 void exit_syscall(int exit_code) {
     register int64_t rax __asm__ ("rax") = 60;
     register int rdi __asm__ ("rdi") = exit_code;
@@ -13,3 +14,14 @@ void exit_syscall(int exit_code) {
         : "rcx", "r11", "memory"
     );
 }
+#elif defined(__aarch64__)
+void exit_syscall(int exit_code) {
+    register long w8 __asm__("w8") = 93;
+    register long x0 __asm__("x0") = exit_code;
+    __asm__ __volatile__(
+        "svc 0"
+        : "=r"(x0)
+        : "r"(w8)
+        : "cc", "memory");
+}
+#endif

--- a/wild_lib/src/aarch64.rs
+++ b/wild_lib/src/aarch64.rs
@@ -229,7 +229,11 @@ impl crate::arch::Arch for AArch64 {
                 Some(PageMask::GotEntryAndPosition),
             ),
             // TODO: missing: G(GDAT(S))
-            //object::elf::R_AARCH64_LD64_GOT_LO12_NC
+            object::elf::R_AARCH64_LD64_GOT_LO12_NC => (
+                RelocationKind::Got,
+                RelocationSize::BitRange { start: 3, end: 12 },
+                None,
+            ),
             object::elf::R_AARCH64_LD64_GOTPAGE_LO15 => (
                 RelocationKind::GotRelGotBase,
                 RelocationSize::BitRange { start: 3, end: 15 },

--- a/wild_lib/src/aarch64.rs
+++ b/wild_lib/src/aarch64.rs
@@ -15,9 +15,10 @@ impl crate::arch::Arch for AArch64 {
 
     fn relocation_from_raw(r_type: u32) -> Result<RelocationKindInfo> {
         let (kind, size) = match r_type {
-            object::elf::R_AARCH64_CALL26 => {
-                (RelocationKind::Relative, RelocationSize::BitRange(2..28))
-            }
+            object::elf::R_AARCH64_CALL26 => (
+                RelocationKind::Relative,
+                RelocationSize::BitRange { start: 2, end: 28 },
+            ),
             object::elf::R_AARCH64_PREL32 => {
                 (RelocationKind::Relative, RelocationSize::ByteSize(4))
             }

--- a/wild_lib/src/aarch64.rs
+++ b/wild_lib/src/aarch64.rs
@@ -228,7 +228,6 @@ impl crate::arch::Arch for AArch64 {
                 RelocationSize::BitRange { start: 12, end: 33 },
                 Some(PageMask::GotEntryAndPosition),
             ),
-            // TODO: missing: G(GDAT(S))
             object::elf::R_AARCH64_LD64_GOT_LO12_NC => (
                 RelocationKind::Got,
                 RelocationSize::BitRange { start: 3, end: 12 },

--- a/wild_lib/src/aarch64.rs
+++ b/wild_lib/src/aarch64.rs
@@ -13,6 +13,8 @@ impl crate::arch::Arch for AArch64 {
         object::elf::EM_AARCH64
     }
 
+    // The table of the relocations is documented here:
+    // https://github.com/ARM-software/abi-aa/blob/main/aaelf64/aaelf64.rst.
     fn relocation_from_raw(r_type: u32) -> Result<RelocationKindInfo> {
         let (kind, size) = match r_type {
             object::elf::R_AARCH64_CALL26 => (

--- a/wild_lib/src/aarch64.rs
+++ b/wild_lib/src/aarch64.rs
@@ -1,0 +1,66 @@
+use crate::elf::RelocationKind;
+use crate::elf::RelocationKindInfo;
+use crate::elf::RelocationSize;
+use anyhow::bail;
+use anyhow::Result;
+
+pub(crate) struct AArch64;
+
+impl crate::arch::Arch for AArch64 {
+    type Relaxation = ();
+
+    fn elf_header_arch_magic() -> u16 {
+        object::elf::EM_AARCH64
+    }
+
+    fn relocation_from_raw(r_type: u32) -> Result<RelocationKindInfo> {
+        let (kind, size) = match r_type {
+            object::elf::R_AARCH64_CALL26 => {
+                (RelocationKind::Relative, RelocationSize::BitRange(2..28))
+            }
+            object::elf::R_AARCH64_PREL32 => {
+                (RelocationKind::Relative, RelocationSize::ByteSize(4))
+            }
+            _ => bail!("Unsupported relocation type {}", r_type),
+        };
+        Ok(RelocationKindInfo { kind, size })
+    }
+}
+
+impl crate::arch::Relaxation for () {
+    #[allow(unused_variables)]
+    fn new(
+        relocation_kind: u32,
+        section_bytes: &[u8],
+        offset_in_section: u64,
+        value_flags: crate::resolution::ValueFlags,
+        output_kind: crate::args::OutputKind,
+        section_flags: linker_utils::elf::SectionFlags,
+    ) -> Option<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        None
+    }
+
+    #[allow(unused_variables)]
+    fn apply(
+        &self,
+        section_bytes: &mut [u8],
+        offset_in_section: &mut u64,
+        addend: &mut u64,
+        next_modifier: &mut crate::relaxation::RelocationModifier,
+    ) {
+    }
+
+    fn rel_info(&self) -> crate::elf::RelocationKindInfo {
+        RelocationKindInfo {
+            kind: RelocationKind::None,
+            size: RelocationSize::ByteSize(0),
+        }
+    }
+
+    fn debug_kind(&self) -> impl std::fmt::Debug {
+        todo!()
+    }
+}

--- a/wild_lib/src/aarch64.rs
+++ b/wild_lib/src/aarch64.rs
@@ -1,3 +1,4 @@
+use crate::elf::PageMask;
 use crate::elf::RelocationKind;
 use crate::elf::RelocationKindInfo;
 use crate::elf::RelocationSize;
@@ -16,23 +17,31 @@ impl crate::arch::Arch for AArch64 {
     // The table of the relocations is documented here:
     // https://github.com/ARM-software/abi-aa/blob/main/aaelf64/aaelf64.rst.
     fn relocation_from_raw(r_type: u32) -> Result<RelocationKindInfo> {
-        let (kind, size) = match r_type {
+        let (kind, size, mask) = match r_type {
             // 5.7.4   Static miscellaneous relocations
-            object::elf::R_AARCH64_NONE => (RelocationKind::None, RelocationSize::ByteSize(0)),
+            object::elf::R_AARCH64_NONE => {
+                (RelocationKind::None, RelocationSize::ByteSize(0), None)
+            }
 
             // 5.7.5   Static Data relocations
             // Data relocations
-            object::elf::R_AARCH64_ABS64 => (RelocationKind::Absolute, RelocationSize::ByteSize(8)),
-            object::elf::R_AARCH64_ABS32 => (RelocationKind::Absolute, RelocationSize::ByteSize(4)),
-            object::elf::R_AARCH64_ABS16 => (RelocationKind::Absolute, RelocationSize::ByteSize(2)),
+            object::elf::R_AARCH64_ABS64 => {
+                (RelocationKind::Absolute, RelocationSize::ByteSize(8), None)
+            }
+            object::elf::R_AARCH64_ABS32 => {
+                (RelocationKind::Absolute, RelocationSize::ByteSize(4), None)
+            }
+            object::elf::R_AARCH64_ABS16 => {
+                (RelocationKind::Absolute, RelocationSize::ByteSize(2), None)
+            }
             object::elf::R_AARCH64_PREL64 => {
-                (RelocationKind::Relative, RelocationSize::ByteSize(8))
+                (RelocationKind::Relative, RelocationSize::ByteSize(8), None)
             }
             object::elf::R_AARCH64_PREL32 => {
-                (RelocationKind::Relative, RelocationSize::ByteSize(4))
+                (RelocationKind::Relative, RelocationSize::ByteSize(4), None)
             }
             object::elf::R_AARCH64_PREL16 => {
-                (RelocationKind::Relative, RelocationSize::ByteSize(2))
+                (RelocationKind::Relative, RelocationSize::ByteSize(2), None)
             }
             // TODO: missing in upstream header file (as well as in Object crate):
             // object::elf::R_AARCH64_PLT32
@@ -42,155 +51,193 @@ impl crate::arch::Arch for AArch64 {
             object::elf::R_AARCH64_MOVW_UABS_G0 | object::elf::R_AARCH64_MOVW_UABS_G0_NC => (
                 RelocationKind::Absolute,
                 RelocationSize::BitRange { start: 0, end: 16 },
+                None,
             ),
             object::elf::R_AARCH64_MOVW_UABS_G1 | object::elf::R_AARCH64_MOVW_UABS_G1_NC => (
                 RelocationKind::Absolute,
                 RelocationSize::BitRange { start: 16, end: 32 },
+                None,
             ),
             object::elf::R_AARCH64_MOVW_UABS_G2 | object::elf::R_AARCH64_MOVW_UABS_G2_NC => (
                 RelocationKind::Absolute,
                 RelocationSize::BitRange { start: 32, end: 48 },
+                None,
             ),
             object::elf::R_AARCH64_MOVW_UABS_G3 => (
                 RelocationKind::Absolute,
                 RelocationSize::BitRange { start: 48, end: 64 },
+                None,
             ),
 
             // Group relocations to create a 16, 32, 48, or 64 bit signed data or offset value inline
             object::elf::R_AARCH64_MOVW_SABS_G0 => (
                 RelocationKind::Absolute,
                 RelocationSize::BitRange { start: 0, end: 16 },
+                None,
             ),
             object::elf::R_AARCH64_MOVW_SABS_G1 => (
                 RelocationKind::Absolute,
                 RelocationSize::BitRange { start: 16, end: 32 },
+                None,
             ),
             object::elf::R_AARCH64_MOVW_SABS_G2 => (
                 RelocationKind::Absolute,
                 RelocationSize::BitRange { start: 32, end: 48 },
+                None,
             ),
 
             // Relocations to generate 19, 21 and 33 bit PC-relative addresses
             object::elf::R_AARCH64_LD_PREL_LO19 => (
                 RelocationKind::Relative,
                 RelocationSize::BitRange { start: 2, end: 21 },
+                None,
             ),
             object::elf::R_AARCH64_ADR_PREL_LO21 => (
                 RelocationKind::Relative,
                 RelocationSize::BitRange { start: 0, end: 21 },
+                None,
             ),
-            // TODO: add page support
-            //object::elf::R_AARCH64_ADR_PREL_PG_HI21=> (RelocationKind::, RelocationSize::BitRange { start: , end: }),
-            //object::elf::R_AARCH64_ADR_PREL_PG_HI21_NC=> (RelocationKind::, RelocationSize::BitRange { start: , end: }),
+            object::elf::R_AARCH64_ADR_PREL_PG_HI21
+            | object::elf::R_AARCH64_ADR_PREL_PG_HI21_NC => (
+                RelocationKind::Relative,
+                RelocationSize::BitRange { start: 12, end: 33 },
+                Some(PageMask::SymbolPlusAddendAndPosition),
+            ),
             object::elf::R_AARCH64_ADD_ABS_LO12_NC => (
                 RelocationKind::Absolute,
                 RelocationSize::BitRange { start: 0, end: 12 },
+                None,
             ),
             object::elf::R_AARCH64_LDST8_ABS_LO12_NC => (
                 RelocationKind::Absolute,
                 RelocationSize::BitRange { start: 0, end: 12 },
+                None,
             ),
             object::elf::R_AARCH64_LDST16_ABS_LO12_NC => (
                 RelocationKind::Absolute,
                 RelocationSize::BitRange { start: 1, end: 12 },
+                None,
             ),
             object::elf::R_AARCH64_LDST32_ABS_LO12_NC => (
                 RelocationKind::Absolute,
                 RelocationSize::BitRange { start: 2, end: 12 },
+                None,
             ),
             object::elf::R_AARCH64_LDST64_ABS_LO12_NC => (
                 RelocationKind::Absolute,
                 RelocationSize::BitRange { start: 3, end: 12 },
+                None,
             ),
             object::elf::R_AARCH64_LDST128_ABS_LO12_NC => (
                 RelocationKind::Absolute,
                 RelocationSize::BitRange { start: 4, end: 12 },
+                None,
             ),
 
             // Relocations for control-flow instructions - all offsets are a multiple of 4
             object::elf::R_AARCH64_TSTBR14 => (
                 RelocationKind::Relative,
                 RelocationSize::BitRange { start: 2, end: 16 },
+                None,
             ),
             object::elf::R_AARCH64_CONDBR19 => (
                 RelocationKind::Relative,
                 RelocationSize::BitRange { start: 2, end: 21 },
+                None,
             ),
             object::elf::R_AARCH64_JUMP26 => (
                 RelocationKind::Relative,
                 RelocationSize::BitRange { start: 2, end: 28 },
+                None,
             ),
             object::elf::R_AARCH64_CALL26 => (
                 RelocationKind::Relative,
                 RelocationSize::BitRange { start: 2, end: 28 },
+                None,
             ),
 
             // Group relocations to create a 16, 32, 48, or 64 bit PC-relative offset inline
             object::elf::R_AARCH64_MOVW_PREL_G0 | object::elf::R_AARCH64_MOVW_PREL_G0_NC => (
                 RelocationKind::Relative,
                 RelocationSize::BitRange { start: 0, end: 16 },
+                None,
             ),
             object::elf::R_AARCH64_MOVW_PREL_G1 | object::elf::R_AARCH64_MOVW_PREL_G1_NC => (
                 RelocationKind::Relative,
                 RelocationSize::BitRange { start: 16, end: 32 },
+                None,
             ),
             object::elf::R_AARCH64_MOVW_PREL_G2 | object::elf::R_AARCH64_MOVW_PREL_G2_NC => (
                 RelocationKind::Relative,
                 RelocationSize::BitRange { start: 32, end: 48 },
+                None,
             ),
             object::elf::R_AARCH64_MOVW_PREL_G3 => (
                 RelocationKind::Relative,
                 RelocationSize::BitRange { start: 48, end: 64 },
+                None,
             ),
 
             // Group relocations to create a 16, 32, 48, or 64 bit GOT-relative offsets inline
             object::elf::R_AARCH64_MOVW_GOTOFF_G0 | object::elf::R_AARCH64_MOVW_GOTOFF_G0_NC => (
                 RelocationKind::GotRelGotBase,
                 RelocationSize::BitRange { start: 0, end: 16 },
+                None,
             ),
             object::elf::R_AARCH64_MOVW_GOTOFF_G1 | object::elf::R_AARCH64_MOVW_GOTOFF_G1_NC => (
                 RelocationKind::GotRelGotBase,
                 RelocationSize::BitRange { start: 16, end: 32 },
+                None,
             ),
             object::elf::R_AARCH64_MOVW_GOTOFF_G2 | object::elf::R_AARCH64_MOVW_GOTOFF_G2_NC => (
                 RelocationKind::GotRelGotBase,
                 RelocationSize::BitRange { start: 32, end: 48 },
+                None,
             ),
             object::elf::R_AARCH64_MOVW_GOTOFF_G3 => (
                 RelocationKind::GotRelGotBase,
                 RelocationSize::BitRange { start: 48, end: 64 },
+                None,
             ),
 
             // GOT-relative data relocations
-            object::elf::R_AARCH64_GOTREL64 => {
-                (RelocationKind::SymRelGotBase, RelocationSize::ByteSize(4))
-            }
-            object::elf::R_AARCH64_GOTREL32 => {
-                (RelocationKind::SymRelGotBase, RelocationSize::ByteSize(8))
-            }
+            object::elf::R_AARCH64_GOTREL64 => (
+                RelocationKind::SymRelGotBase,
+                RelocationSize::ByteSize(4),
+                None,
+            ),
+            object::elf::R_AARCH64_GOTREL32 => (
+                RelocationKind::SymRelGotBase,
+                RelocationSize::ByteSize(8),
+                None,
+            ),
             // TODO: missing in upstream header file (as well as in Object crate)
             // object::elf::R_AARCH64_GOTPCREL32
             object::elf::R_AARCH64_GOT_LD_PREL19 => (
                 RelocationKind::GotRelative,
                 RelocationSize::BitRange { start: 2, end: 21 },
+                None,
             ),
             object::elf::R_AARCH64_LD64_GOTOFF_LO15 => (
                 RelocationKind::GotRelGotBase,
                 RelocationSize::BitRange { start: 3, end: 15 },
+                None,
             ),
-            // TODO: add page support
-            //object::elf::R_AARCH64_ADR_GOT_PAGE
-
+            object::elf::R_AARCH64_ADR_GOT_PAGE => (
+                RelocationKind::GotRelGotBase,
+                RelocationSize::BitRange { start: 12, end: 33 },
+                Some(PageMask::GotEntryAndPosition),
+            ),
             // TODO: missing: G(GDAT(S))
             //object::elf::R_AARCH64_LD64_GOT_LO12_NC
-            //object::elf::R_AARCH64_LD32_GOT_LO12_NC
-
-            // TODO: missing: G(GDAT(S))-Page(GOT)
-            // object::elf::R_AARCH64_LD64_GOTPAGE_LO15
-            //object::elf::R_AARCH64_LD32_GOTPAGE_LO14
+            object::elf::R_AARCH64_LD64_GOTPAGE_LO15 => (
+                RelocationKind::GotRelGotBase,
+                RelocationSize::BitRange { start: 3, end: 15 },
+                Some(PageMask::GotBase),
+            ),
             _ => bail!("Unsupported relocation type {}", r_type),
         };
-        Ok(RelocationKindInfo { kind, size })
+        Ok(RelocationKindInfo { kind, size, mask })
     }
 }
 
@@ -224,6 +271,7 @@ impl crate::arch::Relaxation for () {
         RelocationKindInfo {
             kind: RelocationKind::None,
             size: RelocationSize::ByteSize(0),
+            mask: None,
         }
     }
 

--- a/wild_lib/src/aarch64.rs
+++ b/wild_lib/src/aarch64.rs
@@ -17,13 +17,177 @@ impl crate::arch::Arch for AArch64 {
     // https://github.com/ARM-software/abi-aa/blob/main/aaelf64/aaelf64.rst.
     fn relocation_from_raw(r_type: u32) -> Result<RelocationKindInfo> {
         let (kind, size) = match r_type {
+            // 5.7.4   Static miscellaneous relocations
+            object::elf::R_AARCH64_NONE => (RelocationKind::None, RelocationSize::ByteSize(0)),
+
+            // 5.7.5   Static Data relocations
+            // Data relocations
+            object::elf::R_AARCH64_ABS64 => (RelocationKind::Absolute, RelocationSize::ByteSize(8)),
+            object::elf::R_AARCH64_ABS32 => (RelocationKind::Absolute, RelocationSize::ByteSize(4)),
+            object::elf::R_AARCH64_ABS16 => (RelocationKind::Absolute, RelocationSize::ByteSize(2)),
+            object::elf::R_AARCH64_PREL64 => {
+                (RelocationKind::Relative, RelocationSize::ByteSize(8))
+            }
+            object::elf::R_AARCH64_PREL32 => {
+                (RelocationKind::Relative, RelocationSize::ByteSize(4))
+            }
+            object::elf::R_AARCH64_PREL16 => {
+                (RelocationKind::Relative, RelocationSize::ByteSize(2))
+            }
+            // TODO: missing in upstream header file (as well as in Object crate):
+            // object::elf::R_AARCH64_PLT32
+
+            // 5.7.6   Static AArch64 relocations
+            // Group relocations to create a 16-, 32-, 48-, or 64-bit unsigned data value or address inline
+            object::elf::R_AARCH64_MOVW_UABS_G0 | object::elf::R_AARCH64_MOVW_UABS_G0_NC => (
+                RelocationKind::Absolute,
+                RelocationSize::BitRange { start: 0, end: 16 },
+            ),
+            object::elf::R_AARCH64_MOVW_UABS_G1 | object::elf::R_AARCH64_MOVW_UABS_G1_NC => (
+                RelocationKind::Absolute,
+                RelocationSize::BitRange { start: 16, end: 32 },
+            ),
+            object::elf::R_AARCH64_MOVW_UABS_G2 | object::elf::R_AARCH64_MOVW_UABS_G2_NC => (
+                RelocationKind::Absolute,
+                RelocationSize::BitRange { start: 32, end: 48 },
+            ),
+            object::elf::R_AARCH64_MOVW_UABS_G3 => (
+                RelocationKind::Absolute,
+                RelocationSize::BitRange { start: 48, end: 64 },
+            ),
+
+            // Group relocations to create a 16, 32, 48, or 64 bit signed data or offset value inline
+            object::elf::R_AARCH64_MOVW_SABS_G0 => (
+                RelocationKind::Absolute,
+                RelocationSize::BitRange { start: 0, end: 16 },
+            ),
+            object::elf::R_AARCH64_MOVW_SABS_G1 => (
+                RelocationKind::Absolute,
+                RelocationSize::BitRange { start: 16, end: 32 },
+            ),
+            object::elf::R_AARCH64_MOVW_SABS_G2 => (
+                RelocationKind::Absolute,
+                RelocationSize::BitRange { start: 32, end: 48 },
+            ),
+
+            // Relocations to generate 19, 21 and 33 bit PC-relative addresses
+            object::elf::R_AARCH64_LD_PREL_LO19 => (
+                RelocationKind::Relative,
+                RelocationSize::BitRange { start: 2, end: 21 },
+            ),
+            object::elf::R_AARCH64_ADR_PREL_LO21 => (
+                RelocationKind::Relative,
+                RelocationSize::BitRange { start: 0, end: 21 },
+            ),
+            // TODO: add page support
+            //object::elf::R_AARCH64_ADR_PREL_PG_HI21=> (RelocationKind::, RelocationSize::BitRange { start: , end: }),
+            //object::elf::R_AARCH64_ADR_PREL_PG_HI21_NC=> (RelocationKind::, RelocationSize::BitRange { start: , end: }),
+            object::elf::R_AARCH64_ADD_ABS_LO12_NC => (
+                RelocationKind::Absolute,
+                RelocationSize::BitRange { start: 0, end: 12 },
+            ),
+            object::elf::R_AARCH64_LDST8_ABS_LO12_NC => (
+                RelocationKind::Absolute,
+                RelocationSize::BitRange { start: 0, end: 12 },
+            ),
+            object::elf::R_AARCH64_LDST16_ABS_LO12_NC => (
+                RelocationKind::Absolute,
+                RelocationSize::BitRange { start: 1, end: 12 },
+            ),
+            object::elf::R_AARCH64_LDST32_ABS_LO12_NC => (
+                RelocationKind::Absolute,
+                RelocationSize::BitRange { start: 2, end: 12 },
+            ),
+            object::elf::R_AARCH64_LDST64_ABS_LO12_NC => (
+                RelocationKind::Absolute,
+                RelocationSize::BitRange { start: 3, end: 12 },
+            ),
+            object::elf::R_AARCH64_LDST128_ABS_LO12_NC => (
+                RelocationKind::Absolute,
+                RelocationSize::BitRange { start: 4, end: 12 },
+            ),
+
+            // Relocations for control-flow instructions - all offsets are a multiple of 4
+            object::elf::R_AARCH64_TSTBR14 => (
+                RelocationKind::Relative,
+                RelocationSize::BitRange { start: 2, end: 16 },
+            ),
+            object::elf::R_AARCH64_CONDBR19 => (
+                RelocationKind::Relative,
+                RelocationSize::BitRange { start: 2, end: 21 },
+            ),
+            object::elf::R_AARCH64_JUMP26 => (
+                RelocationKind::Relative,
+                RelocationSize::BitRange { start: 2, end: 28 },
+            ),
             object::elf::R_AARCH64_CALL26 => (
                 RelocationKind::Relative,
                 RelocationSize::BitRange { start: 2, end: 28 },
             ),
-            object::elf::R_AARCH64_PREL32 => {
-                (RelocationKind::Relative, RelocationSize::ByteSize(4))
+
+            // Group relocations to create a 16, 32, 48, or 64 bit PC-relative offset inline
+            object::elf::R_AARCH64_MOVW_PREL_G0 | object::elf::R_AARCH64_MOVW_PREL_G0_NC => (
+                RelocationKind::Relative,
+                RelocationSize::BitRange { start: 0, end: 16 },
+            ),
+            object::elf::R_AARCH64_MOVW_PREL_G1 | object::elf::R_AARCH64_MOVW_PREL_G1_NC => (
+                RelocationKind::Relative,
+                RelocationSize::BitRange { start: 16, end: 32 },
+            ),
+            object::elf::R_AARCH64_MOVW_PREL_G2 | object::elf::R_AARCH64_MOVW_PREL_G2_NC => (
+                RelocationKind::Relative,
+                RelocationSize::BitRange { start: 32, end: 48 },
+            ),
+            object::elf::R_AARCH64_MOVW_PREL_G3 => (
+                RelocationKind::Relative,
+                RelocationSize::BitRange { start: 48, end: 64 },
+            ),
+
+            // Group relocations to create a 16, 32, 48, or 64 bit GOT-relative offsets inline
+            object::elf::R_AARCH64_MOVW_GOTOFF_G0 | object::elf::R_AARCH64_MOVW_GOTOFF_G0_NC => (
+                RelocationKind::GotRelGotBase,
+                RelocationSize::BitRange { start: 0, end: 16 },
+            ),
+            object::elf::R_AARCH64_MOVW_GOTOFF_G1 | object::elf::R_AARCH64_MOVW_GOTOFF_G1_NC => (
+                RelocationKind::GotRelGotBase,
+                RelocationSize::BitRange { start: 16, end: 32 },
+            ),
+            object::elf::R_AARCH64_MOVW_GOTOFF_G2 | object::elf::R_AARCH64_MOVW_GOTOFF_G2_NC => (
+                RelocationKind::GotRelGotBase,
+                RelocationSize::BitRange { start: 32, end: 48 },
+            ),
+            object::elf::R_AARCH64_MOVW_GOTOFF_G3 => (
+                RelocationKind::GotRelGotBase,
+                RelocationSize::BitRange { start: 48, end: 64 },
+            ),
+
+            // GOT-relative data relocations
+            object::elf::R_AARCH64_GOTREL64 => {
+                (RelocationKind::SymRelGotBase, RelocationSize::ByteSize(4))
             }
+            object::elf::R_AARCH64_GOTREL32 => {
+                (RelocationKind::SymRelGotBase, RelocationSize::ByteSize(8))
+            }
+            // TODO: missing in upstream header file (as well as in Object crate)
+            // object::elf::R_AARCH64_GOTPCREL32
+            object::elf::R_AARCH64_GOT_LD_PREL19 => (
+                RelocationKind::GotRelative,
+                RelocationSize::BitRange { start: 2, end: 21 },
+            ),
+            object::elf::R_AARCH64_LD64_GOTOFF_LO15 => (
+                RelocationKind::GotRelGotBase,
+                RelocationSize::BitRange { start: 3, end: 15 },
+            ),
+            // TODO: add page support
+            //object::elf::R_AARCH64_ADR_GOT_PAGE
+
+            // TODO: missing: G(GDAT(S))
+            //object::elf::R_AARCH64_LD64_GOT_LO12_NC
+            //object::elf::R_AARCH64_LD32_GOT_LO12_NC
+
+            // TODO: missing: G(GDAT(S))-Page(GOT)
+            // object::elf::R_AARCH64_LD64_GOTPAGE_LO15
+            //object::elf::R_AARCH64_LD32_GOTPAGE_LO14
             _ => bail!("Unsupported relocation type {}", r_type),
         };
         Ok(RelocationKindInfo { kind, size })

--- a/wild_lib/src/aarch64.rs
+++ b/wild_lib/src/aarch64.rs
@@ -224,7 +224,7 @@ impl crate::arch::Arch for AArch64 {
                 None,
             ),
             object::elf::R_AARCH64_ADR_GOT_PAGE => (
-                RelocationKind::GotRelGotBase,
+                RelocationKind::GotRelative,
                 RelocationSize::BitRange { start: 12, end: 33 },
                 Some(PageMask::GotEntryAndPosition),
             ),

--- a/wild_lib/src/arch.rs
+++ b/wild_lib/src/arch.rs
@@ -1,12 +1,18 @@
 //! Abstraction over different CPU architectures.
 
 use crate::args::OutputKind;
+use crate::elf::RelocationKindInfo;
 use crate::relaxation::RelocationModifier;
 use crate::resolution::ValueFlags;
+use anyhow::Result;
 use linker_utils::elf::SectionFlags;
 
 pub(crate) trait Arch {
     type Relaxation: Relaxation;
+
+    fn elf_header_arch_magic() -> u16;
+
+    fn relocation_from_raw(r_type: u32) -> Result<RelocationKindInfo>;
 }
 
 pub(crate) trait Relaxation {

--- a/wild_lib/src/arch.rs
+++ b/wild_lib/src/arch.rs
@@ -4,8 +4,10 @@ use crate::args::OutputKind;
 use crate::elf::RelocationKindInfo;
 use crate::relaxation::RelocationModifier;
 use crate::resolution::ValueFlags;
+use anyhow::bail;
 use anyhow::Result;
 use linker_utils::elf::SectionFlags;
+use std::str::FromStr;
 
 pub(crate) trait Arch {
     type Relaxation: Relaxation;
@@ -13,6 +15,23 @@ pub(crate) trait Arch {
     fn elf_header_arch_magic() -> u16;
 
     fn relocation_from_raw(r_type: u32) -> Result<RelocationKindInfo>;
+}
+
+pub(crate) enum Architecture {
+    X86_64,
+    AArch64,
+}
+
+impl FromStr for Architecture {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "elf_x86_64" => Ok(Architecture::X86_64),
+            "aarch64elf" | "aarch64linux" => Ok(Architecture::AArch64),
+            _ => bail!("-m {s} is not yet supported"),
+        }
+    }
 }
 
 pub(crate) trait Relaxation {

--- a/wild_lib/src/arch.rs
+++ b/wild_lib/src/arch.rs
@@ -12,8 +12,10 @@ use std::str::FromStr;
 pub(crate) trait Arch {
     type Relaxation: Relaxation;
 
+    // Get ELF header magic for the architecture.
     fn elf_header_arch_magic() -> u16;
 
+    // Make architecture-specific parsing of the relocation types.
     fn relocation_from_raw(r_type: u32) -> Result<RelocationKindInfo>;
 }
 

--- a/wild_lib/src/args.rs
+++ b/wild_lib/src/args.rs
@@ -4,6 +4,7 @@
 //! order is important for some arguments, and it's not clear how easy it would be to get that
 //! correct with something like clap.
 
+use crate::arch::Architecture;
 use crate::error::Result;
 use crate::input_data::FileId;
 use crate::save_dir::SaveDir;
@@ -13,10 +14,12 @@ use anyhow::Context as _;
 use std::num::NonZeroUsize;
 use std::path::Path;
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::atomic::AtomicI64;
 use std::sync::Arc;
 
 pub(crate) struct Args {
+    pub(crate) arch: Architecture,
     pub(crate) lib_search_path: Vec<Box<Path>>,
     pub(crate) inputs: Vec<Input>,
     pub(crate) output: Arc<Path>,
@@ -152,6 +155,17 @@ const DEFAULT_FLAGS: &[&str] = &[
 
 // Parse the supplied input arguments, which should not include the program name.
 pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(mut input: I) -> Result<Action> {
+    #[allow(unused_assignments)]
+    let mut architecture = None;
+    #[cfg(target_arch = "x86_64")]
+    {
+        architecture = Some(Architecture::X86_64);
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        architecture = Some(Architecture::AArch64);
+    }
+
     let mut lib_search_path = Vec::new();
     let mut inputs = Vec::new();
     let mut output = None;
@@ -312,12 +326,14 @@ pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(mut input: I) -> Resul
         } else if long_arg_eq("no-fork") {
             should_fork = false;
         } else if arg == "-m" {
-            match input.next().context("Missing argument to -m")?.as_ref() {
-                "elf_x86_64" => {}
-                other => {
-                    bail!("-m {other} is not yet supported");
-                }
-            }
+            let arg_value = input.next().context("Missing argument to -m")?;
+            let arg_value = arg_value.as_ref();
+            architecture = Some(Architecture::from_str(arg_value)?);
+        } else if let Some(arg_value) = arg.strip_prefix("-m") {
+            architecture = Some(Architecture::from_str(arg_value)?);
+        } else if long_arg_eq("EL") {
+        } else if long_arg_eq("EB") {
+            bail!("Big-endian target is not supported");
         } else if arg == "-z" {
             handle_z_option(input.next().context("Missing argument to -z")?.as_ref())?;
         } else if let Some(arg) = arg.strip_prefix("-z") {
@@ -444,6 +460,9 @@ pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(mut input: I) -> Resul
     if !unrecognised.is_empty() {
         bail!("Unrecognised argument(s): {}", unrecognised.join(" "));
     }
+    let Some(arch) = architecture else {
+        bail!("Missing -m arch option");
+    };
     let num_threads = num_threads.unwrap_or_else(crate::threading::available_parallelism);
     let output_kind = output_kind.unwrap_or({
         if is_dynamic_executable {
@@ -457,6 +476,7 @@ pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(mut input: I) -> Resul
         return Ok(a);
     }
     Ok(Action::Link(Args {
+        arch,
         lib_search_path,
         inputs,
         output: output.unwrap_or_else(|| Arc::from(Path::new("a.out"))),

--- a/wild_lib/src/args.rs
+++ b/wild_lib/src/args.rs
@@ -331,7 +331,6 @@ pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(mut input: I) -> Resul
             architecture = Some(Architecture::from_str(arg_value)?);
         } else if let Some(arg_value) = arg.strip_prefix("-m") {
             architecture = Some(Architecture::from_str(arg_value)?);
-        } else if long_arg_eq("EL") {
         } else if long_arg_eq("EB") {
             bail!("Big-endian target is not supported");
         } else if arg == "-z" {

--- a/wild_lib/src/elf.rs
+++ b/wild_lib/src/elf.rs
@@ -423,7 +423,7 @@ impl Default for PageMaskValue {
     }
 }
 
-const DEFAULT_AARCH64_MASK: u64 = 0xfff;
+const DEFAULT_AARCH64_MASK: u64 = !0xfff;
 
 pub(crate) fn get_page_mask(mask: Option<PageMask>) -> PageMaskValue {
     let Some(mask) = mask else {

--- a/wild_lib/src/elf.rs
+++ b/wild_lib/src/elf.rs
@@ -454,6 +454,7 @@ pub(crate) enum RelocationKind {
 #[derive(Clone, Debug)]
 pub(crate) enum RelocationSize {
     ByteSize(usize),
+    #[allow(dead_code)]
     BitRange(Range<usize>),
 }
 

--- a/wild_lib/src/elf.rs
+++ b/wild_lib/src/elf.rs
@@ -465,6 +465,9 @@ pub(crate) enum RelocationKind {
     /// The offset of the symbol's GOT entry, relative to the start of the GOT.
     GotRelGotBase,
 
+    /// The address of the symbol's GOT entry.
+    Got,
+
     /// The address of the symbol's PLT entry, relative to the base address of the GOT.
     PltRelGotBase,
 

--- a/wild_lib/src/elf_writer.rs
+++ b/wild_lib/src/elf_writer.rs
@@ -1784,12 +1784,10 @@ fn apply_relocation<S: StorageModel, A: Arch>(
             .wrapping_add(addend),
         RelocationKind::None => 0,
     };
-    let value_bytes = value.to_le_bytes();
-    let end = offset_in_section as usize + rel_info.byte_size;
-    if out.len() < end {
-        bail!("Relocation outside of bounds of section");
-    }
-    out[offset_in_section as usize..end].copy_from_slice(&value_bytes[..rel_info.byte_size]);
+    rel_info
+        .size
+        .write_to_buffer(value, &mut out[offset_in_section as usize..])?;
+
     Ok(next_modifier)
 }
 
@@ -1854,12 +1852,9 @@ fn apply_debug_relocation<S: StorageModel>(
         bail!("Could not find a relocation resolution for a debug info section");
     };
 
-    let value_bytes = value.to_le_bytes();
-    let end = offset_in_section as usize + rel_info.byte_size;
-    if out.len() < end {
-        bail!("Relocation outside of bounds of section");
-    }
-    out[offset_in_section as usize..end].copy_from_slice(&value_bytes[..rel_info.byte_size]);
+    rel_info
+        .size
+        .write_to_buffer(value, &mut out[offset_in_section as usize..])?;
     Ok(())
 }
 

--- a/wild_lib/src/elf_writer.rs
+++ b/wild_lib/src/elf_writer.rs
@@ -1764,6 +1764,10 @@ fn apply_relocation<S: StorageModel, A: Arch>(
             .bitand(mask.got_entry)
             .wrapping_sub(layout.got_base().bitand(mask.got))
             .wrapping_add(addend),
+        RelocationKind::Got => resolution
+            .got_address()?
+            .bitand(mask.got_entry)
+            .wrapping_add(addend),
         RelocationKind::SymRelGotBase => resolution
             .value()
             .bitand(mask.symbol_plus_addend)

--- a/wild_lib/src/layout.rs
+++ b/wild_lib/src/layout.rs
@@ -2465,6 +2465,7 @@ fn resolution_flags(rel_kind: RelocationKind) -> ResolutionFlags {
         | RelocationKind::DtpOff
         | RelocationKind::TpOff
         | RelocationKind::SymRelGotBase
+        | RelocationKind::Got
         | RelocationKind::None => ResolutionFlags::DIRECT,
     }
 }

--- a/wild_lib/src/layout.rs
+++ b/wild_lib/src/layout.rs
@@ -71,6 +71,7 @@ use linker_utils::elf::shf;
 use linker_utils::elf::SectionFlags;
 use object::elf::gnu_hash;
 use object::elf::Rela64;
+use object::elf::GNU_PROPERTY_AARCH64_FEATURE_1_AND;
 use object::elf::GNU_PROPERTY_X86_UINT32_AND_HI;
 use object::elf::GNU_PROPERTY_X86_UINT32_AND_LO;
 use object::elf::GNU_PROPERTY_X86_UINT32_OR_AND_HI;
@@ -282,6 +283,7 @@ enum PropertyClass {
 fn get_property_class(property_type: u32) -> Option<PropertyClass> {
     match property_type {
         GNU_PROPERTY_X86_UINT32_AND_LO..=GNU_PROPERTY_X86_UINT32_AND_HI => Some(PropertyClass::And),
+        GNU_PROPERTY_AARCH64_FEATURE_1_AND => Some(PropertyClass::And),
         GNU_PROPERTY_X86_UINT32_OR_LO..=GNU_PROPERTY_X86_UINT32_OR_HI => Some(PropertyClass::Or),
         GNU_PROPERTY_X86_UINT32_OR_AND_LO..=GNU_PROPERTY_X86_UINT32_OR_AND_HI => {
             Some(PropertyClass::AndOr)

--- a/wild_lib/src/layout.rs
+++ b/wild_lib/src/layout.rs
@@ -19,7 +19,6 @@ use crate::elf::EhFrameHdrEntry;
 use crate::elf::File;
 use crate::elf::FileHeader;
 use crate::elf::RelocationKind;
-use crate::elf::RelocationKindInfo;
 use crate::elf::Versym;
 use crate::elf_writer;
 use crate::error::Error;
@@ -2399,7 +2398,7 @@ fn process_relocation<S: StorageModel, A: Arch>(
         ) {
             relaxation.rel_info()
         } else {
-            RelocationKindInfo::from_raw(r_type)?
+            A::relocation_from_raw(r_type)?
         };
         if does_relocation_require_static_tls(r_type) {
             resources

--- a/wild_lib/src/lib.rs
+++ b/wild_lib/src/lib.rs
@@ -5,6 +5,7 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 
+pub(crate) mod aarch64;
 pub(crate) mod alignment;
 pub(crate) mod arch;
 pub(crate) mod archive;

--- a/wild_lib/src/lib.rs
+++ b/wild_lib/src/lib.rs
@@ -95,7 +95,14 @@ impl Linker {
                         .with(EnvFilter::from_default_env())
                         .init();
                 }
-                link::<storage::InMemory, x86_64::X86_64>(args, done_closure)
+                match args.arch {
+                    arch::Architecture::X86_64 => {
+                        link::<storage::InMemory, x86_64::X86_64>(args, done_closure)
+                    }
+                    arch::Architecture::AArch64 => {
+                        link::<storage::InMemory, aarch64::AArch64>(args, done_closure)
+                    }
+                }
             }
             args::Action::Version => {
                 println!(

--- a/wild_lib/src/x86_64.rs
+++ b/wild_lib/src/x86_64.rs
@@ -66,6 +66,7 @@ impl crate::arch::Arch for X86_64 {
         Ok(RelocationKindInfo {
             kind,
             size: RelocationSize::ByteSize(size),
+            mask: None,
         })
     }
 }

--- a/wild_lib/src/x86_64.rs
+++ b/wild_lib/src/x86_64.rs
@@ -390,7 +390,7 @@ impl crate::arch::Relaxation for Relaxation {
     }
 
     fn rel_info(&self) -> crate::elf::RelocationKindInfo {
-        self.rel_info.clone()
+        self.rel_info
     }
 
     fn debug_kind(&self) -> impl std::fmt::Debug {

--- a/wild_lib/src/x86_64.rs
+++ b/wild_lib/src/x86_64.rs
@@ -16,7 +16,7 @@ impl crate::arch::Arch for X86_64 {
     type Relaxation = Relaxation;
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(crate) struct Relaxation {
     kind: RelaxationKind,
     rel_info: RelocationKindInfo,
@@ -336,7 +336,7 @@ impl crate::arch::Relaxation for Relaxation {
     }
 
     fn rel_info(&self) -> crate::elf::RelocationKindInfo {
-        self.rel_info
+        self.rel_info.clone()
     }
 
     fn debug_kind(&self) -> impl std::fmt::Debug {


### PR DESCRIPTION
This a very basic support for the AArch64 architecture where I could link a `trivial.C` test case (2 relocation types are needed) on the real hardware :confetti_ball: I included parsing of the `-m` option in args.rs where default architecture is selected based on target_arch. Later on, the option value is converted to the proper `Arch` implementation and I've added more template Arch arguments in elf_writer.rs.

Please review the changes before I'll carry on :)

Related to #43.