### PR TITLE
arch.Dockerfile: Add rr

### DIFF
--- a/docker/arch.Dockerfile
+++ b/docker/arch.Dockerfile
@@ -1,11 +1,44 @@
-# Run on Arch Linux
+# Run on Arch Linux. Includes some useful tools for debugging linker problems. In particular,
+# includes rr - the replay debugger.
 #
 # docker build --progress=plain -t wild-dev-arch . -f docker/arch.Dockerfile
+#
 # docker run -it wild-dev-arch
+#
+# To actually use rr, you'll need to run with
+# `--cap-add=SYS_PTRACE --security-opt seccomp=unconfined`
+# See https://github.com/rr-debugger/rr/wiki/Docker
 
 FROM archlinux:base-20250302.0.316047 AS chef
 
-RUN pacman --noconfirm -Syu wget less gcc clang lld aarch64-linux-gnu-gcc qemu-user
+RUN pacman --noconfirm -Syu \
+    wget \
+    less \
+    gcc \
+    clang \
+    lld \
+    aarch64-linux-gnu-gcc \
+    qemu-user \
+    git \
+    base-devel \
+    perf \
+    capnproto \
+    cmake \
+    gdb \
+    ninja
+
+# Install rr
+RUN useradd --no-create-home --shell=/bin/false build && usermod -L build && \
+    echo -e "build ALL=(ALL) NOPASSWD: ALL\nroot ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
+    mkdir /build && \
+    chown build /build
+USER build
+RUN cd /build && \
+    git clone https://aur.archlinux.org/rr.git && \
+    cd /build/rr && \
+    makepkg
+USER root
+RUN pacman --noconfirm -U /build/rr/rr-*.tar.zst
 
 RUN wget -qO- https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.71/cargo-chef-x86_64-unknown-linux-musl.tar.gz | tar -xzf- && \
     mv cargo-chef /usr/local/bin


### PR DESCRIPTION
rr is makes debugging linker bugs that aren't picked up by linker-diff a heap easier than just using gdb.