### PR TITLE
AArch64: implement proper application of the insn-related relocations

### DIFF
--- a/wild_lib/src/aarch64.rs
+++ b/wild_lib/src/aarch64.rs
@@ -1,5 +1,8 @@
+use crate::elf::extract_bits;
+use crate::elf::BitRange;
 use crate::elf::DynamicRelocationKind;
 use crate::elf::PageMask;
+use crate::elf::RelocationInsn;
 use crate::elf::RelocationKind;
 use crate::elf::RelocationKindInfo;
 use crate::elf::RelocationSize;
@@ -44,6 +47,7 @@ impl crate::arch::Arch for AArch64 {
             object::elf::R_AARCH64_PREL16 => {
                 (RelocationKind::Relative, RelocationSize::ByteSize(2), None)
             }
+
             // TODO: missing in upstream header file (as well as in Object crate):
             // object::elf::R_AARCH64_PLT32
 
@@ -51,153 +55,283 @@ impl crate::arch::Arch for AArch64 {
             // Group relocations to create a 16-, 32-, 48-, or 64-bit unsigned data value or address inline
             object::elf::R_AARCH64_MOVW_UABS_G0 | object::elf::R_AARCH64_MOVW_UABS_G0_NC => (
                 RelocationKind::Absolute,
-                RelocationSize::BitRange { start: 0, end: 16 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 0, end: 16 },
+                    insn: RelocationInsn::Movkz,
+                },
                 None,
             ),
             object::elf::R_AARCH64_MOVW_UABS_G1 | object::elf::R_AARCH64_MOVW_UABS_G1_NC => (
                 RelocationKind::Absolute,
-                RelocationSize::BitRange { start: 16, end: 32 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 16, end: 32 },
+                    insn: RelocationInsn::Movkz,
+                },
                 None,
             ),
             object::elf::R_AARCH64_MOVW_UABS_G2 | object::elf::R_AARCH64_MOVW_UABS_G2_NC => (
                 RelocationKind::Absolute,
-                RelocationSize::BitRange { start: 32, end: 48 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 32, end: 48 },
+                    insn: RelocationInsn::Movkz,
+                },
                 None,
             ),
             object::elf::R_AARCH64_MOVW_UABS_G3 => (
                 RelocationKind::Absolute,
-                RelocationSize::BitRange { start: 48, end: 64 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 48, end: 64 },
+                    insn: RelocationInsn::Movkz,
+                },
                 None,
             ),
-
             // Group relocations to create a 16, 32, 48, or 64 bit signed data or offset value inline
             object::elf::R_AARCH64_MOVW_SABS_G0 => (
                 RelocationKind::Absolute,
-                RelocationSize::BitRange { start: 0, end: 16 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 0, end: 16 },
+                    insn: RelocationInsn::Movnz,
+                },
                 None,
             ),
             object::elf::R_AARCH64_MOVW_SABS_G1 => (
                 RelocationKind::Absolute,
-                RelocationSize::BitRange { start: 16, end: 32 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 16, end: 32 },
+                    insn: RelocationInsn::Movnz,
+                },
                 None,
             ),
             object::elf::R_AARCH64_MOVW_SABS_G2 => (
                 RelocationKind::Absolute,
-                RelocationSize::BitRange { start: 32, end: 48 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 32, end: 48 },
+                    insn: RelocationInsn::Movnz,
+                },
                 None,
             ),
