### PR TITLE
Parse version scripts as bytes and use winnow for parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ typed-arena = "2.0.0"
 uuid = { version = "1.0.0", features = ["v4"] }
 wait-timeout = "0.2.0"
 which = "7.0.2"
-winnow = "0.7.0"
+winnow = {version = "0.7.0", features = ["simd"] }
 zstd = "0.13.0"
 
 [profile.opt-debug]

--- a/libwild/src/hash.rs
+++ b/libwild/src/hash.rs
@@ -44,6 +44,12 @@ pub(crate) struct PreHashed<T> {
     hash: u64,
 }
 
+impl<T: std::fmt::Debug> std::fmt::Debug for PreHashed<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&self.value, f)
+    }
+}
+
 impl<T: PartialEq> PartialEq for PreHashed<T> {
     fn eq(&self, other: &Self) -> bool {
         self.value == other.value

--- a/libwild/src/input_data.rs
+++ b/libwild/src/input_data.rs
@@ -29,7 +29,7 @@ pub(crate) struct InputData<'data> {
 
 #[derive(Clone, Copy)]
 pub(crate) struct VersionScriptData<'data> {
-    pub(crate) raw: &'data str,
+    pub(crate) raw: &'data [u8],
 }
 
 /// Identifies an input file. IDs start from 0 which is reserved for our prelude file.
@@ -292,10 +292,7 @@ fn read_version_script<'data>(
         data: Some(data),
     });
 
