### PR TITLE
AArch64: implement properly local-exec TLS model relocations

### DIFF
--- a/libwild/src/aarch64.rs
+++ b/libwild/src/aarch64.rs
@@ -644,7 +644,7 @@ impl crate::arch::Arch for AArch64 {
 
             // 5.7.11.4   Local Exec thread-local storage model
             object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G2 => (
-                RelocationKind::TpOff,
+                RelocationKind::TpOffAArch64,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 32, end: 48 },
                     insn: RelocationInstruction::Movnz,
@@ -652,7 +652,7 @@ impl crate::arch::Arch for AArch64 {
                 None,
             ),
             object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G1 => (
-                RelocationKind::TpOff,
+                RelocationKind::TpOffAArch64,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 16, end: 32 },
                     insn: RelocationInstruction::Movnz,
@@ -660,7 +660,7 @@ impl crate::arch::Arch for AArch64 {
                 None,
             ),
             object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G1_NC => (
-                RelocationKind::TpOff,
+                RelocationKind::TpOffAArch64,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 16, end: 32 },
                     insn: RelocationInstruction::Movkz,
@@ -668,7 +668,7 @@ impl crate::arch::Arch for AArch64 {
                 None,
             ),
             object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G0 => (
-                RelocationKind::TpOff,
+                RelocationKind::TpOffAArch64,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 0, end: 16 },
                     insn: RelocationInstruction::Movnz,
@@ -676,7 +676,7 @@ impl crate::arch::Arch for AArch64 {
                 None,
             ),
             object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G0_NC => (
-                RelocationKind::TpOff,
+                RelocationKind::TpOffAArch64,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 0, end: 16 },
                     insn: RelocationInstruction::Movkz,
@@ -684,7 +684,7 @@ impl crate::arch::Arch for AArch64 {
                 None,
             ),
             object::elf::R_AARCH64_TLSLE_ADD_TPREL_HI12 => (
-                RelocationKind::TpOff,
+                RelocationKind::TpOffAArch64,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 12, end: 24 },
                     insn: RelocationInstruction::Add,
@@ -693,7 +693,7 @@ impl crate::arch::Arch for AArch64 {
             ),
             object::elf::R_AARCH64_TLSLE_ADD_TPREL_LO12
             | object::elf::R_AARCH64_TLSLE_ADD_TPREL_LO12_NC => (
-                RelocationKind::TpOff,
+                RelocationKind::TpOffAArch64,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 0, end: 12 },
                     insn: RelocationInstruction::Add,
@@ -702,7 +702,7 @@ impl crate::arch::Arch for AArch64 {
             ),
             object::elf::R_AARCH64_TLSLE_LDST8_TPREL_LO12
             | object::elf::R_AARCH64_TLSLE_LDST8_TPREL_LO12_NC => (
-                RelocationKind::TpOff,
+                RelocationKind::TpOffAArch64,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 0, end: 12 },
                     insn: RelocationInstruction::LdSt,
@@ -711,7 +711,7 @@ impl crate::arch::Arch for AArch64 {
             ),
             object::elf::R_AARCH64_TLSLE_LDST16_TPREL_LO12
             | object::elf::R_AARCH64_TLSLE_LDST16_TPREL_LO12_NC => (
-                RelocationKind::TpOff,
+                RelocationKind::TpOffAArch64,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 1, end: 12 },
                     insn: RelocationInstruction::LdSt,
@@ -720,7 +720,7 @@ impl crate::arch::Arch for AArch64 {
             ),
             object::elf::R_AARCH64_TLSLE_LDST32_TPREL_LO12
             | object::elf::R_AARCH64_TLSLE_LDST32_TPREL_LO12_NC => (
-                RelocationKind::TpOff,
+                RelocationKind::TpOffAArch64,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 2, end: 12 },
                     insn: RelocationInstruction::LdSt,
@@ -729,7 +729,7 @@ impl crate::arch::Arch for AArch64 {
             ),
             object::elf::R_AARCH64_TLSLE_LDST64_TPREL_LO12
             | object::elf::R_AARCH64_TLSLE_LDST64_TPREL_LO12_NC => (
-                RelocationKind::TpOff,
+                RelocationKind::TpOffAArch64,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 3, end: 12 },
                     insn: RelocationInstruction::LdSt,
@@ -738,7 +738,7 @@ impl crate::arch::Arch for AArch64 {
             ),
             object::elf::R_AARCH64_TLSLE_LDST128_TPREL_LO12
             | object::elf::R_AARCH64_TLSLE_LDST128_TPREL_LO12_NC => (
-                RelocationKind::TpOff,
+                RelocationKind::TpOffAArch64,
                 RelocationSize::BitMasking {
                     range: BitRange { start: 4, end: 12 },
                     insn: RelocationInstruction::LdSt,

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -1872,6 +1872,10 @@ fn apply_relocation<S: StorageModel, A: Arch>(
             .value()
             .wrapping_sub(layout.tls_end_address())
             .wrapping_add(addend),
+        RelocationKind::TpOffAArch64 => resolution
+            .value()
+            .wrapping_sub(layout.tls_start_address_aarch64())
+            .wrapping_add(addend),
         RelocationKind::None => 0,
     };
     rel_info

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -1346,6 +1346,14 @@ impl<'data, S: StorageModel> Layout<'data, '_, S> {
         alignment.align_up(tls_end)
     }
 
+    /// Returns the memory address of the start of the TLS segment used by the AArch64.
+    pub(crate) fn tls_start_address_aarch64(&self) -> u64 {
+        let tdata = self.section_layouts.get(output_section_id::TDATA);
+        // Two words at TP are reserved by the arch.
+        let tls_start = tdata.mem_offset - 2 * 8;
+        tdata.alignment.align_down(tls_start)
+    }
+
     pub(crate) fn layout_data(&self) -> linker_layout::Layout {
         let files = self
             .group_layouts
@@ -2478,6 +2486,7 @@ fn resolution_flags(rel_kind: RelocationKind) -> ResolutionFlags {
         | RelocationKind::Relative
         | RelocationKind::DtpOff
         | RelocationKind::TpOff
+        | RelocationKind::TpOffAArch64
         | RelocationKind::SymRelGotBase
         | RelocationKind::Got
         | RelocationKind::None => ResolutionFlags::DIRECT,

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -571,6 +571,9 @@ pub enum RelocationKind {
     /// The offset of a TLS variable within the executable's TLS storage.
     TpOff,
 
+    /// The offset of a TLS variable within the executable's TLS storage, AArch64 TLS block layout.
+    TpOffAArch64,
+
     /// No relocation needs to be applied. Produced when we eliminate a relocation due to an
     /// optimisation.
     None,

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -1340,7 +1340,8 @@ fn integration_test(
         "cpp-integration.cc",
         "rust-tls.rs",
         "input_does_not_exist.c",
-        "ifunc2.c"
+        "ifunc2.c",
+        "tls-local-exec.c"
     )]
     program_name: &'static str,
     #[allow(unused_variables)] setup_symlink: (),

--- a/wild/tests/sources/tls-local-exec.c
+++ b/wild/tests/sources/tls-local-exec.c
@@ -1,0 +1,19 @@
+//#AbstractConfig:default
+//#DiffIgnore:.dynamic.DT_NEEDED
+//#DiffIgnore:section.data
+//#DiffIgnore:section.data.alignment
+//#DiffIgnore:section.rodata
+//#DiffIgnore:section.rodata.alignment
+
+//#Config:pie:default
+//#CompArgs:-fpie
+//#LinkArgs:--cc=gcc -Wl,-z,now
+
+__thread long tvar = 1;
+__thread int tvar2 = 2;
+__thread char tvar3 = 3;
+
+int main() {
+  // __builtin_printf ("%ld, %d, %d\n", tvar, tvar2, tvar3);
+  return tvar + tvar2 + tvar3 + 36;
+}


### PR DESCRIPTION
There are 2 TLS variants and AArch64 uses the other one than x86_64:
https://maskray.me/blog/2021-02-14-all-about-thread-local-storage#tls-variants