### PR TITLE
Verify that input files didn't change while we were running

### DIFF
--- a/libwild/src/archive_splitter.rs
+++ b/libwild/src/archive_splitter.rs
@@ -1,34 +1,19 @@
 use crate::archive::ArchiveEntry;
 use crate::archive::ArchiveIterator;
 use crate::archive::EntryMeta;
-use crate::archive::evaluate_identifier;
 use crate::args::Modifiers;
 use crate::error::Result;
 use crate::file_kind::FileKind;
 use crate::input_data::InputData;
 use crate::input_data::InputRef;
-use crate::input_data::mmap_file;
-use memmap2::Mmap;
 use rayon::iter::IntoParallelRefIterator;
 use rayon::iter::ParallelIterator;
-use std::ffi::OsStr;
 use std::fmt::Display;
-use std::os::unix::ffi::OsStrExt;
-use std::path::Path;
-
-pub(crate) enum DataKind<'data> {
-    // Data originating from the archive itself,
-    // e.g. typical archive contents
-    InlineData(&'data [u8]),
-    // Data originating from a freshly opened file,
-    // e.g. files referenced by thin archive
-    NewFileData(Mmap),
-}
 
 pub(crate) struct InputBytes<'data> {
     pub(crate) input: InputRef<'data>,
     pub(crate) kind: FileKind,
-    pub(crate) data: DataKind<'data>,
+    pub(crate) data: &'data [u8],
     pub(crate) modifiers: Modifiers,
 }
 
@@ -56,27 +41,11 @@ pub fn split_archives<'data>(input_data: &'data InputData) -> Result<Vec<InputBy
                                         from: archive_entry.data_range(),
                                     }),
                                 },
-                                data: DataKind::InlineData(archive_entry.entry_data),
+                                data: archive_entry.entry_data,
                                 modifiers: f.modifiers,
                             });
                         }
-                        ArchiveEntry::Thin(ident) => {
-                            let fname = evaluate_identifier(ident, extended_filenames);
-                            let bytes =
-                                mmap_file(Path::new(OsStr::from_bytes(fname.as_slice())), false)?;
-                            outputs.push(InputBytes {
-                                kind: f.kind,
-                                input: InputRef {
-                                    file: f,
-                                    entry: Some(EntryMeta {
-                                        identifier: fname,
-                                        from: 0..bytes.len(),
-                                    }),
-                                },
-                                data: DataKind::NewFileData(bytes),
-                                modifiers: f.modifiers,
-                            });
-                        }
+                        ArchiveEntry::Thin(_) => unreachable!(),
                     }
                 }
                 Ok(outputs)
@@ -87,7 +56,7 @@ pub fn split_archives<'data>(input_data: &'data InputData) -> Result<Vec<InputBy
                     entry: None,
                 },
                 kind: f.kind,
-                data: DataKind::InlineData(f.data()),
+                data: f.data(),
                 modifiers: f.modifiers,
             }]),
         })

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -125,6 +125,9 @@ pub(crate) struct Modifiers {
     /// Whether object files in archives should be linked even if they do not contain symbols that
     /// are referenced.
     pub(crate) whole_archive: bool,
+
+    /// Whether archive semantics should be applied even for regular objects.
+    pub(crate) archive_semantics: bool,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -713,6 +716,7 @@ impl Default for Modifiers {
             as_needed: false,
             allow_shared: true,
             whole_archive: false,
+            archive_semantics: false,
         }
     }
 }

--- a/libwild/src/file_kind.rs
+++ b/libwild/src/file_kind.rs
@@ -6,22 +6,23 @@ use anyhow::bail;
 use object::LittleEndian;
 use object::read::elf::FileHeader;
 
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub(crate) enum FileKind {
     Prelude,
     ElfObject,
     ElfDynamic,
     Archive,
+    ThinArchive,
     Text,
     Epilogue,
 }
 
 impl FileKind {
     pub(crate) fn identify_bytes(bytes: &[u8]) -> Result<FileKind> {
-        if bytes.starts_with(&object::archive::MAGIC)
-            || bytes.starts_with(&object::archive::THIN_MAGIC)
-        {
+        if bytes.starts_with(&object::archive::MAGIC) {
             Ok(FileKind::Archive)
+        } else if bytes.starts_with(&object::archive::THIN_MAGIC) {
+            Ok(FileKind::ThinArchive)
         } else if bytes.starts_with(&object::elf::ELFMAG) {
             const HEADER_LEN: usize = size_of::<elf::FileHeader>();
             if bytes.len() < HEADER_LEN {

--- a/linker-diff/src/section_map.rs
+++ b/linker-diff/src/section_map.rs
@@ -100,7 +100,7 @@ impl<'data> IndexedLayout<'data> {
                 .get(&file.path)
                 .expect("We should have read all the files");
 
-            if mmap.starts_with(b"!<thin>") {
+            if mmap.starts_with(&object::archive::THIN_MAGIC) {
                 // We will encounter the files referenced by this
                 // archive in other iterations
                 continue;


### PR DESCRIPTION
In order to have easy access to all the input files that we mmapped, I moved expansion of thin archives earlier in the process, so it's now handled a little bit like basic linker scripts.