### PR TITLE
Slightly improve CLI compatibility with other linkers

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -154,6 +154,7 @@ const SILENTLY_IGNORED_FLAGS: &[&str] = &[
     "fatal-warnings",
     "color-diagnostics",
     "undefined-version",
+    "sort-common",
 ];
 
 const IGNORED_FLAGS: &[&str] = &["gdb-index", "disable-new-dtags"];

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -143,6 +143,8 @@ const SILENTLY_IGNORED_FLAGS: &[&str] = &[
     // so perhaps ignoring these is the right thing to do.
     "start-group",
     "end-group",
+    "(",
+    ")",
     // TODO: This is supposed to suppress built-in search paths, but I don't think we have any
     // built-in search paths. Perhaps we should?
     "nostdlib",
@@ -330,10 +332,10 @@ pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(mut input: I) -> Resul
             num_threads = Some(NonZeroUsize::try_from(rest.parse::<usize>()?)?);
         } else if long_arg_eq("no-threads") {
             num_threads = Some(NonZeroUsize::new(1).unwrap());
-        } else if long_arg_eq("strip-all") {
+        } else if long_arg_eq("strip-all") || arg == "-s" {
             strip_all = true;
             strip_debug = true;
-        } else if long_arg_eq("strip-debug") {
+        } else if long_arg_eq("strip-debug") || arg == "-S" {
             strip_debug = true;
         } else if long_arg_eq("gc-sections") {
             gc_sections = true;


### PR DESCRIPTION
- Add aliases for strip and group arguments
- Ignore `--sort-common` flag 
Arch Linux uses this flag when building packages:
https://gitlab.archlinux.org/archlinux/packaging/packages/pacman/-/blob/1b80cb88cf499898d10bb04964107d684f95acaf/makepkg.conf#L48