### PR TITLE
Make relaxations adjust `place` when computing relocation value

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -1794,11 +1794,11 @@ fn apply_relocation<S: StorageModel, A: Arch>(
     table_writer: &mut TableWriter,
 ) -> Result<RelocationModifier> {
     let section_address = section_info.section_address;
-    let place = section_address + offset_in_section;
+    let original_place = section_address + offset_in_section;
     let _span = tracing::trace_span!(
         "relocation",
-        address = place,
-        address_hex = format!("{place:x}")
+        address = original_place,
+        address_hex = format!("{original_place:x}")
     )
     .entered();
 
@@ -1841,6 +1841,10 @@ fn apply_relocation<S: StorageModel, A: Arch>(
         rel_info = A::relocation_from_raw(r_type)?;
         tracing::trace!(%value_flags, %resolution_flags, ?rel_info.kind, %symbol_name, "relocation applied");
     }
+
+    // Compute place to which IP-relative relocations will be relative. This is different to
+    // `original_place` in that our `offset_in_section` may have been adjusted by a relaxation.
+    let place = section_address + offset_in_section;
 
     let mask = get_page_mask(rel_info.mask);
     let value = match rel_info.kind {

--- a/linker-utils/src/x86_64.rs
+++ b/linker-utils/src/x86_64.rs
@@ -117,7 +117,6 @@ impl RelaxationKind {
                     0x48, 0x03, 0x05,
                 ]);
                 *offset_in_section += 8;
-                *addend = -12_i64;
             }
             RelaxationKind::TlsLdToLocalExec => {
                 section_bytes[offset - 3..offset + 9].copy_from_slice(&[


### PR DESCRIPTION
This should be a no-op, but makes the code less confusing. Only one relaxation both adjusted the offset and was used in conjuction with a place-relative relocation. That relaxation, TlsGdToInitialExec now doesn't need to set a weird addend of -12, which was only needed previously because the old offset was used as the place.