### PR TITLE
Add missing relaxation to linker-diff and fix extraction

### DIFF
--- a/linker-diff/src/aarch64.rs
+++ b/linker-diff/src/aarch64.rs
@@ -112,6 +112,10 @@ impl Arch for AArch64 {
                 relax(RelaxationKind::ReplaceWithNop, object::elf::R_AARCH64_NONE);
             }
             object::elf::R_AARCH64_TLSDESC_LD64_LO12 => {
+                relax(
+                    RelaxationKind::MovkX0,
+                    object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G0_NC,
+                );
                 relax(RelaxationKind::ReplaceWithNop, object::elf::R_AARCH64_NONE);
             }
             object::elf::R_AARCH64_TLSDESC_ADD_LO12 => {
@@ -123,6 +127,7 @@ impl Arch for AArch64 {
                     RelaxationKind::AdrpX0,
                     object::elf::R_AARCH64_TLSIE_ADR_GOTTPREL_PAGE21,
                 );
+                relax(RelaxationKind::ReplaceWithNop, object::elf::R_AARCH64_NONE);
             }
             object::elf::R_AARCH64_TLSDESC_CALL => {
                 relax(
@@ -133,6 +138,7 @@ impl Arch for AArch64 {
                     RelaxationKind::LdrX0,
                     object::elf::R_AARCH64_TLSIE_LD64_GOTTPREL_LO12_NC,
                 );
+                relax(RelaxationKind::ReplaceWithNop, object::elf::R_AARCH64_NONE);
             }
             object::elf::R_AARCH64_TLSIE_ADR_GOTTPREL_PAGE21 => {
                 relax(

--- a/linker-diff/src/aarch64.rs
+++ b/linker-diff/src/aarch64.rs
@@ -505,4 +505,8 @@ impl crate::arch::RelaxationKind for RelaxationKind {
     fn is_no_op(self) -> bool {
         matches!(self, RelaxationKind::NoOp)
     }
+
+    fn is_replace_with_no_op(self) -> bool {
+        matches!(self, RelaxationKind::ReplaceWithNop)
+    }
 }

--- a/linker-diff/src/arch.rs
+++ b/linker-diff/src/arch.rs
@@ -140,6 +140,9 @@ pub(crate) trait RType: Copy + Debug + Display + Eq + PartialEq {
 pub(crate) trait RelaxationKind: Copy + Clone + Debug + Eq + PartialEq {
     /// Returns whether this relaxation does nothing.
     fn is_no_op(self) -> bool;
+
+    /// Returns whether this relaxation replaces an instruction with a nop.
+    fn is_replace_with_no_op(self) -> bool;
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/linker-diff/src/asm_diff.rs
+++ b/linker-diff/src/asm_diff.rs
@@ -1761,7 +1761,7 @@ impl<'data> RelaxationTester<'data> {
         &self,
         relaxations_matches: &[RelaxationMatch<A>],
     ) -> Result<Reference<'data, A::RType>> {
-        let mut merged_value = 0;
+        let mut merged_value: u64 = 0;
         let mut addend = 0;
         let mut referent = None;
 
@@ -1820,7 +1820,7 @@ impl<'data> RelaxationTester<'data> {
                 allow_got_dereference = false;
             }
 
-            merged_value += value;
+            merged_value = merged_value.wrapping_add(value);
         }
 
         // The relocation info for our primary and alt r-types should be the same for our purposes

--- a/linker-diff/src/x86_64.rs
+++ b/linker-diff/src/x86_64.rs
@@ -444,4 +444,8 @@ impl crate::arch::RelaxationKind for RelaxationKind {
     fn is_no_op(self) -> bool {
         matches!(self, RelaxationKind::NoOp)
     }
+
+    fn is_replace_with_no_op(self) -> bool {
+        false
+    }
 }

--- a/linker-utils/src/aarch64.rs
+++ b/linker-utils/src/aarch64.rs
@@ -1029,7 +1029,7 @@ impl RelocationInstruction {
                 low_bits(value >> 29, 2) | ((low_bits_signed(value >> 5, 19)) << 2)
             }
             // C6.2.252, C6.2.254
-            RelocationInstruction::Movkz => u64::from(value >> 5),
+            RelocationInstruction::Movkz => low_bits_signed(value >> 5, 16),
             // C6.2.253, C6.2.254
             RelocationInstruction::Movnz => {
                 negative = (value & (1 << 30)) == 0;


### PR DESCRIPTION
The change does not fix any linker-diff per se, but it fixed a subtle issue I found while working on #564.