### PR TITLE
zlib: switch to faster native Rust implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -675,6 +676,15 @@ dependencies = [
  "typed-arena",
  "uuid",
  "zstd",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "902bc563b5d65ad9bba616b490842ef0651066a1a1dc3ce1087113ffcb873c8d"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1624,6 +1634,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b20717f0917c908dc63de2e44e97f1e6b126ca58d0e391cee86d504eb8fbd05"
 
 [[package]]
 name = "zstd"

--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -40,7 +40,7 @@ sharded-offset-map = "0.2.0"
 sharded-vec-writer = "0.3.0"
 itertools = "0.14.0"
 bytesize = "2.0.1"
-flate2 = "1.1.0"
+flate2 = { version = "1.1.0", features = ["zlib-rs"] }
 bumpalo-herd = "0.1.2"
 zstd = "0.13.3"
 blake3 = { version = "1.6.1", features = ["rayon"] }


### PR DESCRIPTION
Following the discussion in https://github.com/astral-sh/uv/pull/11894, I also tried switching the default back-end for `flate2` from `miniz_oxide` to `zlib-rs`, the results are pretty nice. Even though the speed-up for linking Clang w/ debug info is quite small (**~4%**), we managed to save pretty many CPU cycles. Note the sum of the input files for Clang is about **1.3 GiB**, but it expands to **6.5GiB** after the decompression of the debug info sections.

First is the current `miniz_oxide`, 2. is the `zlib-rs` implementation:

```
Benchmark 1 (3 runs): bash ./run-with -B/tmp/
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          3.68s  ± 59.4ms    3.62s  … 3.74s           0 ( 0%)        0%
  peak_rss            104MB ± 23.6KB     104MB …  104MB          0 ( 0%)        0%
  cpu_cycles          293G  ± 1.38G      292G  …  294G           0 ( 0%)        0%
  instructions        301G  ± 42.8M      301G  …  301G           0 ( 0%)        0%
  cache_references   4.01G  ± 22.1M     3.99G  … 4.03G           0 ( 0%)        0%
  cache_misses        853M  ±  931K      852M  …  854M           0 ( 0%)        0%
  branch_misses      2.03G  ± 1.58M     2.03G  … 2.03G           0 ( 0%)        0%
Benchmark 2 (3 runs): bash ./run-with -B /home/marxin/Programming/wild
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          3.53s  ± 72.6ms    3.45s  … 3.58s           0 ( 0%)          -  4.0% ±  4.1%
  peak_rss            104MB ± 39.5KB     104MB …  104MB          0 ( 0%)          -  0.0% ±  0.1%
  cpu_cycles          262G  ± 1.21G      261G  …  263G           0 ( 0%)        ⚡- 10.8% ±  1.0%
  instructions        252G  ± 8.30M      252G  …  252G           0 ( 0%)        ⚡- 16.5% ±  0.0%
  cache_references   3.99G  ± 18.3M     3.97G  … 4.00G           0 ( 0%)          -  0.5% ±  1.1%
  cache_misses        855M  ± 2.90M      853M  …  859M           0 ( 0%)          +  0.3% ±  0.6%
  branch_misses      1.13G  ± 1.65M     1.13G  … 1.13G           0 ( 0%)        ⚡- 44.2% ±  0.2%
```
