### PR TITLE
Support all 3 access TLS ABIs at the same time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,6 +1080,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+
+[[package]]
 name = "ryu"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1194,6 +1200,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "symbolic-common"
@@ -1416,6 +1444,8 @@ dependencies = [
  "object",
  "os_info",
  "rstest",
+ "strum",
+ "strum_macros",
  "wait-timeout",
  "which",
 ]

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -4083,13 +4083,13 @@ impl Resolution {
                 .contains(ResolutionFlags::GOT_TLS_MODULE),
             "Called tlsgd_got_address without GOT_TLS_MODULE being set"
         );
-        let got_address = self.got_address()?;
         // If we've got both a GOT_TLS_OFFSET and a GOT_TLS_MODULE, then the latter comes second.
+        let mut got_address = self.got_address()?;
         if self
             .resolution_flags
             .contains(ResolutionFlags::GOT_TLS_OFFSET)
         {
-            return Ok(got_address + elf::GOT_ENTRY_SIZE);
+            got_address += elf::GOT_ENTRY_SIZE;
         }
         Ok(got_address)
     }

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -19,7 +19,6 @@ use crate::elf;
 use crate::elf::EhFrameHdrEntry;
 use crate::elf::File;
 use crate::elf::FileHeader;
-use crate::elf::GOT_ENTRY_SIZE;
 use crate::elf::Versym;
 use crate::elf_writer;
 use crate::error::Error;
@@ -748,6 +747,12 @@ fn allocate_resolution(
             mem_sizes.increment(part_id::RELA_DYN_RELATIVE, elf::RELA_ENTRY_SIZE);
         }
     }
+    if resolution_flags.contains(ResolutionFlags::GOT_TLS_OFFSET) {
+        mem_sizes.increment(part_id::GOT, elf::GOT_ENTRY_SIZE);
+        if !value_flags.contains(ValueFlags::CAN_BYPASS_GOT) {
+            mem_sizes.increment(part_id::RELA_DYN_GENERAL, elf::RELA_ENTRY_SIZE);
+        }
+    }
     if resolution_flags.contains(ResolutionFlags::GOT_TLS_MODULE) {
         mem_sizes.increment(part_id::GOT, elf::GOT_ENTRY_SIZE * 2);
         // For executables, the TLS module ID is known at link time. For shared objects, we
@@ -756,12 +761,6 @@ fn allocate_resolution(
             mem_sizes.increment(part_id::RELA_DYN_GENERAL, elf::RELA_ENTRY_SIZE);
         }
         if !value_flags.contains(ValueFlags::CAN_BYPASS_GOT) && has_dynamic_symbol {
-            mem_sizes.increment(part_id::RELA_DYN_GENERAL, elf::RELA_ENTRY_SIZE);
-        }
-    }
-    if resolution_flags.contains(ResolutionFlags::GOT_TLS_OFFSET) {
-        mem_sizes.increment(part_id::GOT, elf::GOT_ENTRY_SIZE);
-        if !value_flags.contains(ValueFlags::CAN_BYPASS_GOT) {
             mem_sizes.increment(part_id::RELA_DYN_GENERAL, elf::RELA_ENTRY_SIZE);
         }
     }
@@ -4024,17 +4023,21 @@ fn create_resolution(
         resolution.got_address = Some(allocate_got(1, memory_offsets));
     } else if res_kind.contains(ResolutionFlags::GOT) {
         resolution.got_address = Some(allocate_got(1, memory_offsets));
-    } else if res_kind.contains(ResolutionFlags::GOT_TLS_OFFSET) {
-        if res_kind.contains(ResolutionFlags::GOT_TLS_MODULE) {
-            resolution.got_address = Some(allocate_got(3, memory_offsets));
-        } else {
-            resolution.got_address = Some(allocate_got(1, memory_offsets));
+    } else {
+        // Handle the TLS GOT addresses where we can combine up to 3 different access methods.
+        let mut num_got_slots = 0;
+        if res_kind.contains(ResolutionFlags::GOT_TLS_OFFSET) {
+            num_got_slots += 1;
         }
-    }
-    if res_kind.contains(ResolutionFlags::GOT_TLS_MODULE)
-        | res_kind.contains(ResolutionFlags::GOT_TLS_DESCRIPTOR)
-    {
-        resolution.got_address = Some(allocate_got(2, memory_offsets));
+        if res_kind.contains(ResolutionFlags::GOT_TLS_MODULE) {
+            num_got_slots += 2;
+        }
+        if res_kind.contains(ResolutionFlags::GOT_TLS_DESCRIPTOR) {
+            num_got_slots += 2;
+        }
+        if num_got_slots > 0 {
+            resolution.got_address = Some(allocate_got(num_got_slots, memory_offsets));
+        }
     }
     resolution
 }
