### PR TITLE
Fix error message when encountering thin archives

### DIFF
--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -20,6 +20,7 @@ linker-utils = { path = "../linker-utils" }
 memchr = "2.7.4"
 memmap2 = "0.9.5"
 object = { version = "0.36.7", default-features = false, features = [
+    "archive",
     "elf",
     "read_core",
     "std",

--- a/libwild/src/archive.rs
+++ b/libwild/src/archive.rs
@@ -78,8 +78,8 @@ impl<'data> ArchiveIterator<'data> {
     /// Create an iterator from the bytes of the whole archive. The supplied bytes should start with
     /// an archive entry.
     pub(crate) fn from_archive_bytes(data: &'data [u8]) -> Result<Self> {
-        let magic = b"!<arch>\n";
-        let Some(data) = data.strip_prefix(magic) else {
+        let magic = object::archive::MAGIC;
+        let Some(data) = data.strip_prefix(&magic) else {
             bail!("Missing header");
         };
         Ok(Self {

--- a/libwild/src/file_kind.rs
+++ b/libwild/src/file_kind.rs
@@ -18,7 +18,7 @@ pub(crate) enum FileKind {
 
 impl FileKind {
     pub(crate) fn identify_bytes(bytes: &[u8]) -> Result<FileKind> {
-        if bytes.starts_with(b"!<arch>") {
+        if bytes.starts_with(&object::archive::MAGIC) {
             Ok(FileKind::Archive)
         } else if bytes.starts_with(&object::elf::ELFMAG) {
             const HEADER_LEN: usize = size_of::<elf::FileHeader>();
@@ -52,7 +52,7 @@ impl FileKind {
             Ok(FileKind::Text)
         } else if bytes.starts_with(b"BC") {
             bail!("LLVM IR (LTO mode) is not supported yet");
-        } else if bytes.starts_with(b"!<thin>") {
+        } else if bytes.starts_with(&object::archive::THIN_MAGIC) {
             bail!("Thin archives are not supported yet");
         } else {
             bail!("Couldn't identify file type");

--- a/libwild/src/file_kind.rs
+++ b/libwild/src/file_kind.rs
@@ -53,7 +53,7 @@ impl FileKind {
         } else if bytes.starts_with(b"BC") {
             bail!("LLVM IR (LTO mode) is not supported yet");
         } else if bytes.starts_with(b"!<thin>") {
-            bail!("ThinLTO archives are not supported yet");
+            bail!("Thin archives are not supported yet");
         } else {
             bail!("Couldn't identify file type");
         }


### PR DESCRIPTION
Sorry for confusing thin archives with LTO objects.