### PR TITLE
ignore `segment.GNU_STACK.alignment` temporary

### DIFF
--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -234,6 +234,8 @@ impl Config {
                 // If we don't optimise a TLS access, then we'll have references to __tls_get_addr,
                 // when GNU ld doesn't.
                 "dynsym.__tls_get_addr.*",
+                // This will be removed soon. See #721.
+                "segment.GNU_STACK.alignment",
             ]
             .into_iter()
             .map(ToOwned::to_owned),


### PR DESCRIPTION
related: #721 

Once this PR is merged, I'll start working on rewriting linker-diff.