### PR TITLE
Replace ahash with foldhash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,18 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,7 +655,6 @@ dependencies = [
 name = "libwild"
 version = "0.4.0"
 dependencies = [
- "ahash",
  "anyhow",
  "ar",
  "atomic-take",
@@ -679,6 +666,7 @@ dependencies = [
  "crossbeam-queue",
  "crossbeam-utils",
  "flate2",
+ "foldhash",
  "hashbrown",
  "hex",
  "itertools",
@@ -1445,12 +1433,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1607,26 +1589,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ rust-version = "1.86"
 edition = "2024"
 
 [workspace.dependencies]
-ahash = { version = "0.8.0", default-features = false, features = ["std"] }
 anyhow = "1.0.97"
 ascii_table = "4.0.0"
 atomic-take = "1.0.0"
@@ -35,6 +34,7 @@ dhat = { version = "0.3.3" }
 fallible-iterator = "0.3.0"
 fd-lock = "4.0.0"
 flate2 = { version = "1.1.0", features = ["zlib-rs"] }
+foldhash = "0.1.0"
 gimli = "0.31.0"
 hashbrown = "0.15.1"
 hex = "0.4.0"

--- a/cackle.toml
+++ b/cackle.toml
@@ -114,7 +114,7 @@ allow_unsafe = true
 [pkg.smallvec]
 allow_unsafe = true
 
-[pkg.ahash]
+[pkg.foldhash]
 allow_unsafe = true
 
 [pkg.tracing-attributes]

--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -8,7 +8,6 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-ahash = { workspace = true }
 anyhow = { workspace = true }
 atomic-take = { workspace = true }
 bitflags = { workspace = true }
@@ -19,6 +18,7 @@ bytesize = { workspace = true }
 crossbeam-queue = { workspace = true }
 crossbeam-utils = { workspace = true }
 flate2 = { workspace = true }
+foldhash = { workspace = true }
 hashbrown = { workspace = true }
 hex = { workspace = true }
 itertools = { workspace = true }

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -65,10 +65,11 @@ use crate::string_merging::get_merged_string_output_address;
 use crate::symbol::UnversionedSymbolName;
 use crate::symbol_db::SymbolDb;
 use crate::symbol_db::SymbolId;
-use ahash::AHashMap;
 use anyhow::Context;
 use anyhow::anyhow;
 use anyhow::bail;
+use foldhash::HashMap as FoldHashMap;
+use foldhash::HashMapExt as _;
 use linker_utils::elf::DynamicRelocationKind;
 use linker_utils::elf::RelocationKind;
 use linker_utils::elf::SectionFlags;
@@ -1721,7 +1722,7 @@ impl<'data> ObjectLayout<'data> {
         let eh_frame_hdr_address = layout.mem_address_of_built_in(output_section_id::EH_FRAME_HDR);
 
         // Map from input offset to output offset of each CIE.
-        let mut cies_offset_conversion: AHashMap<u32, u32> = AHashMap::new();
+        let mut cies_offset_conversion: FoldHashMap<u32, u32> = FoldHashMap::new();
 
         while input_pos + PREFIX_LEN <= data.len() {
             let prefix: elf::EhFrameEntryPrefix =

--- a/libwild/src/hash.rs
+++ b/libwild/src/hash.rs
@@ -33,7 +33,7 @@ impl BuildHasher for PassThroughHasher {
 }
 
 pub(crate) fn hash_bytes(bytes: &[u8]) -> u64 {
-    let mut hasher = ahash::AHasher::default();
+    let mut hasher = foldhash::fast::FixedState::default().build_hasher();
     hasher.write(bytes);
     hasher.finish()
 }

--- a/libwild/src/input_data.rs
+++ b/libwild/src/input_data.rs
@@ -10,10 +10,10 @@ use crate::args::Modifiers;
 use crate::error::Result;
 use crate::file_kind::FileKind;
 use crate::linker_script::LinkerScript;
-use ahash::HashSet;
-use ahash::RandomState;
 use anyhow::Context;
 use anyhow::bail;
+use foldhash::HashSet;
+use foldhash::fast::RandomState;
 use memmap2::Mmap;
 use rayon::iter::IntoParallelRefIterator;
 use rayon::iter::ParallelIterator;
@@ -250,7 +250,7 @@ impl InputData {
 impl<'data> TemporaryState<'data> {
     fn new(args: &'data Args) -> Self {
         Self {
-            filenames: HashSet::with_hasher(RandomState::new()),
+            filenames: HashSet::with_hasher(RandomState::default()),
             args,
         }
     }

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -35,8 +35,9 @@ use crate::part_id::PartId;
 use crate::part_id::REGULAR_PART_BASE;
 use crate::program_segments::ProgramSegmentId;
 use crate::resolution::SectionSlot;
-use ahash::AHashMap;
 use anyhow::anyhow;
+use foldhash::HashMap as FoldHashMap;
+use foldhash::HashMapExt as _;
 use linker_utils::elf::SectionFlags;
 use linker_utils::elf::SectionType;
 #[allow(clippy::wildcard_imports)]
@@ -127,7 +128,7 @@ pub(crate) struct OutputSections<'data> {
     /// being output.
     pub(crate) output_section_indexes: Vec<Option<u16>>,
 
-    custom_by_name: AHashMap<SectionName<'data>, OutputSectionId>,
+    custom_by_name: FoldHashMap<SectionName<'data>, OutputSectionId>,
     sections_and_segments_events: Vec<OrderEvent>,
 }
 
@@ -688,7 +689,7 @@ impl Debug for SectionName<'_> {
 
 pub(crate) struct OutputSectionsBuilder<'data> {
     base_address: u64,
-    custom_by_name: AHashMap<SectionName<'data>, OutputSectionId>,
+    custom_by_name: FoldHashMap<SectionName<'data>, OutputSectionId>,
     // TODO: Change this to be an OutputSectionMap.
     section_infos: Vec<SectionOutputInfo<'data>>,
 }
@@ -782,7 +783,7 @@ impl<'data> OutputSectionsBuilder<'data> {
         Self {
             section_infos,
             base_address,
-            custom_by_name: AHashMap::new(),
+            custom_by_name: FoldHashMap::new(),
         }
     }
 }

--- a/libwild/src/save_dir.rs
+++ b/libwild/src/save_dir.rs
@@ -1,8 +1,9 @@
 //! Support for saving inputs for later use.
 
 use crate::error::Result;
-use ahash::AHashMap;
 use anyhow::Context;
+use foldhash::HashMap as FoldHashMap;
+use foldhash::HashMapExt as _;
 use std::io::BufWriter;
 use std::io::Write;
 use std::path::Path;
@@ -10,7 +11,7 @@ use std::path::PathBuf;
 
 pub(crate) struct SaveDir {
     dir: Option<PathBuf>,
-    copied_paths: AHashMap<String, String>,
+    copied_paths: FoldHashMap<String, String>,
 }
 
 const SAVE_DIR_ENV: &str = "WILD_SAVE_DIR";
@@ -64,7 +65,7 @@ impl SaveDir {
     fn with_dir(dir: Option<PathBuf>) -> Self {
         SaveDir {
             dir,
-            copied_paths: AHashMap::new(),
+            copied_paths: FoldHashMap::new(),
         }
     }
 

--- a/libwild/src/string_merging.rs
+++ b/libwild/src/string_merging.rs
@@ -34,11 +34,11 @@ use crate::part_id::PartId;
 use crate::resolution::ResolvedFile;
 use crate::resolution::ResolvedGroup;
 use crate::resolution::SectionSlot;
-use ahash::HashMap;
 use anyhow::Context;
 use anyhow::bail;
 use crossbeam_queue::ArrayQueue;
 use crossbeam_utils::atomic::AtomicCell;
+use foldhash::HashMap;
 use itertools::Itertools as _;
 use object::LittleEndian;
 use object::read::elf::Sym as _;
@@ -143,7 +143,7 @@ impl Default for MergedStringsSection<'_> {
             buckets: Default::default(),
             bucket_offsets: [0; MERGE_STRING_BUCKETS],
             string_offsets: Default::default(),
-            overflowed_string_offsets: HashMap::with_hasher(ahash::RandomState::new()),
+            overflowed_string_offsets: HashMap::with_hasher(foldhash::fast::RandomState::default()),
         }
     }
 }

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -24,12 +24,12 @@ use crate::symbol::PreHashedSymbolName;
 use crate::symbol::UnversionedSymbolName;
 use crate::symbol::VersionedSymbolName;
 use crate::version_script::VersionScript;
-use ahash::HashMap;
-use ahash::RandomState;
 use anyhow::Context;
 use anyhow::Error;
 use anyhow::bail;
 use crossbeam_queue::SegQueue;
+use foldhash::HashMap;
+use foldhash::fast::RandomState;
 use itertools::Itertools;
 use object::LittleEndian;
 use object::read::elf::Sym as _;
@@ -308,8 +308,8 @@ impl<'data> SymbolDb<'data> {
         buckets.resize_with(num_buckets, || SymbolBucket {
             name_to_id: Default::default(),
             versioned_name_to_id: Default::default(),
-            alternative_definitions: HashMap::with_hasher(RandomState::new()),
-            alternative_versioned_definitions: HashMap::with_hasher(RandomState::new()),
+            alternative_definitions: HashMap::with_hasher(RandomState::default()),
+            alternative_versioned_definitions: HashMap::with_hasher(RandomState::default()),
         });
 
         let mut index = SymbolDb {
@@ -733,7 +733,7 @@ fn process_alternatives(
 ) {
     for (first, alternatives) in replace(
         alternative_definitions,
-        HashMap::with_hasher(RandomState::new()),
+        HashMap::with_hasher(RandomState::default()),
     ) {
         // Compute the most restrictive visibility of any of the alternative definitions. This is
         // the visibility we'll use for our selected symbol. This seems like odd behaviour, but it


### PR DESCRIPTION
Hashbrown already did it https://github.com/rust-lang/hashbrown/pull/563

Benchmarks without LTO:
```
~/llvm-tblgen
❯ OUT=/tmp/bin powerprofilesctl launch -p performance poop "./run-with ~/Projects/wild/target/ahash/ld --no-fork" "./run-with ~/Projects/wild/target/foldhash/ld --no-fork"
Benchmark 1 (150 runs): ./run-with ~/Projects/wild/target/ahash/ld --no-fork
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          33.2ms ± 2.91ms    28.7ms … 44.0ms          5 ( 3%)        0%
  peak_rss           46.9MB ± 7.01MB    38.1MB … 71.6MB          4 ( 3%)        0%
  cpu_cycles          994M  ± 68.6M      691M  … 1.16G           8 ( 5%)        0%
  instructions        301M  ± 5.95M      276M  …  316M           6 ( 4%)        0%
  cache_references   11.6M  ±  240K     10.9M  … 12.2M           1 ( 1%)        0%
  cache_misses       3.18M  ± 65.7K     2.98M  … 3.43M           4 ( 3%)        0%
  branch_misses      1.09M  ± 19.6K     1.02M  … 1.14M           8 ( 5%)        0%
Benchmark 2 (153 runs): ./run-with ~/Projects/wild/target/foldhash/ld --no-fork
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          32.8ms ± 2.24ms    29.0ms … 41.4ms          4 ( 3%)          -  1.2% ±  1.8%
  peak_rss           46.1MB ± 5.62MB    38.1MB … 65.1MB          2 ( 1%)          -  1.6% ±  3.1%
  cpu_cycles         1.00G  ± 71.1M      472M  … 1.14G           9 ( 6%)          +  0.8% ±  1.6%
  instructions        301M  ± 8.28M      242M  …  315M           5 ( 3%)          -  0.0% ±  0.5%
  cache_references   11.5M  ±  279K     10.4M  … 12.3M           3 ( 2%)          -  0.5% ±  0.5%
  cache_misses       3.17M  ± 77.7K     2.73M  … 3.36M           3 ( 2%)          -  0.5% ±  0.5%
  branch_misses      1.10M  ± 25.4K      912K  … 1.16M          10 ( 7%)          +  0.4% ±  0.5%

~/clang
❯ OUT=/tmp/bin powerprofilesctl launch -p performance poop "./run-with ~/Projects/wild/target/ahash/ld --no-fork" "./run-with ~/Projects/wild/target/foldhash/ld --no-fork"
Benchmark 1 (36 runs): ./run-with ~/Projects/wild/target/ahash/ld --no-fork
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           139ms ± 3.69ms     135ms …  156ms          1 ( 3%)        0%
  peak_rss            816MB ± 4.72MB     809MB …  830MB          0 ( 0%)        0%
  cpu_cycles         5.88G  ±  135M     5.57G  … 6.17G           0 ( 0%)        0%
  instructions       3.62G  ± 16.8M     3.58G  … 3.65G           0 ( 0%)        0%
  cache_references   82.8M  ±  567K     81.6M  … 83.8M           0 ( 0%)        0%
  cache_misses       23.0M  ±  193K     22.7M  … 23.4M           0 ( 0%)        0%
  branch_misses      8.02M  ± 60.7K     7.94M  … 8.30M           1 ( 3%)        0%
Benchmark 2 (36 runs): ./run-with ~/Projects/wild/target/foldhash/ld --no-fork
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           139ms ± 2.57ms     135ms …  146ms          1 ( 3%)          -  0.0% ±  1.1%
  peak_rss            817MB ± 5.20MB     809MB …  834MB          1 ( 3%)          +  0.0% ±  0.3%
  cpu_cycles         5.96G  ± 95.5M     5.80G  … 6.14G           0 ( 0%)          +  1.3% ±  0.9%
  instructions       3.61G  ± 12.9M     3.59G  … 3.65G           1 ( 3%)          -  0.2% ±  0.2%
  cache_references   83.1M  ±  492K     82.2M  … 84.1M           0 ( 0%)          +  0.4% ±  0.3%
  cache_misses       23.3M  ±  191K     22.9M  … 23.9M           3 ( 8%)          +  1.1% ±  0.4%
  branch_misses      8.07M  ± 28.5K     8.02M  … 8.14M           0 ( 0%)          +  0.6% ±  0.3%
```

With dist profile:
```
❯ OUT=/tmp/bin powerprofilesctl launch -p performance poop "./run-with ~/Projects/wild/target/ahash/ld-dist --no-fork" "./run-with ~/Projects/wild/target/foldhash/ld-dist --no-fork"
Benchmark 1 (154 runs): ./run-with ~/Projects/wild/target/ahash/ld-dist --no-fork
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          32.5ms ± 2.83ms    28.8ms … 42.1ms         11 ( 7%)        0%
  peak_rss           45.4MB ± 6.45MB    38.4MB … 70.8MB          6 ( 4%)        0%
  cpu_cycles          988M  ± 58.3M      786M  … 1.13G           1 ( 1%)        0%
  instructions        329M  ± 10.5M      300M  …  363M           1 ( 1%)        0%
  cache_references   11.6M  ±  274K     10.8M  … 12.4M           3 ( 2%)        0%
  cache_misses       3.16M  ± 73.1K     2.97M  … 3.50M           1 ( 1%)        0%
  branch_misses      1.14M  ± 24.6K     1.06M  … 1.20M           1 ( 1%)        0%
Benchmark 2 (155 runs): ./run-with ~/Projects/wild/target/foldhash/ld-dist --no-fork
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          32.4ms ± 2.89ms    28.5ms … 51.2ms          4 ( 3%)          -  0.3% ±  2.0%
  peak_rss           44.7MB ± 6.17MB    38.3MB … 86.0MB          7 ( 5%)          -  1.6% ±  3.1%
  cpu_cycles          997M  ± 55.7M      725M  … 1.12G           5 ( 3%)          +  0.8% ±  1.3%
  instructions        329M  ± 9.97M      302M  …  365M           2 ( 1%)          +  0.0% ±  0.7%
  cache_references   11.6M  ±  261K     10.9M  … 12.3M           0 ( 0%)          -  0.0% ±  0.5%
  cache_misses       3.18M  ± 62.6K     3.01M  … 3.34M           1 ( 1%)          +  0.7% ±  0.5%
  branch_misses      1.14M  ± 22.4K     1.08M  … 1.20M           3 ( 2%)          +  0.1% ±  0.5%

❯ OUT=/tmp/bin powerprofilesctl launch -p performance poop "./run-with ~/Projects/wild/target/ahash/ld-dist --no-fork" "./run-with ~/Projects/wild/target/foldhash/ld-dist --no-fork"
Benchmark 1 (36 runs): ./run-with ~/Projects/wild/target/ahash/ld-dist --no-fork
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           139ms ± 2.45ms     134ms …  147ms          1 ( 3%)        0%
  peak_rss            817MB ± 6.19MB     810MB …  837MB          5 (14%)        0%
  cpu_cycles         5.92G  ±  109M     5.68G  … 6.15G           0 ( 0%)        0%
  instructions       3.61G  ± 14.0M     3.58G  … 3.64G           0 ( 0%)        0%
  cache_references   83.3M  ±  491K     82.4M  … 84.5M           0 ( 0%)        0%
  cache_misses       23.1M  ±  193K     22.7M  … 23.5M           0 ( 0%)        0%
  branch_misses      8.05M  ± 34.7K     7.99M  … 8.13M           0 ( 0%)        0%
Benchmark 2 (36 runs): ./run-with ~/Projects/wild/target/foldhash/ld-dist --no-fork
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           139ms ± 2.91ms     133ms …  146ms          0 ( 0%)          -  0.1% ±  0.9%
  peak_rss            816MB ± 5.69MB     810MB …  838MB          3 ( 8%)          -  0.2% ±  0.3%
  cpu_cycles         5.94G  ±  115M     5.76G  … 6.15G           0 ( 0%)          +  0.4% ±  0.9%
  instructions       3.61G  ± 13.1M     3.58G  … 3.65G           1 ( 3%)          +  0.0% ±  0.2%
  cache_references   83.1M  ±  470K     82.1M  … 84.2M           1 ( 3%)          -  0.3% ±  0.3%
  cache_misses       23.2M  ±  188K     22.7M  … 23.5M           0 ( 0%)          +  0.4% ±  0.4%
  branch_misses      8.05M  ± 27.5K     8.00M  … 8.11M           0 ( 0%)          -  0.0% ±  0.2%
```

Doesn't seem to make a difference on my PC.