-    // TODO: Experiment with switching version scripts to parsing bytes instead of strings.
-    let raw = std::str::from_utf8(file.data()).context("Invalid UTF-8 in version script")?;
-
-    Ok(VersionScriptData { raw })
+    Ok(VersionScriptData { raw: file.data() })
 }
 
 impl Input {

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3493,7 +3493,7 @@ impl<'data> EpilogueLayoutState<'data> {
             // Take all but the base version
             for version in symbol_db.version_script.version_iter().skip(1) {
                 verdefs.push(VersionDef {
-                    name: version.name.as_bytes().to_vec(),
+                    name: version.name.to_vec(),
                     parent_index: version.parent_index,
                 });
                 common.allocate(part_id::DYNSTR, version.name.len() as u64 + 1);

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -124,10 +124,13 @@ fn parse_token<'input>(input: &mut &'input BStr) -> winnow::Result<&'input [u8]>
     take_while(1.., |b| !b" (){}\n\t".contains(&b)).parse_next(input)
 }
 
-fn skip_comments_and_whitespace(input: &mut &BStr) -> winnow::Result<()> {
+pub(crate) fn skip_comments_and_whitespace(input: &mut &BStr) -> winnow::Result<()> {
     loop {
         multispace0(input)?;
-        if input.starts_with(b"/*") {
+
+        if input.starts_with(b"#") {
+            take_until(1.., "\n").parse_next(input)?;
+        } else if input.starts_with(b"/*") {
             take_until(1.., "*/").parse_next(input)?;
             "*/".parse_next(input)?;
         } else {

--- a/libwild/src/symbol.rs
+++ b/libwild/src/symbol.rs
@@ -71,6 +71,12 @@ impl Display for UnversionedSymbolName<'_> {
     }
 }
 
+impl std::fmt::Debug for UnversionedSymbolName<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&String::from_utf8_lossy(self.bytes), f)
+    }
+}
+
 pub(crate) struct SymDebug<'data>(pub(crate) &'data crate::elf::SymtabEntry);
 
 impl<'data> PreHashedSymbolName<'data> {

--- a/libwild/src/version_script.rs
+++ b/libwild/src/version_script.rs
@@ -8,11 +8,16 @@ use crate::error::Result;
 use crate::hash::PassThroughHasher;
 use crate::hash::PreHashed;
 use crate::input_data::VersionScriptData;
+use crate::linker_script::skip_comments_and_whitespace;
 use crate::symbol::UnversionedSymbolName;
-use anyhow::Context as _;
 use anyhow::anyhow;
-use anyhow::bail;
 use std::collections::HashSet;
+use winnow::BStr;
+use winnow::Parser;
+use winnow::error::ContextError;
+use winnow::error::FromExternalError;
+use winnow::token::take_until;
+use winnow::token::take_while;
 
 /// A version script. See https://sourceware.org/binutils/docs/ld/VERSION.html
 #[derive(Default)]
@@ -55,6 +60,21 @@ impl<'data> MatchRules<'data> {
                 .iter()
                 .any(|prefix| name.bytes().starts_with(prefix))
     }
+
+    fn merge(&mut self, other: &MatchRules<'data>) {
+        if other.matches_all {
+            self.matches_all = true;
+        }
+
+        if self.matches_all {
+            self.exact.clear();
+            self.prefixes.clear();
+            return;
+        }
+
+        self.exact.extend(&other.exact);
+        self.prefixes.extend(&other.prefixes);
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -64,77 +84,88 @@ enum SymbolMatcher<'data> {
     Exact(&'data [u8]),
 }
 
+fn parse_version_script<'input>(input: &mut &'input BStr) -> winnow::Result<VersionScript<'input>> {
+    // List of version names in the script, used to map parent version to version indexes
+    let mut version_names: Vec<&[u8]> = Vec::new();
+
+    skip_comments_and_whitespace(input)?;
+
+    // Simple version script, only defines symbols visibility
+    if input.starts_with(b"{") {
+        let script = parse_version_section(input)?;
+
+        ";".parse_next(input)?;
+
+        skip_comments_and_whitespace(input)?;
+
+        return Ok(script);
+    }
+
+    let mut version_script = VersionScript::default();
+
+    // Base version placeholder
+    version_names.push(b"");
+    version_script.versions.push(Version {
+        name: b"",
+        symbols: MatchRules::default(),
+        parent_index: None,
+    });
+
+    while !input.is_empty() {
+        let name = parse_token(input)?;
+
+        skip_comments_and_whitespace(input)?;
+
+        let version = parse_version_section(input)?;
+
+        let parent_name = take_until(0.., b';').parse_next(input)?;
+
+        let parent_index = if parent_name.is_empty() {
+            None
+        } else {
+            // We don't expect lots of versions, so a linear scan seems reasonable.
+            Some(
+                version_names
+                    .iter()
+                    .position(|v| v == &parent_name)
+                    .ok_or_else(|| {
+                        ContextError::from_external_error(
+                            input,
+                            VersionScriptError::UnknownParentVersion,
+                        )
+                    })? as u16,
+            )
+        };
+
+        ";".parse_next(input)?;
+
+        skip_comments_and_whitespace(input)?;
+
+        version_script.globals.merge(&version.globals);
+        version_script.locals.merge(&version.locals);
+
+        let mut version_symbols = MatchRules::default();
+        version_symbols.merge(&version.globals);
+        version_symbols.merge(&version.locals);
+
+        version_names.push(name);
+
+        version_script.versions.push(Version {
+            name,
+            parent_index,
+            symbols: version_symbols,
+        });
+    }
+
+    Ok(version_script)
+}
+
 impl<'data> VersionScript<'data> {
     #[tracing::instrument(skip_all, name = "Parse version script")]
     pub(crate) fn parse(data: VersionScriptData<'data>) -> Result<VersionScript<'data>> {
-        let mut tokens = Tokeniser::new(data.raw);
-        let mut version_script = Self::default();
-
-        // List of version names in the script, used to map parent version to version indexes
-        let mut version_names: Vec<&[u8]> = Vec::new();
-
-        tokens.text = trim(tokens.text);
-
-        let mut token = tokens.next().ok_or_else(|| anyhow!("No tokens found"))?;
-        // Simple version script, only defines symbols visibility
-        if token.starts_with(b"{") {
-            parse_version_section(
-                &mut tokens,
-                &mut version_script.locals,
-                &mut version_script.globals,
-                None,
-            )?;
-            return Ok(version_script);
-        }
-
-        // Base version placeholder
-        version_names.push(b"");
-        version_script.versions.push(Version {
-            name: b"",
-            symbols: MatchRules::default(),
-            parent_index: None,
-        });
-
-        loop {
-            tokens.expect(b"{")?;
-            version_names.push(token);
-
-            let mut version_symbols = MatchRules::default();
-            let parent = parse_version_section(
-                &mut tokens,
-                &mut version_script.locals,
-                &mut version_script.globals,
-                Some(&mut version_symbols),
-            )?;
-            let parent_index = if let Some(parent) = parent {
-                // TODO: For longer version scripts IndexSet makes sense, but is it even realistic use case?
-                Some(
-                    version_names
-                        .iter()
-                        .position(|v| v == &parent)
-                        .with_context(|| {
-                            format!("Could not find version {}", String::from_utf8_lossy(parent))
-                        })? as u16,
-                )
-            } else {
-                None
-            };
-
-            version_script.versions.push(Version {
-                name: token,
-                parent_index,
-                symbols: version_symbols,
-            });
-
-            // Next version for the symbols
-            if let Some(next_token) = tokens.next() {
-                token = next_token;
-            } else {
-                break;
-            };
-        }
-
-        Ok(version_script)
+        parse_version_script
+            .parse(BStr::new(data.raw))
+            .map_err(|err| anyhow!("Failed to parse version script:\n{err}",))
     }
 
     pub(crate) fn is_local(&self, name: &PreHashed<UnversionedSymbolName>) -> bool {
@@ -171,90 +202,48 @@ impl<'data> VersionScript<'data> {
     }
 }
 
-fn trim(text: &[u8]) -> &[u8] {
-    trim_start(trim_end(text))
-}
-
-const WHITESPACE: &[u8] = b" \n\r\t";
-
-fn trim_start(text: &[u8]) -> &[u8] {
-    if let Some(pos) = text.iter().position(|b| !WHITESPACE.contains(b)) {
-        return &text[pos..];
-    }
-    text
-}
-
-fn trim_end(text: &[u8]) -> &[u8] {
-    if let Some(pos) = text.iter().rev().position(|b| !WHITESPACE.contains(b)) {
-        return &text[..text.len() - pos];
-    }
-    text
-}
-
 enum VersionRuleSection {
     Global,
     Local,
 }
 
-/// Parses contents after opening brace up to closing brace, adding symbols to the respective rules.
-/// Returns contents after closing brace if any.
-fn parse_version_section<'data>(
-    tokens: &mut Tokeniser<'data>,
-    locals: &mut MatchRules<'data>,
-    globals: &mut MatchRules<'data>,
-    mut versioned_symbols: Option<&mut MatchRules<'data>>,
-) -> Result<Option<&'data [u8]>> {
+fn parse_version_section<'data>(input: &mut &'data BStr) -> winnow::Result<VersionScript<'data>> {
     let mut section = None;
 
