### PR TITLE
AArch64: add write_plt_entry

### DIFF
--- a/libwild/src/arch.rs
+++ b/libwild/src/arch.rs
@@ -3,10 +3,10 @@
 use crate::args::OutputKind;
 use crate::elf::DynamicRelocationKind;
 use crate::elf::RelocationKindInfo;
+use crate::error::Result;
 use crate::relaxation::RelocationModifier;
 use crate::resolution::ValueFlags;
 use anyhow::bail;
-use anyhow::Result;
 use linker_utils::elf::SectionFlags;
 use std::borrow::Cow;
 use std::str::FromStr;
@@ -19,6 +19,9 @@ pub(crate) trait Arch {
 
     // Get dynamic relocation value specific for the architecture.
     fn get_dynamic_relocation_type(relocation: DynamicRelocationKind) -> u32;
+
+    // Write PLT entry for the architecture.
+    fn write_plt_entry(plt_entry: &mut [u8], got_address: u64, plt_address: u64) -> Result;
 
     // Make architecture-specific parsing of the relocation types.
     fn relocation_from_raw(r_type: u32) -> Result<RelocationKindInfo>;


### PR DESCRIPTION
Right now, we share the entry size for x86_64 and AArch64; however, we could use a smaller size for AArch64. 

The problem is that the size is used in `const SECTION_DEFINITIONS`, a const array for which we don't currently make any special code based on the `Arch`. Do you have any idea how to tackle this in the future?

With the changes, I was able to emit a working PLT entry for a symbol from `libc` shared library on AArch64 platform.