### PR TITLE
Support `rel.match_failed.R_AARCH64_TLSDESC_LD64_LO12`

### DIFF
--- a/linker-diff/src/aarch64.rs
+++ b/linker-diff/src/aarch64.rs
@@ -112,6 +112,10 @@ impl Arch for AArch64 {
                 relax(RelaxationKind::ReplaceWithNop, object::elf::R_AARCH64_NONE);
             }
             object::elf::R_AARCH64_TLSDESC_LD64_LO12 => {
+                relax(
+                    RelaxationKind::MovkX0,
+                    object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G0_NC,
+                );
                 relax(RelaxationKind::ReplaceWithNop, object::elf::R_AARCH64_NONE);
             }
             object::elf::R_AARCH64_TLSDESC_ADD_LO12 => {
@@ -123,6 +127,7 @@ impl Arch for AArch64 {
                     RelaxationKind::AdrpX0,
                     object::elf::R_AARCH64_TLSIE_ADR_GOTTPREL_PAGE21,
                 );
+                relax(RelaxationKind::ReplaceWithNop, object::elf::R_AARCH64_NONE);
             }
             object::elf::R_AARCH64_TLSDESC_CALL => {
                 relax(
@@ -133,6 +138,7 @@ impl Arch for AArch64 {
                     RelaxationKind::LdrX0,
                     object::elf::R_AARCH64_TLSIE_LD64_GOTTPREL_LO12_NC,
                 );
+                relax(RelaxationKind::ReplaceWithNop, object::elf::R_AARCH64_NONE);
             }
             object::elf::R_AARCH64_TLSIE_ADR_GOTTPREL_PAGE21 => {
                 relax(

--- a/linker-diff/src/aarch64.rs
+++ b/linker-diff/src/aarch64.rs
@@ -505,4 +505,8 @@ impl crate::arch::RelaxationKind for RelaxationKind {
     fn is_no_op(self) -> bool {
         matches!(self, RelaxationKind::NoOp)
     }
+
+    fn is_replace_with_no_op(self) -> bool {
+        matches!(self, RelaxationKind::ReplaceWithNop)
+    }
 }

--- a/linker-diff/src/arch.rs
+++ b/linker-diff/src/arch.rs
@@ -140,6 +140,9 @@ pub(crate) trait RType: Copy + Debug + Display + Eq + PartialEq {
 pub(crate) trait RelaxationKind: Copy + Clone + Debug + Eq + PartialEq {
     /// Returns whether this relaxation does nothing.
     fn is_no_op(self) -> bool;
+
+    /// Returns whether this relaxation replaces an instruction with a nop.
+    fn is_replace_with_no_op(self) -> bool;
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -199,7 +199,6 @@ impl Config {
                 // We don't yet support emitting warnings.
                 "section.gnu.warning",
                 // GNU ld sometimes applies relaxations that we don't yet.
-                "rel.match_failed.R_AARCH64_TLSDESC_LD64_LO12",
                 "rel.match_failed.R_AARCH64_TLSGD_ADD_LO12_NC",
                 "rel.missing-opt.R_X86_64_TLSGD.TlsGdToInitialExec.shared-object",
                 // GNU ld sometimes relaxes an adrp instruction to an adr instruction when the

--- a/linker-diff/src/x86_64.rs
+++ b/linker-diff/src/x86_64.rs
@@ -444,4 +444,8 @@ impl crate::arch::RelaxationKind for RelaxationKind {
     fn is_no_op(self) -> bool {
         matches!(self, RelaxationKind::NoOp)
     }
+
+    fn is_replace_with_no_op(self) -> bool {
+        false
+    }
 }

--- a/linker-utils/src/aarch64.rs
+++ b/linker-utils/src/aarch64.rs
@@ -1029,7 +1029,7 @@ impl RelocationInstruction {
                 low_bits(value >> 29, 2) | ((low_bits_signed(value >> 5, 19)) << 2)
             }
             // C6.2.252, C6.2.254
-            RelocationInstruction::Movkz => u64::from(value >> 5),
+            RelocationInstruction::Movkz => low_bits_signed(value >> 5, 16),
             // C6.2.253, C6.2.254
             RelocationInstruction::Movnz => {
                 negative = (value & (1 << 30)) == 0;

--- a/wild/tests/sources/tls-variant.c
+++ b/wild/tests/sources/tls-variant.c
@@ -29,6 +29,9 @@
 //#CompArgs:-fpic
 //#Shared:tls-variant-1.c,tls-variant-2.c:-ftls-model=global-dynamic -mtls-dialect=trad,tls-variant-3.c:-ftls-model=initial-exec -mtls-dialect=trad
 //#Arch: aarch64
+// TODO: ld.bfd supports relaxation where TLSDESC is replaced with R_AARCH64_TLS_TPREL64
+// if initial-exec mode is used for one of the compilation units.
+//#DiffIgnore:rel.match_failed.R_AARCH64_TLSDESC_LD64_LO12
 
 int foo();
 int bar();


### PR DESCRIPTION
After my change, `linker-diff` can properly find the corresponding parts of `R_AARCH64_TLSLE_MOVW_TPREL_G1`, `R_AARCH64_TLSLE_MOVW_TPREL_G0_NC`, but seems the symbol address look up is off:

```
$ WILD_TEST_CROSS=aarch64 cargo t tls_variant
...
rel.R_AARCH64_NONE.R_AARCH64_TLSLE_MOVW_TPREL_G1
  `/home/marxin/Programming/wild/wild/tests/build/tls-variant-1.gcc-aarch64-aarch64-c672ffb113a4c0aa.o` .text foo
  ORIG 0x000008: [ 00 00 00 90 ] adrp	x0, 0x0
                   ^^^^^^^^^^^ R_AARCH64_TLSDESC_ADR_PAGE21 
  ORIG 0x00000c: [ 01 00 40 f9 ] ldr	x1, [x0]
                   ^^^^^ R_AARCH64_TLSDESC_LD64_LO12 
  ORIG 0x000010: [ 00 00 00 91 ] add	x0, x0, #0x0
                   ^^^^^ R_AARCH64_TLSDESC_ADD_LO12 
  ORIG 0x000014: [ 20 00 3f d6 ] blr	x1
                   ^ R_AARCH64_TLSDESC_CALL 
       global_tls1
  wild 0x41122c: [ 1f 20 03 d5 ] nop
                   ^ R_AARCH64_NONE ReplaceWithNop 
  wild 0x411230: [ 1f 20 03 d5 ] nop
                   ^ R_AARCH64_NONE ReplaceWithNop 
  wild 0x411234: [ 00 00 a0 d2 ] movz	x0, #0x0, lsl #16
                   ^^^^^ R_AARCH64_TLSLE_MOVW_TPREL_G1 MovzX0Lsl16 
  wild 0x411238: [ 00 02 80 f2 ] movk	x0, #0x10
                   ^^^^^ R_AARCH64_TLSLE_MOVW_TPREL_G0_NC MovkX0 
       0x7940010 (symbol is too far away)
  wild TRACE: relaxation applied relaxation=ReplaceWithNop, value_flags=ADDRESS | CAN_BYPASS_GOT,
  wild TRACE: resolution_flags=DIRECT | GOT_TLS_MODULE, rel_kind=None,
  wild TRACE: value=0x0, symbol_name=global_tls1
  wild TRACE: relaxation applied relaxation=ReplaceWithNop, value_flags=ADDRESS | CAN_BYPASS_GOT,
  wild TRACE: resolution_flags=DIRECT | GOT_TLS_MODULE, rel_kind=None,
  wild TRACE: value=0x0, symbol_name=global_tls1
  wild TRACE: relaxation applied relaxation=MovzX0Lsl16, value_flags=ADDRESS | CAN_BYPASS_GOT,
  wild TRACE: resolution_flags=DIRECT | GOT_TLS_MODULE, rel_kind=TpOffAArch64,
  wild TRACE: value=0x10, symbol_name=global_tls1
  wild TRACE: relaxation applied relaxation=MovkX0, value_flags=ADDRESS | CAN_BYPASS_GOT,
  wild TRACE: resolution_flags=DIRECT | GOT_TLS_MODULE, rel_kind=TpOffAArch64,
  wild TRACE: value=0x10, symbol_name=global_tls1
  ld   0x40075c: [ 00 00 a0 d2 ] movz	x0, #0x0, lsl #16
                   ^^^^^ R_AARCH64_TLSLE_MOVW_TPREL_G1 MovzX0Lsl16 
  ld   0x400760: [ 00 02 80 f2 ] movk	x0, #0x10
                   ^^^^^ R_AARCH64_TLSLE_MOVW_TPREL_G0_NC MovkX0 
  ld   0x400764: [ 1f 20 03 d5 ] nop
                   ^ R_AARCH64_NONE ReplaceWithNop 
  ld   0x400768: [ 1f 20 03 d5 ] nop
                   ^ R_AARCH64_NONE ReplaceWithNop 
       0x7940010 (symbol is too far away)
```

I suspect it's extracted from one of the NOP instructions.

@davidlattimore Can you help me with that, please?