@@ -4086,7 +4089,7 @@ impl Resolution {
             .resolution_flags
             .contains(ResolutionFlags::GOT_TLS_OFFSET)
         {
-            return Ok(got_address + crate::elf::GOT_ENTRY_SIZE);
+            return Ok(got_address + elf::GOT_ENTRY_SIZE);
         }
         Ok(got_address)
     }
@@ -4097,16 +4100,23 @@ impl Resolution {
                 .contains(ResolutionFlags::GOT_TLS_DESCRIPTOR),
             "Called tls_descriptor_got_address without GOT_TLS_DESCRIPTOR being set"
         );
-        // We might have both GOT_TLS_OFFSET and GOT_TLS_DESCRIPTOR at the same time
-        // for a single symbol. Then the TLS descriptor comes later and we reflect that in the GOT address.
+        // We might have both GOT_TLS_OFFSET, GOT_TLS_MODULE and GOT_TLS_DESCRIPTOR at the same time
+        // for a single symbol. Then the TLS descriptor comes as the last one.
+        let mut got_address = self.got_address()?;
         if self
             .resolution_flags
             .contains(ResolutionFlags::GOT_TLS_OFFSET)
         {
-            self.got_address().map(|v| v + GOT_ENTRY_SIZE)
-        } else {
-            self.got_address()
+            got_address += elf::GOT_ENTRY_SIZE;
         }
