### PR TITLE
x86_64: relax TLSDESC for statically linked executables

### DIFF
--- a/libwild/src/x86_64.rs
+++ b/libwild/src/x86_64.rs
@@ -283,6 +283,17 @@ impl crate::arch::Relaxation for Relaxation {
                     return create(RelaxationKind::TlsLdToLocalExec, object::elf::R_X86_64_NONE);
                 }
             }
+            object::elf::R_X86_64_GOTPC32_TLSDESC
+                if can_bypass_got && output_kind.is_static_executable() =>
+            {
+                // lea    0x0(%rip),%rax
+                if section_bytes.get(offset - 3..offset)? == [0x48, 0x8d, 0x05] {
+                    return create(
+                        RelaxationKind::TlsDescToLocalExec,
+                        object::elf::R_X86_64_TPOFF32,
+                    );
+                }
+            }
             _ => return None,
         };
         None

--- a/wild/tests/sources/tlsdesc.c
+++ b/wild/tests/sources/tlsdesc.c
@@ -23,6 +23,12 @@
 //#CompArgs:-mtls-dialect=desc
 //#Arch: aarch64
 
+//#Config:gcc-tls-desc-static:gcc-tls-desc
+//#CompArgs:-mtls-dialect=gnu2 -fPIC -static
+//#Shared:tlsdesc-obj.c
+//#DiffIgnore:asm.get_value
+//#Arch: x86_64
+
 //#Config:gcc-tls-desc-shared:gcc-tls-desc
 //#CompArgs:-mtls-dialect=gnu2 -fPIC
 //#Shared:tlsdesc-obj.c


### PR DESCRIPTION
Fixed the following Mold test: test/tlsdesc-static.sh.