### PR TITLE
linker-diff: Detect differences between program segments

### DIFF
--- a/libwild/src/alignment.rs
+++ b/libwild/src/alignment.rs
@@ -45,6 +45,9 @@ pub(crate) const EH_FRAME_HDR: Alignment = Alignment { exponent: 2 };
 pub(crate) const NOTE_GNU_PROPERTY: Alignment = Alignment { exponent: 3 };
 pub(crate) const NOTE_GNU_BUILD_ID: Alignment = Alignment { exponent: 2 };
 
+// GNU_STACK.alignment
+pub(crate) const STACK_ALIGNMENT: Alignment = Alignment { exponent: 4 };
+
 impl Alignment {
     pub(crate) fn new(raw: u64) -> Result<Self> {
         if !raw.is_power_of_two() {

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -614,6 +614,8 @@ fn write_program_headers(program_headers_out: &mut ProgramHeaderWriter, layout: 
 
         if layout.program_segments.is_load_segment(segment_id) {
             alignment = alignment.max(layout.args().loadable_segment_alignment());
+        } else if layout.program_segments.is_stack_segment(segment_id) {
+            alignment = alignment::STACK_ALIGNMENT;
         }
 
         let e = LittleEndian;

--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -43,6 +43,7 @@ mod gnu_hash;
 mod header_diff;
 mod init_order;
 pub(crate) mod section_map;
+mod segment;
 mod symbol_diff;
 mod symtab;
 mod trace;
@@ -570,6 +571,7 @@ impl Report {
         version_diff::report_diffs(self, objects);
         debug_info_diff::check_debug_info(self, objects);
         symbol_diff::report_diffs(self, objects);
+        segment::report_diffs(self, objects);
 
         match arch {
             ArchKind::X86_64 => {

--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -235,6 +235,8 @@ impl Config {
                 // If we don't optimise a TLS access, then we'll have references to __tls_get_addr,
                 // when GNU ld doesn't.
                 "dynsym.__tls_get_addr.*",
+                // temporary
+                "segment.LOAD.*",
             ]
             .into_iter()
             .map(ToOwned::to_owned),

--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -235,8 +235,8 @@ impl Config {
                 // If we don't optimise a TLS access, then we'll have references to __tls_get_addr,
                 // when GNU ld doesn't.
                 "dynsym.__tls_get_addr.*",
-                // temporary
-                "segment.LOAD.*",
+                // GNU ld emits two segments, whereas wild emits only a single segment.
+                "segment.LOAD.R.*",
             ]
             .into_iter()
             .map(ToOwned::to_owned),

--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -237,6 +237,13 @@ impl Config {
                 "dynsym.__tls_get_addr.*",
                 // GNU ld emits two segments, whereas wild emits only a single segment.
                 "segment.LOAD.R.*",
+                // We haven't provided an implementation that is compatible with existing linkers.
+                "segment.PT_NOTE.*",
+                "segment.PT_INTERP.*",
+                "segment.PT_PHDR.*",
+                "segment.PT_GNU_RELRO.*",
+                "segment.PT_GNU_STACK.*",
+                "segment.PT_GNU_PROPERTY.*",
             ]
             .into_iter()
             .map(ToOwned::to_owned),

--- a/linker-diff/src/segment.rs
+++ b/linker-diff/src/segment.rs
@@ -1,0 +1,55 @@
+use crate::header_diff::Converter;
+use crate::header_diff::DiffMode;
+use crate::header_diff::FieldValues;
+use anyhow::Ok;
+use anyhow::Result;
+use object::LittleEndian;
+use object::elf::PT_GNU_STACK;
+use object::elf::PT_LOAD;
+use object::read::elf::ProgramHeader as _;
+
+pub(crate) fn report_diffs(report: &mut crate::Report, objects: &[crate::Binary]) {
+    report.add_diffs(crate::header_diff::diff_fields(
+        objects,
+        read_program_segment_fields,
+        "segment",
+        DiffMode::Normal,
+    ));
+}
+
+#[allow(clippy::unnecessary_wraps)]
+fn read_program_segment_fields(object: &crate::Binary) -> Result<FieldValues> {
+    let e = LittleEndian;
+    let mut values = FieldValues::default();
+
+    for segment in object.elf_file.elf_program_headers() {
+        let p_type = segment.p_type(e);
+        let p_flags = segment.p_flags(e);
+        let p_align = segment.p_align(e);
+
+        match p_type {
+            PT_GNU_STACK => {
+                values.insert("GNU_STACK.alignment", p_align, Converter::None, object);
+                values.insert("GNU_STACK.flags", p_flags, Converter::None, object);
+            }
+            PT_LOAD => {
+                let mut flag_str = String::new();
+                if p_flags & 4 != 0 {
+                    flag_str.push('R');
+                }
+                if p_flags & 2 != 0 {
+                    flag_str.push('W');
+                }
+                if p_flags & 1 != 0 {
+                    flag_str.push('X');
+                }
+
+                let key = format!("LOAD.{flag_str}.alignment");
+                values.insert(key, p_align, Converter::None, object);
+            }
+            _ => {}
+        }
+    }
+
+    Ok(values)
+}

--- a/linker-diff/src/segment.rs
+++ b/linker-diff/src/segment.rs
@@ -3,8 +3,8 @@ use crate::header_diff::DiffMode;
 use crate::header_diff::FieldValues;
 use anyhow::Ok;
 use anyhow::Result;
+use linker_utils::elf::segment_type_to_string;
 use object::LittleEndian;
-use object::elf::PT_GNU_STACK;
 use object::elf::PT_LOAD;
 use object::read::elf::ProgramHeader as _;
 
@@ -27,27 +27,39 @@ fn read_program_segment_fields(object: &crate::Binary) -> Result<FieldValues> {
         let p_flags = segment.p_flags(e);
         let p_align = segment.p_align(e);
 
-        match p_type {
-            PT_GNU_STACK => {
-                values.insert("GNU_STACK.alignment", p_align, Converter::None, object);
-                values.insert("GNU_STACK.flags", p_flags, Converter::None, object);
+        if p_type == PT_LOAD {
+            let mut flag_str = String::new();
+            if p_flags & 4 != 0 {
+                flag_str.push('R');
             }
-            PT_LOAD => {
-                let mut flag_str = String::new();
-                if p_flags & 4 != 0 {
-                    flag_str.push('R');
-                }
-                if p_flags & 2 != 0 {
-                    flag_str.push('W');
-                }
-                if p_flags & 1 != 0 {
-                    flag_str.push('X');
-                }
+            if p_flags & 2 != 0 {
+                flag_str.push('W');
+            }
+            if p_flags & 1 != 0 {
+                flag_str.push('X');
+            }
 
-                let key = format!("LOAD.{flag_str}.alignment");
-                values.insert(key, p_align, Converter::None, object);
-            }
-            _ => {}
+            values.insert(
+                format!("LOAD.{flag_str}.alignment"),
+                p_align,
+                Converter::None,
+                object,
+            );
+        } else {
+            let type_str = segment_type_to_string(p_type);
+
+            values.insert(
+                format!("{type_str}.alignment"),
+                p_align,
+                Converter::None,
+                object,
+            );
+            values.insert(
+                format!("{type_str}.flags"),
+                p_flags,
+                Converter::None,
+                object,
+            );
         }
     }
 

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -209,6 +209,29 @@ pub fn aarch64_rel_type_to_string(r_type: u32) -> Cow<'static, str> {
     }
 }
 
+#[must_use]
+pub fn segment_type_to_string(p_type: u32) -> Cow<'static, str> {
+    if let Some(name) = const_name_by_value![
+        p_type,
+        PT_NULL,
+        PT_LOAD,
+        PT_DYNAMIC,
+        PT_INTERP,
+        PT_NOTE,
+        PT_SHLIB,
+        PT_PHDR,
+        PT_TLS,
+        PT_GNU_EH_FRAME,
+        PT_GNU_STACK,
+        PT_GNU_RELRO,
+        PT_GNU_PROPERTY
+    ] {
+        Cow::Borrowed(name)
+    } else {
+        Cow::Owned(format!("UNKNOWN_P_TYPE_{p_type}"))
+    }
+}
+
 /// Section flag bit values.
 pub mod shf {
     use super::SectionFlags;

--- a/wild/tests/sources/archive_activation.c
+++ b/wild/tests/sources/archive_activation.c
@@ -23,6 +23,7 @@
 //#Object:archive_activation1.c
 //#Object:runtime.c
 //#Object:empty.a
+//#DiffIgnore:segment.GNU_STACK.alignment
 
 #include "runtime.h"
 

--- a/wild/tests/sources/basic-comdat.s
+++ b/wild/tests/sources/basic-comdat.s
@@ -3,6 +3,8 @@
 //#Static:false
 //#LinkArgs:-shared -z now
 //#DiffIgnore:section.got
+//#DiffIgnore:segment.GNU_STACK.alignment
+//#DiffIgnore:segment.GNU_STACK.flags
 
 .section .data.foo1,"awG",@progbits,foobar,comdat
 .globl foo1

--- a/wild/tests/sources/eh_frame.c
+++ b/wild/tests/sources/eh_frame.c
@@ -1,5 +1,6 @@
 //#Object:eh_frame_end.c
 //#Object:runtime.c
+//#DiffIgnore: segment.LOAD.RW.alignment
 
 #include <stdint.h>
 

--- a/wild/tests/sources/linker-script-executable.c
+++ b/wild/tests/sources/linker-script-executable.c
@@ -1,5 +1,6 @@
 //#LinkerScript:linker-script-executable.ld
 //#Object:runtime.c
+//#DiffIgnore: segment.LOAD.RW.alignment
 
 #include <stddef.h>
 

--- a/wild/tests/sources/no_start.c
+++ b/wild/tests/sources/no_start.c
@@ -3,6 +3,7 @@
 
 //#Config:no-gc:default
 //#LinkArgs:-z now --no-gc-sections
+//#DiffIgnore: segment.LOAD.RW.alignment
 
 // With --gc-sections enabled, all code gets eliminated and there's nothing to run. If we try to
 // execute this binary, it will segfault, so we don't.


### PR DESCRIPTION
close #721 

Modify linker-diff to detect differences in program segments. Also, update libwild to set `GNU_STACK.alignment` to `0x10`, consistent with GNU ld.