### PR TITLE
Implement support for thin archives

### DIFF
--- a/libwild/src/archive.rs
+++ b/libwild/src/archive.rs
@@ -236,6 +236,12 @@ impl<'data> Identifier<'data> {
         let end = memchr::memchr(b'/', self.data).unwrap_or(self.data.len());
         &self.data[..end]
     }
+
+    // Get the filename indicated by this identifier
+    pub(crate) fn as_filename(&self) -> &'data [u8] {
+        let end = memchr::memchr(b'\n', self.data).unwrap_or(self.data.len());
+        &self.data[..end]
+    }
 }
 
 impl<'data> Iterator for ArchiveIterator<'data> {
@@ -309,6 +315,9 @@ mod tests {
                     match entry {
                         ArchiveEntry::Regular(content) => {
                             our_entries.push(content);
+                        }
+                        ArchiveEntry::FileReference(_) => {
+                            // TODO: Implement
                         }
                         ArchiveEntry::Ignored => {}
                         ArchiveEntry::Filenames(table) => filenames = Some(table),

--- a/libwild/src/archive_splitter.rs
+++ b/libwild/src/archive_splitter.rs
@@ -46,10 +46,9 @@ pub fn split_archives<'data>(input_data: &'data InputData) -> Result<Vec<InputBy
                             });
                         },
                         ArchiveEntry::FileReference(archive_entry) => {
-                            let filename = archive_entry.identifier(extended_filenames).as_slice();
-                            let filename = std::str::from_utf8(filename)
-                                .expect("Bad filename");
-                            println!("TODO: Read referenced file {}", filename);
+                            let filename = archive_entry.identifier(extended_filenames).as_filename();
+                            let filename = std::str::from_utf8(filename).unwrap_or("<invalid filename>");
+                            println!("TODO: read referenced file `{}`", filename);
                         },
                     }
                 }

--- a/libwild/src/archive_splitter.rs
+++ b/libwild/src/archive_splitter.rs
@@ -45,10 +45,14 @@ pub fn split_archives<'data>(input_data: &'data InputData) -> Result<Vec<InputBy
                         ArchiveEntry::Filenames(t) => extended_filenames = Some(t),
                         ArchiveEntry::Regular(archive_entry) => {
                             let (from, data) = if let Some(entry_data) = archive_entry.entry_data {
-                                (archive_entry.data_range().unwrap(), DataKind::InlineData(entry_data))
+                                (
+                                    archive_entry.data_range().unwrap(),
+                                    DataKind::InlineData(entry_data),
+                                )
                             } else {
                                 // This is a thin archive entry
-                                let fname = archive_entry.parse_as_thin_reference(extended_filenames.unwrap())?;
+                                let fname = archive_entry
+                                    .parse_as_thin_reference(extended_filenames.unwrap())?;
                                 let bytes = mmap_file(&PathBuf::from(fname), false)?;
                                 (0..bytes.len(), DataKind::NewFileData(bytes))
                             };
@@ -64,7 +68,7 @@ pub fn split_archives<'data>(input_data: &'data InputData) -> Result<Vec<InputBy
                                 data,
                                 modifiers: f.modifiers,
                             });
-                        },
+                        }
                     }
                 }
                 Ok(outputs)

--- a/libwild/src/archive_splitter.rs
+++ b/libwild/src/archive_splitter.rs
@@ -44,7 +44,13 @@ pub fn split_archives<'data>(input_data: &'data InputData) -> Result<Vec<InputBy
                                 data: archive_entry.entry_data,
                                 modifiers: f.modifiers,
                             });
-                        }
+                        },
+                        ArchiveEntry::FileReference(archive_entry) => {
+                            let filename = archive_entry.identifier(extended_filenames).as_slice();
+                            let filename = std::str::from_utf8(filename)
+                                .expect("Bad filename");
+                            println!("TODO: Read referenced file {}", filename);
+                        },
                     }
                 }
                 Ok(outputs)

