### PR TITLE
Extend support for TLSDESC to AArch64

### DIFF
--- a/libwild/src/aarch64.rs
+++ b/libwild/src/aarch64.rs
@@ -746,6 +746,64 @@ impl crate::arch::Arch for AArch64 {
                 None,
             ),
 
+            // 5.7.11.5 Thread-local storage descriptors
+            object::elf::R_AARCH64_TLSDESC_LD_PREL19 => (
+                RelocationKind::TlsDesc,
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 2, end: 21 },
+                    insn: RelocationInstruction::Ldr,
+                },
+                None,
+            ),
+            object::elf::R_AARCH64_TLSDESC_ADR_PREL21 => (
+                RelocationKind::TlsDesc,
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 0, end: 21 },
+                    insn: RelocationInstruction::Adr,
+                },
+                None,
+            ),
+            object::elf::R_AARCH64_TLSDESC_ADR_PAGE21 => (
+                RelocationKind::TlsDesc,
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 12, end: 33 },
+                    insn: RelocationInstruction::Adr,
+                },
+                Some(PageMask::GotEntryAndPosition),
+            ),
+            object::elf::R_AARCH64_TLSDESC_LD64_LO12 => (
+                RelocationKind::TlsDescGot,
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 3, end: 12 },
+                    insn: RelocationInstruction::Ldr,
+                },
+                None,
+            ),
+            object::elf::R_AARCH64_TLSDESC_ADD_LO12 => (
+                RelocationKind::TlsDescGot,
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 0, end: 12 },
+                    insn: RelocationInstruction::Add,
+                },
+                None,
+            ),
+            object::elf::R_AARCH64_TLSDESC_OFF_G1 => (
+                RelocationKind::TlsDescGotBase,
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 16, end: 32 },
+                    insn: RelocationInstruction::Movnz,
+                },
+                None,
+            ),
+            object::elf::R_AARCH64_TLSDESC_OFF_G0_NC => (
+                RelocationKind::TlsDescGotBase,
+                RelocationSize::BitMasking {
+                    range: BitRange { start: 0, end: 16 },
+                    insn: RelocationInstruction::Movkz,
+                },
+                None,
+            ),
+
             _ => bail!(
                 "Unsupported relocation type {}",
                 Self::rel_type_to_string(r_type)

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -1957,6 +1957,15 @@ fn apply_relocation<S: StorageModel, A: Arch>(
             .bitand(mask.got_entry)
             .wrapping_add(addend)
             .wrapping_sub(place.bitand(mask.place)),
+        RelocationKind::TlsDescGot => resolution
+            .tls_descriptor_got_address()?
+            .bitand(mask.got_entry)
+            .wrapping_add(addend),
+        RelocationKind::TlsDescGotBase => resolution
+            .tls_descriptor_got_address()?
+            .bitand(mask.got_entry)
+            .wrapping_add(addend)
+            .wrapping_sub(layout.got_base().bitand(mask.got)),
         RelocationKind::None | RelocationKind::TlsDescCall => 0,
     };
     rel_info

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -2482,9 +2482,10 @@ fn resolution_flags(rel_kind: RelocationKind) -> ResolutionFlags {
         RelocationKind::TlsGd | RelocationKind::TlsGdGot | RelocationKind::TlsGdGotBase => {
             ResolutionFlags::GOT_TLS_MODULE
         }
-        RelocationKind::TlsDesc | RelocationKind::TlsDescCall => {
-            ResolutionFlags::GOT_TLS_DESCRIPTOR
-        }
+        RelocationKind::TlsDesc
+        | RelocationKind::TlsDescGot
+        | RelocationKind::TlsDescGotBase
+        | RelocationKind::TlsDescCall => ResolutionFlags::GOT_TLS_DESCRIPTOR,
         RelocationKind::TlsLd | RelocationKind::TlsLdGot | RelocationKind::TlsLdGotBase => {
             ResolutionFlags::empty()
         }

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -574,8 +574,14 @@ pub enum RelocationKind {
     /// The offset of a TLS variable within the executable's TLS storage, AArch64 TLS block layout.
     TpOffAArch64,
 
-    /// GOT offset for TLS descriptor, relative to the place of the relocation.
+    /// The address of a TLS descriptor structure, relative to the place of the relocation.
     TlsDesc,
+
+    /// The address of a TLS descriptor structure.
+    TlsDescGot,
+
+    /// The address of a TLS descriptor structure, relative to the start of the GOT.
+    TlsDescGotBase,
 
     /// Call to the TLS descriptor trampoline. Used only as a placeholder for a linker relaxation opportunity.
     TlsDescCall,

--- a/wild/tests/sources/tlsdesc.c
+++ b/wild/tests/sources/tlsdesc.c
@@ -9,24 +9,49 @@
 //#CompArgs:-mtls-dialect=gnu2
 //#LinkArgs:--cc=gcc -Wl,-z,now
 //#Object:tlsdesc-obj.c
+//#Arch: x86_64
+
+//#Config:gcc-tls-desc-aarch64:gcc-tls-desc
+//#CompArgs:-mtls-dialect=desc
+//#Arch: aarch64
 
 //#Config:gcc-tls-desc-pie:gcc-tls-desc
 //#CompArgs:-mtls-dialect=gnu2 -fPIE
+//#Arch: x86_64
+
+//#Config:gcc-tls-desc-pie-aarch64:gcc-tls-desc-pie
+//#CompArgs:-mtls-dialect=desc
+//#Arch: aarch64
 
 //#Config:gcc-tls-desc-shared:gcc-tls-desc
 //#CompArgs:-mtls-dialect=gnu2 -fPIC
 //#Shared:tlsdesc-obj.c
 //#DiffIgnore:asm.get_value
+//#Arch: x86_64
+
+//#Config:gcc-tls-desc-shared-aarch64:gcc-tls-desc-shared
+//#CompArgs:-mtls-dialect=desc
+//#Arch: aarch64
 
 //#Config:clang-tls-desc:gcc-tls-desc
 //#CompArgs:-mtls-dialect=gnu2
 //#Compiler:clang
 //#RequiresClangWithTlsDesc:true
+//#Arch: x86_64
+
+//#Config:clang-tls-desc-aarch64:clang-tls-desc
+//#CompArgs:-mtls-dialect=desc
+//#Arch: aarch64
 
 //#Config:clang-tls-desc-shared:clang-tls-desc
 //#CompArgs:-mtls-dialect=gnu2 -fPIC
 //#Shared:tlsdesc-obj.c
 //#DiffIgnore:asm.get_value
+//#Arch: x86_64
+
+//#Config:clang-tls-desc-shared-aarch64:clang-tls-desc-shared
+//#CompArgs:-mtls-dialect=desc
+//#Arch: aarch64
 
 int get_value();
 


### PR DESCRIPTION
Related issue: #258 