### PR TITLE
Add cross toolchain support to openSUSE TW image

### DIFF
--- a/docker/opensuse.Dockerfile
+++ b/docker/opensuse.Dockerfile
@@ -3,13 +3,16 @@
 # docker build --progress=plain -t wild-dev-opensuse . -f docker/opensuse.Dockerfile
 # docker run -it wild-dev-opensuse
 
-FROM opensuse/tumbleweed@sha256:a8b3f189cb0a1379c618b4fa581003f9551486d98fc21a1df559f7172f87c626 AS chef
+FROM opensuse/tumbleweed@sha256:56df080fe1129ac6f15a59dd7c9a3ae27bd1f4719e2cfc0e8890afd090c677c9 AS chef
 RUN zypper install -y -t pattern devel_C_C++ && \
     zypper install -y \
         rustup \
         clang \
         glibc-devel-static \
         cross-aarch64-gcc14 \
+        cross-aarch64-binutils \
+        cross-riscv64-gcc14 \
+        cross-riscv64-binutils \
         qemu-linux-user \
         lld \
         vim \
@@ -21,6 +24,8 @@ RUN rustup toolchain install nightly && \
         x86_64-unknown-linux-musl \
         aarch64-unknown-linux-gnu \
         aarch64-unknown-linux-musl \
+        riscv64gc-unknown-linux-gnu \
+        riscv64gc-unknown-linux-musl \
         && \
     rustup component add rustc-codegen-cranelift-preview --toolchain nightly
 WORKDIR /wild


### PR DESCRIPTION
Using the provided Docker image, there's still one failing C++ test case for which I likely added a missing symlink on my host system:

```
/wild/wild/tests/build/cpp-integration.cc-pie-aarch64.ld: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory

```