### PR TITLE
ci: Do a check build on our MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,9 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
-    - uses: dtolnay/rust-toolchain@stable
+    # This is where we check that we're not using features from a more recent rust version. When
+    # updating this, please also update workspace.package.rust-version in `Cargo.toml`.
+    - uses: dtolnay/rust-toolchain@1.85.0
       id: rust-toolchain
       with:
         components: clippy


### PR DESCRIPTION
This should ensure that we don't start using features from more recent rust versions without bumping rust-version in our Cargo.toml.

Fixes #211