### PR TITLE
Propagate section types from input to output sections

### DIFF
--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -43,7 +43,6 @@ use bitflags::bitflags;
 use crossbeam_queue::ArrayQueue;
 use crossbeam_queue::SegQueue;
 use linker_utils::elf::SectionFlags;
-use linker_utils::elf::SectionType;
 use linker_utils::elf::shf;
 use object::LittleEndian;
 use object::read::elf::Sym as _;
@@ -788,7 +787,6 @@ fn resolve_sections_for_object<'data>(
                 let custom_section = CustomSectionDetails {
                     name: SectionName(section_name),
                     alignment,
-                    ty: SectionType::from_header(input_section),
                     index: input_section_index,
                 };
 

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -378,7 +378,7 @@ impl std::ops::BitAnd for SectionFlags {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SectionType(u32);
 
 impl SectionType {


### PR DESCRIPTION
This is necessary for linker scripts since they provide sections, but don't define their type, so we need to get the type from somewhere.

Issue #44