### PR TITLE
Initial support for TLS Descriptors (x86_64)

### DIFF
--- a/libwild/src/aarch64.rs
+++ b/libwild/src/aarch64.rs
@@ -763,6 +763,7 @@ impl crate::arch::Arch for AArch64 {
             DynamicRelocationKind::TpOff => object::elf::R_AARCH64_TLS_TPREL,
             DynamicRelocationKind::Relative => object::elf::R_AARCH64_RELATIVE,
             DynamicRelocationKind::DynamicSymbol => object::elf::R_AARCH64_GLOB_DAT,
+            DynamicRelocationKind::TlsDesc => object::elf::R_AARCH64_TLSDESC,
         }
     }
 

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -26,6 +26,8 @@ use std::sync::atomic::Ordering;
 /// up file and memory offsets.
 pub const NON_PIE_START_MEM_ADDRESS: u64 = 0x400_000;
 
+pub(crate) const TLS_MODULE_BASE_SYMBOL_NAME: &str = "_TLS_MODULE_BASE_";
+
 pub(crate) type FileHeader = object::elf::FileHeader64<LittleEndian>;
 pub(crate) type ProgramHeader = object::elf::ProgramHeader64<LittleEndian>;
 pub(crate) type SectionHeader = object::elf::SectionHeader64<LittleEndian>;

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -549,6 +549,7 @@ pub(crate) enum DynamicRelocationKind {
     Irelative,
     DtpMod,
     DtpOff,
+    TlsDesc,
     TpOff,
     Relative,
     DynamicSymbol,

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2542,21 +2542,16 @@ fn write_internal_symbols<S: StorageModel>(
             shndx = 1;
         }
 
-        let mut address = resolution.address()?;
-        let st_type = if symbol_name.bytes() == TLS_MODULE_BASE_SYMBOL_NAME.as_bytes() {
-            // TODO: handle properly the symbol address
-            if layout.args().output_kind != OutputKind::SharedObject {
-                address = layout.tls_end_address();
-            }
-            object::elf::STT_TLS
-        } else {
-            object::elf::STT_NOTYPE
-        };
-
+        let address = resolution.address()?;
         let entry = symbol_writer
             .define_symbol(false, shndx, address, 0, symbol_name.bytes())
             .with_context(|| format!("Failed to write {}", layout.symbol_debug(symbol_id)))?;
 
+        let st_type = if symbol_name.bytes() == TLS_MODULE_BASE_SYMBOL_NAME.as_bytes() {
+            object::elf::STT_TLS
+        } else {
+            object::elf::STT_NOTYPE
+        };
         entry.set_st_info(object::elf::STB_GLOBAL, st_type);
     }
     Ok(())

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2542,16 +2542,21 @@ fn write_internal_symbols<S: StorageModel>(
             shndx = 1;
         }
 
-        let address = resolution.address()?;
-        let entry = symbol_writer
-            .define_symbol(false, shndx, address, 0, symbol_name.bytes())
-            .with_context(|| format!("Failed to write {}", layout.symbol_debug(symbol_id)))?;
-
+        let mut address = resolution.address()?;
         let st_type = if symbol_name.bytes() == TLS_MODULE_BASE_SYMBOL_NAME.as_bytes() {
+            // TODO: handle properly the symbol address
+            if layout.args().output_kind != OutputKind::SharedObject {
+                address = layout.tls_end_address();
+            }
             object::elf::STT_TLS
         } else {
             object::elf::STT_NOTYPE
         };
