### PR TITLE
Set O_CLOEXEC on our output file

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -343,6 +343,14 @@ impl SizedOutput {
         should_write_trace: bool,
     ) -> Result<SizedOutput> {
         let mut open_options = std::fs::OpenOptions::new();
+
+        // If another thread spawns a subprocess while we have this file open, we don't want the
+        // subprocess to inherit our file descriptor. This unfortunately doesn't prevent that, since
+        // unless and until the subprocess calls exec, it will inherit the file descriptor. However,
+        // assuming it eventually calls exec, this at least means that it inherits the file
+        // descriptor for less time. i.e. this doesn't really fix anything, but makes problems less bad.
+        std::os::unix::fs::OpenOptionsExt::custom_flags(&mut open_options, libc::O_CLOEXEC);
+
         match write_mode {
             FileWriteMode::UnlinkAndReplace => {
                 open_options.truncate(true);


### PR DESCRIPTION
This means that when libwild is used in a multithreaded environment that is spawning subprocesses at the same time as we're writing our output file, that the inherited file lock is held only until exec is called rather than for the entire execution time of the subprocess.