### PR TITLE
Parse relocations index later

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -1584,7 +1584,7 @@ impl<'data> ObjectLayout<'data> {
         let object_section = self.object.section(section.index)?;
         let section_flags = SectionFlags::from_header(object_section);
         let mut modifier = RelocationModifier::Normal;
-        let relocations = self.object.relocations(section.index)?;
+        let relocations = self.relocations(section.index)?;
         layout
             .relocation_statistics
             .get(section.part_id.output_section_id())
@@ -1640,7 +1640,7 @@ impl<'data> ObjectLayout<'data> {
                 0
             };
 
-        let relocations = self.object.relocations(section.index)?;
+        let relocations = self.relocations(section.index)?;
         layout
             .relocation_statistics
             .get(section.part_id.output_section_id())
@@ -1670,11 +1670,7 @@ impl<'data> ObjectLayout<'data> {
         const PREFIX_LEN: usize = size_of::<elf::EhFrameEntryPrefix>();
         let e = LittleEndian;
         let section_flags = SectionFlags::from_header(eh_frame_section);
-        let mut relocations = self
-            .object
-            .relocations(eh_frame_section_index)?
-            .iter()
-            .peekable();
+        let mut relocations = self.relocations(eh_frame_section_index)?.iter().peekable();
         let mut input_pos = 0;
         let mut output_pos = 0;
         let frame_info_ptr_base = table_writer.eh_frame_start_address;

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -264,6 +264,8 @@ fn resolve_sections<'data>(
                     &loaded_metrics,
                 )?;
 
+                non_dynamic.relocations = obj.object.parse_relocations()?;
+
                 obj.non_dynamic = Some(non_dynamic);
             }
             Ok(())
@@ -426,6 +428,8 @@ pub(crate) struct ResolvedObject<'data> {
 /// Parts of a resolved object that are only applicable to non-dynamic objects.
 pub(crate) struct NonDynamicResolved<'data> {
     pub(crate) sections: Vec<SectionSlot>,
+    pub(crate) relocations: object::read::elf::RelocationSections,
+
     pub(crate) string_merge_extras: Vec<StringMergeSectionExtra<'data>>,
 
     /// Details about each custom section that is defined in this object.
@@ -675,6 +679,7 @@ impl<'data> ResolvedObject<'data> {
             // We'll fill this in during section resolution.
             non_dynamic = Some(NonDynamicResolved {
                 sections: Default::default(),
+                relocations: Default::default(),
                 string_merge_extras: Default::default(),
                 custom_sections: Default::default(),
             });


### PR DESCRIPTION
This allows our File type to not implement Drop. It also means that we no longer build a relocation index for archive entries that aren't loaded.