### PR TITLE
arch docker: Make toolchain explicit

### DIFF
--- a/docker/arch.Dockerfile
+++ b/docker/arch.Dockerfile
@@ -45,7 +45,7 @@ RUN wget -qO- https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.
 
 RUN wget https://sh.rustup.rs -O rustup-installer && \
     chmod +x rustup-installer && \
-    ./rustup-installer -y
+    ./rustup-installer -y --default-toolchain 1.86.0
 
 ENV PATH="/root/.cargo/bin:$PATH"
 


### PR DESCRIPTION
Otherwise, we end up caching the old version, which then results in failure when we bump the MSRV.