### PR TITLE
Rename wild crate to wild-linker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,7 +1431,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "wild"
+name = "wild-linker"
 version = "0.3.0"
 dependencies = [
  "anyhow",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ and manually copy the `wild` binary somewhere on your path.
 To build and install, you can run:
 
 ```sh
-cargo install --locked --bin wild --git https://github.com/davidlattimore/wild.git wild
+cargo install --locked --bin wild --git https://github.com/davidlattimore/wild.git wild-linker
 ```
 
 ## Using as your default linker

--- a/wild/Cargo.toml
+++ b/wild/Cargo.toml
@@ -1,10 +1,14 @@
 [package]
-name = "wild"
+name = "wild-linker"
 version.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 edition.workspace = true
+
+[[bin]]
+name = "wild"
+path = "src/main.rs"
 
 [dependencies]
 libwild = { path = "../libwild" }


### PR DESCRIPTION
This should help with publishing, since the name "wild" belongs to another project.

Issue #223