### PR TITLE
better error reporting for duplicate strong symbols

### DIFF
--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -2158,7 +2158,8 @@ fn integration_test(
         "tls-local-exec.c",
         "undefined_symbols.c",
         "whole_archive.c",
-        "shared.c"
+        "shared.c",
+        "duplicate_strong_symbols.c"
     )]
     program_name: &'static str,
     #[allow(unused_variables)] setup_symlink: (),

--- a/wild/tests/sources/duplicate_strong_symbols.c
+++ b/wild/tests/sources/duplicate_strong_symbols.c
@@ -1,0 +1,13 @@
+//#Config:dup
+//#SkipLinker:ld
+//#Object:duplicate_strong_symbols2.c
+//#Object:exit.c
+//#ExpectError:Duplicate symbols
+
+int test_func(void) {
+    return 0;
+}
+
+void _start(void) {
+    test_func();
+}

--- a/wild/tests/sources/duplicate_strong_symbols2.c
+++ b/wild/tests/sources/duplicate_strong_symbols2.c
@@ -1,0 +1,3 @@
+int test_func(void) {
+    return 1;
+}


### PR DESCRIPTION
close #521 

The current implementation lacks proper error reporting logic for cases where multiple duplicate strong symbols exist in the link target.