### PR TITLE
Fix linking against protected symbols in shared objects

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -3317,9 +3317,14 @@ impl<'data> DynamicLayout<'data> {
                         res.value(),
                     )?;
                 } else {
-                    table_writer
+                    let entry = table_writer
                         .dynsym_writer
-                        .copy_symbol_shndx(symbol, name, 0, 0)?;
+                        .define_symbol(false, 0, 0, 0, name)?;
+
+                    // Note, we copy st_info, but not st_other since we don't want to copy the
+                    // visibility. We want to emit the symbol with default visibility, otherwise the
+                    // runtime loader may ignore dynamic relocations that reference the symbol.
+                    entry.st_info = symbol.st_info();
 
                     if let Some(versym) = table_writer.version_writer.versym.as_mut() {
                         write_symbol_version(

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -693,7 +693,10 @@ pub(crate) fn resolve_alternative_symbol_definitions<'data>(
         // change its visibility too. We need somewhere to store this information. We also need
         // linker-diff to report when we get exported dynamic symbols wrong.
         if r.visibility != Visibility::Default {
-            symbol_db.symbol_value_flags[r.replace.as_usize()] |= ValueFlags::NON_INTERPOSABLE;
+            let value_flags = &mut symbol_db.symbol_value_flags[r.replace.as_usize()];
+            if !value_flags.contains(ValueFlags::DYNAMIC) {
+                *value_flags |= ValueFlags::NON_INTERPOSABLE;
+            }
         }
         symbol_db.replace_definition(r.replace, r.selected);
     }

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -2240,6 +2240,7 @@ fn integration_test(
         "undefined_symbols.c",
         "whole_archive.c",
         "dynamic-bss-only.c",
+        "shared-priority.c",
         "shared.c",
         "duplicate_strong_symbols.c"
     )]

--- a/wild/tests/sources/shared-priority-1.c
+++ b/wild/tests/sources/shared-priority-1.c
@@ -1,0 +1,6 @@
+__attribute__ ((weak, visibility(("protected"))))
+int foo(void) {
+    return 10;
+}
+
+int var1 = 65;

--- a/wild/tests/sources/shared-priority-2.c
+++ b/wild/tests/sources/shared-priority-2.c
@@ -1,0 +1,4 @@
+__attribute__ ((weak, visibility(("protected"))))
+int foo(void) {
+    return 20;
+}

--- a/wild/tests/sources/shared-priority.c
+++ b/wild/tests/sources/shared-priority.c
@@ -1,0 +1,35 @@
+// Tests related to how we handle symbols that are defined in shared objects and also in other
+// places like archives.
+
+//#AbstractConfig:default
+//#CompArgs:-fPIC
+//#Object:exit.c
+//#Static:false
+//#DiffIgnore:.dynamic.DT_NEEDED
+//#DiffIgnore:.dynamic.DT_RELA
+//#DiffIgnore:.dynamic.DT_RELAENT
+//#DiffIgnore:section.got
+
+//#Config:shared-first-archive-not-loaded:default
+//#Shared:shared-priority-1.c
+//#Archive:shared-priority-2.c
+
+//#Config:archive-first:default
+//#Archive:shared-priority-1.c
+//#Shared:shared-priority-2.c
+
+#include "exit.h"
+
+int foo(void);
+
+extern int var1;
+
+void _start(void) {
+    if (var1 != 65) {
+        exit_syscall(101);
+    }
+    if (foo() != 10) {
+        exit_syscall(100);
+    }
+    exit_syscall(42);
+}


### PR DESCRIPTION
There were two problems. Firstly, we were copying the visibility of the symbol from the shared object to the executable, which meant that the runtime loader would ignore relocations for that symbol.

Secondly, we were marking the symbol as NON_INTERPOSABLE, which doesn't really make sense when the symbol is dynamic, so coming from elsewhere.

Issue #668