### PR TITLE
x86_64: Apply MovIndirectToLea for non-REX GOTPCRELX

### DIFF
--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -510,7 +510,7 @@ pub enum RelocationKind {
     Absolute,
 
     /// The absolute address of a symbol or section. We are going to extract only the offset
-    /// within a page, so dynamic relocation creation must be skiped.
+    /// within a page, so dynamic relocation creation must be skipped.
     AbsoluteAArch64,
 
     /// The address of the symbol, relative to the place of the relocation.


### PR DESCRIPTION
We already applied MovIndirectToLea for REX_GOTPCRELX. For the non-REX variant however, we were missing this relaxation.