### PR TITLE
arch docker: Avoid using base images with known vulnerabilities

### DIFF
--- a/docker/arch-basic.Dockerfile
+++ b/docker/arch-basic.Dockerfile
@@ -4,7 +4,7 @@
 #
 # docker run -it wild-dev-arch-basic
 
-FROM archlinux:base-20250302.0.316047 AS chef
+FROM archlinux:base-20250406.0.331908 AS chef
 
 RUN pacman --noconfirm -Syu \
     wget \

--- a/docker/arch.Dockerfile
+++ b/docker/arch.Dockerfile
@@ -9,7 +9,7 @@
 # `--cap-add=SYS_PTRACE --security-opt seccomp=unconfined`
 # See https://github.com/rr-debugger/rr/wiki/Docker
 
-FROM archlinux:base-20250302.0.316047 AS chef
+FROM archlinux:base-20250406.0.331908 AS chef
 
 RUN pacman --noconfirm -Syu \
     wget \


### PR DESCRIPTION
The current Arch Linux base image has multiple reported vulnerabilities.

https://hub.docker.com/layers/library/archlinux/base-20250302.0.316047/images/sha256-068aa6bfc1e735cdf9be3dbf66327011f99126656f479168f479d68b28181106