### PR TITLE
Support `-l:<name.ext>` args

### DIFF
--- a/libwild/src/input_data.rs
+++ b/libwild/src/input_data.rs
@@ -221,7 +221,7 @@ impl Input {
     fn path(&self, args: &Args) -> Result<InputPath> {
         match &self.spec {
             InputSpec::File(p) => {
-                if self.search_first.is_some() {
+                if self.search_first.is_some() || p.parent() == Some(Path::new("")) {
                     if let Some(absolute) = search_for_file(
                         &args.lib_search_path,
                         self.search_first.as_ref(),


### PR DESCRIPTION
Currently, when seeing `-l:lib85caec4suo0pxg06jm2ma7b0o.so` wild would fail with:
```
Error: Couldn't find library `:lib85caec4suo0pxg06jm2ma7b0o.so` on library search path
```

I'm not sure if this is the best way to handle it and probably could use some kind of test, but I don't see a straightforward way to do it.

Part of issue #609 