### PR TITLE
tests: Add musl target option for Rust build tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,8 @@ Currently, the behavior for the following test options can be configured using t
 
 - `use_qemu`: Determines whether to run tests for architectures different from the host. This setting is overridden by the `$WILD_TEST_CROSS` environment variable. The default value is `false`.
 
+- `allow_rust_musl_target`: Specifies whether to allow the musl target Rust. The default value is `false`, so you’ll need to set it to `true` if you want to run tests targeting musl.
+
 A sample configuration file is provided as `test-config.toml.sample`.
 By default, Wild uses `test-config.toml` as the configuration file.
 If you have written your configuration in a different file, specify its location using the `WILD_TEST_CONFIG` environment variable as follows:

--- a/test-config-ci.toml
+++ b/test-config-ci.toml
@@ -1,2 +1,3 @@
 rustc_channel = "nightly"
 use_qemu = false
+allow_rust_musl_target = true

--- a/test-config.toml.sample
+++ b/test-config.toml.sample
@@ -1,2 +1,3 @@
 rustc_channel = FILLHERE # `"stable"`, `"beta"`, `"nightly"` or "default"
 use_qemu = FILLHERE # `true` or `false`
+allow_rust_musl_target = FILLHERE # `true` or `false`

--- a/wild/tests/sources/rust-integration.rs
+++ b/wild/tests/sources/rust-integration.rs
@@ -6,19 +6,23 @@
 
 //#Config:llvm-static:default
 //#CompArgs:--target x86_64-unknown-linux-musl -C relocation-model=static -C target-feature=+crt-static -C debuginfo=2
+//#RequiresRustMusl: true
 //#Arch: x86_64
 
 //#Config:llvm-static-aarch64:default
 //#CompArgs:--target aarch64-unknown-linux-musl -C relocation-model=static -C target-feature=+crt-static -C debuginfo=2
+//#RequiresRustMusl: true
 //#Arch: aarch64
 
 //#Config:cranelift-static:default
 //#CompArgs:-Zcodegen-backend=cranelift --target x86_64-unknown-linux-musl -C relocation-model=static -C target-feature=+crt-static -C debuginfo=2 --cfg cranelift
 //#RequiresNightlyRustc: true
+//#RequiresRustMusl: true
 //#Arch: x86_64
 
 //#Config:cranelift-static-aarch64:default
 //#CompArgs:-Zcodegen-backend=cranelift --target aarch64-unknown-linux-musl -C relocation-model=static -C target-feature=+crt-static -C debuginfo=2 --cfg cranelift
+//#RequiresRustMusl: true
 //#Arch: aarch64
 
 //#Config:llvm-dynamic:default


### PR DESCRIPTION
This patch adds the `allow_rust_musl_target` option to `test-config.toml`, and adds the `RequiresRustMusl` option to each test.

What I’m struggling with is the default value of `allow_rust_musl_target`.
Setting it to `true` would be more friendly for new developers, but it would require configuration in automated testing environments, such as for distribution. On the other hand, setting it to false would have the opposite effect.
For now, as noted in `CONTRIBUTING.md`, the default value is set to `false`, and the idea is to have developers enable it themselves (set it to true) when they need it.

close #651 