### PR TITLE
Remove the need for output sections to know their loadable segment

### DIFF
--- a/libwild/src/output_section_map.rs
+++ b/libwild/src/output_section_map.rs
@@ -34,10 +34,6 @@ impl<T> OutputSectionMap<T> {
             .map(|(raw, info)| (OutputSectionId::from_usize(raw), info))
     }
 
-    pub(crate) fn values_iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
-        self.values.iter_mut()
-    }
-
     pub(crate) fn from_values(values: Vec<T>) -> Self {
         Self { values }
     }


### PR DESCRIPTION
This was a bit ugly before because the loadable_segment_id was initially None, then filled in later.

The only thing it was used for was to know when we were starting a new loadable segment, which is much more cleanly found by just iterating through the order events.

In order to directly access the order events, we skip calling OutputSectionPartMap::output_order_map, so that was refactored slightly.