### PR TITLE
Refactor argument parsing to directly populate Args struct

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -551,7 +551,7 @@ fn populate_file_header<S: StorageModel, A: Arch>(
     header: &mut FileHeader,
 ) -> Result {
     let args = layout.args();
-    let ty = if args.output_kind.is_relocatable() {
+    let ty = if args.output_kind().is_relocatable() {
         object::elf::ET_DYN
     } else {
         object::elf::ET_EXEC
@@ -701,7 +701,7 @@ impl<'data, 'layout, 'out> TableWriter<'data, 'layout, 'out> {
             SymbolTableWriter::new(strtab_start_offset, buffers, &layout.output_sections);
 
         Self::new(
-            layout.args().output_kind,
+            layout.args().output_kind(),
             layout.tls_start_address()..layout.tls_end_address(),
             buffers,
             dynsym_writer,
@@ -1772,7 +1772,7 @@ fn apply_relocation<S: StorageModel, A: Arch>(
     let mut next_modifier = RelocationModifier::Normal;
     let r_type = rel.r_type(e, false);
     let rel_info;
-    let output_kind = layout.args().output_kind;
+    let output_kind = layout.args().output_kind();
     if let Some(relaxation) = Relaxation::new(
         r_type,
         out,
@@ -2114,7 +2114,7 @@ impl PreludeLayout {
     ) -> Result {
         // Write a pair of GOT entries for use by any TLSLD or TLSGD relocations.
         if let Some(got_address) = self.tlsld_got_entry {
-            if layout.args().output_kind.is_executable() {
+            if layout.args().output_kind().is_executable() {
                 table_writer.process_resolution::<A>(&Resolution {
                     raw_value: crate::elf::CURRENT_EXE_TLS_MOD,
                     dynamic_symbol_index: None,
@@ -2630,7 +2630,7 @@ const EPILOGUE_DYNAMIC_ENTRY_WRITERS: &[DynamicEntryWriter] = &[
         |inputs| {
             // Not sure why, but GNU ld seems to emit this for executables but not for shared
             // objects.
-            inputs.args.output_kind != OutputKind::SharedObject
+            inputs.args.output_kind() != OutputKind::SharedObject
         },
         |_inputs| 0,
     ),
@@ -2704,7 +2704,7 @@ impl DynamicEntryInputs<'_> {
     fn dt_flags(&self) -> u64 {
         let mut flags = 0;
         flags |= object::elf::DF_BIND_NOW;
-        if !self.args.output_kind.is_executable() && self.has_static_tls {
+        if !self.args.output_kind().is_executable() && self.has_static_tls {
             flags |= object::elf::DF_STATIC_TLS;
         }
         u64::from(flags)
@@ -2713,7 +2713,7 @@ impl DynamicEntryInputs<'_> {
     fn dt_flags_1(&self) -> u64 {
         let mut flags = 0;
         flags |= object::elf::DF_1_NOW;
-        if self.args.output_kind.is_executable() && self.args.is_relocatable() {
+        if self.args.output_kind().is_executable() && self.args.is_relocatable() {
             flags |= object::elf::DF_1_PIE;
         }
         u64::from(flags)

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -621,7 +621,7 @@ trait SymbolRequestHandler<'data, S: StorageModel>: std::fmt::Display + HandlerD
                 verify_consistent_allocation_handling(
                     value_flags,
                     resolution_flags.get(),
-                    symbol_db.args.output_kind,
+                    symbol_db.args.output_kind(),
                 )?;
             }
 
@@ -629,7 +629,7 @@ trait SymbolRequestHandler<'data, S: StorageModel>: std::fmt::Display + HandlerD
                 value_flags,
                 resolution_flags,
                 &mut common.mem_sizes,
-                symbol_db.args.output_kind,
+                symbol_db.args.output_kind(),
             );
         }
         if symbol_db.args.should_output_symbol_versions() {
@@ -842,7 +842,7 @@ impl<'data, S: StorageModel> SymbolRequestHandler<'data, S> for DynamicLayoutSta
         symbol_db: &SymbolDb<'data, S>,
         symbol_id: SymbolId,
     ) -> Result {
-        if symbol_db.args.output_kind == OutputKind::SharedObject {
+        if symbol_db.args.output_kind() == OutputKind::SharedObject {
             bail!("Cannot directly access dynamic symbol when building a shared object",);
         }
         let symbol = self
@@ -1301,7 +1301,7 @@ impl<'data, S: StorageModel> Layout<'data, '_, S> {
     }
 
     pub(crate) fn entry_symbol_address(&self) -> Result<u64> {
-        if self.args().output_kind == OutputKind::SharedObject {
+        if self.args().output_kind() == OutputKind::SharedObject {
             // Shared objects don't have an entry point.
             return Ok(0);
         }
@@ -2402,7 +2402,7 @@ fn process_relocation<S: StorageModel, A: Arch>(
             object.object.raw_section_data(section)?,
             rel_offset,
             symbol_value_flags,
-            args.output_kind,
+            args.output_kind(),
             SectionFlags::from_header(section),
         ) {
             relaxation.rel_info()
@@ -2532,7 +2532,7 @@ impl PreludeLayoutState {
             common.allocate(part_id::STRTAB, 1);
         }
 
-        if resources.symbol_db.args.output_kind.is_executable() {
+        if resources.symbol_db.args.output_kind().is_executable() {
             self.load_entry_point(resources, queue)?;
         }
         if resources.symbol_db.args.tls_mode() == TlsMode::Preserve {
@@ -2541,7 +2541,7 @@ impl PreludeLayoutState {
             self.needs_tlsld_got_entry = true;
             // For shared objects, we'll need to use a DTPMOD relocation to fill in the TLS module
             // number.
-            if !resources.symbol_db.args.output_kind.is_executable() {
+            if !resources.symbol_db.args.output_kind().is_executable() {
                 common.allocate(part_id::RELA_DYN_GENERAL, crate::elf::RELA_ENTRY_SIZE);
             }
         }
@@ -3142,7 +3142,7 @@ impl<'data> ObjectLayoutState<'data> {
             process_gnu_property_note(self, note_gnu_property_index)?;
         }
 
-        if resources.symbol_db.args.output_kind == OutputKind::SharedObject {
+        if resources.symbol_db.args.output_kind() == OutputKind::SharedObject {
             self.load_non_hidden_symbols::<S, A>(common, resources, queue)?;
         }
         self.load_sections::<S, A>(common, resources, queue)
@@ -3296,7 +3296,7 @@ impl<'data> ObjectLayoutState<'data> {
         if !symbol_db.args.strip_all {
             self.allocate_symtab_space(common, symbol_db, symbol_resolution_flags);
         }
-        let output_kind = symbol_db.args.output_kind;
+        let output_kind = symbol_db.args.output_kind();
         for slot in &mut self.sections {
             if let SectionSlot::Loaded(section) = slot {
                 allocate_resolution(

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -237,7 +237,7 @@ impl Prelude {
             // .rela.plt start/stop symbols are only emitted for non-relocatable executables.
             // Emitting them for relocatable binaries causes glibc to try to call the resolver
             // functions without taking into account that the binary has been relocated.
-            if args.output_kind != OutputKind::StaticExecutable(RelocationModel::NonRelocatable)
+            if args.output_kind() != OutputKind::StaticExecutable(RelocationModel::NonRelocatable)
                 && section_id == output_section_id::RELA_PLT
             {
                 continue;

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -499,13 +499,13 @@ fn value_flags_from_elf_symbol(sym: &crate::elf::Symbol, args: &Args) -> ValueFl
     let is_undefined = sym.is_undefined(LittleEndian);
     let mut can_bypass_got = sym.st_visibility() != object::elf::STV_DEFAULT
         || sym.is_local()
-        || args.output_kind.is_static_executable()
+        || args.output_kind().is_static_executable()
         // Symbols defined in an executable cannot be interposed since the executable is always the
         // first place checked for a symbol by the dynamic loader.
-        || (args.output_kind.is_executable() && !is_undefined);
+        || (args.output_kind().is_executable() && !is_undefined);
     // When writing a shared object, TLS variables should never bypass the GOT, even if they're
     // local variables.
-    if args.output_kind == OutputKind::SharedObject && sym.st_type() == object::elf::STT_TLS {
+    if args.output_kind() == OutputKind::SharedObject && sym.st_type() == object::elf::STT_TLS {
         can_bypass_got = false;
     }
     let mut flags: ValueFlags = if sym.is_absolute(LittleEndian) {


### PR DESCRIPTION
This reduces the number of places that need changing when parsing a new argument from 4 to 3. Once `default_field_values` is stable, we can further reduce this to 2.

Note, there is a subtle behaviour change, which is that we no longer support running the linker on architectures that we don't target.