### PR TITLE
Update openSUSE docker to a more recent base image

### DIFF
--- a/docker/opensuse.Dockerfile
+++ b/docker/opensuse.Dockerfile
@@ -3,7 +3,7 @@
 # docker build --progress=plain -t wild-dev-opensuse . -f docker/opensuse.Dockerfile
 # docker run -it wild-dev-opensuse
 
-FROM opensuse/tumbleweed@sha256:e2d80ae78aeeceab7c715f43d3b6c2c873d64c44095f737d27b43702b5417215 AS chef
+FROM opensuse/tumbleweed@sha256:a8b3f189cb0a1379c618b4fa581003f9551486d98fc21a1df559f7172f87c626 AS chef
 RUN zypper install -y -t pattern devel_C_C++ && \
     zypper install -y \
         rustup \


### PR DESCRIPTION
The old image, at least with the config supplied, only had rustc 1.82, which didn't meet our current MSRV.