### PR TITLE
Make _TLS_MODULE_BASE_ debug symbol relative to TLS segment

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2843,16 +2843,19 @@ fn write_internal_symbols(
             shndx = 1;
         }
 
-        let address = resolution.value();
-        let entry = symbol_writer
-            .define_symbol(false, shndx, address, 0, symbol_name.bytes())
-            .with_context(|| format!("Failed to write {}", layout.symbol_debug(symbol_id)))?;
+        let mut address = resolution.value();
 
         let st_type = if symbol_name.bytes() == TLS_MODULE_BASE_SYMBOL_NAME.as_bytes() {
+            address -= layout.tls_start_address();
             object::elf::STT_TLS
         } else {
             object::elf::STT_NOTYPE
         };
+
+        let entry = symbol_writer
+            .define_symbol(false, shndx, address, 0, symbol_name.bytes())
+            .with_context(|| format!("Failed to write {}", layout.symbol_debug(symbol_id)))?;
+
         entry.set_st_info(object::elf::STB_GLOBAL, st_type);
     }
     Ok(())


### PR DESCRIPTION
This makes this symbol consistent with how other TLS symbols are emitted and also with what GNU ld does.