### PR TITLE
Don't attempt to export dynamic symbols for discarded archive entries

### DIFF
--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -204,14 +204,6 @@ impl<'data> ParsedInput<'data> {
         }
     }
 
-    pub(crate) fn is_regular_object(&self) -> bool {
-        match self {
-            ParsedInput::Object(o) => !o.is_dynamic(),
-            ParsedInput::Prelude(_) => false,
-            ParsedInput::Epilogue(_) => false,
-        }
-    }
-
     pub(crate) fn file_id(&self) -> FileId {
         let file_id = match self {
             ParsedInput::Prelude(_) => PRELUDE_FILE_ID,

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -1825,7 +1825,8 @@ fn integration_test(
         "ifunc2.c",
         "tls-local-exec.c",
         "undefined_symbols.c",
-        "whole_archive.c"
+        "whole_archive.c",
+        "shared.c"
     )]
     program_name: &'static str,
     #[allow(unused_variables)] setup_symlink: (),

--- a/wild/tests/sources/shared-a1.c
+++ b/wild/tests/sources/shared-a1.c
@@ -1,0 +1,3 @@
+int bar1(void) {
+    return 40;
+}

--- a/wild/tests/sources/shared-a2.c
+++ b/wild/tests/sources/shared-a2.c
@@ -1,0 +1,3 @@
+int baz(void) {
+    return 10;
+}

--- a/wild/tests/sources/shared-s1.c
+++ b/wild/tests/sources/shared-s1.c
@@ -1,0 +1,9 @@
+int baz(void);
+
+int call_baz(void) {
+    return baz();
+}
+
+int bar2(void) {
+    return 2;
+}

--- a/wild/tests/sources/shared.c
+++ b/wild/tests/sources/shared.c
@@ -1,0 +1,21 @@
+// We don't currently run this, we just make sure that we can produce a shared object and that it
+// passes the diff test.
+//
+// One notable scenario that this test tests is having a non-weak undefined symbol (baz) in a shared
+// object and having that symbol be defined by an archive entry that we don't load.
+
+//#RunEnabled:false
+//#LinkArgs:-shared -z now
+//#Static:false
+//#Archive:shared-a1.c,shared-a2.c
+//#Shared:shared-s1.c
+//#DiffIgnore:.dynamic.DT_RELA
+//#DiffIgnore:.dynamic.DT_RELAENT
+//#DiffIgnore:.dynamic.DT_NEEDED
+
+int bar1(void);
+int bar2(void);
+
+int foo(void) {
+    return bar1() + bar2();
+}


### PR DESCRIPTION
At the place where we were requesting export of the symbol, we didn't have easy access to whether the object defining the symbol was discarded, so the code is changed to send an ExportDynamic request to the defining object. It can then ignore the request if it wasn't loaded.

Fixes #498