+
+        let entry = symbol_writer
+            .define_symbol(false, shndx, address, 0, symbol_name.bytes())
+            .with_context(|| format!("Failed to write {}", layout.symbol_debug(symbol_id)))?;
+
         entry.set_st_info(object::elf::STB_GLOBAL, st_type);
     }
     Ok(())

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -877,6 +877,8 @@ impl<'data, 'layout, 'out> TableWriter<'data, 'layout, 'out> {
         res: &Resolution,
         got_address: u64,
     ) -> Result {
+        // TLS descriptor occupies 2 entries
+        self.take_next_got_entry()?;
         self.take_next_got_entry()?;
 
         anyhow::ensure!(
@@ -897,8 +899,6 @@ impl<'data, 'layout, 'out> TableWriter<'data, 'layout, 'out> {
         };
         self.write_tls_descriptor_relocation::<A>(got_address, dynamic_symbol_index, addend)?;
 
-        // TLS descriptor occupies 2 entries
-        self.take_next_got_entry()?;
         Ok(())
     }
 

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -879,6 +879,11 @@ impl<'data, 'layout, 'out> TableWriter<'data, 'layout, 'out> {
     ) -> Result {
         self.take_next_got_entry()?;
 
+        anyhow::ensure!(
+            !self.output_kind.is_static_executable(),
+            "Cannot create dynamic TLSDESC relocation (function trampoline will be missed) for a static executable"
+        );
+
         let dynamic_symbol_index = res.dynamic_symbol_index.map_or(0, std::num::NonZero::get);
         debug_assert_bail!(
             *compute_allocations(res, self.output_kind).get(part_id::RELA_DYN_GENERAL) > 0,

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -1075,7 +1075,7 @@ impl<'data, 'layout, 'out> TableWriter<'data, 'layout, 'out> {
     ) -> Result {
         debug_assert_bail!(
             self.output_kind.needs_dynsym(),
-            "write_glob_dat called when output is not dynamic"
+            "write_rela_dyn_general called when output is not dynamic"
         );
         let rela = self.take_rela_dyn()?;
         rela.r_offset.set(LittleEndian, place);
@@ -1952,7 +1952,7 @@ fn apply_relocation<S: StorageModel, A: Arch>(
             .bitand(mask.got_entry)
             .wrapping_add(addend)
             .wrapping_sub(place.bitand(mask.place)),
-        RelocationKind::None => 0,
+        RelocationKind::None | RelocationKind::TlsDescCall => 0,
     };
     rel_info
         .size

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -770,12 +770,11 @@ impl<'data, 'layout, 'out> TableWriter<'data, 'layout, 'out> {
         }
         if resolution_flags.contains(ResolutionFlags::GOT_TLS_MODULE) {
             return self.process_got_tls_mod::<A>(res, got_address);
+        } else if resolution_flags.contains(ResolutionFlags::GOT_TLS_DESCRIPTOR) {
+            return self.process_got_tls_descriptor::<A>(res, got_address);
         }
         if resolution_flags.contains(ResolutionFlags::GOT_TLS_OFFSET) {
             return Ok(());
-        }
-        if resolution_flags.contains(ResolutionFlags::GOT_TLS_DESCRIPTOR) {
-            return self.process_got_tls_descriptor::<A>(res, got_address);
         }
 
         let got_entry = self.take_next_got_entry()?;

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -2481,7 +2481,9 @@ fn resolution_flags(rel_kind: RelocationKind) -> ResolutionFlags {
         RelocationKind::TlsGd | RelocationKind::TlsGdGot | RelocationKind::TlsGdGotBase => {
             ResolutionFlags::GOT_TLS_MODULE
         }
-        RelocationKind::TlsDesc => ResolutionFlags::GOT_TLS_DESCRIPTOR,
+        RelocationKind::TlsDesc | RelocationKind::TlsDescCall => {
+            ResolutionFlags::GOT_TLS_DESCRIPTOR
+        }
         RelocationKind::TlsLd | RelocationKind::TlsLdGot | RelocationKind::TlsLdGotBase => {
             ResolutionFlags::empty()
         }

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -757,6 +757,10 @@ fn allocate_resolution(
             mem_sizes.increment(part_id::RELA_DYN_GENERAL, elf::RELA_ENTRY_SIZE);
         }
     }
+    if resolution_flags.contains(ResolutionFlags::GOT_TLS_DESCRIPTOR) {
+        mem_sizes.increment(part_id::GOT, elf::GOT_ENTRY_SIZE * 2);
+        mem_sizes.increment(part_id::RELA_DYN_GENERAL, elf::RELA_ENTRY_SIZE);
+    }
 }
 
 impl HandlerData for ObjectLayoutState<'_> {
@@ -1059,13 +1063,18 @@ bitflags! {
         /// TLS block.
         const GOT_TLS_OFFSET = 1 << 4;
 
+        /// A double GOT entry is needed in order to store the function pointer and a pointer that
+        /// points to a pair of words (module number and offset within the module).
+        /// Only set for TLS variables.
+        const GOT_TLS_DESCRIPTOR = 1 << 5;
+
         /// The request originated from a dynamic object, so the symbol should be put into the dynamic
         /// symbol table.
-        const EXPORT_DYNAMIC = 1 << 5;
+        const EXPORT_DYNAMIC = 1 << 6;
 
         /// We encountered a direct reference to a symbol from a non-writable section and so we're
         /// going to need to do a copy relocation.
-        const COPY_RELOCATION = 1 << 6;
+        const COPY_RELOCATION = 1 << 7;
     }
 }
 
@@ -2472,6 +2481,7 @@ fn resolution_flags(rel_kind: RelocationKind) -> ResolutionFlags {
         RelocationKind::TlsGd | RelocationKind::TlsGdGot | RelocationKind::TlsGdGotBase => {
             ResolutionFlags::GOT_TLS_MODULE
         }
+        RelocationKind::TlsDesc => ResolutionFlags::GOT_TLS_DESCRIPTOR,
         RelocationKind::TlsLd | RelocationKind::TlsLdGot | RelocationKind::TlsLdGotBase => {
             ResolutionFlags::empty()
         }
@@ -3850,7 +3860,9 @@ fn create_resolution(
         } else {
             resolution.got_address = Some(allocate_got(1, memory_offsets));
         }
-    } else if res_kind.contains(ResolutionFlags::GOT_TLS_MODULE) {
+    } else if res_kind.contains(ResolutionFlags::GOT_TLS_MODULE)
+        | res_kind.contains(ResolutionFlags::GOT_TLS_DESCRIPTOR)
+    {
         resolution.got_address = Some(allocate_got(2, memory_offsets));
     }
     resolution
@@ -3906,6 +3918,15 @@ impl Resolution {
             return Ok(got_address + crate::elf::GOT_ENTRY_SIZE);
         }
         Ok(got_address)
+    }
+
+    pub(crate) fn tls_descriptor_got_address(&self) -> Result<u64> {
+        debug_assert_bail!(
+            self.resolution_flags
+                .contains(ResolutionFlags::GOT_TLS_DESCRIPTOR),
+            "Called tls_descriptor_got_address without GOT_TLS_DESCRIPTOR being set"
+        );
+        self.got_address()
     }
 
     pub(crate) fn plt_address(&self) -> Result<u64> {

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3930,7 +3930,7 @@ impl Resolution {
             "Called tls_descriptor_got_address without GOT_TLS_DESCRIPTOR being set"
         );
         // We might have both GOT_TLS_OFFSET and GOT_TLS_DESCRIPTOR at the same time
-        // for a single symbol. Then the TLS descriptor comes later and my reflect that in the GOT address.
+        // for a single symbol. Then the TLS descriptor comes later and we reflect that in the GOT address.
         if self
             .resolution_flags
             .contains(ResolutionFlags::GOT_TLS_OFFSET)

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -15,6 +15,7 @@
 //! related to `part_id.rs` and insert later in `SECTION_DEFINITIONS` (probably at the end). Also,
 //! update `NUM_BUILT_IN_REGULAR_SECTIONS`.
 
+use self::elf::TLS_MODULE_BASE_SYMBOL_NAME;
 use crate::alignment;
 use crate::alignment::Alignment;
 use crate::alignment::NUM_ALIGNMENTS;
@@ -478,6 +479,7 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = [
         name: SectionName(TDATA_SECTION_NAME),
         ty: sht::PROGBITS,
         section_flags: shf::WRITE.with(shf::ALLOC).with(shf::TLS),
+        start_symbol_name: Some(TLS_MODULE_BASE_SYMBOL_NAME),
         ..DEFAULT_DEFS
     },
     BuiltInSectionDetails {

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -504,13 +504,13 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = [
         section_flags: shf::WRITE.with(shf::ALLOC).with(shf::TLS),
         // The symbol is defined twice, but later on we make a filtering based on the output type!
         start_symbol_name: Some(TLS_MODULE_BASE_SYMBOL_NAME),
-        end_symbol_name: Some(TLS_MODULE_BASE_SYMBOL_NAME),
         ..DEFAULT_DEFS
     },
     BuiltInSectionDetails {
         name: SectionName(TBSS_SECTION_NAME),
         ty: sht::NOBITS,
         section_flags: shf::WRITE.with(shf::ALLOC).with(shf::TLS),
+        end_symbol_name: Some(TLS_MODULE_BASE_SYMBOL_NAME),
         ..DEFAULT_DEFS
     },
     BuiltInSectionDetails {

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -242,25 +242,29 @@ impl Prelude {
             {
                 continue;
             }
-            if def.start_symbol_name.is_some() {
+            if def.start_symbol_name(args.output_kind).is_some() {
                 symbol_definitions.push(InternalSymDefInfo::SectionStart(section_id));
             }
-            if def.end_symbol_name.is_some() {
+            if def.end_symbol_name(args.output_kind).is_some() {
                 symbol_definitions.push(InternalSymDefInfo::SectionEnd(section_id));
             }
         }
         Self { symbol_definitions }
     }
 
-    pub(crate) fn symbol_name(&self, symbol_id: SymbolId) -> SymbolName<'static> {
+    pub(crate) fn symbol_name(
+        &self,
+        symbol_id: SymbolId,
+        output_kind: OutputKind,
+    ) -> SymbolName<'static> {
         let def = &self.symbol_definitions[symbol_id.as_usize()];
         let name = match def {
             InternalSymDefInfo::Undefined => Some(""),
             InternalSymDefInfo::SectionStart(section_id) => {
-                section_id.built_in_details().start_symbol_name
+                section_id.built_in_details().start_symbol_name(output_kind)
             }
             InternalSymDefInfo::SectionEnd(section_id) => {
-                section_id.built_in_details().end_symbol_name
+                section_id.built_in_details().end_symbol_name(output_kind)
             }
         }
         .unwrap();

--- a/libwild/src/validation.rs
+++ b/libwild/src/validation.rs
@@ -78,6 +78,7 @@ fn validate_resolution(
     if value_flags.contains(ValueFlags::IFUNC)
         || res_flags.contains(ResolutionFlags::GOT_TLS_MODULE)
         || res_flags.contains(ResolutionFlags::GOT_TLS_OFFSET)
+        || res_flags.contains(ResolutionFlags::GOT_TLS_DESCRIPTOR)
     {
         return Ok(());
     };

--- a/libwild/src/x86_64.rs
+++ b/libwild/src/x86_64.rs
@@ -61,6 +61,7 @@ impl crate::arch::Arch for X86_64 {
             DynamicRelocationKind::TpOff => object::elf::R_X86_64_TPOFF64,
             DynamicRelocationKind::Relative => object::elf::R_X86_64_RELATIVE,
             DynamicRelocationKind::DynamicSymbol => object::elf::R_X86_64_GLOB_DAT,
+            DynamicRelocationKind::TlsDesc => object::elf::R_X86_64_TLSDESC,
         }
     }
 

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -574,6 +574,9 @@ pub enum RelocationKind {
     /// The offset of a TLS variable within the executable's TLS storage, AArch64 TLS block layout.
     TpOffAArch64,
 
+    /// GOT offset for TLS descriptor, relative to the place of the relocation.
+    TlsDesc,
+
     /// No relocation needs to be applied. Produced when we eliminate a relocation due to an
     /// optimisation.
     None,

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -577,6 +577,9 @@ pub enum RelocationKind {
     /// GOT offset for TLS descriptor, relative to the place of the relocation.
     TlsDesc,
 
+    /// Call to the TLS descriptor trampoline. Used only as a placeholder for a linker relaxation opportunity.
+    TlsDescCall,
+
     /// No relocation needs to be applied. Produced when we eliminate a relocation due to an
     /// optimisation.
     None,

--- a/linker-utils/src/x86_64.rs
+++ b/linker-utils/src/x86_64.rs
@@ -179,7 +179,7 @@ pub fn relocation_kind_and_size(r_type: u32) -> Option<(RelocationKind, usize)> 
         }
         object::elf::R_X86_64_TPOFF32 => (RelocationKind::TpOff, 4),
         object::elf::R_X86_64_GOTPC32_TLSDESC => (RelocationKind::TlsDesc, 4),
-        object::elf::R_X86_64_TLSDESC_CALL => (RelocationKind::None, 0),
+        object::elf::R_X86_64_TLSDESC_CALL => (RelocationKind::TlsDescCall, 0),
         object::elf::R_X86_64_NONE => (RelocationKind::None, 0),
         _ => return None,
     };

--- a/linker-utils/src/x86_64.rs
+++ b/linker-utils/src/x86_64.rs
@@ -178,6 +178,8 @@ pub fn relocation_kind_and_size(r_type: u32) -> Option<(RelocationKind, usize)> 
             (RelocationKind::GotRelative, 4)
         }
         object::elf::R_X86_64_TPOFF32 => (RelocationKind::TpOff, 4),
+        object::elf::R_X86_64_GOTPC32_TLSDESC => (RelocationKind::TlsDesc, 4),
+        object::elf::R_X86_64_TLSDESC_CALL => (RelocationKind::None, 0),
         object::elf::R_X86_64_NONE => (RelocationKind::None, 0),
         _ => return None,
     };

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -455,14 +455,7 @@ fn parse_configs(src_filename: &Path) -> Result<Vec<Config>> {
                         .collect::<Result<Vec<_>>>()?;
                 }
                 "RequiresClangWithTlsDesc" => {
-                    config.requires_clang_with_tlsdesc = match arg.to_lowercase().as_str() {
-                        "true" => Ok(true),
-                        "false" => Ok(false),
-                        _ => Err(anyhow!(format!(
-                            "Unsupported RequiresClangWithTlsDesc argument: `{}`",
-                            arg
-                        ))),
-                    }?;
+                    config.requires_clang_with_tlsdesc = arg.to_lowercase().parse()?;
                 }
                 other => bail!("{}: Unknown directive '{other}'", src_filename.display()),
             }

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -1357,6 +1357,7 @@ fn integration_test(
         "ifunc.c",
         "internal-syms.c",
         "tls.c",
+        "tlsdesc.c",
         "old_init.c",
         "custom_section.c",
         "stack_alignment.s",

--- a/wild/tests/sources/tlsdesc-obj.c
+++ b/wild/tests/sources/tlsdesc-obj.c
@@ -1,0 +1,16 @@
+_Thread_local long g1 = 1;
+static _Thread_local long l2 = 2;
+static _Thread_local long l3 = 3;
+static _Thread_local long l4 = 4;
+_Thread_local long g5 = 5;
+_Thread_local long g6 = 6;
+_Thread_local long g7 = 7;
+static _Thread_local long bss1 = 0;
+_Thread_local long bss2 = 0;
+
+int get_value() {
+    bss1 = 6;
+    bss2 = 8;
+
+    return g1 + l2 + l3 + l4 + g5 + g6 + g7 + bss1 + bss2;
+}

--- a/wild/tests/sources/tlsdesc.c
+++ b/wild/tests/sources/tlsdesc.c
@@ -21,6 +21,7 @@
 //#Config:clang-tls-desc:gcc-tls-desc
 //#CompArgs:-mtls-dialect=gnu2
 //#Compiler:clang
+//#RequiresClangWithTlsDesc:true
 
 //#Config:clang-tls-desc-shared:clang-tls-desc
 //#CompArgs:-mtls-dialect=gnu2 -fPIC

--- a/wild/tests/sources/tlsdesc.c
+++ b/wild/tests/sources/tlsdesc.c
@@ -1,0 +1,35 @@
+// TODO: remove DiffIgnore for asm.* once relaxations are supported
+
+//#AbstractConfig:default
+//#DiffIgnore:.dynamic.DT_NEEDED
+//#DiffIgnore:section.data
+//#DiffIgnore:section.rodata
+
+//#Config:gcc-tls-desc:default
+//#CompArgs:-mtls-dialect=gnu2
+//#LinkArgs:--cc=gcc -Wl,-z,now
+//#Object:tlsdesc-obj.c
+
+//#Config:gcc-tls-desc-pie:gcc-tls-desc
+//#CompArgs:-mtls-dialect=gnu2 -fPIE
+
+//#Config:gcc-tls-desc-shared:gcc-tls-desc
+//#CompArgs:-mtls-dialect=gnu2 -fPIC
+//#Shared:tlsdesc-obj.c
+//#DiffIgnore:asm.get_value
+
+//#Config:clang-tls-desc:gcc-tls-desc
+//#CompArgs:-mtls-dialect=gnu2
+//#Compiler:clang
+
+//#Config:clang-tls-desc-shared:clang-tls-desc
+//#CompArgs:-mtls-dialect=gnu2 -fPIC
+//#Shared:tlsdesc-obj.c
+//#DiffIgnore:asm.get_value
+
+int get_value();
+
+int main()
+{
+    return get_value();
+}


### PR DESCRIPTION
I am in the process of implementation the feature for `x86_64` Linux target. Even though it's non-default for `x86_64` (one needs `-mtls-dialect=gnu2`), it's the default mechanism used for `global-dynamic` and `local-dynamic` on AArch64.

I've got a working prototype, however, I struggle with the static symbols when the TLS Descriptor is combined with `R_X86_64_DTPOFF32` relocation and I would like to ask for a second pair of eyes (@davidlattimore).

Having the following example:
```c
_Thread_local long g1 = 1;
static _Thread_local long l2 = 2;
static _Thread_local long l3 = 3;
static _Thread_local long l4 = 4;
_Thread_local long g5 = 5;
_Thread_local long g6 = 6;
_Thread_local long g7 = 7;

void foo() {
  __builtin_printf("g1: %p: %ld\n", &g1, g1);
  __builtin_printf("l2: %p: %ld\n", &l2, l2);
  __builtin_printf("l3: %p: %ld\n", &l3, l3);
  __builtin_printf("l4: %p: %ld\n", &l4, l4);
  __builtin_printf("g5: %p: %ld\n", &g5, g5);
  __builtin_printf("g6: %p: %ld\n", &g6, g6);
  __builtin_printf("g7: %p: %ld\n", &g7, g7);
}

#ifdef MAIN
int main() {
  foo();
  return 0;
}
#endif
```

The scenario where the code is built as a shared library is fine:
```
✦ ❯ gcc tls.c -mtls-dialect=gnu2 -fPIC -shared -o libx.so --save-temps -B ~/Programming/wild && echo "int foo(); int main() { foo(); return 0; }" | gcc -x c - -L. -lx -B ~/Programming/wild -mtls-dialect=gnu2 && ./a.out
WARNING: wild: --plugin /usr/lib64/gcc/x86_64-suse-linux/14/liblto_plugin.so is not yet supported
WARNING: wild: --plugin /usr/lib64/gcc/x86_64-suse-linux/14/liblto_plugin.so is not yet supported
g1: 0x7fb39699cb48: 1
l2: 0x7fb39699cb50: 2
l3: 0x7fb39699cb58: 3
l4: 0x7fb39699cb60: 4
g5: 0x7fb39699cb68: 5
g6: 0x7fb39699cb70: 6
g7: 0x7fb39699cb78: 7
✦ ❯ clang tls.c -mtls-dialect=gnu2 -fPIC -shared -o libx.so --save-temps -B ~/Programming/wild && echo "int foo(); int main() { foo(); return 0; }" | clang -x c - -L. -lx -B ~/Programming/wild -mtls-dialect=gnu2 && ./a.out
WARNING: wild: -z relro is not yet supported
WARNING: wild: -z relro is not yet supported
g1: 0x7fef43cd7b48: 1
l2: 0x7fef43cd7b68: 2
l3: 0x7fef43cd7b70: 3
l4: 0x7fef43cd7b78: 4
g5: 0x7fef43cd7b50: 5
g6: 0x7fef43cd7b58: 6
g7: 0x7fef43cd7b60: 7
```

However, it starts failing for Clang if being built as an executable:

```
$ gcc tls.c -mtls-dialect=gnu2 -B ~/Programming/wild -DMAIN -fPIC --save-temps && ./a.out
WARNING: wild: --plugin /usr/lib64/gcc/x86_64-suse-linux/14/liblto_plugin.so is not yet supported
g1: 0x7efe4a230708: 1
l2: 0x7efe4a230710: 2
l3: 0x7efe4a230718: 3
l4: 0x7efe4a230720: 4
g5: 0x7efe4a230728: 5
g6: 0x7efe4a230730: 6
g7: 0x7efe4a230738: 7
$ clang tls.c -mtls-dialect=gnu2 -B ~/Programming/wild -DMAIN -fPIC --save-temps && ./a.out
WARNING: wild: -z relro is not yet supported
g1: 0x7f81e666b708: 1
l2: 0x7f81e666b6f0: 0
l3: 0x7f81e666b6f8: 0
l4: 0x7f81e666b700: 0
g5: 0x7f81e666b710: 5
g6: 0x7f81e666b718: 6
g7: 0x7f81e666b720: 7
```

The main difference here is that Clang uses `R_X86_64_DTPOFF32` for the local TLS variables and the TLSDESCR relocations are based on `_TLS_MODULE_BASE_`:

```
  57:	48 8d 05 00 00 00 00 	lea    0x0(%rip),%rax        # 5e <foo+0x5e>
  5e:	ff 10                	call   *(%rax)
  60:	48 8d b4 08 00 00 00 	lea    0x0(%rax,%rcx,1),%rsi
...
000000000000005a  0000001000000022 R_X86_64_GOTPC32_TLSDESC 0000000000000000 _TLS_MODULE_BASE_ - 4
000000000000005e  0000001000000023 R_X86_64_TLSDESC_CALL  0000000000000000 _TLS_MODULE_BASE_ + 0
0000000000000064  0000000400000015 R_X86_64_DTPOFF32      0000000000000020 l2 + 0
```

I noticed the `R_X86_64_DTPOFF32` relocation resolution is different when shlib and exe are built:
https://github.com/davidlattimore/wild/blob/b9d22b891b2f59a365000409409462e58f685f81/libwild/src/elf_writer.rs#L1888-L1895. Making various tweeks, I was unable to make all 4 scenarios working :/

Maybe one needs to specially place the artificial symbol (`_TLS_MODULE_BASE_`) as briefly mention here:
https://www.fsfla.org/~lxoliva/writeups/TLS/RFC-TLSDESC-x86.txt

> Because of the way @DTPOFF has historically been relaxed in main
> executables, when using the GNU TLS extensions, _TLS_MODULE_BASE_ is
> handled differently on final executables than on dynamic libraries.

> 
> In general, _TLS_MODULE_BASE_ is defined at the lowest address in the
> TLS segment, i.e., so that adding its NTPOFF (computed in the sequence
> above) to the linker-computed DTPOFF of a variable yields the TP
> offset of the variable.
> 
> On main executables, the DTPOFF is relaxed into NTPOFF, so we must
> stop _TLS_MODULE_BASE_'s standard NTPOFF from affecting the direct LE
> addressing.  Therefore, for main executables, the call sequence must
> be relaxed in such a way that the base address computed into %eax is
> zero.  Whether this is accomplished by setting _TLS_MODULE_BASE_ to
> the end of the TLS section, by handling its relaxation especially, or
> by any other means, is unspecified.  _TLS_MODULE_BASE_ is a special
> internal symbol, not to be relied upon for any other purposes; it
> needs not even be defined as a symbol in the linker output.
> 