### PR TITLE
linker-diff: Accept optimisation CallIndirectToRelative for static bins

### DIFF
--- a/linker-diff/src/arch.rs
+++ b/linker-diff/src/arch.rs
@@ -11,7 +11,7 @@ pub(crate) trait Arch: Clone + Copy + Eq + PartialEq {
     type RType: RType;
 
     /// A type representing relaxations on this architecture.
-    type RelaxationKind: Copy + Clone + Debug + Eq + PartialEq;
+    type RelaxationKind: RelaxationKind;
 
     /// A type representing a decoded instruction on this architecture.
     type RawInstruction: Copy + Clone;
@@ -67,6 +67,11 @@ pub(crate) trait RType: Copy + Debug + Display + Eq + PartialEq {
     }
 
     fn dynamic_relocation_kind(self) -> Option<DynamicRelocationKind>;
+}
+
+pub(crate) trait RelaxationKind: Copy + Clone + Debug + Eq + PartialEq {
+    /// Returns whether this relaxation does nothing.
+    fn is_no_op(self) -> bool;
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -172,7 +172,11 @@ impl Config {
                 "section.note.package",
                 // TLSDESC relaxations aren't yet implemented.
                 "rel.match_failed.R_X86_64_GOTPC32_TLSDESC",
-                "rel.R_X86_64_TLSDESC_CALL.R_X86_64_NONE",
+                "rel.missing-opt.R_X86_64_TLSDESC_CALL.SkipTlsDescCall.*",
+                // Wild eliminates GOTPCRELX in statically linked executables even for undefined
+                // symbols, whereas other linkers don't. This is a valid optimisation that other
+                // linkers don't currently do.
+                "rel.extra-opt.R_X86_64_GOTPCRELX.CallIndirectToRelative.static-*",
                 // We don't yet support emitting warnings.
                 "section.gnu.warning",
             ]

--- a/linker-diff/src/x86_64.rs
+++ b/linker-diff/src/x86_64.rs
@@ -7,6 +7,7 @@ use crate::arch::RelocationTypeInfo;
 use iced_x86::Formatter as _;
 use linker_utils::elf::x86_64_rel_type_to_string;
 use linker_utils::elf::DynamicRelocationKind;
+use linker_utils::x86_64::RelaxationKind;
 use object::SectionKind;
 use std::fmt::Display;
 
@@ -278,5 +279,11 @@ impl crate::arch::RType for RType {
 impl Display for RType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Display::fmt(&x86_64_rel_type_to_string(self.0), f)
+    }
+}
+
+impl crate::arch::RelaxationKind for RelaxationKind {
+    fn is_no_op(self) -> bool {
+        matches!(self, RelaxationKind::NoOp)
     }
 }


### PR DESCRIPTION
We eliminate GOTPCRELX for static binaries even when the symbol is undefined. This is valid, since the binary cannot be provided by a shared object at runtime since the binary is statically linked. Other linkers don't do this.

Issue #230