### PR TITLE
Alternative fix and test for #694

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -3242,7 +3242,8 @@ fn write_section_headers(out: &mut [u8], layout: &Layout) {
             continue;
         };
 
-        let section_type = output_sections.section_type(section_id);
+        let output_info = output_sections.output_info(section_id);
+        let section_type = output_info.ty;
         let section_layout = layout.section_layouts.get(section_id);
 
         if output_sections
@@ -3252,7 +3253,7 @@ fn write_section_headers(out: &mut [u8], layout: &Layout) {
             continue;
         }
 
-        let entsize = section_id.element_size();
+        let entsize = output_info.entsize.max(section_id.element_size());
         let mut size;
         let alignment;
 

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3591,7 +3591,9 @@ impl<'data> ObjectLayoutState<'data> {
 
         for (i, section) in self.sections.iter().enumerate() {
             match section {
-                SectionSlot::MustLoad(..) | SectionSlot::UnloadedDebugInfo(..) => {
+                SectionSlot::MustLoad(..)
+                | SectionSlot::UnloadedDebugInfo(..)
+                | SectionSlot::MergeStrings(_) => {
                     queue
                         .local_work
                         .push(WorkItem::LoadSection(SectionLoadRequest::new(
@@ -3789,7 +3791,7 @@ impl<'data> ObjectLayoutState<'data> {
         let header = self.object.section(section_index)?;
         let section = Section::create(header, self, section_index, part_id)?;
         tracing::debug!(loaded_debug_section = %self.object.section_display_name(section_index),);
-        common.allocate(part_id, section.capacity());
+        common.section_loaded(part_id, header, section);
         self.sections[section_index.0] = SectionSlot::LoadedDebugInfo(section);
 
         Ok(())

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -167,10 +167,6 @@ impl OutputSections<'_> {
         OutputSectionMap::from_values(values)
     }
 
-    pub(crate) fn section_type(&self, section_id: OutputSectionId) -> SectionType {
-        self.output_info(section_id).ty
-    }
-
     pub(crate) fn section_flags(&self, section_id: OutputSectionId) -> SectionFlags {
         self.output_info(section_id).section_flags
     }
@@ -182,6 +178,7 @@ pub(crate) struct SectionOutputInfo<'data> {
     pub(crate) section_flags: SectionFlags,
     pub(crate) ty: SectionType,
     pub(crate) min_alignment: Alignment,
+    pub(crate) entsize: u64,
 }
 
 pub(crate) struct BuiltInSectionDetails {
@@ -781,6 +778,7 @@ impl<'data> OutputSections<'data> {
                 section_flags: SectionFlags::empty(),
                 ty: ty.unwrap_or(SectionType::from_u32(0)),
                 min_alignment,
+                entsize: 0,
             })
         })
     }
@@ -793,6 +791,7 @@ impl<'data> OutputSections<'data> {
                 name: d.name,
                 ty: d.ty,
                 min_alignment: d.min_alignment,
+                entsize: d.element_size,
             })
             .collect();
 

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -60,7 +60,6 @@ pub(crate) struct CustomSectionDetails<'data> {
     pub(crate) name: SectionName<'data>,
     pub(crate) index: object::SectionIndex,
     pub(crate) alignment: Alignment,
-    pub(crate) ty: SectionType,
 }
 
 // Single-part sections that we generate ourselves rather than copying directly from input objects.
@@ -756,7 +755,7 @@ impl<'data> OutputSections<'data> {
         sections: &mut [SectionSlot],
     ) {
         for custom in custom_sections {
-            let section_id = self.add_section(custom.name, custom.alignment, Some(custom.ty));
+            let section_id = self.add_section(custom.name, custom.alignment);
 
             if let Some(slot) = sections.get_mut(custom.index.0) {
                 slot.set_part_id(section_id.part_id_with_alignment(custom.alignment));
@@ -768,7 +767,6 @@ impl<'data> OutputSections<'data> {
         &mut self,
         name: SectionName<'data>,
         min_alignment: Alignment,
-        ty: Option<SectionType>,
     ) -> OutputSectionId {
         *self.custom_by_name.entry(name).or_insert_with(|| {
             self.section_infos.add_new(SectionOutputInfo {
@@ -776,7 +774,7 @@ impl<'data> OutputSections<'data> {
                 // Section flags and type will be filled in based on the attributes of the sections
                 // that get placed into this output section.
                 section_flags: SectionFlags::empty(),
-                ty: ty.unwrap_or(SectionType::from_u32(0)),
+                ty: SectionType::from_u32(0),
                 min_alignment,
                 entsize: 0,
             })
@@ -895,10 +893,10 @@ impl<'data> OutputSections<'data> {
     #[cfg(test)]
     pub(crate) fn for_testing() -> OutputSections<'static> {
         let mut output_sections = OutputSections::with_base_address(0x1000);
-        output_sections.add_section(SectionName(b"ro"), alignment::MIN, None);
-        output_sections.add_section(SectionName(b"exec"), alignment::MIN, None);
-        output_sections.add_section(SectionName(b"data"), alignment::MIN, None);
-        output_sections.add_section(SectionName(b"bss"), alignment::MIN, None);
+        output_sections.add_section(SectionName(b"ro"), alignment::MIN);
+        output_sections.add_section(SectionName(b"exec"), alignment::MIN);
+        output_sections.add_section(SectionName(b"data"), alignment::MIN);
+        output_sections.add_section(SectionName(b"bss"), alignment::MIN);
         output_sections
     }
 }

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -43,7 +43,6 @@ use bitflags::bitflags;
 use crossbeam_queue::ArrayQueue;
 use crossbeam_queue::SegQueue;
 use linker_utils::elf::SectionFlags;
-use linker_utils::elf::SectionType;
 use linker_utils::elf::shf;
 use object::LittleEndian;
 use object::read::elf::Sym as _;
@@ -511,8 +510,7 @@ fn assign_section_ids<'data>(
     let mut output_sections = OutputSections::with_base_address(symbol_db.args.base_address());
 
     for section in &layout_rules.user_defined_sections {
-        let output_section_id =
-            output_sections.add_section(section.name, section.min_alignment, None);
+        let output_section_id = output_sections.add_section(section.name, section.min_alignment);
 
         for sym in &section.start_symbols {
             symbol_db.add_start_stop_symbol(*sym);
@@ -833,7 +831,6 @@ fn resolve_sections_for_object<'data>(
                     name: SectionName(section_name),
                     alignment,
                     index: input_section_index,
-                    ty: SectionType::from_header(input_section),
                 };
 
                 custom_sections.push(custom_section);

--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -147,7 +147,6 @@ impl Config {
                 "section.phdr",
                 // We don't yet support these sections.
                 "section.data.rel.ro",
-                "section.debug*",
                 "section.stapsdt.base",
                 "section.note.gnu.build-id",
                 "section.note.gnu.property",

--- a/wild/tests/sources/ifunc.c
+++ b/wild/tests/sources/ifunc.c
@@ -1,5 +1,4 @@
 //#AbstractConfig:default
-//#DiffIgnore:section.plt.entsize
 //#Object:ifunc1.c
 //#Object:ifunc_init.c
 //#Object:exit.c

--- a/wild/tests/sources/libc-integration.c
+++ b/wild/tests/sources/libc-integration.c
@@ -5,8 +5,6 @@
 //#DiffIgnore:.dynamic.DT_PLTGOT
 //#DiffIgnore:.dynamic.DT_JMPREL
 //#DiffIgnore:.dynamic.DT_PLTREL
-//#DiffIgnore:section.plt.entsize
-//#DiffIgnore:section.rodata.cst32.entsize
 // This is only an issue on openSUSE
 //#DiffIgnore:section.rela.plt.link
 //#DiffIgnore:section.data.alignment
@@ -64,7 +62,6 @@
 //#LinkArgs:-fPIC -dynamic -Wl,--strip-debug -Wl,--gc-sections -Wl,-rpath,$ORIGIN -Wl,-z,now
 //#EnableLinker:lld
 //#DiffIgnore:section.relro_padding
-//#DiffIgnore:section.rodata.entsize
 
 //#Config:gcc-dynamic-pie:shared
 //#CompArgs:-g -fpie -DDYNAMIC_DEP -DVERIFY_CTORS

--- a/wild/tests/sources/local_symbol_refs.s
+++ b/wild/tests/sources/local_symbol_refs.s
@@ -1,7 +1,6 @@
 // The C compiler seems to always reference local symbols by offsets from the section containing the
 // symbol. We want to make sure that actual symbol references work properly too.
 
-//#DiffIgnore:section.rodata.entsize
 //#Object:exit.c
 //#LinkArgs:-z noexecstack
 //#EnableLinker:lld

--- a/wild/tests/sources/rust-integration.rs
+++ b/wild/tests/sources/rust-integration.rs
@@ -19,6 +19,9 @@
 //#RequiresNightlyRustc: true
 //#RequiresRustMusl: true
 //#Arch: x86_64
+// GNU ld clears these flags and sets entsize to 0. It's not clear why.
+//#DiffIgnore:section.debug_str.flags
+//#DiffIgnore:section.debug_str.entsize
 
 //#Config:cranelift-static-aarch64:default
 //#CompArgs:-Zcodegen-backend=cranelift --target aarch64-unknown-linux-musl -C relocation-model=static -C target-feature=+crt-static -C debuginfo=2 --cfg cranelift

--- a/wild/tests/sources/string_merging.c
+++ b/wild/tests/sources/string_merging.c
@@ -1,7 +1,6 @@
 // Defines identical string literals in two different C files and checks that they end up pointing
 // to the same memory.
 
-//#DiffIgnore:section.custom1.entsize
 //#LinkArgs:-z noexecstack
 //#Object:string_merging1.s
 //#Object:string_merging2.s

--- a/wild/tests/sources/trivial_asm.s
+++ b/wild/tests/sources/trivial_asm.s
@@ -1,7 +1,6 @@
 //#LinkArgs:-z noexecstack
 //#Object:exit.c
 //#Arch: x86_64
-//#DiffIgnore:section.data.rel.ro.entsize
 
 .section        .data.foo
 .p2align        4, 0x0


### PR DESCRIPTION
See individual commits for details. This also adds propagation of sh_entsize, which was necessary to make tests not fail now that we're not ignoring "section.debug*"