### PR TITLE
Run link check twice per month rather than on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,3 @@ jobs:
       with:
         components: rustfmt
     - run: cargo fmt --all -- --check
-
-  markdown-link-check:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,13 @@
+on:
+  schedule:
+    - cron: '35 12 9,22 * *'
+  workflow_dispatch:
+
+name: Cron continuous integration
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1


### PR DESCRIPTION
I worry a bit about putting unnecessary load on people's servers by checking the same links on every PR. Also, it's annoying to have CI fail when a site is temporarily down.