### PR TITLE
Add -fno-stack-protector to `weak-vars.c`

### DIFF
--- a/wild/tests/sources/weak-vars.c
+++ b/wild/tests/sources/weak-vars.c
@@ -1,7 +1,7 @@
 //#AbstractConfig:default
 //#Object:weak-vars1.c
 //#Object:exit.c
-//#CompArgs:-ffreestanding -fno-builtin
+//#CompArgs:-ffreestanding -fno-builtin -fno-stack-protector
 
 #include "exit.h"
 


### PR DESCRIPTION
This fixes linking this test with ld.bfd on Arch Linux.

CC https://github.com/davidlattimore/wild/issues/230