### PR TITLE
CI: unify used names for Ubuntu containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           - 'ubuntu:22.04'
           - 'ubuntu:24.04'
           - 'ubuntu:24.10'
+          - 'ubuntu:25.04'
           - 'opensuse/tumbleweed:latest'
         test-qemu:
           - false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,18 +20,18 @@ jobs:
     strategy:
       matrix:
         runs-on:
-          - ubuntu-latest
+          - ubuntu-24.04
           - ubuntu-24.04-arm
         container:
           - 'ubuntu:22.04'
-          - 'ubuntu:latest'
-          - 'ubuntu:rolling'
+          - 'ubuntu:24.04'
+          - 'ubuntu:24.10'
           - 'opensuse/tumbleweed:latest'
         test-qemu:
           - false
         include:
-          - runs-on: ubuntu-latest
-            container: 'ubuntu:rolling'
+          - runs-on: ubuntu-24.04
+            container: 'ubuntu:24.10'
             test-qemu: true
       fail-fast: false
 


### PR DESCRIPTION
The tags 'rolling' and 'latest' are somewhat moving targets (in case of `25.05` will even point to the same version), thus I would like to use explicit numbered release versions.

Link: https://hub.docker.com/_/ubuntu