### PR TITLE
Replace CAN_BYPASS_GOT with NON_INTERPOSABLE

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -748,6 +748,10 @@ impl OutputKind {
         !matches!(self, OutputKind::SharedObject)
     }
 
+    pub(crate) fn is_shared_object(self) -> bool {
+        matches!(self, OutputKind::SharedObject)
+    }
+
     pub(crate) fn is_static_executable(self) -> bool {
         matches!(self, OutputKind::StaticExecutable(_))
     }

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -769,7 +769,7 @@ fn allocate_resolution(
 
     if resolution_flags.needs_got_tls_offset() {
         mem_sizes.increment(part_id::GOT, elf::GOT_ENTRY_SIZE);
-        if value_flags.is_interposable() {
+        if value_flags.is_interposable() || output_kind.is_shared_object() {
             mem_sizes.increment(part_id::RELA_DYN_GENERAL, elf::RELA_ENTRY_SIZE);
         }
     }
@@ -2570,6 +2570,7 @@ fn process_relocation<A: Arch>(
         } else {
             A::relocation_from_raw(r_type)?
         };
+
         if does_relocation_require_static_tls(r_type) {
             resources
                 .has_static_tls

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -1003,9 +1003,8 @@ bitflags! {
         /// The value refers to an ifunc. The actual address won't be known until runtime.
         const IFUNC = 1 << 3;
 
-        /// Whether the GOT can be bypassed for this value. Always true for non-symbols. For symbols,
-        /// this indicates that the symbol cannot be interposed (overridden at runtime).
-        const CAN_BYPASS_GOT = 1 << 4;
+        /// Whether the definition of the symbol is final and cannot be overridden at runtime.
+        const NON_INTERPOSABLE = 1 << 4;
 
         /// We have a version script and the version script says that the symbol should be downgraded to
         /// a local. It's still treated as a global for name lookup purposes, but after that, it becomes
@@ -1025,8 +1024,8 @@ impl ValueFlags {
     /// symbol gives the symbol default visibility. In this case, we want references in the object
     /// defining it as hidden to be allowed to bypass the GOT/PLT.
     pub(crate) fn merge(&mut self, other: ValueFlags) {
-        if other.can_bypass_got() {
-            *self |= ValueFlags::CAN_BYPASS_GOT;
+        if other.contains(ValueFlags::NON_INTERPOSABLE) {
+            *self |= ValueFlags::NON_INTERPOSABLE;
         }
     }
 
@@ -1060,13 +1059,8 @@ impl ValueFlags {
     }
 
     #[must_use]
-    pub(crate) fn can_bypass_got(self) -> bool {
-        self.contains(ValueFlags::CAN_BYPASS_GOT)
-    }
-
-    #[must_use]
     pub(crate) fn is_interposable(self) -> bool {
-        !self.can_bypass_got()
+        !self.contains(ValueFlags::NON_INTERPOSABLE)
     }
 }
 


### PR DESCRIPTION
While there is a lot of overlap between these two concepts, they're not exactly the same. There are thread-locals where we cannot bypass the GOT even though they're local variables and thus non-interposable.

In a later change, we also want to generate certain runtime relocations for non-interposable symbols in ways that don't involve the GOT.