### PR TITLE
Retain section type for custom sections

### DIFF
--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -60,6 +60,7 @@ pub(crate) struct CustomSectionDetails<'data> {
     pub(crate) name: SectionName<'data>,
     pub(crate) index: object::SectionIndex,
     pub(crate) alignment: Alignment,
+    pub(crate) ty: SectionType,
 }
 
 // Single-part sections that we generate ourselves rather than copying directly from input objects.
@@ -758,7 +759,7 @@ impl<'data> OutputSections<'data> {
         sections: &mut [SectionSlot],
     ) {
         for custom in custom_sections {
-            let section_id = self.add_section(custom.name, custom.alignment);
+            let section_id = self.add_section(custom.name, custom.alignment, Some(custom.ty));
 
             if let Some(slot) = sections.get_mut(custom.index.0) {
                 slot.set_part_id(section_id.part_id_with_alignment(custom.alignment));
@@ -770,6 +771,7 @@ impl<'data> OutputSections<'data> {
         &mut self,
         name: SectionName<'data>,
         min_alignment: Alignment,
+        ty: Option<SectionType>,
     ) -> OutputSectionId {
         *self.custom_by_name.entry(name).or_insert_with(|| {
             self.section_infos.add_new(SectionOutputInfo {
@@ -777,7 +779,7 @@ impl<'data> OutputSections<'data> {
                 // Section flags and type will be filled in based on the attributes of the sections
                 // that get placed into this output section.
                 section_flags: SectionFlags::empty(),
-                ty: SectionType::from_u32(0),
+                ty: ty.unwrap_or(SectionType::from_u32(0)),
                 min_alignment,
             })
         })
@@ -894,10 +896,10 @@ impl<'data> OutputSections<'data> {
     #[cfg(test)]
     pub(crate) fn for_testing() -> OutputSections<'static> {
         let mut output_sections = OutputSections::with_base_address(0x1000);
-        output_sections.add_section(SectionName(b"ro"), alignment::MIN);
-        output_sections.add_section(SectionName(b"exec"), alignment::MIN);
-        output_sections.add_section(SectionName(b"data"), alignment::MIN);
-        output_sections.add_section(SectionName(b"bss"), alignment::MIN);
+        output_sections.add_section(SectionName(b"ro"), alignment::MIN, None);
+        output_sections.add_section(SectionName(b"exec"), alignment::MIN, None);
+        output_sections.add_section(SectionName(b"data"), alignment::MIN, None);
+        output_sections.add_section(SectionName(b"bss"), alignment::MIN, None);
         output_sections
     }
 }

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -43,6 +43,7 @@ use bitflags::bitflags;
 use crossbeam_queue::ArrayQueue;
 use crossbeam_queue::SegQueue;
 use linker_utils::elf::SectionFlags;
+use linker_utils::elf::SectionType;
 use linker_utils::elf::shf;
 use object::LittleEndian;
 use object::read::elf::Sym as _;
@@ -510,7 +511,8 @@ fn assign_section_ids<'data>(
     let mut output_sections = OutputSections::with_base_address(symbol_db.args.base_address());
 
     for section in &layout_rules.user_defined_sections {
-        let output_section_id = output_sections.add_section(section.name, section.min_alignment);
+        let output_section_id =
+            output_sections.add_section(section.name, section.min_alignment, None);
 
         for sym in &section.start_symbols {
             symbol_db.add_start_stop_symbol(*sym);
@@ -831,6 +833,7 @@ fn resolve_sections_for_object<'data>(
                     name: SectionName(section_name),
                     alignment,
                     index: input_section_index,
+                    ty: SectionType::from_header(input_section),
                 };
 
                 custom_sections.push(custom_section);


### PR DESCRIPTION
Fixes #694

As a first attempt, I tried adding this chunk:
```rust
common
    .section_attributes
    .get_mut(part_id.output_section_id())
    .merge(SectionAttributes::from_header(header));
```
to `load_debug_section` but couldn't manage to also cover `.debug_str` because `handle_section_load_request` doesn't seem to be processing it.

With all the previous changes and this one, Rust tests are finally passing using the configuration from #694 (extending the configuration with `profiler = true` results in #665):
```
❯ PATH=~/Projects/wild/:$PATH ./x.py t --skip tests/debuginfo --no-fail-fast
...
Build completed successfully in 0:07:46
```