### PR TITLE
Refactoring: Change Layout to take ownership of SymbolDb

### DIFF
--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -151,7 +151,7 @@ fn link_with_input_data<'shutdown_span, A: arch::Arch>(
     let mut symbol_db =
         symbol_db::SymbolDb::build(&groups, input_data.version_script_data.as_ref(), args)?;
     let resolved = resolution::resolve_symbols_and_sections(&groups, &mut symbol_db, &herd)?;
-    let layout = layout::compute::<A>(&symbol_db, resolved, &mut output)?;
+    let layout = layout::compute::<A>(symbol_db, resolved, &mut output)?;
     let output_file = output.write::<A>(&layout)?;
     diff::maybe_diff()?;
 
@@ -162,7 +162,6 @@ fn link_with_input_data<'shutdown_span, A: arch::Arch>(
         done_callback();
     }
     shutdown::free_layout(layout);
-    shutdown::free_symbol_db(symbol_db);
 
     Ok(shutdown_scope)
 }

--- a/libwild/src/shutdown.rs
+++ b/libwild/src/shutdown.rs
@@ -8,12 +8,7 @@
 //! can then exit while the forked process cleans up.
 
 #[tracing::instrument(skip_all, name = "Drop layout")]
-pub(crate) fn free_layout<'data, 'symbol_db>(d: crate::layout::Layout<'data, 'symbol_db>) {
-    drop(d);
-}
-
-#[tracing::instrument(skip_all, name = "Drop symbol DB")]
-pub(crate) fn free_symbol_db<'data>(d: crate::symbol_db::SymbolDb<'data>) {
+pub(crate) fn free_layout<'data>(d: crate::layout::Layout<'data>) {
     drop(d);
 }
 


### PR DESCRIPTION
This simplifies code by reducing the use of lifetimes, so is worthwhile in its own right, however the actual motivation is that it'll make it possible to mutate SymbolDb without dropping Layout in incremental linking.