### PR TITLE
copy-relocations test: Fix when running with qemu

### DIFF
--- a/wild/tests/sources/copy-relocations-2.c
+++ b/wild/tests/sources/copy-relocations-2.c
@@ -1,33 +1,39 @@
-int bar = 1;
+int s1 = 1;
 
-// Because this alias is a weak symbol, any copy relocations produced by references to foo should
-// instead locate the strong symbol `bar` that is at the same address and emit a copy relocation for
+// Because this alias is a weak symbol, any copy relocations produced by references to w1 should
+// instead locate the strong symbol `s1` that is at the same address and emit a copy relocation for
 // that instead.
-__attribute__ ((weak, alias("bar"))) extern int foo;
+__attribute__ ((weak, alias("s1"))) extern int w1;
 
-int get_foo(void) {
-    return foo;
+int get_w1(void) {
+    return w1;
 }
 
-int get_bar(void) {
-    return bar;
+int get_s1(void) {
+    return s1;
 }
 
 // Repeat the same scenario twice more. These are effectively identical in this file. The
 // differences are in how they are referenced in the main file.
 
-int bar2 = 2;
+int s2 = 2;
 
-__attribute__ ((weak, alias("bar2"))) extern int foo2;
+__attribute__ ((weak, alias("s2"))) extern int w2;
 
-int get_foo2(void) {
-    return bar2;
+int get_s2(void) {
+    return s2;
+}
+int get_w2(void) {
+    return w2;
 }
 
-int bar3 = 3;
+int s3 = 3;
 
-__attribute__ ((weak, alias("bar3"))) extern int foo3;
+__attribute__ ((weak, alias("s3"))) extern int w3;
 
-int get_foo3(void) {
-    return bar3;
+int get_s3(void) {
+    return s3;
+}
+int get_w3(void) {
+    return w3;
 }

--- a/wild/tests/sources/copy-relocations-3.c
+++ b/wild/tests/sources/copy-relocations-3.c
@@ -1,5 +1,5 @@
-extern int bar;
+extern int s1;
 
-int get_bar(void) {
-    return bar;
+int get_s1_pic(void) {
+    return s1;
 }

--- a/wild/tests/sources/copy-relocations.c
+++ b/wild/tests/sources/copy-relocations.c
@@ -7,50 +7,67 @@
 //#Object:copy-relocations-3.c:-fPIC
 // We're linking different .so files, so this is expected.
 //#DiffIgnore:.dynamic.DT_NEEDED
+//#DiffIgnore:dynsym.w2.section
 
 #include "exit.h"
 
 // These two symbols are at the same address in the shared object, so references to both should
-// point to the same copy relocation and that location should be what `get_foo` returns.
-extern int foo;
-extern int bar;
-int get_foo(void);
+// point to the same copy relocation and that location should be what `get_w` returns.
+extern int w1;
+extern int s1;
+int get_w1(void);
+int get_s1(void);
 
 // This time we only reference the non-weak symbol.
-extern int foo2;
-int get_foo2(void);
+extern int s2;
+int get_s2(void);
+int get_w2(void);
 
 // Lastly, we reference the weak symbol and not the strong one.
-extern int bar3;
-int get_foo3(void);
+extern int w3;
+int get_s3(void);
+int get_w3(void);
 
 // This is defined in a separate object file that is compiled with -fPIC.
-int get_bar(void);
+int get_s1_pic(void);
 
 void _start(void) {
-    foo = 10;
-    if (get_foo() != 10) {
-        exit_syscall(19);
-    }
-    if (get_bar() != 10) {
+    // Reference both the weak and the strong versions of the symbol.
+    w1 = 10;
+    if (get_w1() != 10) {
         exit_syscall(20);
     }
-    bar = 11;
-    if (get_foo() != 11) {
+    if (get_s1() != 10) {
         exit_syscall(21);
     }
-    if (get_bar() != 11) {
-        exit_syscall(24);
-    }
-
-    foo2 = 12;
-    if (get_foo2() != 12) {
+    if (get_s1_pic() != 10) {
         exit_syscall(22);
     }
+    s1 = 11;
+    if (get_w1() != 11) {
+        exit_syscall(30);
+    }
+    if (get_s1() != 11) {
+        exit_syscall(31);
+    }
+    if (get_s1_pic() != 11) {
+        exit_syscall(32);
+    }
 
-    bar3 = 13;
-    if (get_foo3() != 13) {
-        exit_syscall(23);
+    // Strong only. Note, we don't check get_w2 since linker behaviour differs in this case. GNU ld
+    // doesn't export the weak alias, lld and Wild do.
+    s2 = 12;
+    if (get_s2() != 12) {
+        exit_syscall(40);
+    }
+
+    // Weak only.
+    w3 = 13;
+    if (get_w3() != 13) {
+        exit_syscall(50);
+    }
+    if (get_s3() != 13) {
+        exit_syscall(51);
     }
 
     exit_syscall(42);


### PR DESCRIPTION
Since we don't yet run with lld when running with qemu, we can't rely on matching LLD's behaviour, so we need to ignore a case where GNU ld doesn't export a weak symbol alias and we and LLD do.

Also, rename various things in the test to make them clearer.

Fixes #705