### PR TITLE
Solve easy todos

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -139,8 +139,7 @@ pub(crate) const FILES_PER_GROUP_ENV: &str = "WILD_FILES_PER_GROUP";
 // other linkers. On the other, we should perhaps somehow let the user know that we don't support a
 // feature.
 const SILENTLY_IGNORED_FLAGS: &[&str] = &[
-    // TODO: Think about if anything is needed here. We don't need groups in order resolve cycles,
-    // so perhaps ignoring these is the right thing to do.
+    // Just like other modern linkers, we don't need groups in order resolve cycles.
     "start-group",
     "end-group",
     // TODO: This is supposed to suppress built-in search paths, but I don't think we have any

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -17,6 +17,7 @@ use object::read::elf::SectionHeader as _;
 use object::LittleEndian;
 use std::borrow::Cow;
 use std::io::Read as _;
+use std::mem::offset_of;
 use std::sync::atomic::Ordering;
 
 /// Our starting address in memory when linking non-relocatable executables. We can start memory
@@ -296,8 +297,7 @@ pub(crate) struct EhFrameHdr {
     pub(crate) entry_count: u32,
 }
 
-// TODO: Use offset-of once it's stable.
-pub(crate) const FRAME_POINTER_FIELD_OFFSET: usize = 4;
+pub(crate) const FRAME_POINTER_FIELD_OFFSET: usize = offset_of!(EhFrameHdr, frame_pointer);
 
 /// The offset of the offset within the structure passed to __tls_get_addr.
 pub(crate) const TLS_OFFSET_OFFSET: u64 = 8;


### PR DESCRIPTION
- Turn TODO about archive groups into a comment
Mold and MinGW backend of LLD do the same thing.
ELF backend of LLD handles them but seems just fine without them.
- Use offset_of! instead of hardcoded value
It was stabilised in Rust 1.77
![image](https://github.com/user-attachments/assets/867d0251-6f7d-4fcd-ae09-aa07f9bff997)