-
             // Relocations to generate 19, 21 and 33 bit PC-relative addresses
             object::elf::R_AARCH64_LD_PREL_LO19 => (
                 RelocationKind::Relative,
-                RelocationSize::BitRange { start: 2, end: 21 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 2, end: 21 },
+                    insn: RelocationInsn::Ldr,
+                },
                 None,
             ),
             object::elf::R_AARCH64_ADR_PREL_LO21 => (
                 RelocationKind::Relative,
-                RelocationSize::BitRange { start: 0, end: 21 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 0, end: 21 },
+                    insn: RelocationInsn::Adr,
+                },
                 None,
             ),
             object::elf::R_AARCH64_ADR_PREL_PG_HI21
             | object::elf::R_AARCH64_ADR_PREL_PG_HI21_NC => (
                 RelocationKind::Relative,
-                RelocationSize::BitRange { start: 12, end: 33 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 12, end: 33 },
+                    insn: RelocationInsn::Adr,
+                },
                 Some(PageMask::SymbolPlusAddendAndPosition),
             ),
             object::elf::R_AARCH64_ADD_ABS_LO12_NC => (
                 RelocationKind::Absolute,
-                RelocationSize::BitRange { start: 0, end: 12 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 0, end: 12 },
+                    insn: RelocationInsn::Add,
+                },
                 None,
             ),
             object::elf::R_AARCH64_LDST8_ABS_LO12_NC => (
                 RelocationKind::Absolute,
-                RelocationSize::BitRange { start: 0, end: 12 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 0, end: 12 },
+                    insn: RelocationInsn::LdSt,
+                },
                 None,
             ),
             object::elf::R_AARCH64_LDST16_ABS_LO12_NC => (
                 RelocationKind::Absolute,
-                RelocationSize::BitRange { start: 1, end: 12 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 1, end: 12 },
+                    insn: RelocationInsn::LdSt,
+                },
                 None,
             ),
             object::elf::R_AARCH64_LDST32_ABS_LO12_NC => (
                 RelocationKind::Absolute,
-                RelocationSize::BitRange { start: 2, end: 12 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 2, end: 12 },
+                    insn: RelocationInsn::LdSt,
+                },
                 None,
             ),
             object::elf::R_AARCH64_LDST64_ABS_LO12_NC => (
                 RelocationKind::Absolute,
-                RelocationSize::BitRange { start: 3, end: 12 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 3, end: 12 },
+                    insn: RelocationInsn::LdSt,
+                },
                 None,
             ),
             object::elf::R_AARCH64_LDST128_ABS_LO12_NC => (
                 RelocationKind::Absolute,
-                RelocationSize::BitRange { start: 4, end: 12 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 4, end: 12 },
+                    insn: RelocationInsn::LdSt,
+                },
                 None,
             ),
 
             // Relocations for control-flow instructions - all offsets are a multiple of 4
             object::elf::R_AARCH64_TSTBR14 => (
                 RelocationKind::Relative,
-                RelocationSize::BitRange { start: 2, end: 16 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 2, end: 16 },
+                    insn: RelocationInsn::TstBr,
+                },
                 None,
             ),
             object::elf::R_AARCH64_CONDBR19 => (
                 RelocationKind::Relative,
-                RelocationSize::BitRange { start: 2, end: 21 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 2, end: 21 },
+                    insn: RelocationInsn::Bcond,
+                },
                 None,
             ),
             object::elf::R_AARCH64_JUMP26 => (
                 RelocationKind::Relative,
-                RelocationSize::BitRange { start: 2, end: 28 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 2, end: 28 },
+                    insn: RelocationInsn::JumpCall,
+                },
                 None,
             ),
             object::elf::R_AARCH64_CALL26 => (
                 RelocationKind::Relative,
-                RelocationSize::BitRange { start: 2, end: 28 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 2, end: 28 },
+                    insn: RelocationInsn::JumpCall,
+                },
                 None,
             ),
 
             // Group relocations to create a 16, 32, 48, or 64 bit PC-relative offset inline
-            object::elf::R_AARCH64_MOVW_PREL_G0 | object::elf::R_AARCH64_MOVW_PREL_G0_NC => (
+            object::elf::R_AARCH64_MOVW_PREL_G0 => (
                 RelocationKind::Relative,
-                RelocationSize::BitRange { start: 0, end: 16 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 0, end: 16 },
+                    insn: RelocationInsn::Movnz,
+                },
                 None,
             ),
-            object::elf::R_AARCH64_MOVW_PREL_G1 | object::elf::R_AARCH64_MOVW_PREL_G1_NC => (
+            object::elf::R_AARCH64_MOVW_PREL_G0_NC => (
                 RelocationKind::Relative,
-                RelocationSize::BitRange { start: 16, end: 32 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 0, end: 16 },
+                    insn: RelocationInsn::Movkz,
+                },
                 None,
             ),
