### PR TITLE
AArch64: Relax TLSIE relocations for static executable

### DIFF
--- a/libwild/src/aarch64.rs
+++ b/libwild/src/aarch64.rs
@@ -143,35 +143,27 @@ impl crate::arch::Relaxation for Relaxation {
         // away fetching it.
 
         match relocation_kind {
-            object::elf::R_AARCH64_TLSDESC_ADR_PAGE21
-                if can_bypass_got && output_kind.is_static_executable() =>
-            {
+            object::elf::R_AARCH64_TLSDESC_ADR_PAGE21 if can_bypass_got => {
                 // TODO: check we met all consecutive 4 instructions!
                 return Some(Relaxation {
                     kind: RelaxationKind::ReplaceWithNop,
                     rel_info: relocation_type_from_raw(object::elf::R_AARCH64_NONE).unwrap(),
                 });
             }
-            object::elf::R_AARCH64_TLSDESC_LD64_LO12
-                if can_bypass_got && output_kind.is_static_executable() =>
-            {
+            object::elf::R_AARCH64_TLSDESC_LD64_LO12 if can_bypass_got => {
                 return Some(Relaxation {
                     kind: RelaxationKind::ReplaceWithNop,
                     rel_info: relocation_type_from_raw(object::elf::R_AARCH64_NONE).unwrap(),
                 });
             }
-            object::elf::R_AARCH64_TLSDESC_ADD_LO12
-                if can_bypass_got && output_kind.is_static_executable() =>
-            {
+            object::elf::R_AARCH64_TLSDESC_ADD_LO12 if can_bypass_got => {
                 return Some(Relaxation {
                     kind: RelaxationKind::MovzX0Lsl16,
                     rel_info: relocation_type_from_raw(object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G1)
                         .unwrap(),
                 });
             }
-            object::elf::R_AARCH64_TLSDESC_CALL
-                if can_bypass_got && output_kind.is_static_executable() =>
-            {
+            object::elf::R_AARCH64_TLSDESC_CALL if can_bypass_got => {
                 return Some(Relaxation {
                     kind: RelaxationKind::MovkX0,
                     rel_info: relocation_type_from_raw(

--- a/libwild/src/aarch64.rs
+++ b/libwild/src/aarch64.rs
@@ -113,14 +113,13 @@ impl crate::arch::Relaxation for Relaxation {
     where
         Self: std::marker::Sized,
     {
-        let rel = AArch64::relocation_from_raw(relocation_kind);
+        let mut relocation = AArch64::relocation_from_raw(relocation_kind).unwrap();
         let can_bypass_got = value_flags.contains(ValueFlags::CAN_BYPASS_GOT);
 
         // IFuncs cannot be referenced directly, they always need to go via the GOT.
         if value_flags.contains(ValueFlags::IFUNC) {
             return match relocation_kind {
-                object::elf::R_AARCH64_CALL26 => {
-                    let mut relocation = rel.unwrap();
+                object::elf::R_AARCH64_CALL26 | object::elf::R_AARCH64_JUMP26 => {
                     relocation.kind = RelocationKind::PltRelative;
                     return Some(Relaxation {
                         kind: RelaxationKind::NoOp,

--- a/libwild/src/aarch64.rs
+++ b/libwild/src/aarch64.rs
@@ -180,6 +180,23 @@ impl crate::arch::Relaxation for Relaxation {
                     .unwrap(),
                 });
             }
+            object::elf::R_AARCH64_TLSIE_ADR_GOTTPREL_PAGE21 if can_bypass_got => {
+                return Some(Relaxation {
+                    kind: RelaxationKind::MovzXnLsl16,
+                    rel_info: relocation_type_from_raw(object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G1)
+                        .unwrap(),
+                });
+            }
+            object::elf::R_AARCH64_TLSIE_LD64_GOTTPREL_LO12_NC if can_bypass_got => {
+                return Some(Relaxation {
+                    kind: RelaxationKind::MovkXn,
+                    rel_info: relocation_type_from_raw(
+                        object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G0_NC,
+                    )
+                    .unwrap(),
+                });
+            }
+
             _ => (),
         }
 

--- a/wild/tests/sources/libc-integration.c
+++ b/wild/tests/sources/libc-integration.c
@@ -78,6 +78,8 @@
 //#LinkArgs:--cc=gcc -dynamic -Wl,--strip-debug -Wl,--gc-sections -Wl,-z,now
 //#Shared:libc-integration-0.c
 //#Shared:libc-integration-1.c
+// TODO: cc1plus: sorry, unimplemented: code model 'large' with '-fPIC'
+//#Arch: x86_64
 
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
With this patch, the following example almost works:
```
$ echo 'int main() { __builtin_printf("42\n"); return 42; }' | clang -x c - -B ~/Programming/wild/fakes-debug -static  && ./a.out
Segmentation fault (core dumped)
$ valgrind ./a.out 
==284278== Memcheck, a memory error detector
==284278== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==284278== Using Valgrind-3.24.0 and LibVEX; rerun with -h for copyright info
==284278== Command: ./a.out
==284278== 
==284278== Syscall param set_robust_list(head) points to uninitialised byte(s)
==284278==    at 0x482AEC: __tls_init_tp (in /home/marxin/Programming/a.out)
==284278==    by 0x438BE3: __libc_setup_tls (in /home/marxin/Programming/a.out)
==284278==    by 0x43894B: (below main) (in /home/marxin/Programming/a.out)
==284278==  Address 0x40000f0 is in the brk data segment 0x4000000-0x4000ae3
==284278== 
==284278== Conditional jump or move depends on uninitialised value(s)
==284278==    at 0x46C508: malloc (in /home/marxin/Programming/a.out)
==284278==    by 0x47EC8B: _dl_get_origin (in /home/marxin/Programming/a.out)
==284278==    by 0x486223: _dl_non_dynamic_init (in /home/marxin/Programming/a.out)
==284278==    by 0x43853F: __libc_init_first (in /home/marxin/Programming/a.out)
==284278==    by 0x4389AB: (below main) (in /home/marxin/Programming/a.out)
42
$ echo $?
42
```

I must be be pretty close, the crash happens here:
```
Program received signal SIGSEGV, Segmentation fault.
0x000000000047d830 in _dl_new_object ()
(gdb) bt
#0  0x000000000047d830 in _dl_new_object ()
#1  0x0000000000486268 in _dl_non_dynamic_init ()
#2  0x0000000000438540 in __libc_init_first ()
#3  0x00000000004389ac in __libc_start_main_impl ()
#4  0x000000000042e0f0 in _start ()
(gdb) display/i $pc
1: x/i $pc
=> 0x47d830 <_dl_new_object+104>:	str	x26, [x26, #40]
```

It crashes at a place in a function where no relocations haven't been applied (if I see it correctly).

@davidlattimore Any hint on what I can try? Would it be possible to use the linker_diff now?