### PR TITLE
Small CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
     branches: [ '**' ]
   workflow_dispatch:
 
+permissions: {}
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: '-D warnings'
@@ -49,6 +51,8 @@ jobs:
         if: ${{ contains(matrix.container, 'opensuse') }}
       - run: useradd -m -g users user && su user && cd ~
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@nightly
         id: rust-toolchain
         with:
@@ -71,6 +75,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - uses: dtolnay/rust-toolchain@stable
       id: rust-toolchain
       with:
@@ -91,6 +97,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - uses: dtolnay/rust-toolchain@nightly
       with:
         components: rustfmt
@@ -101,5 +109,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Spell Check Repo
         uses: crate-ci/typos@v1.29.8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,3 +95,11 @@ jobs:
       with:
         components: rustfmt
     - run: cargo fmt --all -- --check
+
+  spelling:
+    name: Spell Check with Typos
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Spell Check Repo
+        uses: crate-ci/typos@v1.29.8

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -5,10 +5,14 @@ on:
 
 name: Cron continuous integration
 
+permissions: {}
+
 jobs:
   markdown-link-check:
     if: github.repository_owner == 'davidlattimore'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -7,6 +7,7 @@ name: Cron continuous integration
 
 jobs:
   markdown-link-check:
+    if: github.repository_owner == 'davidlattimore'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
First commit is analogous to https://github.com/rust-lang/cc-rs/pull/1302

Second addresses https://github.com/davidlattimore/wild/pull/301#issuecomment-2585482709

Finally, zizmor rules can be found here: https://woodruffw.github.io/zizmor/audits/. I have intentionally skipped `release.yml` since its generated.