### PR TITLE
integration_tests: Separate LinkerDriver into its own config option

### DIFF
--- a/wild/tests/sources/cpp-integration.cc
+++ b/wild/tests/sources/cpp-integration.cc
@@ -7,23 +7,27 @@
 
 //#Config:pie:default
 //#CompArgs:-fpie -fmerge-constants
-//#LinkArgs:--cc=g++ -pie -Wl,-z,now
+//#LinkerDriver:g++
+//#LinkArgs:-pie -Wl,-z,now
 //#EnableLinker:lld
 
 //#Config:no-pie:default
 //#CompArgs:-fno-pie -fmerge-constants
-//#LinkArgs:--cc=g++ -no-pie -Wl,-z,now
+//#LinkerDriver:g++
+//#LinkArgs:-no-pie -Wl,-z,now
 //#EnableLinker:lld
 
 //#Config:clang-pie:default
 //#CompArgs:-fpie
 //#Compiler:clang
-//#LinkArgs:--cc=clang++ -pie -Wl,-z,now
+//#LinkerDriver:clang++
+//#LinkArgs:-pie -Wl,-z,now
 //#EnableLinker:lld
 
 //#Config:model-large:default
 //#CompArgs:-mcmodel=large
-//#LinkArgs:--cc=g++ -Wl,-z,now
+//#LinkerDriver:g++
+//#LinkArgs:-Wl,-z,now
 //#EnableLinker:lld
 // TODO: Ubuntu: cc1plus: sorry, unimplemented: code model 'large' with '-fPIC'
 //#Arch: x86_64
@@ -31,7 +35,8 @@
 //#Config:clang-model-large:default
 //#Compiler:clang
 //#CompArgs:-mcmodel=large
-//#LinkArgs:--cc=clang++ -Wl,-z,now
+//#LinkerDriver:clang++
+//#LinkArgs:-Wl,-z,now
 //#EnableLinker:lld
 //#Arch: x86_64
 

--- a/wild/tests/sources/ifunc2.c
+++ b/wild/tests/sources/ifunc2.c
@@ -7,7 +7,8 @@
 
 //#Config:pie:default
 //#CompArgs:-fpie
-//#LinkArgs:--cc=gcc -Wl,-z,now
+//#LinkerDriver:gcc
+//#LinkArgs:-Wl,-z,now
 
 int exit_code = 2;
 

--- a/wild/tests/sources/libc-integration.c
+++ b/wild/tests/sources/libc-integration.c
@@ -21,39 +21,45 @@
 //#DiffIgnore:.dynamic.DT_NEEDED
 
 //#Config:clang-static:default
-//#LinkArgs:--cc=clang -static -Wl,--strip-debug -Wl,--gc-sections -Wl,-z,now
+//#LinkerDriver:clang
+//#LinkArgs:-static -Wl,--strip-debug -Wl,--gc-sections -Wl,-z,now
 //#Object:libc-integration-0.c
 //#Object:libc-integration-1.c
 
 //#Config:clang-static-pie:default
 //#CompArgs:-fPIE -fPIC
-//#LinkArgs:--cc=clang -static-pie -Wl,--strip-debug -Wl,--gc-sections -Wl,-z,now
+//#LinkerDriver:clang
+//#LinkArgs:-static-pie -Wl,--strip-debug -Wl,--gc-sections -Wl,-z,now
 //#Object:libc-integration-0.c
 //#Object:libc-integration-1.c
 //#EnableLinker:lld
 
 //#Config:gcc-static:default
-//#LinkArgs:--cc=gcc -static -Wl,--strip-debug -Wl,--gc-sections -Wl,-z,now
+//#LinkerDriver:gcc
+//#LinkArgs:-static -Wl,--strip-debug -Wl,--gc-sections -Wl,-z,now
 //#Object:libc-integration-0.c
 //#Object:libc-integration-1.c
 
 //#Config:gcc-static-pie:default
 //#CompArgs:-fPIE
-//#LinkArgs:--cc=gcc -static-pie -Wl,--strip-debug -Wl,--gc-sections -Wl,-z,now
+//#LinkerDriver:gcc
+//#LinkArgs:-static-pie -Wl,--strip-debug -Wl,--gc-sections -Wl,-z,now
 //#Object:libc-integration-0.c
 //#Object:libc-integration-1.c
 //#EnableLinker:lld
 
 //#Config:clang-initial-exec:shared
 //#CompArgs:-g -fPIC -ftls-model=initial-exec -DDYNAMIC_DEP
