### PR TITLE
Add support for --start-lib and --end-lib

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -439,6 +439,10 @@ pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(mut input: I) -> Resul
             modifier_stack.last_mut().unwrap().whole_archive = true;
         } else if long_arg_eq("no-whole-archive") {
             modifier_stack.last_mut().unwrap().whole_archive = false;
+        } else if long_arg_eq("start-lib") {
+            modifier_stack.last_mut().unwrap().archive_semantics = true;
+        } else if long_arg_eq("end-lib") {
+            modifier_stack.last_mut().unwrap().archive_semantics = false;
         } else if long_arg_eq("push-state") {
             modifier_stack.push(*modifier_stack.last().unwrap());
         } else if long_arg_eq("pop-state") {

--- a/wild/tests/sources/archive_activation.c
+++ b/wild/tests/sources/archive_activation.c
@@ -14,6 +14,16 @@
 //#ThinArchive:exit.c
 //#ThinArchive:empty.a
 
+//#Config:lib:default
+// GNU ld doesn't yet support --start-lib
+//#SkipLinker:ld
+//#Cross:false
+//#LinkArgs:--start-lib
+//#Object:archive_activation0.c
+//#Object:archive_activation1.c
+//#Object:exit.c
+//#Object:empty.a
+
 #include "exit.h"
 
 int bar(void);


### PR DESCRIPTION
Also, mostly because it was required to make the test pass, load _start if it's defined in an archive entry.