### PR TITLE
Allow sections starting with '.debug_' to be kept if they're alloc

### DIFF
--- a/libwild/src/part_id.rs
+++ b/libwild/src/part_id.rs
@@ -148,7 +148,10 @@ impl<'data> UnresolvedSection<'data> {
             // We don't currently allow references to these sections, discard them so that we avoid
             // allocating output section IDs.
             None
-        } else if args.strip_debug && section_name.starts_with(b".debug_") {
+        } else if args.strip_debug
+            && section_name.starts_with(b".debug_")
+            && !section_flags.contains(shf::ALLOC)
+        {
             // Drop soon string merge debug info section.
             None
         } else if section_name == NOTE_GNU_PROPERTY_SECTION_NAME {

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -45,6 +45,7 @@ use bitflags::bitflags;
 use crossbeam_queue::ArrayQueue;
 use crossbeam_queue::SegQueue;
 use itertools::Itertools;
+use linker_utils::elf::shf;
 use linker_utils::elf::SectionFlags;
 use linker_utils::elf::SectionType;
 use object::read::elf::Sym as _;
@@ -771,7 +772,9 @@ fn resolve_sections_for_object<'data>(
                         }
                         TemporaryPartId::Custom(custom_section_id, _alignment) => {
                             let section_name = custom_section_id.name.bytes();
-                            if section_name.starts_with(b".debug_") {
+                            if section_name.starts_with(b".debug_")
+                                && !section_flags.contains(shf::ALLOC)
+                            {
                                 if args.strip_debug {
                                     custom_section = None;
                                     SectionSlot::Discard

--- a/wild/tests/sources/custom_section.c
+++ b/wild/tests/sources/custom_section.c
@@ -30,6 +30,9 @@ extern int __stop_w2[] __attribute__ ((weak));
 static int dot1 __attribute__ ((used, retain, section (".dot"))) = 7;
 static int dot2 __attribute__ ((used, retain, section (".dot.2"))) = 8;
 
+// Make sure we don't discard this custom, alloc section just because of its name.
+static int debug_script __attribute__ ((section (".debug_script"))) = 15;
+
 // Override a symbol that would normally be created by the custom section.
 int __stop_w3 = 88;
 
@@ -82,6 +85,10 @@ void _start(void) {
     set_foo1(10);
     if (get_foo1() != 10) {
         exit_syscall(109);
+    }
+
+    if (debug_script != 15) {
+        exit_syscall(110);
     }
 
     exit_syscall(value);


### PR DESCRIPTION
Issue #376