### PR TITLE
linker-diff: Improve ifunc handling

### DIFF
--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -185,6 +185,10 @@ impl Config {
                 // TODO: Implement proper ordering of .init .ctors etc
                 "init_array",
                 "fini_array",
+                // When GNU ld encounters a GOT-forming reference to an ifunc, it generates a
+                // canonical PLT entry and points the GOT at that. This means that it ends up with
+                // GOT->PLT->GOT. We don't as yet support doing this.
+                "rel.missing-got-plt-got",
                 // We do support this. TODO: Should definitely look into why we're seeing this missing
                 // in our output.
                 "section.rela.plt",

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -457,6 +457,8 @@ pub mod secnames {
     pub const GNU_HASH_SECTION_NAME: &[u8] = GNU_HASH_SECTION_NAME_STR.as_bytes();
     pub const PLT_SECTION_NAME_STR: &str = ".plt";
     pub const PLT_SECTION_NAME: &[u8] = PLT_SECTION_NAME_STR.as_bytes();
+    pub const IPLT_SECTION_NAME_STR: &str = ".iplt";
+    pub const IPLT_SECTION_NAME: &[u8] = IPLT_SECTION_NAME_STR.as_bytes();
     pub const PLT_GOT_SECTION_NAME_STR: &str = ".plt.got";
     pub const PLT_GOT_SECTION_NAME: &[u8] = PLT_GOT_SECTION_NAME_STR.as_bytes();
     pub const GOT_PLT_SECTION_NAME_STR: &str = ".got.plt";


### PR DESCRIPTION
* Resolve and compare ifunc names
* Index .iplt, which is used by lld
* Recognise GOT->PLT->GOT as used by GNU ld in some cases