### PR TITLE
Identify ThinLTO archives to show nicer error

### DIFF
--- a/libwild/src/file_kind.rs
+++ b/libwild/src/file_kind.rs
@@ -52,6 +52,8 @@ impl FileKind {
             Ok(FileKind::Text)
         } else if bytes.starts_with(b"BC") {
             bail!("LLVM IR (LTO mode) is not supported yet");
+        } else if bytes.starts_with(b"!<thin>") {
+            bail!("ThinLTO archives are not supported yet");
         } else {
             bail!("Couldn't identify file type");
         }


### PR DESCRIPTION
When linking openh264 project with wild*, this error occurs:
```
[2/8] Linking target test/common/test_common
FAILED: test/common/test_common
c++  -o test/common/test_common test/common/test_common.p/CWelsListTest.cpp.o test/common/test_common.p/ExpandPicture.cpp.o test/common/test_common.p/WelsThreadPoolTest.cpp.o test/common/test_common.p/WelsTaskListTest.cpp.o -Wl,--as-needed -Wl,--no-undefined -B/home/mateusz/projects/wild -Wl,--start-group codec/common/libcommon.a /usr/lib/libgtest_main.so /usr/lib/libgtest.so -Wl,--end-group -pthread
WARNING: wild: --plugin /usr/lib/gcc/x86_64-pc-linux-gnu/14.2.1/liblto_plugin.so is not yet supported
Error: Couldn't identify file type
collect2: error: ld returned 255 exit status
```

This is the file that causes it:
```
❯ xxd _build/codec/common/libcommon.a
00000000: 213c 7468 696e 3e0a 2f20 2020 2020 2020  !<thin>./
00000010: 2020 2020 2020 2020 3020 2020 2020 2020          0
00000020: 2020 2020 3020 2020 2020 3020 2020 2020      0     0
00000030: 3020 2020 2020 2020 3131 3230 3020 2020  0       11200
```

Steps to reproduce in openh264 repo checkout:
1. `mkdir -p build`
2. `meson setup _build/ -Dc_link_args="-B/home/mateusz/projects/wild" -Dcpp_link_args="-B/home/mateusz/projects/wild"`
3. `meson compile -C _build`

---

*Additional patch is necessary to get to this point:
```diff
diff --git a/libwild/src/args.rs b/libwild/src/args.rs
index 350009f12f..15e75b2591 100644
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -162,6 +162,7 @@
     "color-diagnostics",
     "undefined-version",
     "sort-common",
+    "no-undefined",
 ];

 const IGNORED_FLAGS: &[&str] = &["gdb-index", "disable-new-dtags"];
```
This is basically https://github.com/davidlattimore/wild/issues/20 and should get proper treatment instead of just ignoring the flags.
Also, other link jobs fail on https://github.com/davidlattimore/wild/issues/272