+        if self
+            .resolution_flags
+            .contains(ResolutionFlags::GOT_TLS_MODULE)
+        {
+            got_address += 2 * elf::GOT_ENTRY_SIZE;
+        }
+
+        Ok(got_address)
     }
 
     pub(crate) fn plt_address(&self) -> Result<u64> {

--- a/wild/Cargo.toml
+++ b/wild/Cargo.toml
@@ -16,8 +16,6 @@ mimalloc = { version = "0.1", default-features = false, optional = true }
 
 dhat = { version = "0.3.3", optional = true }
 os_info = "3.10.0"
-strum = { version = "0.27.1", features = ["derive"] }
-strum_macros = "0.27.1"
 
 [dev-dependencies]
 anyhow = "1.0.95"
@@ -33,6 +31,8 @@ linker-diff = { path = "../linker-diff" }
 which = "7.0.2"
 rstest = "0.24.0"
 fd-lock = "4.0.2"
+strum = { version = "0.27.1", features = ["derive"] }
+strum_macros = "0.27.1"
 
 [features]
 default = ["fork"]

--- a/wild/Cargo.toml
+++ b/wild/Cargo.toml
@@ -16,6 +16,8 @@ mimalloc = { version = "0.1", default-features = false, optional = true }
 
 dhat = { version = "0.3.3", optional = true }
 os_info = "3.10.0"
+strum = { version = "0.27.1", features = ["derive"] }
+strum_macros = "0.27.1"
 
 [dev-dependencies]
 anyhow = "1.0.95"

--- a/wild/tests/sources/tls-variant-1.c
+++ b/wild/tests/sources/tls-variant-1.c
@@ -1,0 +1,5 @@
+_Thread_local int global_tls1 = 1;
+
+int foo() {
+  return global_tls1;
+}

--- a/wild/tests/sources/tls-variant-2.c
+++ b/wild/tests/sources/tls-variant-2.c
@@ -1,0 +1,5 @@
+extern _Thread_local int global_tls1;
+
+int bar() {
+  return global_tls1;
+}

--- a/wild/tests/sources/tls-variant-3.c
+++ b/wild/tests/sources/tls-variant-3.c
@@ -1,0 +1,5 @@
+extern _Thread_local int global_tls1;
+
+int baz() {
+  return global_tls1;
+}

--- a/wild/tests/sources/tls-variant.c
+++ b/wild/tests/sources/tls-variant.c
@@ -4,6 +4,7 @@
 //#DiffIgnore:section.data
 //#DiffIgnore:section.rodata
 //#DiffIgnore:section.rodata.alignment
+//#DiffIgnore:rel.match_failed.R_AARCH64_TLSGD_ADR_PAGE21
 
 //#Config:gcc:default
 //#CompArgs:-fpic

--- a/wild/tests/sources/tls-variant.c
+++ b/wild/tests/sources/tls-variant.c
@@ -1,0 +1,37 @@
+//#AbstractConfig:default
+//#LinkerDriver:gcc
+//#DiffIgnore:.dynamic.DT_NEEDED
+//#DiffIgnore:section.data
+//#DiffIgnore:section.rodata
+//#DiffIgnore:section.rodata.alignment
+
+//#Config:gcc:default
+//#CompArgs:-fpic
+//#Object:tls-variant-1.c:-mtls-dialect=gnu2
+//#Object:tls-variant-2.c:-ftls-model=global-dynamic 
+//#Object:tls-variant-3.c:-ftls-model=initial-exec
+//#Arch: x86_64
+
+//#Config:gcc-shared:default
+//#CompArgs:-fpic
+//#Shared:tls-variant-1.c:-mtls-dialect=gnu2,tls-variant-2.c:-ftls-model=global-dynamic,tls-variant-3.c:-ftls-model=initial-exec
+//#Arch: x86_64
+
+int foo();
+int bar();
+int baz();
+
+int main()
+{
+    if (foo() != 1) {
+        return 1;
+    }
+    if (bar() != 1) {
+        return 1;
+    }
+    if (baz() != 1) {
+        return 1;
+    }
+
+    return 42;
+}

--- a/wild/tests/sources/tls-variant.c
+++ b/wild/tests/sources/tls-variant.c
@@ -17,14 +17,14 @@
 //#Shared:tls-variant-1.c:-mtls-dialect=gnu2,tls-variant-2.c:-ftls-model=global-dynamic,tls-variant-3.c:-ftls-model=initial-exec
 //#Arch: x86_64
 
-//#Config:gcc:default
+//#Config:gcc-aarch64:default
 //#CompArgs:-fpic
 //#Object:tls-variant-1.c
 //#Object:tls-variant-2.c:-ftls-model=global-dynamic -mtls-dialect=trad
 //#Object:tls-variant-3.c:-ftls-model=initial-exec -mtls-dialect=trad
 //#Arch: aarch64
 
-//#Config:gcc-shared:default
+//#Config:gcc-shared-aarch64:default
 //#CompArgs:-fpic
 //#Shared:tls-variant-1.c,tls-variant-2.c:-ftls-model=global-dynamic -mtls-dialect=trad,tls-variant-3.c:-ftls-model=initial-exec -mtls-dialect=trad
 //#Arch: aarch64

--- a/wild/tests/sources/tls-variant.c
+++ b/wild/tests/sources/tls-variant.c
@@ -17,6 +17,18 @@
 //#Shared:tls-variant-1.c:-mtls-dialect=gnu2,tls-variant-2.c:-ftls-model=global-dynamic,tls-variant-3.c:-ftls-model=initial-exec
 //#Arch: x86_64
 
+//#Config:gcc:default
+//#CompArgs:-fpic
+//#Object:tls-variant-1.c
+//#Object:tls-variant-2.c:-ftls-model=global-dynamic -mtls-dialect=trad
+//#Object:tls-variant-3.c:-ftls-model=initial-exec -mtls-dialect=trad
+//#Arch: aarch64
+
+//#Config:gcc-shared:default
+//#CompArgs:-fpic
+//#Shared:tls-variant-1.c,tls-variant-2.c:-ftls-model=global-dynamic -mtls-dialect=trad,tls-variant-3.c:-ftls-model=initial-exec -mtls-dialect=trad
+//#Arch: aarch64
+
 int foo();
 int bar();
 int baz();


### PR DESCRIPTION
Right now, we can properly handle the following test case: https://github.com/davidlattimore/wild/issues/448#issuecomment-2676699324 and hopefully the code is more readable right now.

I've also added support for extra compilation arguments for `Objects/Shared/Archive`, but it seems I would need help with addressing the linker-diff.

Related to: #463.