### PR TITLE
Support alternative form of undefined symbol arg

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -544,14 +544,18 @@ pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(mut input: I) -> Resul
             args.no_undefined = true;
         } else if let Some(rest) = long_arg_split_prefix("undefined=") {
             args.undefined.push(rest.to_owned());
-        } else if arg == "-u" {
-            args.undefined.push(
-                input
-                    .next()
-                    .context("Missing argument to -u")?
-                    .as_ref()
-                    .to_owned(),
-            );
+        } else if let Some(rest) = arg.strip_prefix("-u") {
+            if rest.is_empty() {
+                args.undefined.push(
+                    input
+                        .next()
+                        .context("Missing argument to -u")?
+                        .as_ref()
+                        .to_owned(),
+                );
+            } else {
+                args.undefined.push(rest.to_owned());
+            }
         } else if long_arg_eq("demangle") {
             args.demangle = true;
         } else if long_arg_eq("no-demangle") {

--- a/wild/tests/sources/force-undefined.c
+++ b/wild/tests/sources/force-undefined.c
@@ -2,9 +2,10 @@
 //#Object:exit.c
 
 //#Config:undefined:default
-//#LinkArgs:--undefined=foo -u bar
+//#LinkArgs:--undefined=foo -u bar -ubaz
 //#ExpectSym:foo
 //#ExpectSym:bar
+//#ExpectSym:baz
 
 // Verify that we can activate an archive entry by listing a symbol it defines as undefined.
 //#Config:archive-activation:default


### PR DESCRIPTION
Turns out Clang uses this form when doing code coverage:
```
❯ clang++ -Wall -Wextra -O0 -fprofile-instr-generate -fcoverage-mapping hello.cpp -o coverage_test_clang -### 2>&1 | tail -n 1
 "/usr/bin/ld" "--hash-style=gnu" "--build-id" "--eh-frame-hdr" "-m" "elf_x86_64" "-pie" "-dynamic-linker" "/lib64/ld-linux-x86-64.so.2" "-o" "coverage_test_clang" "/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../lib64/Scrt1.o" "/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../lib64/crti.o" "/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/crtbeginS.o" "-L/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1" "-L/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../lib64" "-L/lib/../lib64" "-L/usr/lib/../lib64" "-L/lib" "-L/usr/lib" "/tmp/hello-4c66c7.o" "-u__llvm_profile_runtime" "/usr/lib/clang/19/lib/linux/libclang_rt.profile-x86_64.a" "-lstdc++" "-lm" "-lgcc_s" "-lgcc" "-lc" "-lgcc_s" "-lgcc" "/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/crtendS.o" "/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/14.2.1/../../../../lib64/crtn.o"
 ```