### PR TITLE
Emit a proper error message if an empty linker script is provided

### DIFF
--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -127,7 +127,7 @@ impl<'data> VersionScript<'data> {
 
         tokens.text = tokens.text.trim();
 
-        let mut token = tokens.next().unwrap();
+        let mut token = tokens.next().ok_or_else(|| anyhow!("No tokens found"))?;
         // Simple version script, only defines symbols visibility
         if token.starts_with('{') {
             parse_version_section(


### PR DESCRIPTION
Apparently, `mold` supports an empty file, but the other linkers do not: ld, lld. Thus I'm suggesting reporting an error rather than panicking.