### PR TITLE
Fixes to --time output

### DIFF
--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -152,11 +152,10 @@ fn link_with_input_data<'shutdown_span, A: arch::Arch>(
         symbol_db::SymbolDb::build(&groups, input_data.version_script_data.as_ref(), args)?;
     let resolved = resolution::resolve_symbols_and_sections(&groups, &mut symbol_db, &herd)?;
     let layout = layout::compute::<A>(symbol_db, resolved, &mut output)?;
-    let output_file = output.write::<A>(&layout)?;
+    output.write::<A>(&layout)?;
     diff::maybe_diff()?;
 
     let shutdown_scope = shutdown_span.enter();
-    shutdown::free_output(output_file);
     // If there is a parent process waiting on this, inform it that linking is done and output ready
     if let Some(done_callback) = done_closure {
         done_callback();

--- a/libwild/src/shutdown.rs
+++ b/libwild/src/shutdown.rs
@@ -16,8 +16,3 @@ pub(crate) fn free_layout<'data>(d: crate::layout::Layout<'data>) {
 pub(crate) fn free_input_data(d: crate::input_data::InputData) {
     drop(d);
 }
-
-#[tracing::instrument(skip_all, name = "Unmap output file")]
-pub(crate) fn free_output(d: crate::elf_writer::SizedOutput) {
-    drop(d);
-}

--- a/libwild/src/timing.rs
+++ b/libwild/src/timing.rs
@@ -77,6 +77,13 @@ where
         });
     }
 
+    fn on_enter(&self, id: &tracing::span::Id, ctx: tracing_subscriber::layer::Context<S>) {
+        let span = ctx.span(id).expect("valid span ID");
+        if let Some(data) = span.extensions_mut().get_mut::<Data>() {
+            data.start = Instant::now();
+        }
+    }
+
     fn on_close(&self, id: tracing::span::Id, ctx: tracing_subscriber::layer::Context<S>) {
         let span = ctx.span(&id).expect("valid span ID");
         let metadata = span.metadata();


### PR DESCRIPTION
Start time from when the scope is entered rather than when the scope is created. This mostly only affects the shutdown time, for which we currently create the scope at the start of linking, but only later enter it.

We also move unmapping of the output file to the write phase rather than the shutdown phase, since the output file isn't really usable until we've unmapped it, since we'll still be holding an exclusive lock on the file.