### PR TITLE
Support RELRO

### DIFF
--- a/libwild/src/part_id.rs
+++ b/libwild/src/part_id.rs
@@ -104,6 +104,8 @@ impl<'data> UnresolvedSection<'data> {
             Some(output_section_id::RODATA)
         } else if section_name.starts_with(TEXT_SECTION_NAME) {
             Some(output_section_id::TEXT)
+        } else if section_name.starts_with(DATA_REL_RO_SECTION_NAME) {
+            Some(output_section_id::DATA_REL_RO)
         } else if section_name.starts_with(DATA_SECTION_NAME) {
             Some(output_section_id::DATA)
         } else if section_name.starts_with(BSS_SECTION_NAME) {

--- a/libwild/src/program_segments.rs
+++ b/libwild/src/program_segments.rs
@@ -15,6 +15,7 @@ pub(crate) const TLS: ProgramSegmentId = ProgramSegmentId(6);
 pub(crate) const EH_FRAME: ProgramSegmentId = ProgramSegmentId(7);
 pub(crate) const DYNAMIC: ProgramSegmentId = ProgramSegmentId(8);
 pub(crate) const STACK: ProgramSegmentId = ProgramSegmentId(9);
+pub(crate) const RELRO: ProgramSegmentId = ProgramSegmentId(10);
 
 pub(crate) struct ProgramSegmentDef {
     pub(crate) segment_type: u32,
@@ -61,6 +62,10 @@ const PROGRAM_SEGMENT_DEFS: &[ProgramSegmentDef] = &[
     ProgramSegmentDef {
         segment_type: object::elf::PT_GNU_STACK,
         segment_flags: object::elf::PF_R | object::elf::PF_W,
+    },
+    ProgramSegmentDef {
+        segment_type: object::elf::PT_GNU_RELRO,
+        segment_flags: object::elf::PF_R,
     },
 ];
 
@@ -167,5 +172,9 @@ fn test_constant_segment_ids() {
     assert_eq!(
         PROGRAM_SEGMENT_DEFS[NOTE.as_usize()].segment_type,
         object::elf::PT_NOTE
+    );
+    assert_eq!(
+        PROGRAM_SEGMENT_DEFS[RELRO.as_usize()].segment_type,
+        object::elf::PT_GNU_RELRO
     );
 }

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -473,6 +473,8 @@ pub mod secnames {
     pub const DEBUG_RANGES_SECTION_NAME: &[u8] = DEBUG_RANGES_SECTION_NAME_STR.as_bytes();
     pub const GROUP_SECTION_NAME_STR: &str = ".group";
     pub const GROUP_SECTION_NAME: &[u8] = GROUP_SECTION_NAME_STR.as_bytes();
+    pub const DATA_REL_RO_SECTION_NAME_STR: &str = ".data.rel.ro";
+    pub const DATA_REL_RO_SECTION_NAME: &[u8] = DATA_REL_RO_SECTION_NAME_STR.as_bytes();
 }
 
 /// For additional information on ELF relocation types, see "ELF-64 Object File Format" -

--- a/wild/tests/sources/trivial_asm.s
+++ b/wild/tests/sources/trivial_asm.s
@@ -1,6 +1,8 @@
 //#LinkArgs:-z noexecstack
 //#Object:exit.c
 //#Arch: x86_64
+//#DiffIgnore:section.data.rel.ro.flags
+//#DiffIgnore:section.data.rel.ro.entsize
 
 .section        .data.foo
 .p2align        4, 0x0


### PR DESCRIPTION
Fix #42.

One remaining issue:
https://github.com/davidlattimore/wild/blob/main/wild/tests/sources/trivial_asm.s#L12
customizes the flags and entsize of the section, but I don't see any general mechanics for passing it in our codebase. Do we need the ability to pass arbitrary `.section` parameters now?