### PR TITLE
support version script comments starting with a hash

### DIFF
--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -198,6 +198,12 @@ impl<'a> Tokeniser<'a> {
                 }
                 continue;
             }
+            if self.text.starts_with('#') {
+                if take_up_to(&mut self.text, "\n").is_err() {
+                    self.text = "";
+                }
+                continue;
+            }
             if self.text.is_empty() {
                 return None;
             }
@@ -422,7 +428,9 @@ mod tests {
     #[test]
     fn test_parse_version_script() {
         let data = VersionScriptData {
-            raw: r#"{global:
+            raw: r#"
+                    # Comment starting with a hash
+                    {global:
                         /* Single-line comment */
                         foo; /* Trailing comment */
                         bar*;


### PR DESCRIPTION
For example, they are present in the LLVM project:
https://github.com/llvm/llvm-project/blob/52c116218b61c088ac77f26c7b57347a5f54224d/clang/tools/libclang/libclang.map#L1

I'm aware the linked version script also requires symbol versioning to be implemented, but this change on its own seems like a viable improvement.