### PR TITLE
integration-tests: Add .d suffix for save directories

### DIFF
--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -770,7 +770,7 @@ fn build_obj(
     // perform the link step.
     let suffix = match compiler_kind {
         CompilerKind::C => ".o",
-        CompilerKind::Rust => "",
+        CompilerKind::Rust => ".d",
     };
 
     let mut command = Command::new(compiler);


### PR DESCRIPTION
Without an extension, shared objects build from the directory end with names like `rdyn.wild.so` rather than
`rdyn1.default-aarch64-405de650e01ab4a5.wild.so`, so are lacking important information.