### PR TITLE
Deduplicate basic linker invocation code

### DIFF
--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -53,6 +53,16 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use typed_arena::Arena;
 
+/// Runs the linker and cleans up associated resources. Only use this function if you've OK with
+/// waiting for cleanup.
+pub fn run(args: &Args) -> error::Result {
+    setup_tracing(args)?;
+    setup_thread_pool(args)?;
+    let linker = Linker::new();
+    linker.run(args)?;
+    Ok(())
+}
+
 /// Sets up whatever tracing, if any, is indicated by the supplied arguments. This can only be
 /// called once and only if nothing else has already set the global tracing dispatcher. Calling this
 /// is optional. If it isn't called, no tracing-based features will function. e.g. --time.

--- a/libwild/src/subprocess.rs
+++ b/libwild/src/subprocess.rs
@@ -52,10 +52,7 @@ fn subprocess_result(args: &Args) -> Result<i32> {
         }
         -1 => {
             // Fork failure in the parent - Fallback to running linker in this process
-            crate::setup_tracing(args)?;
-            crate::setup_thread_pool(args)?;
-            let linker = crate::Linker::new();
-            linker.run(args)?;
+            crate::run(args)?;
             Ok(0)
         }
         pid => {

--- a/libwild/src/subprocess_unsupported.rs
+++ b/libwild/src/subprocess_unsupported.rs
@@ -1,10 +1,7 @@
-use crate::Args;
-use crate::error::Result;
-
 /// # Safety
 /// See function of the same name in `subprocess.rs`
 pub unsafe fn run_in_subprocess(args: &crate::Args) -> ! {
-    let exit_code = match run_with_args(args) {
+    let exit_code = match crate::run(args) {
         Ok(()) => 0,
         Err(error) => {
             eprintln!("{error}");
@@ -12,12 +9,4 @@ pub unsafe fn run_in_subprocess(args: &crate::Args) -> ! {
         }
     };
     std::process::exit(exit_code);
-}
-
-fn run_with_args(args: &Args) -> Result {
-    crate::setup_tracing(args)?;
-    crate::setup_thread_pool(args)?;
-    let linker = crate::Linker::new();
-    linker.run(args)?;
-    Ok(())
 }

--- a/wild/src/main.rs
+++ b/wild/src/main.rs
@@ -17,10 +17,6 @@ fn main() -> libwild::error::Result {
         unsafe { libwild::run_in_subprocess(&args) };
     } else {
         // Run the linker in this process without forking.
-        let linker = libwild::Linker::new();
-        libwild::setup_tracing(&args)?;
-        libwild::setup_thread_pool(&args)?;
-        linker.run(&args)?;
-        Ok(())
+        libwild::run(&args)
     }
 }


### PR DESCRIPTION
Note that in the case of --no-fork, the duplicated code was slightly out-of-order. It was creating `Linker` before initialising tracing, which meant that the top-level timing event wasn't being emitted.