### PR TITLE
Reduce minimal versions of our dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,16 +857,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5438dd2b2ff4c6df6e1ce22d825ed2fa93ee2922235cc45186991717f0a892d"
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
-]
-
-[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,12 +881,6 @@ dependencies = [
  "serde",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -954,9 +938,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit",
 ]
@@ -1137,9 +1121,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
@@ -1416,18 +1400,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
 ]
 
 [[package]]
@@ -1437,15 +1409,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
- "nu-ansi-term",
  "once_cell",
  "regex",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -1474,12 +1443,6 @@ checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -1539,28 +1502,6 @@ dependencies = [
  "wait-timeout",
  "which",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,71 @@ readme = "README.md"
 rust-version = "1.86"
 edition = "2024"
 
+[workspace.dependencies]
+ahash = { version = "0.8.0", default-features = false, features = ["std"] }
+anyhow = "1.0.97"
+ascii_table = "4.0.0"
+atomic-take = "1.0.0"
+bitflags = "2.4.0"
+blake3 = { version = "1.0.0", features = ["rayon"] }
+bumpalo-herd = "0.1.0"
+bytemuck = { version = "1.10.0", features = ["derive"] }
+bytesize = "2.0.0"
+clap = { version = "4.0.0", features = ["derive"] }
+colored = "3.0.0"
+crossbeam-queue = "0.3.10"
+crossbeam-utils = "0.8.18"
+dhat = { version = "0.3.3" }
+fallible-iterator = "0.3.0"
+fd-lock = "4.0.0"
+flate2 = { version = "1.1.0", features = ["zlib-rs"] }
+gimli = "0.31.0"
+hashbrown = "0.15.1"
+hex = "0.4.0"
+iced-x86 = { version = "1.17.0", default-features = false, features = [
+    "std",
+    "decoder",
+    "gas",
+] }
+itertools = "0.14.0"
+libc = "0.2.152"
+memchr = "2.6.0"
+memmap2 = "0.9.0"
+mimalloc = { version = "0.1", default-features = false }
+normalize-path = "0.2.0"
+object = { version = "0.36.7", default-features = false, features = [
+    "elf",
+    "read_core",
+    "std",
+    "unaligned",
+    "archive",
+] }
+os_info = "3.0.0"
+postcard = { version = "1.1.1", features = ["use-std"] }
+rayon = "1.2.1"
+rstest = "0.25.0"
+serde = { version = "1.0.219", features = ["derive"] }
+sharded-offset-map = "0.2.0"
+sharded-vec-writer = "0.3.0"
+smallvec = "1.6.1"
+strum = { version = "0.27.0", features = ["derive"] }
+strum_macros = "0.27.0"
+symbolic-demangle = "12.0.0"
+tempfile = "3.0.0"
+toml = "0.8.0"
+tracing = "0.1.35"
+tracing-subscriber = { version = "0.3.16", default-features = false, features = [
+    "env-filter",
+    "fmt",
+    "registry",
+] }
+typed-arena = "2.0.0"
+uuid = { version = "1.0.0", features = ["v4"] }
+wait-timeout = "0.2.0"
+which = "7.0.2"
+winnow = "0.7.0"
+zstd = "0.13.0"
+
 [profile.opt-debug]
 inherits = "release"
 debug = true

--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -8,49 +8,39 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-ahash = { version = "0.8.11", default-features = false, features = ["std"] }
-anyhow = "1.0.97"
-bitflags = "2.9.0"
-bytemuck = { version = "1.22.0", features = ["derive"] }
-crossbeam-queue = "0.3.12"
-crossbeam-utils = "0.8.21"
-libc = "0.2"
+ahash = { workspace = true }
+anyhow = { workspace = true }
+atomic-take = { workspace = true }
+bitflags = { workspace = true }
+blake3 = { workspace = true }
+bumpalo-herd = { workspace = true }
+bytemuck = { workspace = true }
+bytesize = { workspace = true }
+crossbeam-queue = { workspace = true }
+crossbeam-utils = { workspace = true }
+flate2 = { workspace = true }
+hashbrown = { workspace = true }
+hex = { workspace = true }
+itertools = { workspace = true }
+libc = { workspace = true }
 linker-layout = { path = "../linker-layout", version = "0.4.0" }
 linker-trace = { path = "../linker-trace", version = "0.4.0" }
 linker-utils = { path = "../linker-utils", version = "0.4.0" }
-memchr = "2.7.4"
-memmap2 = "0.9.5"
-object = { version = "0.36.7", default-features = false, features = [
-    "archive",
-    "elf",
-    "read_core",
-    "std",
-    "unaligned",
-] }
-rayon = "1.10.0"
-smallvec = "1.15.0"
-symbolic-demangle = "12.14.1"
-tracing = { version = "0.1.41" }
-tracing-subscriber = { version = "0.3.19", default-features = false, features = [
-    "env-filter",
-    "fmt",
-    "registry",
-] }
-sharded-offset-map = "0.2.0"
-sharded-vec-writer = "0.3.0"
-itertools = "0.14.0"
-bytesize = "2.0.1"
-flate2 = { version = "1.1.1", features = ["zlib-rs"] }
-bumpalo-herd = "0.1.2"
-zstd = "0.13.3"
-blake3 = { version = "1.8.1", features = ["rayon"] }
-uuid = { version = "1.16.0", features = ["v4"] }
-hex = "0.4.3"
-atomic-take = "1.1.0"
-normalize-path = "0.2.1"
-typed-arena = "2.0.2"
-winnow = "0.7.4"
-hashbrown = "0.15.2"
+memchr = { workspace = true }
+memmap2 = { workspace = true }
+normalize-path = { workspace = true }
+object = { workspace = true }
+rayon = { workspace = true }
+sharded-offset-map = { workspace = true }
+sharded-vec-writer = { workspace = true }
+smallvec = { workspace = true }
+symbolic-demangle = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+typed-arena = { workspace = true }
+uuid = { workspace = true }
+winnow = { workspace = true }
+zstd = { workspace = true }
 
 [dev-dependencies]
 ar = "0.9.0"

--- a/linker-diff/Cargo.toml
+++ b/linker-diff/Cargo.toml
@@ -11,34 +11,24 @@ edition.workspace = true
 linker-layout = { path = "../linker-layout", version = "0.4.0" }
 linker-trace = { path = "../linker-trace", version = "0.4.0" }
 linker-utils = { path = "../linker-utils", version = "0.4.0" }
-object = { version = "0.36.7", default-features = false, features = [
-    "elf",
-    "read_core",
-    "std",
-    "unaligned",
-    "archive",
-] }
-iced-x86 = { version = "1.21.0", default-features = false, features = [
-    "std",
-    "decoder",
-    "gas",
-] }
-symbolic-demangle = "12.14.1"
-anyhow = "1.0.97"
-clap = { version = "4.5.35", features = ["derive"] }
-rayon = "1.10.0"
-bytemuck = { version = "1.22.0", features = ["derive"] }
-itertools = "0.14.0"
-gimli = "0.31.1"
-fallible-iterator = "0.3.0"
-colored = "3.0.0"
-tracing = "0.1.41"
-tracing-subscriber = "0.3.19"
-memmap2 = "0.9.5"
-memchr = "2.7.4"
-tempfile = "3.19.1"
-which = "7.0.2"
-ascii_table = "4.0.6"
+object = { workspace = true }
+iced-x86 = { workspace = true }
+symbolic-demangle = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true }
+rayon = { workspace = true }
+bytemuck = { workspace = true }
+itertools = { workspace = true }
+gimli = { workspace = true }
+fallible-iterator = { workspace = true }
+colored = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+memmap2 = { workspace = true }
+memchr = { workspace = true }
+tempfile = { workspace = true }
+which = { workspace = true }
+ascii_table = { workspace = true }
 
 [lints]
 workspace = true