-            object::elf::R_AARCH64_MOVW_PREL_G2 | object::elf::R_AARCH64_MOVW_PREL_G2_NC => (
+            object::elf::R_AARCH64_MOVW_PREL_G1 => (
                 RelocationKind::Relative,
-                RelocationSize::BitRange { start: 32, end: 48 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 16, end: 32 },
+                    insn: RelocationInsn::Movnz,
+                },
+                None,
+            ),
+            object::elf::R_AARCH64_MOVW_PREL_G1_NC => (
+                RelocationKind::Relative,
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 16, end: 32 },
+                    insn: RelocationInsn::Movkz,
+                },
+                None,
+            ),
+            object::elf::R_AARCH64_MOVW_PREL_G2 => (
+                RelocationKind::Relative,
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 32, end: 48 },
+                    insn: RelocationInsn::Movnz,
+                },
+                None,
+            ),
+            object::elf::R_AARCH64_MOVW_PREL_G2_NC => (
+                RelocationKind::Relative,
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 32, end: 48 },
+                    insn: RelocationInsn::Movkz,
+                },
                 None,
             ),
             object::elf::R_AARCH64_MOVW_PREL_G3 => (
                 RelocationKind::Relative,
-                RelocationSize::BitRange { start: 48, end: 64 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 48, end: 64 },
+                    insn: RelocationInsn::Movnz,
+                },
                 None,
             ),
 
             // Group relocations to create a 16, 32, 48, or 64 bit GOT-relative offsets inline
-            object::elf::R_AARCH64_MOVW_GOTOFF_G0 | object::elf::R_AARCH64_MOVW_GOTOFF_G0_NC => (
+            object::elf::R_AARCH64_MOVW_GOTOFF_G0 => (
                 RelocationKind::GotRelGotBase,
-                RelocationSize::BitRange { start: 0, end: 16 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 0, end: 16 },
+                    insn: RelocationInsn::Movnz,
+                },
                 None,
             ),
-            object::elf::R_AARCH64_MOVW_GOTOFF_G1 | object::elf::R_AARCH64_MOVW_GOTOFF_G1_NC => (
+            object::elf::R_AARCH64_MOVW_GOTOFF_G0_NC => (
                 RelocationKind::GotRelGotBase,
-                RelocationSize::BitRange { start: 16, end: 32 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 0, end: 16 },
+                    insn: RelocationInsn::Movkz,
+                },
                 None,
             ),
-            object::elf::R_AARCH64_MOVW_GOTOFF_G2 | object::elf::R_AARCH64_MOVW_GOTOFF_G2_NC => (
+            object::elf::R_AARCH64_MOVW_GOTOFF_G1 => (
                 RelocationKind::GotRelGotBase,
-                RelocationSize::BitRange { start: 32, end: 48 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 16, end: 32 },
+                    insn: RelocationInsn::Movnz,
+                },
+                None,
+            ),
+            object::elf::R_AARCH64_MOVW_GOTOFF_G1_NC => (
+                RelocationKind::GotRelGotBase,
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 16, end: 32 },
+                    insn: RelocationInsn::Movkz,
+                },
+                None,
+            ),
+            object::elf::R_AARCH64_MOVW_GOTOFF_G2 => (
+                RelocationKind::GotRelGotBase,
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 32, end: 48 },
+                    insn: RelocationInsn::Movnz,
+                },
+                None,
+            ),
+            object::elf::R_AARCH64_MOVW_GOTOFF_G2_NC => (
+                RelocationKind::GotRelGotBase,
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 32, end: 48 },
+                    insn: RelocationInsn::Movkz,
+                },
                 None,
             ),
             object::elf::R_AARCH64_MOVW_GOTOFF_G3 => (
                 RelocationKind::GotRelGotBase,
-                RelocationSize::BitRange { start: 48, end: 64 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 48, end: 64 },
+                    insn: RelocationInsn::Movnz,
+                },
                 None,
             ),
 
@@ -216,27 +350,42 @@ impl crate::arch::Arch for AArch64 {
             // object::elf::R_AARCH64_GOTPCREL32
             object::elf::R_AARCH64_GOT_LD_PREL19 => (
                 RelocationKind::GotRelative,
-                RelocationSize::BitRange { start: 2, end: 21 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 2, end: 21 },
+                    insn: RelocationInsn::LdSt,
+                },
                 None,
             ),
             object::elf::R_AARCH64_LD64_GOTOFF_LO15 => (
                 RelocationKind::GotRelGotBase,
-                RelocationSize::BitRange { start: 3, end: 15 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 3, end: 15 },
+                    insn: RelocationInsn::LdSt,
+                },
                 None,
             ),
             object::elf::R_AARCH64_ADR_GOT_PAGE => (
                 RelocationKind::GotRelative,
-                RelocationSize::BitRange { start: 12, end: 33 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 12, end: 33 },
+                    insn: RelocationInsn::Adr,
+                },
                 Some(PageMask::GotEntryAndPosition),
             ),
             object::elf::R_AARCH64_LD64_GOT_LO12_NC => (
                 RelocationKind::Got,
-                RelocationSize::BitRange { start: 3, end: 12 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 3, end: 12 },
+                    insn: RelocationInsn::LdSt,
+                },
                 None,
             ),
             object::elf::R_AARCH64_LD64_GOTPAGE_LO15 => (
                 RelocationKind::GotRelGotBase,
-                RelocationSize::BitRange { start: 3, end: 15 },
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 3, end: 15 },
+                    insn: RelocationInsn::LdSt,
+                },
                 Some(PageMask::GotBase),
             ),
             _ => bail!("Unsupported relocation type {}", r_type),
