### PR TITLE
Back out "Downgrade AArch64 CI builds host OS to Ubuntu 22.04"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         runs-on:
           - ubuntu-latest
-          - ubuntu-22.04-arm
+          - ubuntu-24.04-arm
         container:
           - 'ubuntu:22.04'
           - 'ubuntu:latest'


### PR DESCRIPTION
This backs out commit 6aecc6a32fcc0e1c79e1ec7e8419a994f85a89b0.

GitHub has rolled back problematic hardware: https://github.com/rust-lang/rust/issues/135867#issuecomment-2660524682