--- a/linker-layout/Cargo.toml
+++ b/linker-layout/Cargo.toml
@@ -8,9 +8,9 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-anyhow = "1.0.97"
-postcard = { version = "1.1.1", features = ["use-std"] }
-serde = { version = "1.0.219", features = ["derive"] }
+anyhow = { workspace = true }
+postcard = { workspace = true }
+serde = { workspace = true }
 
 [lints]
 workspace = true

--- a/linker-trace/Cargo.toml
+++ b/linker-trace/Cargo.toml
@@ -8,9 +8,9 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-anyhow = "1.0.97"
-postcard = { version = "1.1.1", features = ["use-std"] }
-serde = { version = "1.0.219", features = ["derive"] }
+anyhow = { workspace = true }
+postcard = { workspace = true }
+serde = { workspace = true }
 
 [lints]
 workspace = true

--- a/linker-utils/Cargo.toml
+++ b/linker-utils/Cargo.toml
@@ -8,13 +8,8 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-anyhow = "1.0.97"
-object = { version = "0.36.7", default-features = false, features = [
-    "elf",
-    "read_core",
-    "std",
-    "unaligned",
-] }
+anyhow = { workspace = true }
+object = { workspace = true }
 
 [lints]
 workspace = true

--- a/wild/Cargo.toml
+++ b/wild/Cargo.toml
@@ -17,30 +17,25 @@ libwild = { path = "../libwild", version = "0.4.0" }
 # This is off by default, since it doesn't appear to help. However, if you're linking against musl
 # libc, which has a comparatively slow allocator, then enabling this does help. To enable this,
 # build with `--features mimalloc`.
-mimalloc = { version = "0.1", default-features = false, optional = true }
+mimalloc = { workspace = true, optional = true }
 
-dhat = { version = "0.3.3", optional = true }
-os_info = "3.10.0"
+dhat = { workspace = true, optional = true }
 
 [dev-dependencies]
-anyhow = "1.0.97"
-wait-timeout = "0.2.1"
-itertools = "0.14.0"
-object = { version = "0.36.7", default-features = false, features = [
-    "elf",
-    "read_core",
-    "std",
-    "unaligned",
-] }
-libc = "0.2"
-linker-diff = { path = "../linker-diff", version = "0.4.0" }
-which = "7.0.2"
-rstest = "0.25.0"
-fd-lock = "4.0.4"
-strum = { version = "0.27.1", features = ["derive"] }
-strum_macros = "0.27.1"
-toml = "0.8.20"
-serde = { version = "1.0.219", features = ["derive"] }
+anyhow = { workspace = true }
+fd-lock = { workspace = true }
+itertools = { workspace = true }
+libc = { workspace = true }
+linker-diff = { path = "../linker-diff" }
+object = { workspace = true }
+os_info = { workspace = true }
+rstest = { workspace = true }
+serde = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+toml = { workspace = true }
+wait-timeout = { workspace = true }
+which = { workspace = true }
 
 [features]
 default = ["fork"]


### PR DESCRIPTION
Also, make all our dependencies workspace dependencies to make it easier to keep versions and features consistent.