### PR TITLE
CI: Don't run on push to any branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ '**' ]
+    branches: [ 'main' ]
   pull_request:
     branches: [ '**' ]
   workflow_dispatch:


### PR DESCRIPTION
It seems wasteful to run when pushing to a temporary branch then again when creating the corresponding PR.