### PR TITLE
Refactoring: Get rid of OutputSectionsBuilder

### DIFF
--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -5139,8 +5139,7 @@ impl<'data> ObjectLayout<'data> {
 fn test_no_disallowed_overlaps() {
     use crate::output_section_id::OrderEvent;
 
-    let mut output_sections =
-        crate::output_section_id::OutputSectionsBuilder::with_base_address(0x1000).build();
+    let mut output_sections = OutputSections::with_base_address(0x1000);
     let output_order = output_sections.output_order();
     let args = Args::default();
     let section_part_sizes = output_sections.new_part_map::<u64>().map(|_, _| 7);
@@ -5249,7 +5248,7 @@ fn verify_consistent_allocation_handling(
     resolution_flags: ResolutionFlags,
     output_kind: OutputKind,
 ) -> Result {
-    let output_sections = output_section_id::OutputSectionsBuilder::with_base_address(0).build();
+    let output_sections = OutputSections::with_base_address(0);
     let output_order = output_sections.output_order();
     let mut mem_sizes = output_sections.new_part_map();
     let resolution_flags = AtomicResolutionFlags::new(resolution_flags);

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -20,7 +20,6 @@ use crate::layout_rules::SectionRuleOutcome;
 use crate::layout_rules::SectionRules;
 use crate::output_section_id::CustomSectionDetails;
 use crate::output_section_id::OutputSections;
-use crate::output_section_id::OutputSectionsBuilder;
 use crate::output_section_id::SectionName;
 use crate::output_section_map::OutputSectionMap;
 use crate::parsing::InternalSymDefInfo;
@@ -508,12 +507,10 @@ fn assign_section_ids<'data>(
     layout_rules: &LayoutRules<'data>,
     custom_start_stop_defs: &mut Vec<InternalSymDefInfo>,
 ) -> OutputSections<'data> {
-    let mut output_sections_builder =
-        OutputSectionsBuilder::with_base_address(symbol_db.args.base_address());
+    let mut output_sections = OutputSections::with_base_address(symbol_db.args.base_address());
 
     for section in &layout_rules.user_defined_sections {
-        let output_section_id =
-            output_sections_builder.add_section(section.name, section.min_alignment);
+        let output_section_id = output_sections.add_section(section.name, section.min_alignment);
 
         for sym in &section.start_symbols {
             symbol_db.add_start_stop_symbol(*sym);
@@ -530,7 +527,7 @@ fn assign_section_ids<'data>(
         for file in &mut group.files {
             if let ResolvedFile::Object(s) = file {
                 if let Some(non_dynamic) = s.non_dynamic.as_mut() {
-                    output_sections_builder.add_sections(
+                    output_sections.add_sections(
                         &non_dynamic.custom_sections,
                         non_dynamic.sections.as_mut_slice(),
                     );
@@ -539,7 +536,7 @@ fn assign_section_ids<'data>(
         }
     }
 
-    output_sections_builder.build()
+    output_sections
 }
 
 struct Outputs<'data> {


### PR DESCRIPTION
It had no substantial difference from OutputSections, so there seemed little point to it.