### PR TITLE
Reimplement implicit linker script parsing to use winnow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,6 +681,7 @@ dependencies = [
  "tracing-subscriber",
  "typed-arena",
  "uuid",
+ "winnow",
  "zstd",
 ]
 
@@ -1599,9 +1600,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
 ]

--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -49,6 +49,7 @@ hex = "0.4.3"
 atomic-take = "1.1.0"
 normalize-path = "0.2.1"
 typed-arena = "2.0.2"
+winnow = "0.7.4"
 
 [dev-dependencies]
 ar = "0.9.0"


### PR DESCRIPTION
This should make it easier to extend what's supported to include more of the linker script syntax.

Issue #44