### PR TITLE
linker-diff: Diff entry even when we have no symbols

### DIFF
--- a/linker-diff/src/header_diff.rs
+++ b/linker-diff/src/header_diff.rs
@@ -113,6 +113,7 @@ impl Converter {
                     String::from_utf8_lossy(&rest[..len]).into_owned(),
                 ))
             }
+            Converter::SymAddress if value == 0 => Ok(ConvertedValue::Single("0x0".to_owned())),
             Converter::SymAddress => {
                 // Find a symbol with the specified address. Give preference to symbols with
                 // non-zero size.
@@ -454,9 +455,7 @@ fn read_file_header_fields(obj: &Binary) -> Result<FieldValues> {
     values.insert("type", header.e_type.get(e), Converter::None, obj);
     values.insert("machine", header.e_machine.get(e), Converter::None, obj);
     values.insert("version", header.e_version.get(e), Converter::None, obj);
-    if obj.has_symbols() {
-        values.insert("entry", header.e_entry.get(e), Converter::SymAddress, obj);
-    }
+    values.insert("entry", header.e_entry.get(e), Converter::SymAddress, obj);
     values.insert("phoff", header.e_phoff.get(e), Converter::None, obj);
     values.insert("flags", header.e_flags.get(e), Converter::None, obj);
     values.insert("ehsize", header.e_ehsize.get(e), Converter::None, obj);

--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -385,10 +385,6 @@ impl<'data> Binary<'data> {
         }
     }
 
-    fn has_symbols(&self) -> bool {
-        !self.name_index.globals_by_name.is_empty()
-    }
-
     fn section_by_name(&self, name: &str) -> Option<ElfSection64<LittleEndian>> {
         self.section_by_name_bytes(name.as_bytes())
     }

--- a/wild/tests/sources/link_args.c
+++ b/wild/tests/sources/link_args.c
@@ -2,6 +2,7 @@
 //#Object:exit.c
 //#LinkArgs:--strip-all
 //#EnableLinker:lld
+//#DiffIgnore:file-header.entry
 
 //#Config:single-threaded
 //#Object:exit.c


### PR DESCRIPTION
Then just ignore entry the our one test where we strip debug symbols. The old approach of ignoring entry based on whether there were symbols was problematic in cases where we emit a symbol or two and GNU ld doesn't.