### PR TITLE
linker-diff: Use mmap to read input files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,6 +670,7 @@ dependencies = [
  "linker-layout",
  "linker-trace",
  "linker-utils",
+ "memmap2",
  "object",
  "rayon",
  "symbolic-demangle",

--- a/linker-diff/Cargo.toml
+++ b/linker-diff/Cargo.toml
@@ -33,6 +33,7 @@ fallible-iterator = "0.3.0"
 colored = "3.0.0"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
+memmap2 = "0.9.5"
 
 [lints]
 workspace = true


### PR DESCRIPTION
This makes it substantially faster to run when there are large parts of the input files that we don't need. For example running on clang, this reduces the runtime from about a minute to about 5 seconds.