### PR TITLE
whole_archive test: Disable cross compilation

### DIFF
--- a/wild/tests/sources/whole_archive.c
+++ b/wild/tests/sources/whole_archive.c
@@ -1,7 +1,7 @@
 //#Object:exit.c
-
 //#LinkArgs:--whole-archive
 //#Archive:whole_archive0.c
+//#Cross:false
 
 #include "exit.h"
 


### PR DESCRIPTION
It fails (at least on Pop-OS 22.04) due to the cross compiler not liking the retain attribute.