### PR TITLE
Downgrade AArch64 CI builds host OS to Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         runs-on:
           - ubuntu-latest
-          - ubuntu-24.04-arm
+          - ubuntu-22.04-arm
         container:
           - 'ubuntu:22.04'
           - 'ubuntu:latest'


### PR DESCRIPTION
There are numerous reports of 24.04-arm host being unstable: https://github.com/rust-lang/rust/issues/135867

I have ran this job 15 times, and the only failure I got was `zypper` crash in **x86_64** build:
```
Retrieving: libasan8-14.2.1+git10750-1.2.x86_64 (openSUSE-Tumbleweed-Oss) (2/46), 479.2 KiB    
Unexpected error 9 on netlink descriptor 20.
/__w/_temp/b78b1ac4-60b7-491c-b5ea-349df212708c.sh: line 1:    19 Aborted                 (core dumped)
```
![image](https://github.com/user-attachments/assets/9ccf4c44-768f-4938-a591-44d8b6ac70e6)
https://github.com/mati865/wild/actions/workflows/ci.yml?query=branch%3Apatch-1

I propose to try these runners for a week or two and see how it goes.

cc #365