### PR TITLE
Move DynamicRelocationKind to linker-utils

### DIFF
--- a/libwild/src/aarch64.rs
+++ b/libwild/src/aarch64.rs
@@ -1,7 +1,6 @@
 use crate::arch::Arch;
 use crate::elf::extract_bits;
 use crate::elf::BitRange;
-use crate::elf::DynamicRelocationKind;
 use crate::elf::PageMask;
 use crate::elf::RelocationInstruction;
 use crate::elf::RelocationKindInfo;
@@ -15,6 +14,7 @@ use anyhow::bail;
 use anyhow::Result;
 use linker_utils::aarch64::RelaxationKind;
 use linker_utils::elf::aarch64_rel_type_to_string;
+use linker_utils::elf::DynamicRelocationKind;
 use linker_utils::elf::RelocationKind;
 use linker_utils::relaxation::RelocationModifier;
 

--- a/libwild/src/arch.rs
+++ b/libwild/src/arch.rs
@@ -1,11 +1,11 @@
 //! Abstraction over different CPU architectures.
 
 use crate::args::OutputKind;
-use crate::elf::DynamicRelocationKind;
 use crate::elf::RelocationKindInfo;
 use crate::error::Result;
 use crate::resolution::ValueFlags;
 use anyhow::bail;
+use linker_utils::elf::DynamicRelocationKind;
 use linker_utils::elf::SectionFlags;
 use linker_utils::relaxation::RelocationModifier;
 use std::borrow::Cow;

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -545,14 +545,3 @@ pub(crate) fn slice_from_all_bytes_mut<T: object::Pod>(data: &mut [u8]) -> &mut 
         .unwrap()
         .0
 }
-
-pub(crate) enum DynamicRelocationKind {
-    Copy,
-    Irelative,
-    DtpMod,
-    DtpOff,
-    TlsDesc,
-    TpOff,
-    Relative,
-    DynamicSymbol,
-}

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -1,5 +1,4 @@
 use self::elf::get_page_mask;
-use self::elf::DynamicRelocationKind;
 use self::elf::NoteHeader;
 use self::elf::NoteProperty;
 use self::elf::GNU_NOTE_PROPERTY_ENTRY_SIZE;
@@ -70,6 +69,7 @@ use linker_utils::elf::secnames::DEBUG_RANGES_SECTION_NAME;
 use linker_utils::elf::secnames::DYNSYM_SECTION_NAME_STR;
 use linker_utils::elf::shf;
 use linker_utils::elf::sht;
+use linker_utils::elf::DynamicRelocationKind;
 use linker_utils::elf::RelocationKind;
 use linker_utils::elf::SectionFlags;
 use linker_utils::relaxation::RelocationModifier;

--- a/libwild/src/x86_64.rs
+++ b/libwild/src/x86_64.rs
@@ -5,7 +5,6 @@
 
 use crate::arch::Arch;
 use crate::args::OutputKind;
-use crate::elf::DynamicRelocationKind;
 use crate::elf::RelocationKindInfo;
 use crate::elf::RelocationSize;
 use crate::elf::PLT_ENTRY_SIZE;
@@ -14,6 +13,7 @@ use anyhow::anyhow;
 use anyhow::Result;
 use linker_utils::elf::shf;
 use linker_utils::elf::x86_64_rel_type_to_string;
+use linker_utils::elf::DynamicRelocationKind;
 use linker_utils::elf::SectionFlags;
 use linker_utils::relaxation::RelocationModifier;
 use linker_utils::x86_64::RelaxationKind;
@@ -53,16 +53,7 @@ impl crate::arch::Arch for X86_64 {
     }
 
     fn get_dynamic_relocation_type(relocation: DynamicRelocationKind) -> u32 {
-        match relocation {
-            DynamicRelocationKind::Copy => object::elf::R_X86_64_COPY,
-            DynamicRelocationKind::Irelative => object::elf::R_X86_64_IRELATIVE,
-            DynamicRelocationKind::DtpMod => object::elf::R_X86_64_DTPMOD64,
-            DynamicRelocationKind::DtpOff => object::elf::R_X86_64_DTPOFF64,
-            DynamicRelocationKind::TpOff => object::elf::R_X86_64_TPOFF64,
-            DynamicRelocationKind::Relative => object::elf::R_X86_64_RELATIVE,
-            DynamicRelocationKind::DynamicSymbol => object::elf::R_X86_64_GLOB_DAT,
-            DynamicRelocationKind::TlsDesc => object::elf::R_X86_64_TLSDESC,
-        }
+        relocation.x86_64_r_type()
     }
 
     fn write_plt_entry(

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -594,3 +594,48 @@ pub enum RelocationKind {
     /// optimisation.
     None,
 }
+
+#[derive(Copy, Clone, Debug)]
+pub enum DynamicRelocationKind {
+    Copy,
+    Irelative,
+    DtpMod,
+    DtpOff,
+    TlsDesc,
+    TpOff,
+    Relative,
+    DynamicSymbol,
+}
+
+impl DynamicRelocationKind {
+    #[must_use]
+    pub fn from_x86_64_r_type(r_type: u32) -> Option<Self> {
+        let kind = match r_type {
+            object::elf::R_X86_64_COPY => DynamicRelocationKind::Copy,
+            object::elf::R_X86_64_IRELATIVE => DynamicRelocationKind::Irelative,
+            object::elf::R_X86_64_DTPMOD64 => DynamicRelocationKind::DtpMod,
+            object::elf::R_X86_64_DTPOFF64 => DynamicRelocationKind::DtpOff,
+            object::elf::R_X86_64_TPOFF64 => DynamicRelocationKind::TpOff,
+            object::elf::R_X86_64_RELATIVE => DynamicRelocationKind::Relative,
+            object::elf::R_X86_64_GLOB_DAT => DynamicRelocationKind::DynamicSymbol,
+            object::elf::R_X86_64_TLSDESC => DynamicRelocationKind::TlsDesc,
+            _ => return None,
+        };
+
+        Some(kind)
+    }
+
+    #[must_use]
+    pub fn x86_64_r_type(self) -> u32 {
+        match self {
+            DynamicRelocationKind::Copy => object::elf::R_X86_64_COPY,
+            DynamicRelocationKind::Irelative => object::elf::R_X86_64_IRELATIVE,
+            DynamicRelocationKind::DtpMod => object::elf::R_X86_64_DTPMOD64,
+            DynamicRelocationKind::DtpOff => object::elf::R_X86_64_DTPOFF64,
+            DynamicRelocationKind::TpOff => object::elf::R_X86_64_TPOFF64,
+            DynamicRelocationKind::Relative => object::elf::R_X86_64_RELATIVE,
+            DynamicRelocationKind::DynamicSymbol => object::elf::R_X86_64_GLOB_DAT,
+            DynamicRelocationKind::TlsDesc => object::elf::R_X86_64_TLSDESC,
+        }
+    }
+}


### PR DESCRIPTION
This will allow it to be reused from linker-diff