### PR TITLE
Reference verdef symbols in the test

### DIFF
--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -199,15 +199,18 @@ impl<'data> VersionScript<'data> {
     pub(crate) fn version_count(&self) -> u16 {
         self.versions.len() as u16
     }
+
     pub(crate) fn parent_count(&self) -> u16 {
         self.versions
             .iter()
             .filter(|v| v.parent_index.is_some())
             .count() as u16
     }
+
     pub(crate) fn version_iter(&self) -> impl Iterator<Item = &Version> {
         self.versions.iter()
     }
+
     pub(crate) fn version_for_symbol(
         &self,
         name: &PreHashed<UnversionedSymbolName>,

--- a/wild/tests/sources/symbol-versions.c
+++ b/wild/tests/sources/symbol-versions.c
@@ -5,7 +5,6 @@
 //#DiffIgnore:.dynamic.DT_RELAENT
 //#DiffIgnore:file-header.entry
 //#Object:exit.c
-//#EnableLinker:lld
 //#VersionScript:symbol-versions-script.map
 
 //#Config:verneed
@@ -25,28 +24,44 @@
 #include "exit.h"
 
 int foo(void);
+int bar_global(void);
+int bar_local(void);
+int bar_v2(void);
+int bar_v2_1(void);
 
 void _start(void) {
     if (foo() != 2) {
         exit_syscall(foo());
     }
+    if (bar_global() != 10) {
+        exit_syscall(bar_global());
+    }
+    if (bar_local() != 11) {
+        exit_syscall(bar_local());
+    }
+    if (bar_v2() != 12) {
+        exit_syscall(bar_v2());
+    }
+    if (bar_v2_1() != 13) {
+        exit_syscall(bar_v2_1());
+    }
 
     exit_syscall(42);
 }
 
-void bar_global(void) {
-    exit_syscall(42);
+int bar_global(void) {
+    return 10;
 }
 
 // TODO: doesn't work, the symbol is global
-void bar_local(void) {
-    exit_syscall(42);
+int bar_local(void) {
+    return 11;
 }
 
-void bar_v2(void) {
-    exit_syscall(42);
+int bar_v2(void) {
+    return 12;
 }
 
-void bar_v2_1(void) {
-    exit_syscall(42);
+int bar_v2_1(void) {
+    return 13;
 }


### PR DESCRIPTION
Fixes #571 by fixing the test to reference the symbols.

Also removes LLD because only recently I've learned how it truly works. That functionality is compliant enough with ld.bfd to not require LLD as an additional reference.