### PR TITLE
Refactoring: Move keep property to section rules

### DIFF
--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -464,7 +464,7 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = [
     BuiltInSectionDetails {
         name: SectionName(INIT_ARRAY_SECTION_NAME),
         ty: sht::INIT_ARRAY,
-        section_flags: shf::ALLOC.with(shf::WRITE).with(shf::GNU_RETAIN),
+        section_flags: shf::ALLOC.with(shf::WRITE),
         element_size: size_of::<u64>() as u64,
         start_symbol_name: Some("__init_array_start"),
         end_symbol_name: Some("__init_array_end"),
@@ -473,7 +473,7 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = [
     BuiltInSectionDetails {
         name: SectionName(FINI_ARRAY_SECTION_NAME),
         ty: sht::FINI_ARRAY,
-        section_flags: shf::ALLOC.with(shf::WRITE).with(shf::GNU_RETAIN),
+        section_flags: shf::ALLOC.with(shf::WRITE),
         element_size: size_of::<u64>() as u64,
         start_symbol_name: Some("__fini_array_start"),
         end_symbol_name: Some("__fini_array_end"),
@@ -482,7 +482,7 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = [
     BuiltInSectionDetails {
         name: SectionName(PREINIT_ARRAY_SECTION_NAME),
         ty: sht::PREINIT_ARRAY,
-        section_flags: shf::ALLOC.with(shf::GNU_RETAIN),
+        section_flags: shf::ALLOC,
         start_symbol_name: Some("__preinit_array_start"),
         end_symbol_name: Some("__preinit_array_end"),
         ..DEFAULT_DEFS
@@ -496,13 +496,13 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = [
     BuiltInSectionDetails {
         name: SectionName(INIT_SECTION_NAME),
         ty: sht::PROGBITS,
-        section_flags: shf::ALLOC.with(shf::EXECINSTR).with(shf::GNU_RETAIN),
+        section_flags: shf::ALLOC.with(shf::EXECINSTR),
         ..DEFAULT_DEFS
     },
     BuiltInSectionDetails {
         name: SectionName(FINI_SECTION_NAME),
         ty: sht::PROGBITS,
-        section_flags: shf::ALLOC.with(shf::EXECINSTR).with(shf::GNU_RETAIN),
+        section_flags: shf::ALLOC.with(shf::EXECINSTR),
         ..DEFAULT_DEFS
     },
     BuiltInSectionDetails {
@@ -536,7 +536,7 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = [
     BuiltInSectionDetails {
         name: SectionName(COMMENT_SECTION_NAME),
         ty: sht::PROGBITS,
-        section_flags: shf::STRINGS.with(shf::MERGE).with(shf::GNU_RETAIN),
+        section_flags: shf::STRINGS.with(shf::MERGE),
         element_size: 1,
         ..DEFAULT_DEFS
     },
@@ -549,7 +549,7 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = [
     BuiltInSectionDetails {
         name: SectionName(NOTE_ABI_TAG_SECTION_NAME),
         ty: sht::NOTE,
-        section_flags: shf::ALLOC.with(shf::GNU_RETAIN),
+        section_flags: shf::ALLOC,
         ..DEFAULT_DEFS
     },
     BuiltInSectionDetails {

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -753,14 +753,10 @@ fn resolve_sections_for_object<'data>(
             let mut is_debug_info = false;
 
             match rules.lookup(section_name, section_flags, input_section) {
-                SectionRuleOutcome::Section(output_section_id) => {
-                    let part_id = output_section_id.part_id_with_alignment(alignment);
+                SectionRuleOutcome::Section(output_info) => {
+                    let part_id = output_info.section_id.part_id_with_alignment(alignment);
 
-                    must_load |= part_id
-                        .output_section_id()
-                        .built_in_details()
-                        .section_flags
-                        .should_retain();
+                    must_load |= output_info.must_keep;
 
                     unloaded_section = UnloadedSection::new(part_id);
                 }


### PR DESCRIPTION
This effectively makes it a property of the input section rather than the output section, which is more accurate to how it's supposed to work. e.g. a linker script could in theory specify to keep some sections and not others, while putting all of them into the same output section.

Issue #44