### PR TITLE
Add flag --update-in-place

### DIFF
--- a/linker-diff/src/asm_diff.rs
+++ b/linker-diff/src/asm_diff.rs
@@ -74,6 +74,7 @@ pub(crate) fn report_function_diffs(report: &mut Report, objects: &[Object]) {
             }
         }
     }
+
     // If we got an error building our index, then don't try to diff functions. We'd just get heaps
     // of diffs due to an incomplete index.
     if objects
@@ -82,6 +83,7 @@ pub(crate) fn report_function_diffs(report: &mut Report, objects: &[Object]) {
     {
         return;
     }
+
     report.add_diffs(
         all_symbols
             .into_par_iter()


### PR DESCRIPTION
When set, this causes us to overwrite the existing file instead of deleting it and putting a new file in its place. On one benchmark (rustc without debug) this gave about a 4% speedup. On another (clang with debug) the difference was small enough that it was hard to measure.