### PR TITLE
refactoring: Add various getters to ValueFlags and ResolutionFlags

### DIFF
--- a/libwild/src/aarch64.rs
+++ b/libwild/src/aarch64.rs
@@ -1,6 +1,5 @@
 use crate::arch::Arch;
 use crate::elf::PLT_ENTRY_SIZE;
-use crate::resolution::ValueFlags;
 use anyhow::Result;
 use anyhow::anyhow;
 use linker_utils::aarch64::DEFAULT_AARCH64_PAGE_IGNORED_MASK;
@@ -114,10 +113,10 @@ impl crate::arch::Relaxation for Relaxation {
         Self: std::marker::Sized,
     {
         let mut relocation = AArch64::relocation_from_raw(relocation_kind).unwrap();
-        let can_bypass_got = value_flags.contains(ValueFlags::CAN_BYPASS_GOT);
+        let can_bypass_got = value_flags.can_bypass_got();
 
         // IFuncs cannot be referenced directly, they always need to go via the GOT.
-        if value_flags.contains(ValueFlags::IFUNC) {
+        if value_flags.is_ifunc() {
             return match relocation_kind {
                 object::elf::R_AARCH64_CALL26 | object::elf::R_AARCH64_JUMP26 => {
                     relocation.kind = RelocationKind::PltRelative;

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -1025,9 +1025,48 @@ impl ValueFlags {
     /// symbol gives the symbol default visibility. In this case, we want references in the object
     /// defining it as hidden to be allowed to bypass the GOT/PLT.
     pub(crate) fn merge(&mut self, other: ValueFlags) {
-        if other.contains(ValueFlags::CAN_BYPASS_GOT) {
+        if other.can_bypass_got() {
             *self |= ValueFlags::CAN_BYPASS_GOT;
         }
+    }
+
+    #[must_use]
+    pub(crate) fn is_dynamic(self) -> bool {
+        self.contains(ValueFlags::DYNAMIC)
+    }
+
+    #[must_use]
+    pub(crate) fn is_ifunc(self) -> bool {
+        self.contains(ValueFlags::IFUNC)
+    }
+
+    #[must_use]
+    pub(crate) fn is_address(self) -> bool {
+        self.contains(ValueFlags::ADDRESS)
+    }
+
+    #[must_use]
+    pub(crate) fn is_absolute(self) -> bool {
+        self.contains(ValueFlags::ABSOLUTE)
+    }
+
+    #[must_use]
+    pub(crate) fn is_function(self) -> bool {
+        self.contains(ValueFlags::FUNCTION)
+    }
+    #[must_use]
+    pub(crate) fn is_downgraded_to_local(self) -> bool {
+        self.contains(ValueFlags::DOWNGRADE_TO_LOCAL)
+    }
+
+    #[must_use]
+    pub(crate) fn can_bypass_got(self) -> bool {
+        self.contains(ValueFlags::CAN_BYPASS_GOT)
+    }
+
+    #[must_use]
+    pub(crate) fn is_interposable(self) -> bool {
+        !self.can_bypass_got()
     }
 }
 

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -704,10 +704,7 @@ fn select_symbol(
     let all_symbols = std::iter::once(symbol_id).chain(alternatives.iter().copied());
 
     for alt in all_symbols {
-        if symbol_db
-            .symbol_value_flags(alt)
-            .contains(ValueFlags::DYNAMIC)
-        {
+        if symbol_db.symbol_value_flags(alt).is_dynamic() {
             continue;
         }
 

--- a/libwild/src/x86_64.rs
+++ b/libwild/src/x86_64.rs
@@ -106,18 +106,17 @@ impl crate::arch::Relaxation for Relaxation {
             Some(Relaxation { kind, rel_info })
         }
 
-        let is_known_address = value_flags.contains(ValueFlags::ADDRESS);
-        let is_absolute = value_flags.contains(ValueFlags::ABSOLUTE)
-            && !value_flags.contains(ValueFlags::DYNAMIC);
+        let is_known_address = value_flags.is_address();
+        let is_absolute = value_flags.is_absolute() && !value_flags.is_dynamic();
         let non_relocatable = !output_kind.is_relocatable();
         let is_absolute_address = is_known_address && non_relocatable;
-        let can_bypass_got = value_flags.contains(ValueFlags::CAN_BYPASS_GOT);
+        let can_bypass_got = value_flags.can_bypass_got();
 
         // IFuncs cannot be referenced directly. They always need to go via the GOT. So if we've got
         // say a PLT32 relocation, we don't want to relax it even if we're in a static executable.
         // Furthermore, if we encounter a relocation like PC32 to an ifunc, then we need to change
         // it so that it goes via the GOT. This is kind of the opposite of relaxation.
-        if value_flags.contains(ValueFlags::IFUNC) {
+        if value_flags.is_ifunc() {
             return match relocation_kind {
                 object::elf::R_X86_64_PC32 => {
                     return create(RelaxationKind::NoOp, object::elf::R_X86_64_PLT32);


### PR DESCRIPTION
Besides making the code that calls these slightly more compact, it also makes it easier to see where these flags are set.