@@ -294,5 +443,67 @@ impl crate::arch::Relaxation for () {
 
     fn debug_kind(&self) -> impl std::fmt::Debug {
         todo!()
+    }
+}
+
+impl RelocationInsn {
+    // Encode computed relocation value and store it based on the encoding of an instruction.
+    // Each instruction links to a chapter in the Arm Architecture Reference Manual for A-profile architecture
+    // manual: https://developer.arm.com/documentation/ddi0487/latest/
+    pub(crate) fn write_to_value(self, extracted_value: u64, original_value: u64, dest: &mut [u8]) {
+        let mut mask;
+        match self {
+            // C6.2.13
+            RelocationInsn::Adr => {
+                mask = ((extract_bits(extracted_value, 0, 2) as u32) << 29)
+                    | ((extract_bits(extracted_value, 2, 32) as u32) << 5);
+            }
+            // C6.2.252, C6.2.254
+            RelocationInsn::Movkz => {
+                mask = (extracted_value as u32) << 5;
+            }
+            // C6.2.253, C6.2.254
+            RelocationInsn::Movnz => {
+                let negative = (original_value as i64) < 0;
+                let mut value = extracted_value as i64;
+                mask = 0u32;
+                if negative {
+                    value = !value;
+                } else {
+                    // Set opcode for MOVZ instruction
+                    mask |= 1 << 30;
+                }
+                mask |= extract_bits(value as u64, 0, 16) as u32;
+            }
+            // C6.2.192
+            RelocationInsn::Ldr => {
+                mask = (extracted_value as u32) << 5;
+            }
+            // C6.2.5
+            RelocationInsn::Add => {
+                mask = (extracted_value as u32) << 10;
+            }
+            // C7.2.208, C6.2.383
+            RelocationInsn::LdSt => {
+                mask = (extracted_value as u32) << 10;
+            }
+            // C6.2.438
+            RelocationInsn::TstBr => {
+                mask = (extracted_value as u32) << 5;
+            }
+            // C6.2.34
+            RelocationInsn::Bcond => {
+                mask = (extracted_value as u32) << 5;
+            }
+            // C6.2.33
+            RelocationInsn::JumpCall => {
+                mask = extracted_value as u32;
+            }
+        }
+        // Read the original value and combine it with the prepared mask.
+        let mask_bytes = &mask.to_le_bytes();
+        for (i, v) in mask_bytes.iter().enumerate() {
+            dest[i] = *v;
+        }
     }
 }

--- a/wild_lib/src/aarch64.rs
+++ b/wild_lib/src/aarch64.rs
@@ -2,7 +2,7 @@ use crate::elf::extract_bits;
 use crate::elf::BitRange;
 use crate::elf::DynamicRelocationKind;
 use crate::elf::PageMask;
-use crate::elf::RelocationInsn;
+use crate::elf::RelocationInstruction;
 use crate::elf::RelocationKind;
 use crate::elf::RelocationKindInfo;
 use crate::elf::RelocationSize;
@@ -57,7 +57,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Absolute,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 0, end: 16 },
-                    insn: RelocationInsn::Movkz,
+                    insn: RelocationInstruction::Movkz,
                 },
                 None,
             ),
@@ -65,7 +65,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Absolute,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 16, end: 32 },
-                    insn: RelocationInsn::Movkz,
+                    insn: RelocationInstruction::Movkz,
                 },
                 None,
             ),
@@ -73,7 +73,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Absolute,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 32, end: 48 },
-                    insn: RelocationInsn::Movkz,
+                    insn: RelocationInstruction::Movkz,
                 },
                 None,
             ),
