### PR TITLE
Make dynamic symbol export triggering more consistent

### DIFF
--- a/wild/tests/sources/libc-integration-0.c
+++ b/wild/tests/sources/libc-integration-0.c
@@ -77,3 +77,7 @@ int black_box(int v) {
 int __attribute__ ((weak)) weak_fn3(void) {
     return 15;
 }
+
+__attribute__ ((weak, visibility(("hidden")))) int atoi(const char *bytes) {
+    return 77;
+}

--- a/wild/tests/sources/libc-integration.c
+++ b/wild/tests/sources/libc-integration.c
@@ -306,5 +306,14 @@ int main() {
     }
 #endif
 
+    // We have a weak, hidden definition of atoi in libc-integration-0.c. Provided we're dynamically
+    // linking, that definition shouldn't be exported from the shared object on account if it being
+    // hidden. That means that we should get the proper definition from libc.
+#ifdef DYNAMIC_DEP
+    if (atoi("1000") != 1000) {
+        return 126;
+    }
+#endif
+
     return 42;
 }


### PR DESCRIPTION
We have two paths that trigger export of a dynamic symbol. One of these paths wasn't checking if the symbol was actually able to be exported, which meant that we could end up exporting a hidden symbol.

Issue #604