### PR TITLE
AArch64: relax TLSDESC for statically linked executables

### DIFF
--- a/linker-diff/src/header_diff.rs
+++ b/linker-diff/src/header_diff.rs
@@ -109,7 +109,7 @@ fn symbol_with_address(obj: &Binary, address: u64, allow_empty: bool) -> Option<
         }
         if sym.address() == address {
             if let Ok(name) = sym.name() {
-                if !name.is_empty() {
+                if !name.is_empty() && name != "$x" {
                     return Some(name.to_owned());
                 }
             }

--- a/wild/tests/sources/libc-integration.c
+++ b/wild/tests/sources/libc-integration.c
@@ -10,6 +10,7 @@
 //#DiffIgnore:section.rodata.cst32.entsize
 // This is only an issue on openSUSE
 //#DiffIgnore:section.rela.plt.link
+//#DiffIgnore:section.data.alignment
 //#CompArgs:-g -ftls-model=global-dynamic
 //#RequiresGlibc:true
 


### PR DESCRIPTION
This is equivalent change I made in #351 and there are a couple of questions I have:

- As opposed to `x86_64`, this relaxation modifies 4 consecutive instructions (and also relocations):

```
 20c:   90000000        adrp    x0, 0 <_ZN3std2rt19lang_start_internal17hc40c77548151fb1dE>     20c: R_AARCH64_TLSDESC_ADR_PAGE21       _ZN3std3sys3pal4unix14stack_overflow3imp5GUARD29_$u7b$$u7b$constant$u7d$$u7d$28_$u7b$$u7b$closure$u7d$$u7d$3VAL17h88df0c7ea033e002E
 210:   f9400001        ldr     x1, [x0]        210: R_AARCH64_TLSDESC_LD64_LO12        _ZN3std3sys3pal4unix14stack_overflow3imp5GUARD29_$u7b$$u7b$constant$u7d$$u7d$28_$u7b$$u7b$closure$u7d$$u7d$3VAL17h88df0c7ea033e002E
 214:   91000000        add     x0, x0, #0x0    214: R_AARCH64_TLSDESC_ADD_LO12 _ZN3std3sys3pal4unix14stack_overflow3imp5GUARD29_$u7b$$u7b$constant$u7d$$u7d$28_$u7b$$u7b$closure$u7d$$u7d$3VAL17h88df0c7ea033e002E
 218:   d63f0020        blr     x1      218: R_AARCH64_TLSDESC_CALL     _ZN3std3sys3pal4unix14stack_overflow3imp5GUARD29_$u7b$$u7b$constant$u7d$$u7d$28_$u7b$$u7b$closure$u7d$$u7d$3VAL17h88df0c7ea033e002E
```

Should I somehow rely on the fact these are used together, or should I ensure that e.g. when a relaxation is built for the first one?

- The `RelaxationKind` would be very instructions specific on AArch64, are you happy with the selected names?
- I hit very interesting debug info size mismatch that I'm investigating right now:

```
debug_info.size_mismatch
  Size mismatch for /rust/deps/compiler_builtins-0.1.143/src/lib.rs/@/compiler_builtins.a69a77954fe228ee-cgu.014 (/rust/deps/compiler_builtins-0.1.143) in ld, expected: 87, got: 77
```