--- a/libwild/src/file_kind.rs
+++ b/libwild/src/file_kind.rs
@@ -18,7 +18,7 @@ pub(crate) enum FileKind {
 
 impl FileKind {
     pub(crate) fn identify_bytes(bytes: &[u8]) -> Result<FileKind> {
-        if bytes.starts_with(&object::archive::MAGIC) {
+        if bytes.starts_with(&object::archive::MAGIC) || bytes.starts_with(&object::archive::THIN_MAGIC) {
             Ok(FileKind::Archive)
         } else if bytes.starts_with(&object::elf::ELFMAG) {
             const HEADER_LEN: usize = size_of::<elf::FileHeader>();
@@ -52,8 +52,6 @@ impl FileKind {
             Ok(FileKind::Text)
         } else if bytes.starts_with(b"BC") {
             bail!("LLVM IR (LTO mode) is not supported yet");
-        } else if bytes.starts_with(&object::archive::THIN_MAGIC) {
-            bail!("Thin archives are not supported yet");
         } else {
             bail!("Couldn't identify file type");
         }

--- a/libwild/src/file_kind.rs
+++ b/libwild/src/file_kind.rs
@@ -18,7 +18,9 @@ pub(crate) enum FileKind {
 
 impl FileKind {
     pub(crate) fn identify_bytes(bytes: &[u8]) -> Result<FileKind> {
-        if bytes.starts_with(&object::archive::MAGIC) || bytes.starts_with(&object::archive::THIN_MAGIC) {
+        if bytes.starts_with(&object::archive::MAGIC)
+            || bytes.starts_with(&object::archive::THIN_MAGIC)
+        {
             Ok(FileKind::Archive)
         } else if bytes.starts_with(&object::elf::ELFMAG) {
             const HEADER_LEN: usize = size_of::<elf::FileHeader>();

--- a/libwild/src/input_data.rs
+++ b/libwild/src/input_data.rs
@@ -122,7 +122,7 @@ impl<'config> InputData<'config> {
             return Ok(());
         }
 
-        let bytes = mmap_file(absolute_path, self.config.prepopulate_maps)?;
+        let bytes = mmap_file(absolute_path.as_path(), self.config.prepopulate_maps)?;
 
         let kind = FileKind::identify_bytes(&bytes)?;
         if matches!(kind, FileKind::Text) {
@@ -205,7 +205,7 @@ impl Input {
     }
 }
 
-pub(crate) fn mmap_file(path: &PathBuf, prepopulate_maps: bool) -> Result<Mmap> {
+pub(crate) fn mmap_file(path: &Path, prepopulate_maps: bool) -> Result<Mmap> {
     let file = std::fs::File::open(path)
         .with_context(|| format!("Failed to open input file `{}`", path.display()))?;
 

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -1,3 +1,4 @@
+use crate::archive_splitter::DataKind;
 use crate::archive_splitter::InputBytes;
 use crate::args::Args;
 use crate::args::Modifiers;
@@ -109,7 +110,11 @@ pub(crate) enum InternalSymDefInfo {
 
 impl<'data> ParsedInputObject<'data> {
     fn new(input: &'data InputBytes, is_dynamic: bool) -> Result<Self> {
-        let object = File::parse(input.data, is_dynamic)
+        let input_data = match &input.data {
+            DataKind::InlineData(data_slice) => data_slice,
+            DataKind::NewFileData(data_mmap) => &(**data_mmap),
+        };
+        let object = File::parse(input_data, is_dynamic)
             .with_context(|| format!("Failed to parse object file `{input}`"))?;
         let num_symbols = object.symbols.len();
         Ok(Self {

--- a/linker-diff/src/section_map.rs
+++ b/linker-diff/src/section_map.rs
@@ -100,6 +100,11 @@ impl<'data> IndexedLayout<'data> {
                 .get(&file.path)
                 .expect("We should have read all the files");
 
+            if mmap.starts_with(b"!<thin>") {
+                // We will encounter the files referenced by this
+                // archive in other iterations
+                continue;
+            }
             let object_bytes = if let Some(entry) = file.archive_entry.as_ref() {
                 &mmap[entry.range.clone()]
             } else {

--- a/wild/tests/sources/archive_activation.c
+++ b/wild/tests/sources/archive_activation.c
@@ -1,9 +1,18 @@
+//#AbstractConfig:default
 //#CompArgs:-ffunction-sections
+//#EnableLinker:lld
+
+//#Config:regular:default
 //#Archive:archive_activation0.c
 //#Archive:archive_activation1.c
 //#Archive:exit.c
 //#Archive:empty.a
-//#EnableLinker:lld
+
+//#Config:thin:default
+//#ThinArchive:archive_activation0.c
+//#ThinArchive:archive_activation1.c
+//#ThinArchive:exit.c
+//#ThinArchive:empty.a
 
 #include "exit.h"
 


### PR DESCRIPTION
Thin archives are like regular archives except that they store references to files on the filesystem instead of the file contents themselves.

May fix #361 