-//#LinkArgs:--cc=clang -fPIC -dynamic -Wl,--strip-debug -Wl,--gc-sections -Wl,-rpath,$ORIGIN -Wl,-z,now
+//#LinkerDriver:clang
+//#LinkArgs:-fPIC -dynamic -Wl,--strip-debug -Wl,--gc-sections -Wl,-rpath,$ORIGIN -Wl,-z,now
 //#EnableLinker:lld
 //#DiffIgnore:section.relro_padding
 
 //#Config:clang-global-dynamic:shared
 //#Compiler:clang
 //#CompArgs:-g -fPIC -ftls-model=global-dynamic -DDYNAMIC_DEP
-//#LinkArgs:--cc=clang -fPIC -dynamic -Wl,--strip-debug -Wl,--gc-sections -Wl,-rpath,$ORIGIN -Wl,-z,now
+//#LinkerDriver:clang
+//#LinkArgs:-fPIC -dynamic -Wl,--strip-debug -Wl,--gc-sections -Wl,-rpath,$ORIGIN -Wl,-z,now
 //#EnableLinker:lld
 //#DiffIgnore:section.relro_padding
 //#DiffIgnore:section.rodata.entsize
@@ -62,17 +68,20 @@
 //#Config:gcc-dynamic-pie:shared
 //#CompArgs:-g -fpie -DDYNAMIC_DEP -DVERIFY_CTORS
 //#CompSoArgs:-g -fPIC -ftls-model=global-dynamic
-//#LinkArgs:--cc=gcc -dynamic -Wl,--strip-debug -Wl,--gc-sections -Wl,-z,now
+//#LinkerDriver:gcc
+//#LinkArgs:-dynamic -Wl,--strip-debug -Wl,--gc-sections -Wl,-z,now
 
 //#Config:gcc-dynamic-no-pie:shared
 //#CompArgs:-g -no-pie -DDYNAMIC_DEP -DVERIFY_CTORS
 //#CompSoArgs:-g -fPIC -ftls-model=global-dynamic
-//#LinkArgs:--cc=gcc -dynamic -no-pie -Wl,--strip-debug -Wl,--gc-sections -Wl,-z,now
+//#LinkerDriver:gcc
+//#LinkArgs:-dynamic -no-pie -Wl,--strip-debug -Wl,--gc-sections -Wl,-z,now
 
 //#Config:gcc-dynamic-pie-large:shared
 //#CompArgs:-g -fpie -DDYNAMIC_DEP -mcmodel=large
 //#CompSoArgs:-g -fPIC -ftls-model=global-dynamic
-//#LinkArgs:--cc=gcc -dynamic -Wl,--strip-debug -Wl,--gc-sections -Wl,-z,now
+//#LinkerDriver:gcc
+//#LinkArgs:-dynamic -Wl,--strip-debug -Wl,--gc-sections -Wl,-z,now
 // TODO: cc1plus: sorry, unimplemented: code model 'large' with '-fPIC'
 //#Arch: x86_64
 

--- a/wild/tests/sources/tls-local-exec.c
+++ b/wild/tests/sources/tls-local-exec.c
@@ -6,7 +6,8 @@
 
 //#Config:pie:default
 //#CompArgs:-fpie
-//#LinkArgs:--cc=gcc -Wl,-z,now
+//#LinkerDriver:gcc
+//#LinkArgs:-Wl,-z,now
 
 __thread long tvar = 1;
 __thread int tvar2 = 2;

--- a/wild/tests/sources/tlsdesc.c
+++ b/wild/tests/sources/tlsdesc.c
@@ -7,7 +7,8 @@
 
 //#Config:gcc-tls-desc:default
 //#CompArgs:-mtls-dialect=gnu2
-//#LinkArgs:--cc=gcc -Wl,-z,now
+//#LinkerDriver:gcc
+//#LinkArgs:-Wl,-z,now
 //#Object:tlsdesc-obj.c
 //#Arch: x86_64
 

--- a/wild/tests/sources/trivial-main.c
+++ b/wild/tests/sources/trivial-main.c
@@ -1,5 +1,6 @@
 //#AbstractConfig:default
-//#LinkArgs:--cc=gcc -Wl,-z,now
+//#LinkerDriver:gcc
+//#LinkArgs:-Wl,-z,now
 //#DiffIgnore:section.rodata
 //#DiffIgnore:section.data
 


### PR DESCRIPTION
Previously, we took the C compiler to use to invoke the linker via `--cc=...` in the first LinkerArg. Now, we instead have a separate config option LinkerDriver.

Fixes #178