### PR TITLE
Use i64 rather than u64 for addend

### DIFF
--- a/libwild/src/aarch64.rs
+++ b/libwild/src/aarch64.rs
@@ -905,7 +905,7 @@ impl crate::arch::Relaxation for Relaxation {
         None
     }
 
-    fn apply(&self, section_bytes: &mut [u8], offset_in_section: &mut u64, addend: &mut u64) {
+    fn apply(&self, section_bytes: &mut [u8], offset_in_section: &mut u64, addend: &mut i64) {
         self.kind.apply(section_bytes, offset_in_section, addend);
     }
 

--- a/libwild/src/arch.rs
+++ b/libwild/src/arch.rs
@@ -61,7 +61,7 @@ pub(crate) trait Relaxation {
     where
         Self: std::marker::Sized;
 
-    fn apply(&self, section_bytes: &mut [u8], offset_in_section: &mut u64, addend: &mut u64);
+    fn apply(&self, section_bytes: &mut [u8], offset_in_section: &mut u64, addend: &mut i64);
 
     fn rel_info(&self) -> crate::elf::RelocationKindInfo;
 

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -4030,7 +4030,7 @@ impl Resolution {
 
     pub(crate) fn value_with_addend(
         &self,
-        addend: u64,
+        addend: i64,
         symbol_index: object::SymbolIndex,
         object_layout: &ObjectLayout,
         merged_strings: &OutputSectionMap<MergedStringsSection>,
@@ -4055,7 +4055,7 @@ impl Resolution {
                 return Ok(r);
             }
         }
-        Ok(self.raw_value.wrapping_add(addend))
+        Ok(self.raw_value.wrapping_add(addend as u64))
     }
 }
 

--- a/libwild/src/string_merging.rs
+++ b/libwild/src/string_merging.rs
@@ -768,7 +768,7 @@ impl<'data> MergeString<'data> {
 /// address in the output.
 pub(crate) fn get_merged_string_output_address(
     symbol_index: object::SymbolIndex,
-    addend: u64,
+    addend: i64,
     object: &crate::elf::File,
     sections: &[SectionSlot],
     merged_strings: &OutputSectionMap<MergedStringsSection>,
@@ -797,7 +797,7 @@ pub(crate) fn get_merged_string_output_address(
         if zero_unnamed {
             return Ok(Some(0));
         }
-        input_offset = input_offset.wrapping_add(addend);
+        input_offset = input_offset.wrapping_add(addend as u64);
     }
 
     let section_id = merge_slot.part_id.output_section_id();
@@ -822,7 +822,7 @@ pub(crate) fn get_merged_string_output_address(
         merged_string_start_addresses.addresses.get(section_id)[string_offset.bucket()];
     let mut address = bucket_base + string_offset.offset_in_bucket();
     if symbol_has_name {
-        address = address.wrapping_add(addend);
+        address = address.wrapping_add(addend as u64);
     }
     Ok(Some(address))
 }

--- a/libwild/src/x86_64.rs
+++ b/libwild/src/x86_64.rs
@@ -288,7 +288,7 @@ impl crate::arch::Relaxation for Relaxation {
         None
     }
 
-    fn apply(&self, section_bytes: &mut [u8], offset_in_section: &mut u64, addend: &mut u64) {
+    fn apply(&self, section_bytes: &mut [u8], offset_in_section: &mut u64, addend: &mut i64) {
         self.kind.apply(section_bytes, offset_in_section, addend);
     }
 

--- a/linker-utils/src/aarch64.rs
+++ b/linker-utils/src/aarch64.rs
@@ -7,7 +7,7 @@ pub enum RelaxationKind {
 }
 
 impl RelaxationKind {
-    pub fn apply(self, _section_bytes: &mut [u8], _offset_in_section: &mut u64, _addend: &mut u64) {
+    pub fn apply(self, _section_bytes: &mut [u8], _offset_in_section: &mut u64, _addend: &mut i64) {
         match self {
             RelaxationKind::NoOp => {}
         }

--- a/linker-utils/src/x86_64.rs
+++ b/linker-utils/src/x86_64.rs
@@ -45,7 +45,7 @@ pub enum RelaxationKind {
 }
 
 impl RelaxationKind {
-    pub fn apply(self, section_bytes: &mut [u8], offset_in_section: &mut u64, addend: &mut u64) {
+    pub fn apply(self, section_bytes: &mut [u8], offset_in_section: &mut u64, addend: &mut i64) {
         let offset = *offset_in_section as usize;
         match self {
             RelaxationKind::MovIndirectToLea => {
@@ -114,7 +114,7 @@ impl RelaxationKind {
                     0x48, 0x03, 0x05,
                 ]);
                 *offset_in_section += 8;
-                *addend = -12_i64 as u64;
+                *addend = -12_i64;
             }
             RelaxationKind::TlsLdToLocalExec => {
                 section_bytes[offset - 3..offset + 9].copy_from_slice(&[


### PR DESCRIPTION
This makes it less likely to get mixed up with offset which is often an adjacent argument. It also makes it nicer if we need to print it out for debugging purposes.

We still cast to u64 before calling `.wrapping_add` when we apply the addend, but now we just do it at the point where we're applying the addend.