-    // We read line-by-line rather than token-by-token because it's much faster. This is
-    // important when for example rustc emits a version script that's more than 300k lines.
-    while let Some(line) = tokens.next_line() {
-        let mut line = trim(line);
-        if let Some(parent_string) = line.strip_prefix(b"}") {
-            if parent_string.starts_with(b";") {
-                return Ok(None);
-            }
-            return Ok(trim(parent_string).strip_suffix(b";"));
-        }
-        // Note, we don't currently support comments that have content after them on the same
-        // line. Doing so would require us to search every line for embedded comments, which
-        // would hurt performance.
-        if line.ends_with(b"*/") {
-            if let Some(start_index) = line.windows(2).position(|w| w == b"/*") {
-                line = trim(&line[..start_index]);
-            }
+    let mut out = VersionScript::default();
+
+    '{'.parse_next(input)?;
+
+    loop {
+        skip_comments_and_whitespace(input)?;
+
+        if input.starts_with(b"}") {
+            '}'.parse_next(input)?;
+            skip_comments_and_whitespace(input)?;
+            break;
         }
 
-        if line.starts_with(b"/*") {
-            while let Some(line) = tokens.next_line() {
-                if line.ends_with(b"*/") {
-                    break;
-                }
-            }
-        } else if line == b"global:" {
+        if input.starts_with(b"global:") {
+            "global:".parse_next(input)?;
             section = Some(VersionRuleSection::Global);
-        } else if line == b"local:" {
+        } else if input.starts_with(b"local:") {
+            "local:".parse_next(input)?;
             section = Some(VersionRuleSection::Local);
-        } else if let Some(pattern) = line.strip_suffix(b";") {
+        } else {
+            let matcher = parse_matcher(input)?;
+
             match section {
                 Some(VersionRuleSection::Global) | None => {
-                    globals.push(SymbolMatcher::from_pattern(pattern)?);
+                    out.globals.push(matcher);
                 }
                 Some(VersionRuleSection::Local) => {
-                    locals.push(SymbolMatcher::from_pattern(pattern)?);
+                    out.locals.push(matcher);
                 }
             }
-            if let Some(versioned_symbols) = versioned_symbols.as_deref_mut() {
-                versioned_symbols.push(SymbolMatcher::from_pattern(pattern)?);
-            }
-        } else if !line.is_empty() {
-            bail!(
-                "Unsupported version script line `{}`",
-                String::from_utf8_lossy(line)
-            );
         }
     }
-    bail!("Missing close '}}' in version script");
+
+    Ok(out)
 }
 
 impl Version<'_> {
@@ -263,123 +252,68 @@ impl Version<'_> {
     }
 }
 
