### PR TITLE
Write unreferenced internal symbols for non-empty sections

### DIFF
--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -901,6 +901,11 @@ impl<'data> OutputSections<'data> {
             .flatten()
     }
 
+    /// Returns whether we're going to emit the specified section.
+    pub(crate) fn will_emit_section(&self, id: OutputSectionId) -> bool {
+        self.output_index_of_section(id).is_some()
+    }
+
     pub(crate) fn loadable_segment_id_for(&self, id: OutputSectionId) -> Option<ProgramSegmentId> {
         self.output_info(id).loadable_segment_id
     }

--- a/libwild/src/output_section_map.rs
+++ b/libwild/src/output_section_map.rs
@@ -15,8 +15,8 @@ impl<T: Default> OutputSectionMap<T> {
         Self { values }
     }
 
-    pub(crate) fn into_raw_values(self) -> Vec<T> {
-        self.values
+    pub(crate) fn values_iter(&self) -> impl Iterator<Item = &T> {
+        self.values.iter()
     }
 }
 

--- a/wild/tests/sources/ifunc.c
+++ b/wild/tests/sources/ifunc.c
@@ -9,6 +9,8 @@
 
 //#Config:pie:default
 //#CompArgs:-fpie -ffunction-sections
+// This can be in any test that's x86_64 only.
+//#ExpectSym:_GLOBAL_OFFSET_TABLE_
 
 //#Config:no-pie:default
 //#CompArgs:-fno-pie


### PR DESCRIPTION
Previously, we only kept internal symbols if they were referenced. Now we also keep them if we're keeping their section.

We don't at this stage match the symbols emitted by other linkers like GNU ld, so we don't attempt to use linker-diff to report differences in which symbols are defined. Instead, we just have one of our tests check that _GLOBAL_OFFSET_TABLE_ is indeed defined.

Issue #308