### PR TITLE
Use bpaf for argument parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bpaf"
+version = "0.9.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd343f000c4472dc4557e093f314c5210375d3e9349ad866fee0ddb7f4ed10bf"
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,6 +655,7 @@ dependencies = [
  "atomic-take",
  "bitflags",
  "blake3",
+ "bpaf",
  "bumpalo-herd",
  "bytemuck",
  "bytesize",

--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -11,6 +11,7 @@ edition.workspace = true
 ahash = { version = "0.8.11", default-features = false, features = ["std"] }
 anyhow = "1.0.97"
 bitflags = "2.9.0"
+bpaf = "0.9"
 bytemuck = { version = "1.22.0", features = ["derive"] }
 crossbeam-queue = "0.3.12"
 crossbeam-utils = "0.8.21"

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -615,6 +615,7 @@ struct BpafArgs {
     output: Arc<PathBuf>,
     time_phases: bool,
     strip_all: bool,
+    strip_debug: bool,
 }
 
 fn bpaf_main_parser() -> impl Parser<BpafArgs> {
@@ -623,7 +624,9 @@ fn bpaf_main_parser() -> impl Parser<BpafArgs> {
     // TODO: We should also set strip_debug = true in this case.
     let strip_all = short_long_arg_flag('s', "strip-all").fallback(false);
 
-    bpaf::construct!(BpafArgs { output(), time_phases, strip_all })
+    let strip_debug = short_long_arg_flag('S', "strip-debug").fallback(false);
+
+    bpaf::construct!(BpafArgs { output(), time_phases, strip_all, strip_debug })
 }
 
 fn bpaf_options() -> bpaf::OptionParser<BpafArgs> {
@@ -1146,5 +1149,37 @@ mod tests {
             .run_inner(&[])
             .unwrap();
         assert_eq!(args.strip_all, false);
+    }
+
+    #[test]
+    fn test_bpaf_strip_debug_with_two_dashes() {
+        let args = bpaf_options()
+            .run_inner(&["--strip-debug"])
+            .unwrap();
+        assert_eq!(args.strip_debug, true);
+    }
+
+    #[test]
+    fn test_bpaf_strip_debug_with_single_dash() {
+        let args = bpaf_options()
+            .run_inner(&["-strip-debug"])
+            .unwrap();
+        assert_eq!(args.strip_debug, true);
+    }
+
+    #[test]
+    fn test_bpaf_strip_debug_with_short() {
+        let args = bpaf_options()
+            .run_inner(&["-S"])
+            .unwrap();
+        assert_eq!(args.strip_debug, true);
+    }
+
+    #[test]
+    fn test_bpaf_strip_debug_fallback() {
+        let args = bpaf_options()
+            .run_inner(&[])
+            .unwrap();
+        assert_eq!(args.strip_debug, false);
     }
 }


### PR DESCRIPTION
Use bpaf crate for argument parsing. Currently this PR is for discussion purposes only.

Relates to https://github.com/davidlattimore/wild/issues/458