### PR TITLE
Explicitly list all relaxations in next_modifier

### DIFF
--- a/linker-utils/src/x86_64.rs
+++ b/linker-utils/src/x86_64.rs
@@ -170,7 +170,15 @@ impl RelaxationKind {
             | RelaxationKind::TlsLdToLocalExec
             | RelaxationKind::TlsLdToLocalExec64
             | RelaxationKind::TlsDescToLocalExec => RelocationModifier::SkipNextRelocation,
-            _ => RelocationModifier::Normal,
+            RelaxationKind::MovIndirectToLea
+            | RelaxationKind::MovIndirectToAbsolute
+            | RelaxationKind::RexMovIndirectToAbsolute
+            | RelaxationKind::RexSubIndirectToAbsolute
+            | RelaxationKind::RexCmpIndirectToAbsolute
+            | RelaxationKind::CallIndirectToRelative
+            | RelaxationKind::JmpIndirectToRelative
+            | RelaxationKind::NoOp
+            | RelaxationKind::SkipTlsDescCall => RelocationModifier::Normal,
         }
     }
 }


### PR DESCRIPTION
The change makes it easier for a newly added enum value to handle it in this match statement.