### PR TITLE
introduce Alpine in CI as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           - 'ubuntu:24.10'
           - 'ubuntu:25.04'
           - 'opensuse/tumbleweed:latest'
+          - 'rust:1.85-alpine'
         test-qemu:
           - false
         include:
@@ -36,6 +37,9 @@ jobs:
           # Ubuntu 22.04 contains an old lld linker which cannot do a relaxation on AArch64 (required by linker-diff)
           - runs-on: ubuntu-24.04
             container: 'ubuntu:22.04'
+        exclude: # TODO: https://github.com/actions/runner/issues/1637
+          - runs-on: ubuntu-24.04-arm
+            container: 'rust:1.85-alpine'
       fail-fast: false
 
     runs-on: ${{ matrix.runs-on }}
@@ -52,7 +56,8 @@ jobs:
         if: ${{ matrix.test-qemu }}
       - run: zypper in -y gcc gcc-c++ glibc-devel-static clang lld curl rustup bubblewrap
         if: ${{ contains(matrix.container, 'opensuse') }}
-      - run: useradd -m -g users user && su user && cd ~
+      - run: apk add build-base lld clang bash curl
+        if: ${{ contains(matrix.container, 'alpine') }}
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
@@ -70,8 +75,12 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-${{ matrix.container }}-${{ matrix.runs-on }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+        if: ${{ !contains(matrix.container, 'alpine') }}
       - run: cargo build --profile ci --workspace --no-default-features
+      - run: cargo test --profile ci --workspace
+        if: ${{ contains(matrix.container, 'alpine') }}
       - run: WILD_TEST_CROSS=$WILD_TEST_CROSS cargo test --profile ci --workspace
+        if: ${{ !contains(matrix.container, 'alpine') }}
 
   clippy:
     name: Clippy

--- a/wild/tests/sources/libc-ifunc.c
+++ b/wild/tests/sources/libc-ifunc.c
@@ -6,6 +6,7 @@
 // we need to diff against lld, which isn't currently enabled for cross compilation.
 //#Cross:false
 //#EnableLinker:lld
+//#RequiresGlibc:true
 
 int foo() {
   return 42;


### PR DESCRIPTION
I’ve made [this patch](https://github.com/davidlattimore/wild/pull/597) pass the tests on Alpine as well, so I think it’s ready to be added to CI. Adding Alpine as a test target will help catch differences between `musl` and `glibc`, like the one found in this patch, at an early stage.