### PR TITLE
save-dirs: Use env to locate bash

### DIFF
--- a/libwild/src/save-dir-prelude.sh
+++ b/libwild/src/save-dir-prelude.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 D=$(dirname $BASH_SOURCE)
 if [ -z "$OUT" ]; then
   OUT=$D/bin${S}


### PR DESCRIPTION
Provided the path to env is more consistent than the path to bash, this can help with portability.