### PR TITLE
dependabot: Change version-strategy to widen

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
+    versioning-strategy: widen
     directory: /
     schedule:
       interval: daily


### PR DESCRIPTION
If libwild is used as a library, we want to provide flexibility as to which versions of our dependencies get used.