### PR TITLE
Don't bypass GOT for copy-relocated symbols

### DIFF
--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -760,11 +760,6 @@ fn allocate_resolution(
         }
         if value_flags.contains(ValueFlags::IFUNC) {
             mem_sizes.increment(part_id::RELA_PLT, elf::RELA_ENTRY_SIZE);
-        } else if resolution_flags.contains(ResolutionFlags::COPY_RELOCATION) {
-            // Copy relocation means that we know the relative address.
-            if output_kind.is_relocatable() {
-                mem_sizes.increment(part_id::RELA_DYN_RELATIVE, elf::RELA_ENTRY_SIZE);
-            }
         } else if !value_flags.contains(ValueFlags::CAN_BYPASS_GOT) && has_dynamic_symbol {
             mem_sizes.increment(part_id::RELA_DYN_GENERAL, elf::RELA_ENTRY_SIZE);
         } else if value_flags.contains(ValueFlags::ADDRESS) && output_kind.is_relocatable() {

--- a/wild/tests/sources/copy-relocations-3.c
+++ b/wild/tests/sources/copy-relocations-3.c
@@ -1,0 +1,5 @@
+extern int bar;
+
+int get_bar(void) {
+    return bar;
+}

--- a/wild/tests/sources/copy-relocations.c
+++ b/wild/tests/sources/copy-relocations.c
@@ -4,6 +4,7 @@
 //#CompSoArgs:-fPIC
 //#LinkArgs:-z now
 //#Shared:copy-relocations-2.c
+//#Object:copy-relocations-3.c:-fPIC
 // We're linking different .so files, so this is expected.
 //#DiffIgnore:.dynamic.DT_NEEDED
 
@@ -23,6 +24,9 @@ int get_foo2(void);
 extern int bar3;
 int get_foo3(void);
 
+// This is defined in a separate object file that is compiled with -fPIC.
+int get_bar(void);
+
 void _start(void) {
     foo = 10;
     if (get_foo() != 10) {
@@ -31,6 +35,9 @@ void _start(void) {
     bar = 11;
     if (get_foo() != 11) {
         exit_syscall(21);
+    }
+    if (get_bar() != 11) {
+        exit_syscall(24);
     }
 
     foo2 = 12;


### PR DESCRIPTION
Bypassing the GOT for a copy-relocated symbol is potentially a legitimate thing to do, but the other linkers don't seem to do it.

Issue #576