### PR TITLE
linker-diff: Fix non-determinism in asm-diff output order

### DIFF
--- a/linker-diff/src/asm_diff.rs
+++ b/linker-diff/src/asm_diff.rs
@@ -124,6 +124,10 @@ pub(crate) fn report_function_diffs_for_arch<A: Arch>(report: &mut Report, binar
     let mut section_ids_to_process: Vec<InputSectionId> =
         matched_sections.keys().copied().collect();
 
+    // Sort sections so that we process sections in a deterministic order, since that affects our
+    // output order.
+    section_ids_to_process.sort();
+
     while let Some(section_id) = section_ids_to_process.pop() {
         let section_versions = matched_sections.get(&section_id).unwrap();
 

--- a/linker-diff/src/section_map.rs
+++ b/linker-diff/src/section_map.rs
@@ -356,3 +356,19 @@ impl Display for FileIdentifier<'_> {
         Ok(())
     }
 }
+
+impl PartialOrd for InputSectionId {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for InputSectionId {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match self.file_index.cmp(&other.file_index) {
+            core::cmp::Ordering::Equal => {}
+            ord => return ord,
+        }
+        self.section_index.0.cmp(&other.section_index.0)
+    }
+}


### PR DESCRIPTION
Fixes #417