### PR TITLE
Declare AArch64 as a supported platform

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,8 @@ linkers need to do.
   * [ELF-64 Object File Format](https://uclibc.org/docs/elf-64-gen.pdf)
   * [ELF x86-64-ABI psABI](https://gitlab.com/x86-psABIs/x86-64-ABI)
   * [ELF Handling For Thread-Local Storage](https://www.uclibc.org/docs/tls.pdf)
+  * [ELF for the Arm® 64-bit Architecture (AArch64)](https://github.com/ARM-software/abi-aa/blob/main/aaelf64/aaelf64.rst)
+  * [System V ABI for the Arm® 64-bit Architecture (AArch64)](https://github.com/ARM-software/abi-aa/blob/main/sysvabi64/sysvabi64.rst)
 * [A Deep dive into (implicit) Thread Local Storage](https://chao-tic.github.io/blog/2018/12/25/tls)
 
 ## Finding an issue to work on

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Wild in Rust, it's hoped that the complexity of incremental linking will be achi
 The following platforms / architectures are currently supported:
 
 * x86-64 on Linux
+* ARM64 on Linux
 
 The following is working with the caveat that there may be bugs:
 
@@ -64,7 +65,7 @@ Lots of stuff. Here are some of the larger things that aren't yet done, roughly 
 priority:
 
 * Incremental linking
-* Support for architectures other than x86-64
+* Support for more architectures
 * Support for a wider range of linker flags
 * Linker scripts
 * Mac support


### PR DESCRIPTION
The architecture still lacks relaxation opportunities, but generally speaking, the port should be working fine based on our preliminary testing effort.

Fixes: #43