### PR TITLE
Force inlining of a few functions

### DIFF
--- a/libwild/src/aarch64.rs
+++ b/libwild/src/aarch64.rs
@@ -38,6 +38,7 @@ impl crate::arch::Arch for AArch64 {
 
     // The table of the relocations is documented here:
     // https://github.com/ARM-software/abi-aa/blob/main/aaelf64/aaelf64.rst.
+    #[inline(always)]
     fn relocation_from_raw(r_type: u32) -> Result<RelocationKindInfo> {
         linker_utils::aarch64::relocation_type_from_raw(r_type).ok_or_else(|| {
             anyhow!(
@@ -99,6 +100,7 @@ const TLSDESC_CALL_INSN_SEQUENCE: &[u8] = &[
 
 impl crate::arch::Relaxation for Relaxation {
     #[allow(unused_variables)]
+    #[inline(always)]
     fn new(
         relocation_kind: u32,
         section_bytes: &[u8],

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -478,6 +478,7 @@ pub(crate) fn get_page_mask(mask: Option<PageMask>) -> PageMaskValue {
     }
 }
 
+#[inline(always)]
 pub(crate) fn write_relocation_to_buffer(
     rel_info: RelocationKindInfo,
     value: u64,

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2229,6 +2229,7 @@ fn apply_debug_relocation<A: Arch>(
     Ok(())
 }
 
+#[inline(always)]
 fn write_absolute_relocation<A: Arch>(
     table_writer: &mut TableWriter,
     resolution: Resolution,

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -1354,6 +1354,7 @@ impl<'data> Layout<'data> {
         self.symbol_db.symbol_debug(symbol_id)
     }
 
+    #[inline(always)]
     pub(crate) fn merged_symbol_resolution(&self, symbol_id: SymbolId) -> Option<Resolution> {
         self.local_symbol_resolution(self.symbol_db.definition(symbol_id))
             .copied()
@@ -4314,6 +4315,7 @@ impl Resolution {
             .get())
     }
 
+    #[inline(always)]
     pub(crate) fn value_with_addend(
         &self,
         addend: i64,

--- a/libwild/src/output_trace.rs
+++ b/libwild/src/output_trace.rs
@@ -34,6 +34,7 @@ impl TraceOutput {
         }
     }
 
+    #[inline(always)]
     pub(crate) fn emit(&self, address: u64, message_cb: impl Fn() -> String) {
         if let Some(state) = self.state.as_ref() {
             let message = message_cb();

--- a/libwild/src/x86_64.rs
+++ b/libwild/src/x86_64.rs
@@ -38,6 +38,7 @@ impl crate::arch::Arch for X86_64 {
         object::elf::EM_X86_64
     }
 
+    #[inline(always)]
     fn relocation_from_raw(r_type: u32) -> Result<RelocationKindInfo> {
         let (kind, size) =
             linker_utils::x86_64::relocation_kind_and_size(r_type).ok_or_else(|| {
@@ -84,6 +85,7 @@ pub(crate) struct Relaxation {
 }
 
 impl crate::arch::Relaxation for Relaxation {
+    #[inline(always)]
     fn new(
         relocation_kind: u32,
         section_bytes: &[u8],

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -752,6 +752,7 @@ pub struct RelocationKindInfo {
 }
 
 impl RelocationKindInfo {
+    #[inline(always)]
     pub fn verify(&self, value: i64) -> Result<()> {
         anyhow::ensure!(
             (value as usize) & (self.alignment - 1) == 0,


### PR DESCRIPTION
These are functions that are called from `apply_relocation`

This gives about a 5% speedup and about a 15% reduction in instruction count.