@@ -81,7 +81,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Absolute,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 48, end: 64 },
-                    insn: RelocationInsn::Movkz,
+                    insn: RelocationInstruction::Movkz,
                 },
                 None,
             ),
@@ -90,7 +90,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Absolute,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 0, end: 16 },
-                    insn: RelocationInsn::Movnz,
+                    insn: RelocationInstruction::Movnz,
                 },
                 None,
             ),
@@ -98,7 +98,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Absolute,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 16, end: 32 },
-                    insn: RelocationInsn::Movnz,
+                    insn: RelocationInstruction::Movnz,
                 },
                 None,
             ),
@@ -106,7 +106,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Absolute,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 32, end: 48 },
-                    insn: RelocationInsn::Movnz,
+                    insn: RelocationInstruction::Movnz,
                 },
                 None,
             ),
@@ -115,7 +115,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Relative,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 2, end: 21 },
-                    insn: RelocationInsn::Ldr,
+                    insn: RelocationInstruction::Ldr,
                 },
                 None,
             ),
@@ -123,7 +123,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Relative,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 0, end: 21 },
-                    insn: RelocationInsn::Adr,
+                    insn: RelocationInstruction::Adr,
                 },
                 None,
             ),
@@ -132,7 +132,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Relative,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 12, end: 33 },
-                    insn: RelocationInsn::Adr,
+                    insn: RelocationInstruction::Adr,
                 },
                 Some(PageMask::SymbolPlusAddendAndPosition),
             ),
@@ -140,7 +140,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Absolute,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 0, end: 12 },
-                    insn: RelocationInsn::Add,
+                    insn: RelocationInstruction::Add,
                 },
                 None,
             ),
@@ -148,7 +148,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Absolute,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 0, end: 12 },
-                    insn: RelocationInsn::LdSt,
+                    insn: RelocationInstruction::LdSt,
                 },
                 None,
             ),
@@ -156,7 +156,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Absolute,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 1, end: 12 },
-                    insn: RelocationInsn::LdSt,
+                    insn: RelocationInstruction::LdSt,
                 },
                 None,
             ),
@@ -164,7 +164,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Absolute,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 2, end: 12 },
-                    insn: RelocationInsn::LdSt,
+                    insn: RelocationInstruction::LdSt,
                 },
                 None,
             ),
@@ -172,7 +172,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Absolute,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 3, end: 12 },
-                    insn: RelocationInsn::LdSt,
+                    insn: RelocationInstruction::LdSt,
                 },
                 None,
             ),
@@ -180,7 +180,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Absolute,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 4, end: 12 },
-                    insn: RelocationInsn::LdSt,
+                    insn: RelocationInstruction::LdSt,
                 },
                 None,
             ),
@@ -190,7 +190,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Relative,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 2, end: 16 },
-                    insn: RelocationInsn::TstBr,
+                    insn: RelocationInstruction::TstBr,
                 },
                 None,
             ),
@@ -198,7 +198,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Relative,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 2, end: 21 },
-                    insn: RelocationInsn::Bcond,
+                    insn: RelocationInstruction::Bcond,
                 },
                 None,
             ),
@@ -206,7 +206,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Relative,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 2, end: 28 },
-                    insn: RelocationInsn::JumpCall,
+                    insn: RelocationInstruction::JumpCall,
                 },
                 None,
             ),
@@ -214,7 +214,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Relative,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 2, end: 28 },
-                    insn: RelocationInsn::JumpCall,
+                    insn: RelocationInstruction::JumpCall,
                 },
                 None,
             ),
@@ -224,7 +224,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Relative,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 0, end: 16 },
-                    insn: RelocationInsn::Movnz,
+                    insn: RelocationInstruction::Movnz,
                 },
                 None,
             ),
@@ -232,7 +232,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Relative,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 0, end: 16 },
-                    insn: RelocationInsn::Movkz,
+                    insn: RelocationInstruction::Movkz,
                 },
                 None,
             ),
@@ -240,7 +240,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Relative,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 16, end: 32 },
-                    insn: RelocationInsn::Movnz,
+                    insn: RelocationInstruction::Movnz,
                 },
                 None,
             ),
@@ -248,7 +248,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Relative,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 16, end: 32 },
-                    insn: RelocationInsn::Movkz,
+                    insn: RelocationInstruction::Movkz,
                 },
                 None,
             ),
