### PR TITLE
Implement errors about undefined symbols

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -53,6 +53,7 @@ pub(crate) struct Args {
     pub(crate) should_fork: bool,
     pub(crate) build_id: BuildIdOption,
     pub(crate) file_write_mode: FileWriteMode,
+    pub(crate) no_undefined: bool,
 
     /// If set, GC stats will be written to the specified filename.
     pub(crate) write_gc_stats: Option<PathBuf>,
@@ -239,6 +240,7 @@ pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(mut input: I) -> Resul
             .ok()
             .map(|s| s.parse())
             .transpose()?,
+        no_undefined: false,
     };
 
     let mut action = None;
@@ -474,6 +476,8 @@ pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(mut input: I) -> Resul
             // Using debug fuel with more than one thread would likely give non-deterministic
             // results.
             args.num_threads = NonZeroUsize::new(1).unwrap();
+        } else if long_arg_eq("no-undefined") {
+            args.no_undefined = true;
         } else if let Some(path) = arg.strip_prefix('@') {
             if input.next().is_some() || arg_num > 1 {
                 bail!("Mixing of @{{filename}} and regular arguments isn't supported");

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -1408,7 +1408,8 @@ fn integration_test(
         "rust-tls.rs",
         "input_does_not_exist.c",
         "ifunc2.c",
-        "tls-local-exec.c"
+        "tls-local-exec.c",
+        "undefined_symbols.c"
     )]
     program_name: &'static str,
     #[allow(unused_variables)] setup_symlink: (),

--- a/wild/tests/sources/undefined_symbols.c
+++ b/wild/tests/sources/undefined_symbols.c
@@ -1,0 +1,23 @@
+//#AbstractConfig:default
+//#DiffEnabled:false
+//#RunEnabled:false
+
+//#Config:shared-lib:default
+//#LinkArgs:--shared
+
+//#Config:no-undefined:default
+//#LinkArgs:--shared --no-undefined
+//#ExpectError:Undefined symbols:
+//#ExpectError:  undefined_strong
+
+//#Config:executable:default
+//#ExpectError:Undefined symbols:
+//#ExpectError:  undefined_strong
+
+int undefined_strong();
+__attribute__((weak)) int undefined_weak();
+
+void _start(void) {
+    undefined_weak();
+    undefined_strong();
+}


### PR DESCRIPTION
Fixes: #20

There are two regressions right now:
```
Error: Undefined symbols found!
  Undefined symbol does_not_exist, referenced by /home/mateusz/projects/wild/wild/tests/build/archive_activation.default-f0cd5ddfa601dc84.o

Error: Undefined symbols found!
  Undefined symbol __start_foo, referenced by /home/mateusz/projects/wild/wild/tests/build/custom_section.archive-95f9e368cdd19b2a.o
  Undefined symbol __stop_foo, referenced by /home/mateusz/projects/wild/wild/tests/build/custom_section.archive-95f9e368cdd19b2a.o
  Undefined symbol __start_bar, referenced by /home/mateusz/projects/wild/wild/tests/build/custom_section.archive-95f9e368cdd19b2a.o
  Undefined symbol __stop_bar, referenced by /home/mateusz/projects/wild/wild/tests/build/custom_section.archive-95f9e368cdd19b2a.o

test integration_test::program_name_19___archive_activation_c__ ... FAILED
test integration_test::program_name_15___custom_section_c__ ... FAILED
```

I don't know about the first one yet, but the second one looks like this function should take into account start/stop symbols from `canonicalise_undefined_symbols`. I'll look into it when I get more time to understand what I'm doing 😅 