### PR TITLE
When building shared objects, don't export non-canonical definitions

### DIFF
--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3643,15 +3643,24 @@ impl<'data> ObjectLayoutState<'data> {
         for (sym_index, sym) in self.object.symbols.enumerate() {
             if can_export_symbol(sym) {
                 let symbol_id = self.symbol_id_range().input_to_id(sym_index);
+
+                if !resources.symbol_db.is_canonical(symbol_id) {
+                    continue;
+                }
+
                 let value_flags = resources.symbol_db.local_symbol_value_flags(symbol_id);
+
                 if value_flags.contains(ValueFlags::DOWNGRADE_TO_LOCAL) {
                     continue;
                 }
+
                 let old_flags = resources.symbol_resolution_flags[symbol_id.as_usize()]
                     .fetch_or(ResolutionFlags::EXPORT_DYNAMIC);
+
                 if old_flags.is_empty() {
                     self.load_symbol::<A>(common, symbol_id, resources, queue)?;
                 }
+
                 if !old_flags.contains(ResolutionFlags::EXPORT_DYNAMIC) {
                     export_dynamic(common, symbol_id, resources)?;
                 }

--- a/wild/tests/sources/libc-integration-0.c
+++ b/wild/tests/sources/libc-integration-0.c
@@ -72,3 +72,8 @@ int sometimes_weak_fn(void) {
 int black_box(int v) {
     return v;
 }
+
+// This function is also defined in libc-integration-0b.c. The definition here should be used.
+int __attribute__ ((weak)) weak_fn3(void) {
+    return 15;
+}

--- a/wild/tests/sources/libc-integration-0b.c
+++ b/wild/tests/sources/libc-integration-0b.c
@@ -1,0 +1,4 @@
+// This function is also defined in libc-integration-0.c. The other definition should be used.
+int __attribute__ ((weak)) weak_fn3(void) {
+    return 16;
+}

--- a/wild/tests/sources/libc-integration.c
+++ b/wild/tests/sources/libc-integration.c
@@ -15,7 +15,7 @@
 //#Cross: false
 
 //#AbstractConfig:shared:default
-//#Shared:libc-integration-0.c
+//#Shared:libc-integration-0.c,libc-integration-0b.c
 //#Shared:libc-integration-1.c
 // Each binary links against shared objects created by that linker. So different names are expected.
 //#DiffIgnore:.dynamic.DT_NEEDED
@@ -92,6 +92,7 @@ void set_tvar2(int v);
 
 int __attribute__ ((weak)) weak_fn1(void);
 int __attribute__ ((weak)) weak_fn2(void);
+int __attribute__ ((weak)) weak_fn3(void);
 
 int __attribute__ ((weak)) sometimes_weak_fn(void) {
     return 7;
@@ -272,6 +273,10 @@ int main() {
         return ctors_init_val;
     }
 #endif
+
+    if (weak_fn3() != 15) {
+        return 123;
+    }
 
     return 42;
 }


### PR DESCRIPTION
Fixes #381