-impl<'data> SymbolMatcher<'data> {
-    fn from_pattern(token: &'data [u8]) -> Result<SymbolMatcher<'data>> {
-        if token == b"*" {
-            return Ok(SymbolMatcher::All);
+fn parse_matcher<'data>(input: &mut &'data BStr) -> winnow::Result<SymbolMatcher<'data>> {
+    let token = take_until(1.., b';').parse_next(input)?;
+
+    skip_comments_and_whitespace(input)?;
+
+    if input.starts_with(b";") {
+        ";".parse_next(input)?;
+    }
+
+    if token == b"*" {
+        return Ok(SymbolMatcher::All);
+    }
+
+    if let Some(prefix) = token.strip_suffix(b"*") {
+        if prefix.contains(&b'*') {
+            return Err(ContextError::new());
         }
-        if let Some(prefix) = token.strip_suffix(b"*") {
-            if prefix.contains(&b'*') {
-                bail!(
-                    "Unsupported symbol pattern '{}'",
-                    String::from_utf8_lossy(token)
-                );
-            }
-            return Ok(SymbolMatcher::Prefix(prefix));
-        }
-        if token.contains(&b'*') {
-            bail!(
-                "Unsupported symbol pattern '{}'",
-                String::from_utf8_lossy(token)
-            );
-        }
-        Ok(SymbolMatcher::Exact(token))
+        return Ok(SymbolMatcher::Prefix(prefix));
+    }
+
+    if token.contains(&b'*') {
+        return Err(ContextError::new());
+    }
+
+    Ok(SymbolMatcher::Exact(token))
+}
+
+fn parse_token<'input>(input: &mut &'input BStr) -> winnow::Result<&'input [u8]> {
+    take_while(1.., |b| !b" (){}\n\t".contains(&b)).parse_next(input)
+}
+
+#[derive(Debug)]
+enum VersionScriptError {
+    UnknownParentVersion,
+}
+
+impl std::error::Error for VersionScriptError {}
+
+impl std::fmt::Display for VersionScriptError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Unknown parent version")
     }
 }
 
-struct Tokeniser<'a> {
-    text: &'a [u8],
-}
-
-impl<'a> Tokeniser<'a> {
-    fn next(&mut self) -> Option<&'a [u8]> {
-        loop {
-            self.text = trim_start(self.text);
-            if try_take(&mut self.text, b"/*") {
-                if take_up_to(&mut self.text, b"*/").is_err() {
-                    self.text = b"";
-                }
-                continue;
-            }
-            if self.text.starts_with(b"#") {
-                if take_up_to(&mut self.text, b"\n").is_err() {
-                    self.text = b"";
-                }
-                continue;
-            }
-            if self.text.is_empty() {
-                return None;
-            }
-            let bytes = self.text;
-            let mut len = 0;
-            for byte in bytes {
-                if b" \n\t(){};".contains(byte) {
-                    break;
-                }
-                len += 1;
-            }
-            if len == 0 {
-                len = 1;
-            }
-            let token = &self.text[..len];
-            self.text = &self.text[len..];
-            return Some(token);
-        }
-    }
-
-    fn next_line(&mut self) -> Option<&'a [u8]> {
-        while let Some(rest) = self.text.strip_prefix(b"\n") {
-            self.text = rest;
-        }
-        if self.text.is_empty() {
-            return None;
-        }
-        let bytes = self.text;
-        let end_pos = memchr::memchr(b'\n', bytes).unwrap_or(bytes.len());
-        let (line, rest) = self.text.split_at(end_pos);
-        self.text = rest;
-        Some(line)
-    }
-
-    fn new(text: &'a [u8]) -> Self {
-        Tokeniser { text }
-    }
-
-    fn expect(&mut self, expected: &[u8]) -> Result {
-        let token = self.next().ok_or_else(|| {
-            anyhow!(
-                "Expected token '{}', got end of input",
-                String::from_utf8_lossy(expected)
-            )
-        })?;
-        if token != expected {
-            bail!(
-                "Expected token '{}', got '{}'",
-                String::from_utf8_lossy(expected),
-                String::from_utf8_lossy(token)
-            );
-        }
-        Ok(())
+impl std::fmt::Debug for Version<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Version")
+            .field("name", &String::from_utf8_lossy(self.name))
+            .field("parent_index", &self.parent_index)
+            .field("symbols", &self.symbols)
+            .finish()
     }
 }
 