@@ -256,7 +256,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Relative,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 32, end: 48 },
-                    insn: RelocationInsn::Movnz,
+                    insn: RelocationInstruction::Movnz,
                 },
                 None,
             ),
@@ -264,7 +264,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Relative,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 32, end: 48 },
-                    insn: RelocationInsn::Movkz,
+                    insn: RelocationInstruction::Movkz,
                 },
                 None,
             ),
@@ -272,7 +272,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Relative,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 48, end: 64 },
-                    insn: RelocationInsn::Movnz,
+                    insn: RelocationInstruction::Movnz,
                 },
                 None,
             ),
@@ -282,7 +282,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::GotRelGotBase,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 0, end: 16 },
-                    insn: RelocationInsn::Movnz,
+                    insn: RelocationInstruction::Movnz,
                 },
                 None,
             ),
@@ -290,7 +290,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::GotRelGotBase,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 0, end: 16 },
-                    insn: RelocationInsn::Movkz,
+                    insn: RelocationInstruction::Movkz,
                 },
                 None,
             ),
@@ -298,7 +298,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::GotRelGotBase,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 16, end: 32 },
-                    insn: RelocationInsn::Movnz,
+                    insn: RelocationInstruction::Movnz,
                 },
                 None,
             ),
@@ -306,7 +306,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::GotRelGotBase,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 16, end: 32 },
-                    insn: RelocationInsn::Movkz,
+                    insn: RelocationInstruction::Movkz,
                 },
                 None,
             ),
@@ -314,7 +314,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::GotRelGotBase,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 32, end: 48 },
-                    insn: RelocationInsn::Movnz,
+                    insn: RelocationInstruction::Movnz,
                 },
                 None,
             ),
@@ -322,7 +322,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::GotRelGotBase,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 32, end: 48 },
-                    insn: RelocationInsn::Movkz,
+                    insn: RelocationInstruction::Movkz,
                 },
                 None,
             ),
@@ -330,7 +330,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::GotRelGotBase,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 48, end: 64 },
-                    insn: RelocationInsn::Movnz,
+                    insn: RelocationInstruction::Movnz,
                 },
                 None,
             ),
@@ -352,7 +352,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::GotRelative,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 2, end: 21 },
-                    insn: RelocationInsn::LdSt,
+                    insn: RelocationInstruction::LdSt,
                 },
                 None,
             ),
@@ -360,7 +360,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::GotRelGotBase,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 3, end: 15 },
-                    insn: RelocationInsn::LdSt,
+                    insn: RelocationInstruction::LdSt,
                 },
                 None,
             ),
@@ -368,7 +368,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::GotRelative,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 12, end: 33 },
-                    insn: RelocationInsn::Adr,
+                    insn: RelocationInstruction::Adr,
                 },
                 Some(PageMask::GotEntryAndPosition),
             ),
@@ -376,7 +376,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::Got,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 3, end: 12 },
-                    insn: RelocationInsn::LdSt,
+                    insn: RelocationInstruction::LdSt,
                 },
                 None,
             ),
@@ -384,7 +384,7 @@ impl crate::arch::Arch for AArch64 {
                 RelocationKind::GotRelGotBase,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 3, end: 15 },
-                    insn: RelocationInsn::LdSt,
+                    insn: RelocationInstruction::LdSt,
                 },
                 Some(PageMask::GotBase),
             ),
@@ -446,7 +446,7 @@ impl crate::arch::Relaxation for () {
     }
 }
 
