### PR TITLE
Rewrite asm_diff.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
+name = "colored"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +662,7 @@ dependencies = [
  "anyhow",
  "bytemuck",
  "clap",
+ "colored",
  "fallible-iterator",
  "gimli",
  "iced-x86",
@@ -663,6 +673,8 @@ dependencies = [
  "object",
  "rayon",
  "symbolic-demangle",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -705,6 +717,12 @@ dependencies = [
  "autocfg",
  "scopeguard",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "matchers"
@@ -764,6 +782,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,6 +805,12 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1216,6 +1250,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
 ]
 
 [[package]]
@@ -1225,12 +1271,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1253,6 +1302,12 @@ checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
@@ -1302,6 +1357,28 @@ dependencies = [
  "wait-timeout",
  "which",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/libwild/src/aarch64.rs
+++ b/libwild/src/aarch64.rs
@@ -832,6 +832,7 @@ impl crate::arch::Arch for AArch64 {
             DynamicRelocationKind::Relative => object::elf::R_AARCH64_RELATIVE,
             DynamicRelocationKind::DynamicSymbol => object::elf::R_AARCH64_GLOB_DAT,
             DynamicRelocationKind::TlsDesc => object::elf::R_AARCH64_TLSDESC,
+            DynamicRelocationKind::JumpSlot => object::elf::R_AARCH64_JUMP_SLOT,
         }
     }
 
@@ -853,7 +854,7 @@ impl crate::arch::Arch for AArch64 {
         let offset = got_address.wrapping_sub(plt_page_address);
         anyhow::ensure!(offset < (1 << 32), "PLT is more than 4GiB away from GOT");
         RelocationInstruction::Adr.write_to_value(
-            // The immediation value represents a distance in pages.
+            // The immediate value represents a distance in pages.
             offset / DEFAULT_AARCH64_PAGE_SIZE,
             false,
             &mut plt_entry[0..4],

--- a/linker-diff/Cargo.toml
+++ b/linker-diff/Cargo.toml
@@ -30,6 +30,9 @@ bytemuck = { version = "1.21.0", features = ["derive"] }
 itertools = "0.14.0"
 gimli = "0.31.1"
 fallible-iterator = "0.3.0"
+colored = "3.0.0"
+tracing = "0.1.41"
+tracing-subscriber = "0.3.19"
 
 [lints]
 workspace = true

--- a/linker-diff/src/arch.rs
+++ b/linker-diff/src/arch.rs
@@ -1,0 +1,147 @@
+use linker_utils::elf::DynamicRelocationKind;
+use linker_utils::elf::RelocationKind;
+use linker_utils::relaxation::RelocationModifier;
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::ops::Range;
+
+/// Provides architecture-specific functionality needed by linker-diff.
+pub(crate) trait Arch: Clone + Copy + Eq + PartialEq {
+    /// The type of relocations on this architecture.
+    type RType: RType;
+
+    /// A type representing relaxations on this architecture.
+    type RelaxationKind: Copy + Clone + Debug + Eq + PartialEq;
+
+    /// A type representing a decoded instruction on this architecture.
+    type RawInstruction: Copy + Clone;
+
+    /// Calls `cb` with each relaxation that we think is possible for the supplied relocation type and
+    /// section kind.
+    fn possible_relaxations_do(
+        r_type: Self::RType,
+        section_kind: object::SectionKind,
+        cb: impl FnMut(Relaxation<Self>),
+    );
+
+    /// Returns a mask that can be used to identify the supplied relaxation.
+    fn relaxation_mask(relaxation: Relaxation<Self>) -> RelaxationMask;
+
+    /// Applies the supplied relaxation to `section_bytes`, possibly also updating
+    /// `offset_in_section` and `addend` according to the relaxation kind.
+    fn apply_relaxation(
+        relaxation_kind: Self::RelaxationKind,
+        section_bytes: &mut [u8],
+        offset_in_section: &mut u64,
+        addend: &mut i64,
+    );
+
+    /// Returns whether the next relocation should be skipped based on a relaxation applied to the
+    /// current relocation.
+    fn next_relocation_modifier(relaxation_kind: Self::RelaxationKind) -> RelocationModifier;
+
+    /// Returns a human readable form of the supplied instruction.
+    fn instruction_to_string(instruction: Self::RawInstruction) -> String;
+
+    /// Decode instructions that are in or overlap with the supplied range. The start of `range` may
+    /// be part way through an instruction. For variable length instructions, implementations will
+    /// want to start decoding from the start of the function. For fixed size instructions, it
+    /// should be possible to start at or just prior to the start of `range`.
+    fn decode_instructions_in_range(
+        section_bytes: &[u8],
+        section_address: u64,
+        function_offset_in_section: u64,
+        range: Range<u64>,
+    ) -> Vec<Instruction<Self>>;
+}
+
+pub(crate) trait RType: Copy + Debug + Display + Eq + PartialEq {
+    fn from_raw(raw: u32) -> Self;
+
+    fn from_dynamic_relocation_kind(kind: DynamicRelocationKind) -> Self;
+
+    fn relocation_info(self) -> Option<RelocationTypeInfo>;
+
+    fn relocation_num_bytes(self) -> Option<usize> {
+        self.relocation_info().map(|info| info.size_in_bytes)
+    }
+
+    fn dynamic_relocation_kind(self) -> Option<DynamicRelocationKind>;
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct Relaxation<A: Arch> {
+    pub(crate) relaxation_kind: A::RelaxationKind,
+    pub(crate) new_r_type: A::RType,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct RelocationTypeInfo {
+    pub(crate) kind: RelocationKind,
+
+    /// The number of whole or partial bytes that the relocation spans.
+    pub(crate) size_in_bytes: usize,
+}
+
+/// A bitmask used for comparing the bytes produced by a relaxation with the bytes in the actual
+/// file.
+pub(crate) struct RelaxationMask {
+    /// Number of bytes prior to the offset of the original relocation at which the bitmask starts.
+    pub(crate) offset_shift: u64,
+
+    /// Which bits should be considered part of the instructions modified by a particular
+    /// relaxation. e.g. a byte of 0xff would indicate that all bits of the corresponding byte
+    /// should be treated as part of the instruction. A 0 byte would indicate that the corresponding
+    /// byte should not be compared - i.e. if it's part of the offset written by the new relocation.
+    /// Note that bytes that are part of the instruction should still be compared even if they're
+    /// not written by the relocation, since the fact that the byte wasn't changed is important in
+    /// identifying a particular relaxation.
+    ///
+    /// Example: 48 8d 3d 00 00 00 00    lea    0x0(%rip),%rdi
+    ///                   ^ The relocation points here
+    ///
+    /// The offset_shift would be -3 so as to point to the start of the instruction (0x48).
+    ///
+    /// The mask would be [0xff, 0xff, 0xff] since the first three bytes of the instruction should
+    /// be compared in their entirety.
+    pub(crate) bitmask: &'static [u8],
+}
+
+impl RelaxationMask {
+    pub(crate) fn new(offset_shift: u64, bitmask: &'static [u8]) -> Self {
+        Self {
+            offset_shift,
+            bitmask,
+        }
+    }
+
+    /// Returns whether `a` == `b`, ignoring bits where the corresponding bit in our mask is 0.
+    pub(crate) fn matches(&self, a: &[u8], b: &[u8]) -> bool {
+        assert_eq!(a.len(), b.len());
+
+        self.bitmask
+            .iter()
+            .zip(a)
+            .zip(b)
+            .all(|((mask, value_a), value_b)| (*value_a & mask) == (*value_b & mask))
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct Instruction<'data, A: Arch> {
+    pub(crate) raw_instruction: A::RawInstruction,
+
+    /// The address of the start of the function that contained this instruction.
+    pub(crate) base_address: u64,
+
+    /// The offset of this instruction within the function.
+    pub(crate) offset: u64,
+
+    pub(crate) bytes: &'data [u8],
+}
+
+impl<A: Arch> Instruction<'_, A> {
+    pub(crate) fn address(&self) -> u64 {
+        self.base_address + self.offset
+    }
+}

--- a/linker-diff/src/bin/linker-diff.rs
+++ b/linker-diff/src/bin/linker-diff.rs
@@ -1,11 +1,15 @@
 fn main() -> anyhow::Result<()> {
+    linker_diff::enable_diagnostics();
+
     let config = linker_diff::Config::from_env();
     let report = linker_diff::Report::from_config(config)?;
+
     if report.has_problems() {
         println!("{report}");
         std::process::exit(1);
     } else {
         println!("No differences or validation failures detected");
     }
+
     Ok(())
 }

--- a/linker-diff/src/debug_info_diff.rs
+++ b/linker-diff/src/debug_info_diff.rs
@@ -1,7 +1,7 @@
 use crate::header_diff::DiffMode;
+use crate::Binary;
 use crate::Diff;
 use crate::DiffValues;
-use crate::Object;
 use crate::Report;
 use anyhow::Result;
 use fallible_iterator::FallibleIterator;
@@ -78,7 +78,7 @@ fn parse_unit_info(
     ))
 }
 
-fn read_file_debug_info(obj: &Object) -> Result<DebugInfo> {
+fn read_file_debug_info(obj: &Binary) -> Result<DebugInfo> {
     let load_section = |id: gimli::SectionId| -> Result<Cow<[u8]>> {
         Ok(match obj.section_by_name(id.name()) {
             Some(section) => section.uncompressed_data()?,
@@ -99,8 +99,8 @@ fn read_file_debug_info(obj: &Object) -> Result<DebugInfo> {
 }
 
 fn diff_debug_info(
-    objects: &[Object<'_>],
-    get_fields_fn: impl Fn(&Object<'_>) -> Result<DebugInfo>,
+    objects: &[Binary<'_>],
+    get_fields_fn: impl Fn(&Binary<'_>) -> Result<DebugInfo>,
     diff_mode: DiffMode,
 ) -> Vec<Diff> {
     let debug_infos = objects.iter().map(get_fields_fn).collect_vec();
@@ -162,7 +162,7 @@ fn diff_debug_info(
     mismatches
 }
 
-pub(crate) fn check_debug_info(report: &mut Report, objects: &[crate::Object]) {
+pub(crate) fn check_debug_info(report: &mut Report, objects: &[crate::Binary]) {
     report.add_diffs(diff_debug_info(
         objects,
         read_file_debug_info,

--- a/linker-diff/src/diagnostics.rs
+++ b/linker-diff/src/diagnostics.rs
@@ -1,0 +1,79 @@
+//! Provides mechanisms for helping diagnose problems in linker-diff. Specifically, a way to set up
+//! tracing so that we can collect tracing logs within some scope and attach them to a diff report.
+//!
+//! To get tracing messages, make sure the code you want to trace from is called from somewhere
+//! inside a call to `trace_scope`. Assuming it is, you can then call `tracing::trace!()` and see
+//! the output in the diff report for whatever was being diffed.
+
+use std::cell::RefCell;
+use std::fmt::Write as _;
+use tracing_subscriber::layer::SubscriberExt as _;
+
+/// Enable diagnostics. Configures the global tracing subscriber, so cannot be used in conjunction
+/// with other things that do that. For that reason, this should be called from the main binary.
+pub fn enable_diagnostics() {
+    let layer = TraceLayer;
+    let subscriber = tracing_subscriber::Registry::default().with(layer);
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("Only one global tracing subscriber can be setup");
+}
+
+#[derive(Default, Debug, Clone)]
+pub(crate) struct TraceOutput {
+    pub(crate) messages: Vec<String>,
+}
+
+thread_local! {
+    pub static TRACE_STACK: RefCell<Vec<TraceOutput>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Runs `f` then returns all trace output emitted while it was running.
+pub(crate) fn trace_scope<T>(trace_output: &mut TraceOutput, f: impl FnOnce() -> T) -> T {
+    TRACE_STACK.with_borrow_mut(|stack| stack.push(TraceOutput::default()));
+
+    let result = f();
+
+    *trace_output = TRACE_STACK.with_borrow_mut(|stack| stack.pop()).unwrap();
+
+    result
+}
+
+struct TraceLayer;
+
+impl<S> tracing_subscriber::Layer<S> for TraceLayer
+where
+    S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+{
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        if TRACE_STACK.with_borrow(|stack| stack.is_empty()) {
+            return;
+        }
+
+        let mut formatter = MessageFormatter::default();
+        event.record(&mut formatter);
+
+        TRACE_STACK.with_borrow_mut(|stack| {
+            if let Some(out) = stack.last_mut() {
+                out.messages.push(formatter.out);
+            }
+        });
+    }
+}
+
+#[derive(Default)]
+struct MessageFormatter {
+    out: String,
+}
+
+impl tracing::field::Visit for MessageFormatter {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if !self.out.is_empty() {
+            self.out.push(' ');
+        }
+        let _ = write!(&mut self.out, "{field}={value:?}");
+    }
+}

--- a/linker-diff/src/eh_frame_diff.rs
+++ b/linker-diff/src/eh_frame_diff.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::mem::offset_of;
 
-pub(crate) fn report_diffs(report: &mut crate::Report, objects: &[crate::Object]) {
+pub(crate) fn report_diffs(report: &mut crate::Report, objects: &[crate::Binary]) {
     report.add_diffs(crate::header_diff::diff_fields(
         objects,
         read_eh_frame_hdr_fields,
@@ -28,7 +28,7 @@ pub(crate) fn report_diffs(report: &mut crate::Report, objects: &[crate::Object]
     ));
 }
 
-fn read_eh_frame_hdr_fields(object: &crate::Object) -> Result<FieldValues> {
+fn read_eh_frame_hdr_fields(object: &crate::Binary) -> Result<FieldValues> {
     let mut values = FieldValues::default();
 
     let Some(segment_hdr) = eh_frame_segment(object) else {
@@ -102,7 +102,7 @@ fn read_eh_frame_hdr_fields(object: &crate::Object) -> Result<FieldValues> {
 const EH_FRAME_PC_BEGIN_OFFSET: usize = 8;
 
 fn verify_frames(
-    object: &crate::Object,
+    object: &crate::Binary,
     values: &mut FieldValues,
     header_entries: &[EhFrameHdrEntry],
     header_base: u64,
@@ -211,7 +211,7 @@ fn read_eh_frame_pc_begin(
     )
 }
 
-fn eh_frame_segment(object: &crate::Object) -> Option<ProgramHeader64<LittleEndian>> {
+fn eh_frame_segment(object: &crate::Binary) -> Option<ProgramHeader64<LittleEndian>> {
     for hdr in object.elf_file.elf_program_headers() {
         if hdr.p_type.get(LittleEndian) == object::elf::PT_GNU_EH_FRAME {
             return Some(*hdr);

--- a/linker-diff/src/gnu_hash.rs
+++ b/linker-diff/src/gnu_hash.rs
@@ -1,4 +1,4 @@
-use crate::Object;
+use crate::Binary;
 use crate::Result;
 use anyhow::anyhow;
 use anyhow::bail;
@@ -15,7 +15,7 @@ use object::SymbolIndex;
 
 type GnuHashHeader = object::elf::GnuHashHeader<LittleEndian>;
 
-pub(crate) fn check_object(obj: &Object) -> Result {
+pub(crate) fn check_object(obj: &Binary) -> Result {
     let num_symbols = obj
         .elf_file
         .dynamic_symbols()

--- a/linker-diff/src/section_map.rs
+++ b/linker-diff/src/section_map.rs
@@ -2,15 +2,25 @@ use crate::ElfFile64;
 use crate::Result;
 use anyhow::bail;
 use anyhow::Context;
+use itertools::Itertools;
 use linker_layout::ArchiveEntryInfo;
+use object::read::elf::ElfSection64;
+use object::LittleEndian;
+use object::Object;
+use object::ObjectSymbol;
+use object::SymbolKind;
+use std::collections::HashMap;
 use std::fmt::Display;
 use std::io::Read;
 use std::ops::Range;
 use std::os::unix::fs::FileExt;
 use std::path::Path;
 
+/// A .layout file plus all the files that it references. All data is owned. This struct mostly
+/// exists so that `IndexedLayout` has something to borrow from.
 pub(crate) struct LayoutAndFiles {
     layout: linker_layout::Layout,
+
     /// The bytes of each file in the layout.
     files: Vec<Vec<u8>>,
 }
@@ -33,15 +43,35 @@ impl LayoutAndFiles {
     }
 }
 
+/// A `.layout` file after we've done some indexing of its contents.
 pub(crate) struct IndexedLayout<'data> {
+    /// All of the object files that were used as inputs during linking.
     files: Vec<InputFile<'data>>,
-    sections: Vec<SectionInfo>,
+
+    /// Mapping from symbol names to the input section they came from. Only symbols that point to
+    /// sections that were copied are present. If multiple symbols with the same name point to
+    /// copied sections, then the name is omitted.
+    pub(crate) symbol_name_to_section_id: HashMap<&'data [u8], SymbolInfo>,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct SymbolInfo {
+    pub(crate) section_id: InputSectionId,
+    pub(crate) offset_in_section: u64,
+    pub(crate) is_ifunc: bool,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct FunctionInfo<'data> {
+    pub(crate) offset_in_section: u64,
+    pub(crate) name: &'data [u8],
 }
 
 impl<'data> IndexedLayout<'data> {
     pub(crate) fn new(layout_and_files: &'data LayoutAndFiles) -> Result<IndexedLayout<'data>> {
         let mut files = Vec::with_capacity(layout_and_files.layout.files.len());
-        let mut sections = Vec::new();
+        let mut symbol_info_by_name = HashMap::new();
+
         for ((file_index, file), object_bytes) in layout_and_files
             .layout
             .files
@@ -49,72 +79,105 @@ impl<'data> IndexedLayout<'data> {
             .enumerate()
             .zip(&layout_and_files.files)
         {
+            let elf_file = crate::ElfFile64::parse(object_bytes)?;
+            let mut functions_by_section = vec![Vec::new(); file.sections.len()];
+
+            for symbol in elf_file.symbols() {
+                let Some(section_index) = symbol.section_index() else {
+                    continue;
+                };
+
+                if !file
+                    .sections
+                    .get(section_index.0)
+                    .is_some_and(|sec| sec.is_some())
+                {
+                    // This symbol points to a section that we didn't copy. Ignore it.
+                }
+
+                let name = symbol.name_bytes()?;
+
+                match symbol_info_by_name.entry(name) {
+                    std::collections::hash_map::Entry::Occupied(mut occupied_entry) => {
+                        // We've got multiple symbols with this name, change the entry to None to
+                        // indicate this.
+                        occupied_entry.insert(None);
+                    }
+                    std::collections::hash_map::Entry::Vacant(vacant_entry) => {
+                        vacant_entry.insert(Some(SymbolInfo {
+                            section_id: InputSectionId {
+                                file_index,
+                                section_index,
+                            },
+                            offset_in_section: symbol.address(),
+                            is_ifunc: symbol.elf_symbol().st_type() == object::elf::STT_GNU_IFUNC,
+                        }));
+                    }
+                }
+
+                if symbol.kind() == SymbolKind::Text {
+                    functions_by_section[section_index.0].push(FunctionInfo {
+                        offset_in_section: symbol.address(),
+                        name,
+                    });
+                }
+            }
+
             files.push(InputFile {
-                filename: file.path.as_path(),
-                archive_entry: file.archive_entry.as_ref(),
-                elf_file: crate::ElfFile64::parse(object_bytes)?,
-            });
-            sections.extend(file.sections.iter().enumerate().filter_map(
-                |(section_index, maybe_sec)| {
-                    maybe_sec.as_ref().map(|sec| SectionInfo {
-                        addresses: sec.mem_range.clone(),
-                        file_index,
-                        section_index,
-                    })
+                identifier: FileIdentifier {
+                    filename: file.path.as_path(),
+                    archive_entry: file.archive_entry.as_ref(),
                 },
-            ));
+                elf_file,
+                sections: file
+                    .sections
+                    .iter()
+                    .zip(functions_by_section)
+                    .enumerate()
+                    .map(|(section_index, (maybe_sec, mut functions))| {
+                        functions.sort_by_key(|f| f.offset_in_section);
+
+                        maybe_sec.as_ref().map(|sec| SectionInfo {
+                            addresses: sec.mem_range.clone(),
+                            section_id: InputSectionId {
+                                file_index,
+                                section_index: object::SectionIndex(section_index),
+                            },
+                            functions,
+                        })
+                    })
+                    .collect(),
+            });
         }
-        sections.sort_by_key(|sec| (sec.addresses.start, sec.addresses.end));
-        let index = IndexedLayout { files, sections };
+
+        // Drop entries with None (non-unique names).
+        let symbol_name_to_section_id: HashMap<&[u8], SymbolInfo> = symbol_info_by_name
+            .into_iter()
+            .filter_map(|(name, sec)| sec.map(|s| (name, s)))
+            .collect();
+
+        let index = IndexedLayout {
+            files,
+            symbol_name_to_section_id,
+        };
+
         index.validate_no_overlaps()?;
+
         Ok(index)
     }
 
-    pub(crate) fn address_range(&self) -> Option<Range<u64>> {
-        let min = self.sections.iter().map(|s| s.addresses.start).min()?;
-        let max = self.sections.iter().map(|s| s.addresses.end).max()?;
-        Some(min..max)
-    }
-
-    /// Returns the first input file, if any that we can determine was mapped into the supplied
-    /// address range.
-    pub(crate) fn file_in_range(&self, addresses: Range<u64>) -> Option<&InputFile> {
-        let mut i = self
-            .sections
-            .binary_search_by_key(&addresses.start, |sec| sec.addresses.start)
-            .unwrap_or_else(|p| p);
-        while let Some(section) = self.sections.get(i) {
-            if section.addresses.start >= addresses.end {
-                return None;
-            }
-            if addresses.end <= section.addresses.start {
-                i += 1;
-            } else {
-                return Some(&self.files[section.file_index]);
-            }
-        }
-        None
-    }
-
-    pub(crate) fn resolve_address(&self, address: u64) -> Option<InputResolution> {
-        let i = self
-            .sections
-            .binary_search_by_key(&address, |sec| sec.addresses.end)
-            .unwrap_or_else(|p| p);
-        let section = self.sections.get(i)?;
-        if !section.addresses.contains(&address) {
-            return None;
-        }
-        Some(InputResolution {
-            file: &self.files[section.file_index],
-            section,
-            offset_in_section: address - section.addresses.start,
-        })
-    }
-
     fn validate_no_overlaps(&self) -> Result {
+        let mut sections = self
+            .files
+            .iter()
+            .flat_map(|file| file.sections.iter())
+            .flatten()
+            .collect_vec();
+
+        sections.sort_by_key(|sec| (sec.addresses.start, sec.addresses.end));
+
         let mut last: Option<&SectionInfo> = None;
-        for section in &self.sections {
+        for section in sections {
             if let Some(last) = last {
                 if section.addresses.start < last.addresses.end {
                     bail!(
@@ -128,18 +191,39 @@ impl<'data> IndexedLayout<'data> {
         }
         Ok(())
     }
+
+    pub(crate) fn get_section_info(&self, section_id: InputSectionId) -> Option<&SectionInfo> {
+        self.files[section_id.file_index].sections[section_id.section_index.0].as_ref()
+    }
+
+    pub(crate) fn get_elf_section(
+        &self,
+        section_id: InputSectionId,
+    ) -> Result<ElfSection64<'data, '_, LittleEndian>> {
+        Ok(self.files[section_id.file_index]
+            .elf_file
+            .section_by_index(section_id.section_index)?)
+    }
+
+    pub(crate) fn input_file_for_section(&self, section_id: InputSectionId) -> &InputFile {
+        &self.files[section_id.file_index]
+    }
+
+    pub(crate) fn input_filename_for_section(&self, section_id: InputSectionId) -> &FileIdentifier {
+        &self.input_file_for_section(section_id).identifier
+    }
 }
 
 struct DisplaySection<'data> {
-    info: SectionInfo,
+    info: SectionInfo<'data>,
     file: &'data InputFile<'data>,
 }
 
 impl<'data> DisplaySection<'data> {
-    fn new(info: &SectionInfo, files: &'data [InputFile]) -> Self {
+    fn new(info: &SectionInfo<'data>, files: &'data [InputFile]) -> Self {
         Self {
             info: info.clone(),
-            file: &files[info.file_index],
+            file: &files[info.section_id.file_index],
         }
     }
 }
@@ -158,9 +242,7 @@ impl Display for DisplaySection<'_> {
             write!(
                 f,
                 "section `{section_name}` (0x{:x}..0x{:x}) ({})",
-                self.info.addresses.start,
-                self.info.addresses.end,
-                self.file.filename.to_string_lossy()
+                self.info.addresses.start, self.info.addresses.end, self.file.identifier,
             )?;
         }
         Ok(())
@@ -168,22 +250,28 @@ impl Display for DisplaySection<'_> {
 }
 
 #[derive(Clone)]
-pub(crate) struct SectionInfo {
+pub(crate) struct SectionInfo<'data> {
     addresses: Range<u64>,
-    file_index: usize,
-    section_index: usize,
+    section_id: InputSectionId,
+    functions: Vec<FunctionInfo<'data>>,
 }
 
 pub(crate) struct InputFile<'data> {
-    filename: &'data Path,
-    archive_entry: Option<&'data ArchiveEntryInfo>,
+    pub(crate) identifier: FileIdentifier<'data>,
     pub(crate) elf_file: ElfFile64<'data>,
+    sections: Vec<Option<SectionInfo<'data>>>,
 }
 
-pub(crate) struct InputResolution<'obj> {
-    pub(crate) file: &'obj InputFile<'obj>,
-    section: &'obj SectionInfo,
-    pub(crate) offset_in_section: u64,
+pub(crate) struct FileIdentifier<'data> {
+    pub(crate) filename: &'data Path,
+    pub(crate) archive_entry: Option<&'data ArchiveEntryInfo>,
+}
+
+/// Identifies an input section.
+#[derive(Clone, Copy, Hash, PartialEq, Eq)]
+pub(crate) struct InputSectionId {
+    pub(crate) file_index: usize,
+    pub(crate) section_index: object::SectionIndex,
 }
 
 fn read_object_bytes(input_file: &linker_layout::InputFile) -> Result<Vec<u8>> {
@@ -199,19 +287,30 @@ fn read_object_bytes(input_file: &linker_layout::InputFile) -> Result<Vec<u8>> {
     Ok(buffer)
 }
 
-impl InputResolution<'_> {
-    pub(crate) fn section_index(&self) -> object::SectionIndex {
-        self.section.index()
-    }
-}
-
-impl SectionInfo {
+impl SectionInfo<'_> {
     pub(crate) fn index(&self) -> object::SectionIndex {
-        object::SectionIndex(self.section_index)
+        self.section_id.section_index
+    }
+
+    pub(crate) fn function_at_offset(&self, offset: u64) -> Option<FunctionInfo> {
+        match self
+            .functions
+            .binary_search_by_key(&offset, |f| f.offset_in_section)
+        {
+            Ok(i) => Some(self.functions[i]),
+            Err(0) => None,
+            Err(i) => Some(self.functions[i - 1]),
+        }
     }
 }
 
 impl Display for InputFile<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.identifier, f)
+    }
+}
+
+impl Display for FileIdentifier<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "`{}`", self.filename.display())?;
         if let Some(entry) = self.archive_entry.as_ref() {

--- a/linker-diff/src/symtab.rs
+++ b/linker-diff/src/symtab.rs
@@ -1,4 +1,4 @@
-use crate::Object;
+use crate::Binary;
 use crate::Result;
 use anyhow::bail;
 use linker_utils::elf::sht;
@@ -9,15 +9,15 @@ use object::Object as _;
 use object::ObjectSymbol;
 use std::ops::Not;
 
-pub(crate) fn validate_debug(object: &Object) -> Result {
+pub(crate) fn validate_debug(object: &Binary) -> Result {
     validate(object, false)
 }
 
-pub(crate) fn validate_dynamic(object: &Object) -> Result {
+pub(crate) fn validate_dynamic(object: &Binary) -> Result {
     validate(object, true)
 }
 
-fn validate(object: &Object, dynamic: bool) -> Result {
+fn validate(object: &Binary, dynamic: bool) -> Result {
     let mut symtab_info = 0;
     let (symtab_section_type, mut symbols) = if dynamic {
         (sht::DYNSYM, object.elf_file.dynamic_symbols())

--- a/linker-diff/src/x86_64.rs
+++ b/linker-diff/src/x86_64.rs
@@ -1,0 +1,275 @@
+use crate::arch::Arch;
+use crate::arch::Instruction;
+use crate::arch::RType as _;
+use crate::arch::Relaxation;
+use crate::arch::RelaxationMask;
+use crate::arch::RelocationTypeInfo;
+use iced_x86::Formatter as _;
+use linker_utils::elf::x86_64_rel_type_to_string;
+use linker_utils::elf::DynamicRelocationKind;
+use object::SectionKind;
+use std::fmt::Display;
+
+const BIT_CLASS: u32 = 64;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct X86_64;
+
+impl Arch for X86_64 {
+    type RType = RType;
+
+    type RelaxationKind = linker_utils::x86_64::RelaxationKind;
+
+    type RawInstruction = iced_x86::Instruction;
+
+    fn next_relocation_modifier(
+        relaxation_kind: Self::RelaxationKind,
+    ) -> linker_utils::relaxation::RelocationModifier {
+        relaxation_kind.next_modifier()
+    }
+
+    fn relaxation_mask(relaxation: Relaxation<Self>) -> crate::arch::RelaxationMask {
+        match relaxation.relaxation_kind {
+            Self::RelaxationKind::MovIndirectToLea => RelaxationMask::new(2, &[0xff; 2]),
+            Self::RelaxationKind::MovIndirectToAbsolute => RelaxationMask::new(2, &[0xff; 2]),
+            Self::RelaxationKind::RexMovIndirectToAbsolute => RelaxationMask::new(3, &[0xff; 3]),
+            Self::RelaxationKind::RexSubIndirectToAbsolute => RelaxationMask::new(3, &[0xff; 3]),
+            Self::RelaxationKind::RexCmpIndirectToAbsolute => RelaxationMask::new(3, &[0xff; 3]),
+            Self::RelaxationKind::CallIndirectToRelative => RelaxationMask::new(2, &[0xff; 2]),
+            Self::RelaxationKind::TlsGdToLocalExec => RelaxationMask::new(4, &[0xff; 12]),
+            Self::RelaxationKind::TlsGdToLocalExecLarge => RelaxationMask::new(
+                3,
+                &[
+                    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0, 0,
+                    0, 0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                ],
+            ),
+            Self::RelaxationKind::TlsGdToInitialExec => RelaxationMask::new(4, &[0xff; 12]),
+            Self::RelaxationKind::TlsLdToLocalExec => RelaxationMask::new(3, &[0xff; 12]),
+            Self::RelaxationKind::TlsLdToLocalExec64 => RelaxationMask::new(3, &[0xff; 18]),
+            Self::RelaxationKind::SkipTlsDescCall => RelaxationMask::new(0, &[0xff; 2]),
+            Self::RelaxationKind::TlsDescToLocalExec => RelaxationMask::new(3, &[0xff; 3]),
+            Self::RelaxationKind::NoOp => match relaxation.new_r_type.0 {
+                // TLSDESC_CALL is a relocation that does nothing unless it's optimised away. To
+                // verify that it hasn't been optimised away, we need to make sure that we compare
+                // the bytes immediately after the relocation.
+                object::elf::R_X86_64_TLSDESC_CALL => RelaxationMask::new(0, &[0xff; 2]),
+                _ => RelaxationMask::new(0, &[]),
+            },
+        }
+    }
+
+    fn possible_relaxations_do(
+        r_type: Self::RType,
+        section_kind: SectionKind,
+        mut cb: impl FnMut(Relaxation<Self>),
+    ) {
+        let mut relax = |relaxation_kind, new_r_type| {
+            cb(Relaxation {
+                relaxation_kind,
+                new_r_type: RType::from_raw(new_r_type),
+            });
+        };
+        match (section_kind, r_type.0) {
+            (SectionKind::Text, object::elf::R_X86_64_REX_GOTPCRELX) => {
+                relax(
+                    Self::RelaxationKind::RexMovIndirectToAbsolute,
+                    object::elf::R_X86_64_32,
+                );
+                relax(
+                    Self::RelaxationKind::RexSubIndirectToAbsolute,
+                    object::elf::R_X86_64_32,
+                );
+                relax(
+                    Self::RelaxationKind::RexCmpIndirectToAbsolute,
+                    object::elf::R_X86_64_32,
+                );
+                relax(
+                    Self::RelaxationKind::MovIndirectToLea,
+                    object::elf::R_X86_64_PC32,
+                );
+            }
+            (SectionKind::Text, object::elf::R_X86_64_GOTPCRELX) => {
+                relax(
+                    Self::RelaxationKind::MovIndirectToAbsolute,
+                    object::elf::R_X86_64_32,
+                );
+                relax(
+                    Self::RelaxationKind::CallIndirectToRelative,
+                    object::elf::R_X86_64_PC32,
+                );
+                relax(
+                    Self::RelaxationKind::MovIndirectToLea,
+                    object::elf::R_X86_64_PC32,
+                );
+            }
+            (SectionKind::Text, object::elf::R_X86_64_GOTPCREL) => {
+                relax(
+                    Self::RelaxationKind::MovIndirectToLea,
+                    object::elf::R_X86_64_PC32,
+                );
+            }
+            (SectionKind::Text, object::elf::R_X86_64_GOTTPOFF) => {
+                relax(
+                    Self::RelaxationKind::RexMovIndirectToAbsolute,
+                    object::elf::R_X86_64_TPOFF32,
+                );
+            }
+            (SectionKind::Text, object::elf::R_X86_64_PLT32) => {
+                relax(Self::RelaxationKind::NoOp, object::elf::R_X86_64_PC32);
+            }
+            (SectionKind::Text, object::elf::R_X86_64_PLTOFF64) => {
+                relax(Self::RelaxationKind::NoOp, object::elf::R_X86_64_GOTOFF64);
+            }
+            (SectionKind::Text, object::elf::R_X86_64_TLSGD) => {
+                relax(
+                    Self::RelaxationKind::TlsGdToLocalExec,
+                    object::elf::R_X86_64_TPOFF32,
+                );
+                relax(
+                    Self::RelaxationKind::TlsGdToLocalExecLarge,
+                    object::elf::R_X86_64_TPOFF32,
+                );
+                relax(
+                    Self::RelaxationKind::TlsGdToInitialExec,
+                    object::elf::R_X86_64_GOTTPOFF,
+                );
+            }
+            (SectionKind::Text, object::elf::R_X86_64_TLSLD) => {
+                relax(
+                    Self::RelaxationKind::TlsLdToLocalExec,
+                    object::elf::R_X86_64_NONE,
+                );
+            }
+            (SectionKind::Text, object::elf::R_X86_64_TLSDESC_CALL) => {
+                relax(
+                    Self::RelaxationKind::SkipTlsDescCall,
+                    object::elf::R_X86_64_NONE,
+                );
+            }
+            _ => {}
+        };
+
+        // We always support just keeping the relocation as-is.
+        relax(Self::RelaxationKind::NoOp, r_type.0);
+    }
+
+    fn apply_relaxation(
+        relaxation_kind: Self::RelaxationKind,
+        section_bytes: &mut [u8],
+        offset_in_section: &mut u64,
+        addend: &mut i64,
+    ) {
+        relaxation_kind.apply(section_bytes, offset_in_section, addend);
+    }
+
+    fn decode_instructions_in_range(
+        section_bytes: &[u8],
+        section_address: u64,
+        function_offset_in_section: u64,
+        range: std::ops::Range<u64>,
+    ) -> Vec<Instruction<Self>> {
+        let mut instructions = Vec::new();
+
+        let mut decoder = AsmDecoder::new(
+            section_address + function_offset_in_section,
+            &section_bytes[function_offset_in_section as usize..],
+        );
+
+        while let Some(instruction) = decoder.next() {
+            let instruction_offset = instruction.address() - section_address;
+
+            if instruction_offset >= range.end {
+                break;
+            }
+
+            let instruction_end = instruction_offset + instruction.bytes.len() as u64;
+
+            if instruction_end > range.start {
+                instructions.push(instruction);
+            }
+        }
+
+        instructions
+    }
+
+    fn instruction_to_string(instruction: Self::RawInstruction) -> String {
+        let mut out = String::new();
+        let mut formatter = iced_x86::GasFormatter::new();
+        formatter.format(&instruction, &mut out);
+        out
+    }
+}
+
+struct AsmDecoder<'data> {
+    base_address: u64,
+    instruction_decoder: iced_x86::Decoder<'data>,
+    bytes: &'data [u8],
+}
+
+impl<'data> AsmDecoder<'data> {
+    fn new(base_address: u64, bytes: &'data [u8]) -> Self {
+        let options = iced_x86::DecoderOptions::NONE;
+        Self {
+            base_address,
+            instruction_decoder: iced_x86::Decoder::with_ip(
+                BIT_CLASS,
+                bytes,
+                base_address,
+                options,
+            ),
+            bytes,
+        }
+    }
+
+    // Note, this could be (and used to be) in an implementation of the Iterator trait. We don't
+    // need it to be though, since we always call it directly. By not using a trait, it's easier to
+    // find callers of this method.
+    fn next(&mut self) -> Option<Instruction<'data, X86_64>> {
+        if !self.instruction_decoder.can_decode() {
+            return None;
+        }
+        let offset = self.instruction_decoder.position();
+        let instruction = self.instruction_decoder.decode();
+        let next_offset = self.instruction_decoder.position();
+        let bytes = &self.bytes[offset..next_offset];
+        Some(Instruction {
+            base_address: self.base_address,
+            offset: offset as u64,
+            raw_instruction: instruction,
+            bytes,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RType(u32);
+
+impl crate::arch::RType for RType {
+    fn from_raw(raw: u32) -> Self {
+        RType(raw)
+    }
+
+    fn from_dynamic_relocation_kind(kind: DynamicRelocationKind) -> Self {
+        Self::from_raw(kind.x86_64_r_type())
+    }
+
+    fn relocation_info(self) -> Option<RelocationTypeInfo> {
+        linker_utils::x86_64::relocation_kind_and_size(self.0).map(|(kind, size_in_bytes)| {
+            RelocationTypeInfo {
+                kind,
+                size_in_bytes,
+            }
+        })
+    }
+
+    fn dynamic_relocation_kind(self) -> Option<DynamicRelocationKind> {
+        DynamicRelocationKind::from_x86_64_r_type(self.0)
+    }
+}
+
+impl Display for RType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&x86_64_rel_type_to_string(self.0), f)
+    }
+}

--- a/linker-layout/src/lib.rs
+++ b/linker-layout/src/lib.rs
@@ -17,7 +17,7 @@ pub struct Layout {
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
 pub struct InputFile {
-    /// Path to the input file on disk. In the of archives, multiple inputs may have the same path.
+    /// Path to the input file on disk. In case of archives, multiple inputs may have the same path.
     pub path: PathBuf,
 
     /// If the input is an archive, then contains information about where in the archive the file

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -595,7 +595,7 @@ pub enum RelocationKind {
     None,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum DynamicRelocationKind {
     Copy,
     Irelative,
@@ -605,6 +605,7 @@ pub enum DynamicRelocationKind {
     TpOff,
     Relative,
     DynamicSymbol,
+    JumpSlot,
 }
 
 impl DynamicRelocationKind {
@@ -619,6 +620,7 @@ impl DynamicRelocationKind {
             object::elf::R_X86_64_RELATIVE => DynamicRelocationKind::Relative,
             object::elf::R_X86_64_GLOB_DAT => DynamicRelocationKind::DynamicSymbol,
             object::elf::R_X86_64_TLSDESC => DynamicRelocationKind::TlsDesc,
+            object::elf::R_X86_64_JUMP_SLOT => DynamicRelocationKind::JumpSlot,
             _ => return None,
         };
 
@@ -636,6 +638,7 @@ impl DynamicRelocationKind {
             DynamicRelocationKind::Relative => object::elf::R_X86_64_RELATIVE,
             DynamicRelocationKind::DynamicSymbol => object::elf::R_X86_64_GLOB_DAT,
             DynamicRelocationKind::TlsDesc => object::elf::R_X86_64_TLSDESC,
+            DynamicRelocationKind::JumpSlot => object::elf::R_X86_64_JUMP_SLOT,
         }
     }
 }

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -1309,6 +1309,7 @@ fn diff_files(instructions: &Config, files: Vec<PathBuf>, display: &dyn Display)
     }
 
     let mut config = linker_diff::Config::default();
+    config.colour = linker_diff::Colour::Always;
     config.wild_defaults = true;
     config
         .ignore

--- a/wild/tests/sources/cpp-integration.cc
+++ b/wild/tests/sources/cpp-integration.cc
@@ -9,14 +9,17 @@
 //#Config:pie:default
 //#CompArgs:-fpie -fmerge-constants
 //#LinkArgs:--cc=g++ -pie -Wl,-z,now
+//#EnableLinker:lld
 
 //#Config:no-pie:default
 //#CompArgs:-fno-pie -fmerge-constants
 //#LinkArgs:--cc=g++ -no-pie -Wl,-z,now
+//#EnableLinker:lld
 
 //#Config:model-large:default
 //#CompArgs:-mcmodel=large
 //#LinkArgs:--cc=g++ -Wl,-z,now
+//#EnableLinker:lld
 
 #include <iostream>
 #include <string>

--- a/wild/tests/sources/libc-integration.c
+++ b/wild/tests/sources/libc-integration.c
@@ -23,6 +23,7 @@
 //#LinkArgs:--cc=clang -static-pie -Wl,--strip-debug -Wl,--gc-sections -Wl,-z,now
 //#Object:libc-integration-0.c
 //#Object:libc-integration-1.c
+//#EnableLinker:lld
 
 //#Config:gcc-static:default
 //#LinkArgs:--cc=gcc -static -Wl,--strip-debug -Wl,--gc-sections -Wl,-z,now
@@ -30,10 +31,11 @@
 //#Object:libc-integration-1.c
 
 //#Config:gcc-static-pie:default
-//#CompArgs:-fPIE -DVERIFY_CTORS
+//#CompArgs:-fPIE
 //#LinkArgs:--cc=gcc -static-pie -Wl,--strip-debug -Wl,--gc-sections -Wl,-z,now
 //#Object:libc-integration-0.c
 //#Object:libc-integration-1.c
+//#EnableLinker:lld
 
 //#Config:clang-initial-exec:default
 //#CompArgs:-g -fPIC -ftls-model=initial-exec -DDYNAMIC_DEP

--- a/wild/tests/sources/rust-integration-dynamic.rs
+++ b/wild/tests/sources/rust-integration-dynamic.rs
@@ -1,4 +1,3 @@
-//#DiffIgnore:asm.__udivti3
 //#DiffIgnore:.dynamic.*
 // It looks like GNU ld sets .tdata's alignment to match .tbss's alignment
 //#DiffIgnore:section.tdata.alignment

--- a/wild/tests/sources/rust-integration.rs
+++ b/wild/tests/sources/rust-integration.rs
@@ -1,5 +1,4 @@
 //#AbstractConfig:default
-//#DiffIgnore:asm.dummy
 //#DiffIgnore:section.tdata.alignment
 // We include some more archive members than what other linkers do (#162).
 //#DiffIgnore:debug_info.missing_unit

--- a/wild/tests/sources/tlsdesc.c
+++ b/wild/tests/sources/tlsdesc.c
@@ -32,7 +32,6 @@
 //#Config:gcc-tls-desc-shared:gcc-tls-desc
 //#CompArgs:-mtls-dialect=gnu2 -fPIC
 //#Shared:tlsdesc-obj.c
-//#DiffIgnore:asm.get_value
 //#Arch: x86_64
 
 //#Config:gcc-tls-desc-shared-aarch64:gcc-tls-desc-shared
@@ -52,7 +51,6 @@
 //#Config:clang-tls-desc-shared:clang-tls-desc
 //#CompArgs:-mtls-dialect=gnu2 -fPIC
 //#Shared:tlsdesc-obj.c
-//#DiffIgnore:asm.get_value
 //#Arch: x86_64
 
 //#Config:clang-tls-desc-shared-aarch64:clang-tls-desc-shared


### PR DESCRIPTION
Details about how the new implementation works are in comments in the code. There's still lots more to be done, but the new approach should be a much more solid foundation on which to build.

The new implementation relies on having a .layout file.

The new implmentation doesn't use a disassembler for diffing, only for reporting problems. This should make porting to aarch64 much more practical, since we no longer need to extract information from the disassembled instructions.