### PR TITLE
Stop using tracing for .trace files

### DIFF
--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -74,8 +74,6 @@ impl Linker {
         let args = &self.args;
         if args.time_phases {
             timing::init_tracing();
-        } else if args.write_trace {
-            output_trace::init(args);
         } else if args.print_allocations.is_some() {
             debug_trace::init();
         } else {

--- a/libwild/src/output_trace.rs
+++ b/libwild/src/output_trace.rs
@@ -1,131 +1,56 @@
 //! Sets up a tracing layer for recording diagnostics associated with particular addresses in the
 //! output file.
 
-use crate::args::Args;
 use crate::error::Result;
 use linker_trace::AddressTrace;
-use std::fmt::Write as _;
 use std::mem::take;
 use std::ops::DerefMut;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
-pub(crate) fn init(args: &Args) {
-    use tracing_subscriber::prelude::*;
-
-    let trace_path = linker_trace::trace_path(&args.output);
-    let layer = OutputTraceLayer {
-        trace_path,
-        data: Default::default(),
-    };
-    let subscriber = tracing_subscriber::Registry::default().with(layer);
-    tracing::subscriber::set_global_default(subscriber).unwrap();
+pub(crate) struct TraceOutput {
+    state: Option<State>,
 }
 
-struct OutputTraceLayer {
+struct State {
     trace_path: PathBuf,
     data: Mutex<linker_trace::TraceData>,
 }
 
-#[derive(Default)]
-struct Data {
-    address: Option<u64>,
-    messages: Mutex<Vec<String>>,
-}
+impl TraceOutput {
+    pub(crate) fn new(should_write_trace: bool, base_output: &Path) -> Self {
+        if !should_write_trace {
+            return TraceOutput { state: None };
+        }
 
-impl tracing::field::Visit for Data {
-    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
-        if field.name() == "address" {
-            self.address = Some(value);
+        let trace_path = linker_trace::trace_path(base_output);
+
+        TraceOutput {
+            state: Some(State {
+                trace_path,
+                data: Default::default(),
+            }),
         }
     }
 
-    fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {}
-}
-
-impl<S> tracing_subscriber::Layer<S> for OutputTraceLayer
-where
-    S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
-{
-    fn on_new_span(
-        &self,
-        attributes: &tracing::span::Attributes,
-        id: &tracing::span::Id,
-        ctx: tracing_subscriber::layer::Context<S>,
-    ) {
-        let span = ctx.span(id).expect("valid span ID");
-
-        let mut data = Data::default();
-        attributes.values().record(&mut data);
-
-        span.extensions_mut().insert(data);
-    }
-
-    fn on_close(&self, id: tracing::span::Id, ctx: tracing_subscriber::layer::Context<S>) {
-        let span = ctx.span(&id).expect("valid span ID");
-        let extensions = span.extensions();
-        let Some(data) = extensions.get::<Data>() else {
-            return;
-        };
-        let Some(address) = data.address else { return };
-        let trace = AddressTrace {
-            address,
-            messages: take(data.messages.lock().unwrap().deref_mut()),
-        };
-        self.data.lock().unwrap().traces.push(trace);
-    }
-
-    fn on_event(&self, event: &tracing::Event<'_>, ctx: tracing_subscriber::layer::Context<'_, S>) {
-        let Some(span) = ctx.event_span(event) else {
-            return;
-        };
-        let extensions = span.extensions();
-        let Some(data) = extensions.get::<Data>() else {
-            return;
-        };
-        let mut formatter = MessageFormatter::default();
-        event.record(&mut formatter);
-        if formatter.output_is_complete {
-            if let Err(error) = self.flush() {
-                eprintln!(
-                    "Failed to write trace to `{}`: {error}",
-                    self.trace_path.display()
-                );
-            }
-            return;
-        }
-        data.messages.lock().unwrap().push(formatter.out);
-    }
-}
-
-#[derive(Default)]
-struct MessageFormatter {
-    out: String,
-    output_is_complete: bool,
-}
-
-impl tracing::field::Visit for MessageFormatter {
-    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
-        if !self.out.is_empty() {
-            self.out.push(' ');
-        }
-        let _ = write!(&mut self.out, "{field}={value:?}");
-    }
-
-    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
-        if field.name() == "output_write_complete" && value {
-            self.output_is_complete = true;
-        } else {
-            self.record_debug(field, &value);
+    pub(crate) fn emit(&self, address: u64, message_cb: impl Fn() -> String) {
+        if let Some(state) = self.state.as_ref() {
+            let message = message_cb();
+            state.data.lock().unwrap().traces.push(AddressTrace {
+                address,
+                messages: message.split('\n').map(|s| s.to_owned()).collect(),
+            });
         }
     }
-}
 
-impl OutputTraceLayer {
-    fn flush(&self) -> Result {
-        let mut file = std::io::BufWriter::new(std::fs::File::create(&self.trace_path)?);
-        let data = take(self.data.lock().unwrap().deref_mut());
-        data.write(&mut file)?;
+    pub(crate) fn close(&self) -> Result {
+        if let Some(state) = self.state.as_ref() {
+            let mut file = std::io::BufWriter::new(std::fs::File::create(&state.trace_path)?);
+            let data = take(state.data.lock().unwrap().deref_mut());
+            data.write(&mut file)?;
+        }
+
         Ok(())
     }
 }

--- a/linker-diff/src/asm_diff.rs
+++ b/linker-diff/src/asm_diff.rs
@@ -1145,33 +1145,9 @@ impl<A: Arch> RelocationInstructionBlock<'_, A> {
     fn write_traces(&self, f: &mut String, maximum_widths: &ColumnWidths) -> Result {
         let name_width = maximum_widths.name;
         let prefix = " TRACE: ";
-        let margin = name_width + prefix.len();
-        const WRAP_COLUMN: usize = 80;
 
         for trace in &self.trace_messages {
-            write!(f, "{:name_width$}{prefix}", self.name.blue())?;
-
-            // Crude word wrapping should be sufficient for a trace message. TODO: Consider changing
-            // our tracing code (in wild) to emit fields separated by newlines, then get rid of this
-            // word wrapping and just indent the lines appropriately.
-            let mut line_length = 0;
-            for word in trace.split(' ') {
-                if line_length > 0 && margin + line_length + word.len() > WRAP_COLUMN {
-                    writeln!(f)?;
-                    write!(f, "{:margin$}", "")?;
-                    line_length = 0;
-                }
-
-                if line_length > 0 {
-                    write!(f, " ")?;
-                    line_length += 1;
-                }
-
-                write!(f, "{word}")?;
-                line_length += word.len();
-            }
-
-            writeln!(f)?;
+            writeln!(f, "{:name_width$}{prefix}{trace}", self.name.blue())?;
         }
 
         Ok(())


### PR DESCRIPTION
Having several separate uses of tracing within wild was cause for confusion. Also, less reliance on tracing makes wild more library-friendly.