### PR TITLE
Don't error if _start isn't defined

### DIFF
--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -2142,6 +2142,7 @@ fn integration_test(
         "tls.c",
         "tlsdesc.c",
         "tls-variant.c",
+        "no_start.c",
         "old_init.c",
         "custom_section.c",
         "stack_alignment.s",

--- a/wild/tests/sources/no_start.c
+++ b/wild/tests/sources/no_start.c
@@ -1,0 +1,19 @@
+//#AbstractConfig:default
+//#Object:exit.c
+
+//#Config:no-gc:default
+//#LinkArgs:-z now --no-gc-sections
+
+// With --gc-sections enabled, all code gets eliminated and there's nothing to run. If we try to
+// execute this binary, it will segfault, so we don't.
+//#Config:gc:default
+//#LinkArgs:-z now --gc-sections
+//#RunEnabled:false
+
+#include "exit.h"
+
+// Provided this is the first function, it'll get used as the entry point - at least by GNU ld. LLD
+// doesn't set an entry point in this case.
+void this_is_the_entry_point(void) {
+    exit_syscall(42);
+}


### PR DESCRIPTION
Instead, issue a warning and possibly set entry point to the start of .text provided it's not empty. This matches what GNU ld does. LLD also just warns in this case, but seems to always leave the entry point as 0.

Fixes #613