### PR TITLE
Introduce `Arch` directive in integration tests

### DIFF
--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -158,6 +158,20 @@ impl Config {
             .into_iter()
             .map(ToOwned::to_owned),
         );
+
+        #[cfg(target_arch = "aarch64")]
+        {
+            self.ignore.extend(
+                [
+                    // Other linkers have a bigger initial PLT entry, thus the entsize is set to zero:
+                    // https://sourceware.org/bugzilla/show_bug.cgi?id=26312
+                    "section.plt.entsize",
+                ]
+                .into_iter()
+                .map(ToOwned::to_owned),
+            )
+        }
+
         self.equiv.push((
             GOT_SECTION_NAME_STR.to_owned(),
             GOT_PLT_SECTION_NAME_STR.to_owned(),

--- a/wild/tests/sources/global_references.c
+++ b/wild/tests/sources/global_references.c
@@ -5,6 +5,7 @@
 
 // Returns the passed value, but don't let the compiler make any assumptions about the returned
 // value.
+#if defined(__x86_64__)
 int black_box(int input) {
     register int rdi __asm__ ("rdi") = input;
     __asm__ __volatile__ (
@@ -13,6 +14,16 @@ int black_box(int input) {
     );
     return rdi;
 }
+#elif defined(__aarch64__)
+int black_box(int input) {
+    register int w0 __asm__ ("w0") = input;
+    __asm__ __volatile__ (
+        "nop"
+        : "+r" (w0)
+    );
+    return w0;
+}
+#endif
 
 void _start() {
     if (global_value != 38) {

--- a/wild/tests/sources/got_ref_to_local.c
+++ b/wild/tests/sources/got_ref_to_local.c
@@ -4,6 +4,7 @@
 //#Object:got_ref_to_local-1.s
 //#LinkArgs:-z noexecstack
 //#Object:exit.c
+//#Arch: x86_64
 
 #include "exit.h"
 

--- a/wild/tests/sources/local_symbol_refs.s
+++ b/wild/tests/sources/local_symbol_refs.s
@@ -7,6 +7,7 @@
 //#Object:exit.c
 //#LinkArgs:-z noexecstack
 //#EnableLinker:lld
+//#Arch: x86_64
 
 .section        .rodata.x,"aM",@progbits,16
 .p2align        4, 0x0

--- a/wild/tests/sources/non-alloc.s
+++ b/wild/tests/sources/non-alloc.s
@@ -2,6 +2,7 @@
 
 //#LinkArgs:-z noexecstack
 //#Object:exit.c
+//#Arch: x86_64
 
 .section .nonloadable, "R", @progbits
     .asciz "Hello, World!"

--- a/wild/tests/sources/old_init.c
+++ b/wild/tests/sources/old_init.c
@@ -12,6 +12,7 @@
 //#Object:exit.c
 //#LinkArgs:-z noexecstack
 //#EnableLinker:lld
+//#Arch: x86_64
 
 #include "exit.h"
 

--- a/wild/tests/sources/rust-integration.rs
+++ b/wild/tests/sources/rust-integration.rs
@@ -6,9 +6,19 @@
 
 //#Config:llvm-static:default
 //#CompArgs:--target x86_64-unknown-linux-musl -C relocation-model=static -C target-feature=+crt-static -C debuginfo=2
+//#Arch: x86_64
+
+//#Config:llvm-static-aarch64:default
+//#CompArgs:--target aarch64-unknown-linux-musl -C relocation-model=static -C target-feature=+crt-static -C debuginfo=2
+//#Arch: aarch64
 
 //#Config:cranelift-static:default
 //#CompArgs:-Zcodegen-backend=cranelift --target x86_64-unknown-linux-musl -C relocation-model=static -C target-feature=+crt-static -C debuginfo=2 --cfg cranelift
+//#Arch: x86_64
+
+//#Config:cranelift-static-aarch64:default
+//#CompArgs:-Zcodegen-backend=cranelift --target aarch64-unknown-linux-musl -C relocation-model=static -C target-feature=+crt-static -C debuginfo=2 --cfg cranelift
+//#Arch: aarch64
 
 //#Config:llvm-dynamic:default
 //#CompArgs:-C debuginfo=2

--- a/wild/tests/sources/stack_alignment.s
+++ b/wild/tests/sources/stack_alignment.s
@@ -4,6 +4,7 @@
 //#Object:exit.c
 //#LinkArgs:-z noexecstack
 //#EnableLinker:lld
+//#Arch: x86_64
 
 .globl _start
 _start:

--- a/wild/tests/sources/string_merging.c
+++ b/wild/tests/sources/string_merging.c
@@ -6,6 +6,7 @@
 //#Object:string_merging1.s
 //#Object:string_merging2.s
 //#Object:exit.c
+//#Arch: x86_64
 
 #include "exit.h"
 

--- a/wild/tests/sources/tls.c
+++ b/wild/tests/sources/tls.c
@@ -2,6 +2,7 @@
 //#Object:tls1.c
 //#Object:init_tls.c
 //#Object:exit.c
+//#Arch: x86_64
 
 //#Config:global-dynamic-0:default
 //#CompArgs:-ftls-model=global-dynamic

--- a/wild/tests/sources/trivial_asm.s
+++ b/wild/tests/sources/trivial_asm.s
@@ -1,5 +1,6 @@
 //#LinkArgs:-z noexecstack
 //#Object:exit.c
+//#Arch: x86_64
 
 .section        .data.foo
 .p2align        4, 0x0


### PR DESCRIPTION
Add AArch64-specific ignores.