### PR TITLE
Ignore `--enable-new-dtags` flag

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -195,6 +195,7 @@ const DEFAULT_FLAGS: &[&str] = &[
     "discard-locals",
     "X",  // alias for --discard-locals
     "EL", // little endian
+    "enable-new-dtags",
 ];
 
 pub(crate) fn available_parallelism() -> std::num::NonZeroUsize {


### PR DESCRIPTION
It's used by Rust's tests