### PR TITLE
Set section flags by merging flags of input sections

### DIFF
--- a/libwild/src/program_segments.rs
+++ b/libwild/src/program_segments.rs
@@ -108,8 +108,9 @@ fn test_all_alloc_sections_in_a_loadable_segment() {
     use linker_utils::elf::shf;
 
     let output_sections = crate::output_section_id::OutputSections::for_testing();
+    let output_order = output_sections.output_order();
     let mut active = Vec::new();
-    for event in output_sections.sections_and_segments_events() {
+    for event in &output_order {
         match event {
             OrderEvent::SegmentStart(segment_id) => {
                 active.push(segment_id);

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -71,7 +71,7 @@ pub fn resolve_symbols_and_sections<'data>(
 
     resolve_sections(&mut resolved_groups, herd, symbol_db.args)?;
 
-    let output_sections = assign_section_ids(&mut resolved_groups, symbol_db.args)?;
+    let output_sections = assign_section_ids(&mut resolved_groups, symbol_db.args);
 
     let merged_strings = crate::string_merging::merge_strings(
         &mut resolved_groups,
@@ -477,8 +477,9 @@ pub(crate) struct ResolvedEpilogue {
 fn assign_section_ids<'data>(
     resolved: &mut [ResolvedGroup<'data>],
     args: &Args,
-) -> Result<OutputSections<'data>> {
+) -> OutputSections<'data> {
     let mut output_sections_builder = OutputSectionsBuilder::with_base_address(args.base_address());
+
     for group in resolved {
         for file in &mut group.files {
             if let ResolvedFile::Object(s) = file {
@@ -491,6 +492,7 @@ fn assign_section_ids<'data>(
             }
         }
     }
+
     output_sections_builder.build()
 }
 
@@ -786,7 +788,6 @@ fn resolve_sections_for_object<'data>(
                 let custom_section = CustomSectionDetails {
                     name: SectionName(section_name),
                     alignment,
-                    section_flags,
                     ty: SectionType::from_header(input_section),
                     index: input_section_index,
                 };

--- a/libwild/src/verification.rs
+++ b/libwild/src/verification.rs
@@ -3,6 +3,7 @@
 
 use crate::error::Result;
 use crate::layout::FileLayout;
+use crate::output_section_id::OutputOrder;
 use crate::output_section_id::OutputSections;
 use crate::output_section_part_map::OutputSectionPartMap;
 use crate::part_id;
@@ -33,14 +34,15 @@ impl OffsetVerifier {
         &self,
         memory_offsets: &OutputSectionPartMap<u64>,
         output_sections: &OutputSections,
+        output_order: &OutputOrder,
         files: &[FileLayout],
     ) -> Result {
         if memory_offsets == &self.expected {
             return Ok(());
         }
-        let expected = offsets_by_key(&self.expected, output_sections);
-        let actual = offsets_by_key(memory_offsets, output_sections);
-        let sizes = offsets_by_key(&self.sizes, output_sections);
+        let expected = offsets_by_key(&self.expected, output_order);
+        let actual = offsets_by_key(memory_offsets, output_order);
+        let sizes = offsets_by_key(&self.sizes, output_order);
         let mut problems = Vec::new();
         for (((part_id, exp), (_, act)), (_, size)) in expected.iter().zip(actual.iter()).zip(sizes)
         {
@@ -92,10 +94,10 @@ pub(crate) fn clear_ignored(expected: &mut OutputSectionPartMap<u64>) {
 
 fn offsets_by_key(
     memory_offsets: &OutputSectionPartMap<u64>,
-    output_sections: &OutputSections,
+    output_order: &OutputOrder,
 ) -> Vec<(PartId, u64)> {
     let mut offsets_by_key = Vec::new();
-    memory_offsets.output_order_map(output_sections, |part_id, _alignment, offset| {
+    memory_offsets.output_order_map(output_order, |part_id, _alignment, offset| {
         offsets_by_key.push((part_id, *offset));
     });
     offsets_by_key

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -370,6 +370,14 @@ impl std::ops::BitOrAssign for SectionFlags {
     }
 }
 
+impl std::ops::BitAnd for SectionFlags {
+    type Output = SectionFlags;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        Self(self.0 & rhs.0)
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SectionType(u32);
 

--- a/wild/tests/sources/libc-integration.c
+++ b/wild/tests/sources/libc-integration.c
@@ -65,7 +65,6 @@
 //#EnableLinker:lld
 //#DiffIgnore:section.relro_padding
 //#DiffIgnore:section.rodata.entsize
-//#DiffIgnore:section.rodata.flags
 
 //#Config:gcc-dynamic-pie:shared
 //#CompArgs:-g -fpie -DDYNAMIC_DEP -DVERIFY_CTORS

--- a/wild/tests/sources/local_symbol_refs.s
+++ b/wild/tests/sources/local_symbol_refs.s
@@ -1,8 +1,6 @@
 // The C compiler seems to always reference local symbols by offsets from the section containing the
 // symbol. We want to make sure that actual symbol references work properly too.
 
-// We don't apply the M flag to our .rodata
-//#DiffIgnore:section.rodata.flags
 //#DiffIgnore:section.rodata.entsize
 //#Object:exit.c
 //#LinkArgs:-z noexecstack

--- a/wild/tests/sources/trivial_asm.s
+++ b/wild/tests/sources/trivial_asm.s
@@ -1,7 +1,6 @@
 //#LinkArgs:-z noexecstack
 //#Object:exit.c
 //#Arch: x86_64
-//#DiffIgnore:section.data.rel.ro.flags
 //#DiffIgnore:section.data.rel.ro.entsize
 
 .section        .data.foo


### PR DESCRIPTION
This is necessary for linker scripts, since otherwise we don't really know what flags to put on the sections specified by the linker script.

It meant that we had to decide the the ordering later, since we need to know section flags in order to know where to put sections.

Issue #44