### PR TITLE
Emit symtab for symbols with copy relocations

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2991,14 +2991,22 @@ impl<'data> DynamicLayout<'data> {
             .zip(self.object.symbols.iter())
         {
             if let Some(res) = resolution {
+                let name = self.object.symbol_name(symbol)?;
+
                 if res
                     .resolution_flags
                     .contains(ResolutionFlags::COPY_RELOCATION)
                 {
-                    // Symbol needs a copy relocation, which means that the symbol will be written
-                    // by the epilogue not by us.
+                    // Symbol needs a copy relocation, which means that the dynamic symbol will be
+                    // written by the epilogue not by us. However, we do need to write a regular
+                    // symtab entry.
+                    table_writer.debug_symbol_writer.copy_symbol(
+                        symbol,
+                        name,
+                        output_section_id::BSS,
+                        res.value(),
+                    )?;
                 } else {
-                    let name = self.object.symbol_name(symbol)?;
                     table_writer
                         .dynsym_writer
                         .copy_symbol_shndx(symbol, name, 0, 0)?;


### PR DESCRIPTION
Previously we only emitted a dynamic symbol, not a symtab symbol. GNU ld emits both, now we do too.

This was showing up as a difference with the upcoming linker-diff rework.