### PR TITLE
Verify lld can do: rel.extra-opt.R_AARCH64_TLSIE_ADR_GOTTPREL_PAGE21.…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
           - ubuntu-24.04
           - ubuntu-24.04-arm
         container:
-          - 'ubuntu:22.04'
           - 'ubuntu:24.04'
           - 'ubuntu:24.10'
           - 'ubuntu:25.04'
@@ -34,6 +33,9 @@ jobs:
           - runs-on: ubuntu-24.04
             container: 'ubuntu:24.10'
             test-qemu: true
+          # Ubuntu 22.04 contains an old lld linker which cannot do a relaxation on AArch64 (required by linker-diff)
+          - runs-on: ubuntu-24.04
+            container: 'ubuntu:22.04'
       fail-fast: false
 
     runs-on: ${{ matrix.runs-on }}

--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -202,9 +202,6 @@ impl Config {
                 "rel.match_failed.R_AARCH64_TLSDESC_LD64_LO12",
                 "rel.match_failed.R_AARCH64_TLSGD_ADD_LO12_NC",
                 "rel.missing-opt.R_X86_64_TLSGD.TlsGdToInitialExec.shared-object",
-                // We seem to do an optimisation here where GNU ld doesn't. TODO: Look into if this
-                // is OK.
-                "rel.extra-opt.R_AARCH64_TLSIE_ADR_GOTTPREL_PAGE21.MovzXnLsl16.*",
                 // GNU ld sometimes relaxes an adrp instruction to an adr instruction when the
                 // address is known and within +/-1MB. We don't as yet.
                 "rel.missing-opt.R_AARCH64_ADR_GOT_PAGE.AdrpToAdr.*",

--- a/wild/tests/sources/libc-integration.c
+++ b/wild/tests/sources/libc-integration.c
@@ -25,6 +25,7 @@
 //#LinkArgs:-static -Wl,--strip-debug -Wl,--gc-sections -Wl,-z,now
 //#Object:libc-integration-0.c
 //#Object:libc-integration-1.c
+//#EnableLinker:lld
 
 //#Config:clang-static-pie:default
 //#CompArgs:-fPIE -fPIC
@@ -39,6 +40,7 @@
 //#LinkArgs:-static -Wl,--strip-debug -Wl,--gc-sections -Wl,-z,now
 //#Object:libc-integration-0.c
 //#Object:libc-integration-1.c
+//#EnableLinker:lld
 
 //#Config:gcc-static-pie:default
 //#CompArgs:-fPIE


### PR DESCRIPTION
…MovzXnLsl16

Once I added `lld`, then the tests passed and so I assume it means `linker-diff` was able to find the same relaxation for `ldd`. Am I right?