### PR TITLE
Implement RelocationKind::Relative AdrpToAdr relaxation

### DIFF
--- a/libwild/src/aarch64.rs
+++ b/libwild/src/aarch64.rs
@@ -280,15 +280,6 @@ impl crate::arch::Relaxation for Relaxation {
                     }
                 }
             }
-            object::elf::R_AARCH64_ADD_ABS_LO12_NC => {
-                // previous instruction must be replaced with adr
-                //debug_assert_eq!(section_bytes.get(offset - 1), Some(&0x10));
-                return Some(Relaxation {
-                    kind: RelaxationKind::ReplaceWithNop,
-                    rel_info: relocation_type_from_raw(object::elf::R_AARCH64_NONE).unwrap(),
-                });
-            }
-
             _ => {}
         }
 

--- a/libwild/src/arch.rs
+++ b/libwild/src/arch.rs
@@ -73,6 +73,7 @@ pub(crate) trait Relaxation {
         output_kind: OutputKind,
         section_flags: SectionFlags,
         non_zero_address: bool,
+        relative_value: Option<i64>,
     ) -> Option<Self>
     where
         Self: std::marker::Sized;

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -2506,6 +2506,7 @@ fn process_relocation<A: Arch>(
             args.output_kind(),
             SectionFlags::from_header(section),
             true,
+            None,
         ) {
             next_modifier = relaxation.next_modifier();
             relaxation.rel_info()

--- a/libwild/src/x86_64.rs
+++ b/libwild/src/x86_64.rs
@@ -94,6 +94,7 @@ impl crate::arch::Relaxation for Relaxation {
         output_kind: OutputKind,
         section_flags: SectionFlags,
         _non_zero_address: bool,
+        _relative_value: Option<i64>,
     ) -> Option<Self> {
         // TODO: Consider removing Option. There are a few callers though, so need to see how this
         // looks.
@@ -377,6 +378,7 @@ fn test_relaxation() {
             OutputKind::StaticExecutable(RelocationModel::Relocatable),
             shf::EXECINSTR,
             true,
+            None,
         ) {
             r.apply(&mut out, &mut offset, &mut 0);
 
@@ -393,6 +395,7 @@ fn test_relaxation() {
             OutputKind::StaticExecutable(RelocationModel::Relocatable),
             shf::EXECINSTR,
             true,
+            None,
         ) {
             out.copy_from_slice(bytes_in);
             r.apply(&mut out, &mut offset, &mut 0);

--- a/linker-diff/src/aarch64.rs
+++ b/linker-diff/src/aarch64.rs
@@ -90,7 +90,7 @@ impl Arch for AArch64 {
     type RawInstruction = Option<String>;
 
     const MAX_RELAX_MODIFY_BEFORE: u64 = 0;
-    const MAX_RELAX_MODIFY_AFTER: u64 = 4;
+    const MAX_RELAX_MODIFY_AFTER: u64 = 5;
 
     fn possible_relaxations_do(
         r_type: Self::RType,

--- a/linker-diff/src/aarch64.rs
+++ b/linker-diff/src/aarch64.rs
@@ -164,7 +164,16 @@ impl Arch for AArch64 {
                     object::elf::R_AARCH64_ADR_PREL_LO21,
                 );
             }
-            object::elf::R_AARCH64_ADR_PREL_PG_HI21 => {
+            object::elf::R_AARCH64_ADR_PREL_PG_HI21
+            | object::elf::R_AARCH64_ADR_PREL_PG_HI21_NC => {
+                relax(
+                    RelaxationKind::AdrpToAdr,
+                    object::elf::R_AARCH64_ADR_PREL_LO21,
+                );
+                relax(RelaxationKind::ReplaceWithNop, object::elf::R_AARCH64_NONE);
+            }
+            object::elf::R_AARCH64_ADD_ABS_LO12_NC => {
+                relax(RelaxationKind::ReplaceWithNop, object::elf::R_AARCH64_NONE);
                 relax(
                     RelaxationKind::AdrpToAdr,
                     object::elf::R_AARCH64_ADR_PREL_LO21,

--- a/linker-diff/src/aarch64.rs
+++ b/linker-diff/src/aarch64.rs
@@ -90,7 +90,7 @@ impl Arch for AArch64 {
     type RawInstruction = Option<String>;
 
     const MAX_RELAX_MODIFY_BEFORE: u64 = 0;
-    const MAX_RELAX_MODIFY_AFTER: u64 = 5;
+    const MAX_RELAX_MODIFY_AFTER: u64 = 8;
 
     fn possible_relaxations_do(
         r_type: Self::RType,
@@ -172,14 +172,6 @@ impl Arch for AArch64 {
                     RelaxationKind::AdrpToAdr,
                     object::elf::R_AARCH64_ADR_PREL_LO21,
                 );
-                relax(RelaxationKind::ReplaceWithNop, object::elf::R_AARCH64_NONE);
-            }
-            object::elf::R_AARCH64_ADD_ABS_LO12_NC => {
-                relax(RelaxationKind::ReplaceWithNop, object::elf::R_AARCH64_NONE);
-                relax(
-                    RelaxationKind::AdrpToAdr,
-                    object::elf::R_AARCH64_ADR_PREL_LO21,
-                );
             }
             _ => {}
         }
@@ -187,10 +179,16 @@ impl Arch for AArch64 {
         relax(Self::RelaxationKind::NoOp, r_type.0);
     }
 
-    fn relaxation_byte_range(_relaxation: Relaxation<Self>) -> RelaxationByteRange {
-        RelaxationByteRange {
-            offset_shift: 0,
-            num_bytes: 4,
+    fn relaxation_byte_range(relaxation: Relaxation<Self>) -> RelaxationByteRange {
+        match relaxation.relaxation_kind {
+            RelaxationKind::AdrpToAdr => RelaxationByteRange {
+                offset_shift: 0,
+                num_bytes: 8,
+            },
+            _ => RelaxationByteRange {
+                offset_shift: 0,
+                num_bytes: 4,
+            },
         }
     }
 

--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -205,7 +205,6 @@ impl Config {
                 // GNU ld sometimes relaxes an adrp instruction to an adr instruction when the
                 // address is known and within +/-1MB. We don't as yet.
                 "rel.missing-opt.R_AARCH64_ADR_GOT_PAGE.AdrpToAdr.*",
-                "rel.missing-opt.R_AARCH64_ADR_PREL_PG_HI21.AdrpToAdr.*",
                 // The other linkers set properties on sections if all input sections have that
                 // property. For sections like .rodata, this seems like an unimportant behaviour to
                 // replicate.

--- a/linker-utils/src/aarch64.rs
+++ b/linker-utils/src/aarch64.rs
@@ -95,6 +95,11 @@ impl RelaxationKind {
             RelaxationKind::AdrpToAdr => {
                 // Clear the op bit of the instruction. See C6.2.12 and C6.2.13.
                 section_bytes[offset + 3] &= !0x80;
+                // We must also take the destination register from the ADD instruction
+                // that follows this one:
+                // adrp    x0, 0
+                // add     x1, x0, #0x0
+                section_bytes[offset] = section_bytes[offset + 4];
             }
             RelaxationKind::AdrpX0 => {
                 section_bytes[offset..offset + 4].copy_from_slice(&[


### PR DESCRIPTION
This is an attempt to implement one of the possible `AdrpToAdr` relaxations as mentioned here:
https://github.com/ARM-software/abi-aa/blob/main/aaelf64/aaelf64.rst#id56

However, it seems to me there are many cases when even `bfd` can't make the relaxation :/
@davidlattimore Do you read it the same as me?