### PR TITLE
Handle symbol aliases when doing copy relocations

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -585,6 +585,11 @@ pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(mut input: I) -> Resul
         bail!("Unrecognised argument(s): {}", unrecognised.join(" "));
     }
 
+    // Copy relocations are only permitted when building executables.
+    if args.output_kind() == OutputKind::SharedObject {
+        args.allow_copy_relocations = false;
+    }
+
     save_dir.finish()?;
 
     Ok(args)

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -2145,6 +2145,7 @@ fn integration_test(
         "trivial_asm.s",
         "non-alloc.s",
         "symbol-versions.c",
+        "copy-relocations.c",
         "force-undefined.c",
         "libc-integration.c",
         "rust-integration.rs",

--- a/wild/tests/sources/copy-relocations-2.c
+++ b/wild/tests/sources/copy-relocations-2.c
@@ -1,0 +1,29 @@
+int bar = 1;
+
+// Because this alias is a weak symbol, any copy relocations produced by references to foo should
+// instead locate the strong symbol `bar` that is at the same address and emit a copy relocation for
+// that instead.
+__attribute__ ((weak, alias("bar"))) extern int foo;
+
+int get_foo(void) {
+    return bar;
+}
+
+// Repeat the same scenario twice more. These are effectively identical in this file. The
+// differences are in how they are referenced in the main file.
+
+int bar2 = 2;
+
+__attribute__ ((weak, alias("bar2"))) extern int foo2;
+
+int get_foo2(void) {
+    return bar2;
+}
+
+int bar3 = 3;
+
+__attribute__ ((weak, alias("bar3"))) extern int foo3;
+
+int get_foo3(void) {
+    return bar3;
+}

--- a/wild/tests/sources/copy-relocations.c
+++ b/wild/tests/sources/copy-relocations.c
@@ -1,0 +1,47 @@
+//#Object:exit.c
+//#EnableLinker:lld
+//#Static:false
+//#CompSoArgs:-fPIC
+//#LinkArgs:-z now
+//#Shared:copy-relocations-2.c
+// We're linking different .so files, so this is expected.
+//#DiffIgnore:.dynamic.DT_NEEDED
+
+#include "exit.h"
+
+// These two symbols are at the same address in the shared object, so references to both should
+// point to the same copy relocation and that location should be what `get_foo` returns.
+extern int foo;
+extern int bar;
+int get_foo(void);
+
+// This time we only reference the non-weak symbol.
+extern int foo2;
+int get_foo2(void);
+
+// Lastly, we reference the weak symbol and not the strong one.
+extern int bar3;
+int get_foo3(void);
+
+void _start(void) {
+    foo = 10;
+    if (get_foo() != 10) {
+        exit_syscall(20);
+    }
+    bar = 11;
+    if (get_foo() != 11) {
+        exit_syscall(21);
+    }
+
+    foo2 = 12;
+    if (get_foo2() != 12) {
+        exit_syscall(22);
+    }
+
+    bar3 = 13;
+    if (get_foo3() != 13) {
+        exit_syscall(23);
+    }
+
+    exit_syscall(42);
+}


### PR DESCRIPTION
It turns out that if there's a direct reference to a dynamic symbol that's weak and there's another non-weak dynamic symbol at the same address, then we need to emit a copy relocation for the non-weak symbol not the weak one, even though it was the weak symbol that we referenced.

Issue #576