-impl RelocationInsn {
+impl RelocationInstruction {
     // Encode computed relocation value and store it based on the encoding of an instruction.
     // Each instruction links to a chapter in the Arm Architecture Reference Manual for A-profile architecture
     // manual: https://developer.arm.com/documentation/ddi0487/latest/
@@ -454,16 +454,16 @@ impl RelocationInsn {
         let mut mask;
         match self {
             // C6.2.13
-            RelocationInsn::Adr => {
+            RelocationInstruction::Adr => {
                 mask = ((extract_bits(extracted_value, 0, 2) as u32) << 29)
                     | ((extract_bits(extracted_value, 2, 32) as u32) << 5);
             }
             // C6.2.252, C6.2.254
-            RelocationInsn::Movkz => {
+            RelocationInstruction::Movkz => {
                 mask = (extracted_value as u32) << 5;
             }
             // C6.2.253, C6.2.254
-            RelocationInsn::Movnz => {
+            RelocationInstruction::Movnz => {
                 let negative = (original_value as i64) < 0;
                 let mut value = extracted_value as i64;
                 mask = 0u32;
@@ -476,27 +476,27 @@ impl RelocationInsn {
                 mask |= extract_bits(value as u64, 0, 16) as u32;
             }
             // C6.2.192
-            RelocationInsn::Ldr => {
+            RelocationInstruction::Ldr => {
                 mask = (extracted_value as u32) << 5;
             }
             // C6.2.5
-            RelocationInsn::Add => {
+            RelocationInstruction::Add => {
                 mask = (extracted_value as u32) << 10;
             }
             // C7.2.208, C6.2.383
-            RelocationInsn::LdSt => {
+            RelocationInstruction::LdSt => {
                 mask = (extracted_value as u32) << 10;
             }
             // C6.2.438
-            RelocationInsn::TstBr => {
+            RelocationInstruction::TstBr => {
                 mask = (extracted_value as u32) << 5;
             }
             // C6.2.34
-            RelocationInsn::Bcond => {
+            RelocationInstruction::Bcond => {
                 mask = (extracted_value as u32) << 5;
             }
             // C6.2.33
-            RelocationInsn::JumpCall => {
+            RelocationInstruction::JumpCall => {
                 mask = extracted_value as u32;
             }
         }

--- a/wild_lib/src/aarch64.rs
+++ b/wild_lib/src/aarch64.rs
@@ -503,7 +503,7 @@ impl RelocationInsn {
         // Read the original value and combine it with the prepared mask.
         let mask_bytes = &mask.to_le_bytes();
         for (i, v) in mask_bytes.iter().enumerate() {
-            dest[i] = *v;
+            dest[i] |= *v;
         }
     }
 }

--- a/wild_lib/src/elf.rs
+++ b/wild_lib/src/elf.rs
@@ -540,7 +540,7 @@ pub(crate) struct BitRange {
 }
 
 #[derive(Clone, Debug, Copy)]
-pub(crate) enum RelocationInsn {
+pub(crate) enum RelocationInstruction {
     Adr,
     Movkz,
     Movnz,
@@ -557,7 +557,7 @@ pub(crate) enum RelocationSize {
     ByteSize(usize),
     BitMasking {
         range: BitRange,
-        insn: RelocationInsn,
+        insn: RelocationInstruction,
     },
 }
 

--- a/wild_lib/src/elf.rs
+++ b/wild_lib/src/elf.rs
@@ -502,104 +502,83 @@ pub(crate) enum RelocationKind {
     None,
 }
 
-#[derive(Clone, Debug, Copy)]
-pub(crate) enum RelocationSize {
-    ByteSize(usize),
-    // Half-opened range bounded inclusively below and exclusively above: [start, end)
-    BitRange { start: u32, end: u32 },
-}
-
-impl RelocationSize {
-    pub(crate) fn write_to_buffer(self, mut value: u64, output: &mut [u8]) -> Result<()> {
-        let byte_size;
-        let mut partial_byte_offset = None;
-
-        match self {
-            RelocationSize::ByteSize(s) => {
-                byte_size = s;
-            }
-            RelocationSize::BitRange { start, end } => {
-                // Drop the upper bits first
-                debug_assert!(end <= u64::BITS);
-                let mask = if end == u64::BITS {
-                    u64::MAX
-                } else {
-                    (1 << end) - 1
-                };
-                value &= mask;
-                value >>= start;
-
-                let bit_count = end - start;
-                byte_size = (bit_count / u8::BITS) as usize;
-                // And extra partial byte needs to be added (ORed) to the output buffer!
-                if bit_count % u8::BITS != 0 {
-                    partial_byte_offset = Some(byte_size);
-                }
-            }
-        }
-
-        ensure!(
-            byte_size <= output.len(),
-            "Relocation outside of bounds of section"
-        );
-        let value_bytes = value.to_le_bytes();
-        output[..byte_size].copy_from_slice(&value_bytes[..byte_size]);
-        if let Some(offset) = partial_byte_offset {
-            output[offset] |= value_bytes[offset];
-        }
-
-        Ok(())
-    }
+/// Extract range-specified ([`start`..`end`]) bits from the provided `value`.
+pub fn extract_bits(value: u64, start: u32, end: u32) -> u64 {
+    debug_assert!(start < end);
+    (value >> (start)) & ((1 << (end - start)) - 1)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::extract_bits;
 
     #[test]
-    fn verify_relocation_write() {
-        let mut buffer = [0xffu8; 4];
-        RelocationSize::ByteSize(2)
-            .write_to_buffer(0x0201, &mut buffer)
-            .unwrap();
-        assert_eq!(buffer, [0x01, 0x02, 0xff, 0xff]);
+    fn test_bit_operations() {
+        assert_eq!(0b11000, extract_bits(0b1100_0000, 3, 8));
+        assert_eq!(0b1010_1010_0000, extract_bits(0b10101010_00001111, 4, 16));
+        assert_eq!(u32::MAX, extract_bits(u64::MAX, 0, 32) as u32);
+    }
 
-        let v = 0x0807060504030201;
-        let mut buffer = [0u8; 128];
-        RelocationSize::ByteSize(8)
-            .write_to_buffer(v, &mut buffer)
-            .unwrap();
-        assert_eq!(
-            &buffer[..8],
-            &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]
-        );
-        assert!(buffer[8..].iter().all(|&x| x == 0));
-        let mut buffer2 = [0u8; 128];
-        RelocationSize::BitRange { start: 0, end: 64 }
-            .write_to_buffer(v, &mut buffer2)
-            .unwrap();
-        assert_eq!(buffer, buffer2);
+    #[test]
+    #[should_panic]
+    fn test_extract_bits_wrong_range() {
+        extract_bits(0, 2, 1);
+    }
 
-        // 2 bits (0b11) are added to the second byte of the buffer
-        let mut buffer = [0, 0b1010_0000];
-        RelocationSize::BitRange { start: 0, end: 10 }
-            .write_to_buffer(0xffff, &mut buffer)
-            .unwrap();
-        assert_eq!(&buffer, &[0b1111_1111, 0b1010_0011]);
+    #[test]
+    #[should_panic]
+    fn test_extract_bits_too_large() {
+        extract_bits(0, 0, 100);
+    }
+}
 
-        // 2 bits (0b11 as the first bit is skipped) are added to the second byte of the buffer
-        let mut buffer = dbg!([0, 0b1010_0000]);
-        RelocationSize::BitRange { start: 1, end: 11 }
-            .write_to_buffer(0xfffe, &mut buffer)
-            .unwrap();
-        assert_eq!(&buffer, &[0b1111_1111, 0b1010_0011]);
+// Half-opened range bounded inclusively below and exclusively above: [`start``, `end`)
+#[derive(Clone, Debug, Copy)]
+pub(crate) struct BitRange {
+    pub(crate) start: u32,
+    pub(crate) end: u32,
+}
 
-        // upper 4 bits of the value are added to buffer
-        let mut buffer = dbg!([0b1010_0000]);
-        RelocationSize::BitRange { start: 4, end: 8 }
-            .write_to_buffer(0b1000_1111, &mut buffer)
-            .unwrap();
-        assert_eq!(&buffer, &[0b1010_1000]);
+#[derive(Clone, Debug, Copy)]
+pub(crate) enum RelocationInsn {
+    Adr,
+    Movkz,
+    Movnz,
+    Ldr,
+    Add,
+    LdSt,
+    TstBr,
+    Bcond,
+    JumpCall,
+}
+
+#[derive(Clone, Debug, Copy)]
+pub(crate) enum RelocationSize {
+    ByteSize(usize),
+    BitMasking {
+        range: BitRange,
+        insn: RelocationInsn,
+    },
+}
+
+impl RelocationSize {
+    pub(crate) fn write_to_buffer(self, value: u64, output: &mut [u8]) -> Result<()> {
+        match self {
+            RelocationSize::ByteSize(byte_size) => {
+                ensure!(
+                    byte_size <= output.len(),
+                    "Relocation outside of bounds of section"
+                );
+                let value_bytes = value.to_le_bytes();
+                output[..byte_size].copy_from_slice(&value_bytes[..byte_size]);
+            }
+            RelocationSize::BitMasking { range, insn } => {
+                let extracted_value = extract_bits(value, range.start, range.end);
+                insn.write_to_value(extracted_value, value, &mut output[..4]);
+            }
+        }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This adds yet another relocation application layer where the AArch64 instruction relocations have a handler that known how to encode a computed value into a given instruction.

With the change, the tests improved from:
`test result: FAILED. 5 passed; 26 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.25s`
to:
`test result: FAILED. 15 passed; 16 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.86s`