### PR TITLE
Add support for symbol assignments in linker scripts

### DIFF
--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -4,11 +4,13 @@ use crate::alignment;
 use crate::alignment::Alignment;
 use crate::elf::SectionHeader;
 use crate::error::Result;
+use crate::hash::PreHashed;
 use crate::hash::hash_bytes;
 use crate::output_section_id;
 use crate::output_section_id::NUM_BUILT_IN_SECTIONS;
 use crate::output_section_id::OutputSectionId;
 use crate::output_section_id::SectionName;
+use crate::symbol::UnversionedSymbolName;
 use anyhow::ensure;
 use foldhash::HashMap;
 use foldhash::fast::RandomState;
@@ -38,6 +40,8 @@ struct SectionIdAllocator<'data> {
 pub(crate) struct UserDefinedSection<'data> {
     pub(crate) name: SectionName<'data>,
     pub(crate) min_alignment: Alignment,
+    pub(crate) start_symbols: Vec<PreHashed<UnversionedSymbolName<'data>>>,
+    pub(crate) end_symbols: Vec<PreHashed<UnversionedSymbolName<'data>>>,
 }
 
 /// Rules governing how input sections should be mapped to output sections.
@@ -377,6 +381,8 @@ impl<'data> SectionIdAllocator<'data> {
         self.user_defined_sections.push(UserDefinedSection {
             name: SectionName(allocator.alloc_slice_copy(name.bytes())),
             min_alignment: alignment::MIN,
+            start_symbols: Vec::new(),
+            end_symbols: Vec::new(),
         });
 
         self.section_name_to_id.insert(name.bytes().to_owned(), id);

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -189,7 +189,12 @@ impl ParsedInput<'_> {
         match self {
             ParsedInput::Prelude(o) => SymbolIdRange::prelude(o.symbol_definitions.len()),
             ParsedInput::Object(o) => o.symbol_id_range,
-            ParsedInput::Epilogue(o) => SymbolIdRange::epilogue(o.start_symbol_id, 0),
+            ParsedInput::Epilogue(o) => SymbolIdRange::epilogue(
+                o.start_symbol_id,
+                // The epilogue allocates symbols after inputs are parsed, so it effectively owns
+                // the rest of the symbol ID space.
+                u32::MAX as usize - o.start_symbol_id.as_usize(),
+            ),
         }
     }
 }

--- a/wild/tests/sources/linker-script.ld
+++ b/wild/tests/sources/linker-script.ld
@@ -1,5 +1,7 @@
 SECTIONS {
     bar : ALIGN(8) {
+        start_bar = .;
         KEEP(*(.data.foo .data.baz*));
+        end_bar = .;
     }
 }


### PR DESCRIPTION
For now, we only support symbols at the start / end of sections.

Issue #44