### PR TITLE
make tests pass on Alpine Linux

### DIFF
--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -366,6 +366,10 @@ fn is_host_debian_based() -> bool {
     )
 }
 
+fn is_musl_used() -> bool {
+    os_info::get().os_type() == Type::Alpine
+}
+
 fn host_supports_clang_with_tls_desc() -> bool {
     static CLANG_SUPPORTS_TLS_DESC: OnceLock<bool> = OnceLock::new();
 
@@ -1105,6 +1109,10 @@ fn build_obj(
                 );
 
                 command.arg(format!("-Clink-arg=--target={target}"));
+            }
+
+            if is_musl_used() {
+                command.args(["-C", "target-feature=-crt-static"]);
             }
 
             if input_type == InputType::SharedObject {


### PR DESCRIPTION
close #286 (I commented on this issue regarding the latest test failures.)

By default, `rustc` attempts to statically link for the `x86_64-unknown-linux-musl` target. As a result, the dynamically linked library being tested does not seem to work correctly on Alpine Linux. By using [the `crt_link` option](https://rust-lang.github.io/rfcs/1721-crt-static.html), we can explicitly enable dynamic linking by adding `-C target-feature=-crt-static`.

I confirmed that all tests pass on Alpine Linux in Docker.