-fn try_take(input: &mut &[u8], pattern: &[u8]) -> bool {
-    if let Some(rest) = input.strip_prefix(pattern) {
-        *input = rest;
-        true
-    } else {
-        false
+impl std::fmt::Debug for MatchRules<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MatchRules")
+            .field("matches_all", &self.matches_all)
+            .field("exact", &self.exact)
+            .field("prefixes", &self.prefixes)
+            .finish()
     }
-}
-
-fn take_up_to<'a>(input: &mut &'a [u8], pattern: &[u8]) -> Result<&'a [u8]> {
-    let end = input
-        .windows(pattern.len())
-        .position(|w| w == pattern)
-        .ok_or_else(|| anyhow!("Missing expected '{}'", String::from_utf8_lossy(pattern)))?;
-    let content = &input[..end];
-    *input = &input[end + pattern.len()..];
-    Ok(content)
 }
 
 #[cfg(test)]
@@ -387,26 +321,6 @@ mod tests {
     use super::*;
     use itertools::Itertools;
     use itertools::assert_equal;
-
-    #[test]
-    fn test_tokenisation() {
-        fn tokenise(text: &str) -> Vec<&str> {
-            let mut t = Tokeniser::new(text.as_bytes());
-            let mut out = Vec::new();
-            while let Some(token) = t.next() {
-                assert!(!token.is_empty());
-                out.push(std::str::from_utf8(token).unwrap());
-            }
-            out
-        }
-
-        assert_eq!(tokenise("/**/ /* a */ GROUP ()"), vec!["GROUP", "(", ")"]);
-        assert_eq!(
-            tokenise("GROUP ( AS_NEEDED ( /a/b/c ))"),
-            vec!["GROUP", "(", "AS_NEEDED", "(", "/a/b/c", ")", ")"]
-        );
-        assert_eq!(tokenise(""), Vec::<&str>::new());
-    }
 
     #[test]
     fn test_parse_simple_version_script() {
@@ -421,7 +335,7 @@ mod tests {
                         /* Multi-line
                            comment */
                         *;
-                    }"#,
+                    };"#,
         };
         let script = VersionScript::parse(data).unwrap();
         assert_equal(
@@ -510,5 +424,37 @@ mod tests {
                 .map(|s| std::str::from_utf8(s.bytes()).unwrap()),
             ["foo2"],
         );
+    }
+
+    #[test]
+    fn single_line_version_script() {
+        let data = VersionScriptData {
+            raw: br#"VERSION42 { global: *; };"#,
+        };
+        let script = VersionScript::parse(data).unwrap();
+        assert!(script.globals.matches_all);
+    }
+
+    #[test]
+    fn invalid_version_scripts() {
+        #[track_caller]
+        fn assert_invalid(src: &str) {
+            let data = VersionScriptData {
+                raw: src.as_bytes(),
+            };
+            assert!(VersionScript::parse(data).is_err());
+        }
+
+        // Missing ';'
+        assert_invalid("{}");
+        assert_invalid("{*};");
+        assert_invalid("{foo};");
+
+        // Missing '}'
+        assert_invalid("{foo;");
+        assert_invalid("VER1 {foo;}; VER2 {bar;} VER1");
+
+        // Missing parent version
+        assert_invalid("VER2 {bar;} VER1;");
     }
 }


### PR DESCRIPTION
Two separate commits. The change to bytes for parsing speeds up parsing by about 7%. The change to winnow seems to be performance neutral., This fixes parsing of version scripts on a single line. #729