### PR TITLE
CI: shorten job name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   test-nightly:
-    name: Test (${{ matrix.runs-on }}) XXX
+    name: Test (${{ contains(matrix.runs-on, 'arm') && 'ARM64' || 'X86_64'}}, ${{ matrix.container }})
 
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   test-nightly:
-    name: Test
+    name: Test (${{ matrix.runs-on }}) XXX
 
     strategy:
       matrix:
@@ -37,7 +37,6 @@ jobs:
         if: ${{ runner.arch == 'X64' }}
       - run: echo "ARCH=aarch64" >> $GITHUB_ENV
         if: ${{ runner.arch == 'ARM64' }}
-      - name: Test ($ARCH, ${{ matrix.container }})
       - run: apt-get update && apt-get -y install gcc g++ clang lld curl bubblewrap
         if: ${{ contains(matrix.container, 'ubuntu') }}      
       - run: zypper in -y gcc gcc-c++ glibc-devel-static clang lld curl rustup bubblewrap

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   test-nightly:
-    name: Test (${{ contains(matrix.runs-on, 'arm') && 'ARM64' || 'X86_64'}}, ${{ matrix.container }})
+    name: Test (${{ contains(matrix.runs-on, 'arm') && 'AArch64' || 'x86_64'}}, ${{ matrix.container }})
 
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         if: ${{ runner.arch == 'X64' }}
       - run: echo "ARCH=aarch64" >> $GITHUB_ENV
         if: ${{ runner.arch == 'ARM64' }}
+      - run-name: Test ($ARCH, ${{ matrix.container }})
       - run: apt-get update && apt-get -y install gcc g++ clang lld curl bubblewrap
         if: ${{ contains(matrix.container, 'ubuntu') }}      
       - run: zypper in -y gcc gcc-c++ glibc-devel-static clang lld curl rustup bubblewrap

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         if: ${{ runner.arch == 'X64' }}
       - run: echo "ARCH=aarch64" >> $GITHUB_ENV
         if: ${{ runner.arch == 'ARM64' }}
-      - run-name: Test ($ARCH, ${{ matrix.container }})
+      - name: Test ($ARCH, ${{ matrix.container }})
       - run: apt-get update && apt-get -y install gcc g++ clang lld curl bubblewrap
         if: ${{ contains(matrix.container, 'ubuntu') }}      
       - run: zypper in -y gcc gcc-c++ glibc-devel-static clang lld curl rustup bubblewrap


### PR DESCRIPTION
Now the job names can fit in the Actions UI:
![image](https://github.com/user-attachments/assets/271996c1-161e-40be-9157-130ea10abe87)