### PR TITLE
Make insn diff more visible

### DIFF
--- a/linker-diff/src/asm_diff.rs
+++ b/linker-diff/src/asm_diff.rs
@@ -1482,7 +1482,13 @@ impl<R: RType> DynamicRelocation<'_, R> {
 
 impl<R: RType> DynamicRelocation<'_, R> {
     fn write_to(&self, f: &mut String) -> Result {
-        write!(f, "{}{}{}", self.r_type, arrow(), self.symbol)?;
+        write!(
+            f,
+            "{}{}{}",
+            self.r_type.to_string().green().bold(),
+            arrow(),
+            self.symbol.to_string().cyan()
+        )?;
         if self.addend != 0 {
             write!(f, " {:+}", self.addend)?;
         }


### PR DESCRIPTION
This is supposed to improve the readability of a diff:
![image](https://github.com/user-attachments/assets/de2f573d-4a7f-4ba2-85c6-574f4ff5ea92)