### PR TITLE
linker-diff: Don't ignore match_failed.R_AARCH64_TLSDESC_ADR_PAGE21

### DIFF
--- a/linker-diff/src/aarch64.rs
+++ b/linker-diff/src/aarch64.rs
@@ -100,6 +100,10 @@ impl Arch for AArch64 {
 
         match r_type.0 {
             object::elf::R_AARCH64_TLSDESC_ADR_PAGE21 => {
+                relax(
+                    RelaxationKind::MovzX0Lsl16,
+                    object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G1,
+                );
                 relax(RelaxationKind::ReplaceWithNop, object::elf::R_AARCH64_NONE);
             }
             object::elf::R_AARCH64_TLSDESC_LD64_LO12 => {

--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -195,7 +195,6 @@ impl Config {
                 // We don't yet support emitting warnings.
                 "section.gnu.warning",
                 // GNU ld sometimes applies relaxations that we don't yet.
-                "rel.match_failed.R_AARCH64_TLSDESC_ADR_PAGE21",
                 "rel.match_failed.R_AARCH64_TLSDESC_LD64_LO12",
                 "rel.match_failed.R_AARCH64_TLSGD_ADD_LO12_NC",
                 "rel.missing-opt.R_X86_64_TLSGD.TlsGdToInitialExec.shared-object",


### PR DESCRIPTION
Issue #530