### PR TITLE
Update dependabot schedule and replace deprecated link checker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
   - package-ecosystem: cargo
     versioning-strategy: lockfile-only
     directory: /

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -15,4 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: umbrelladocs/action-linkspector@v1
+        with:
+          reporter: github-check
+          filter_mode: "nofilter"


### PR DESCRIPTION
Commits:
1. Set dependabot GitHub Actions update interval to weekly
Daily updates for `github-actions` via dependabot are likely unnecessary, so I changed the interval to weekly to align with `cargo`.

2. Replace `github-action-markdown-link-check` with `action-linkspector`
`github-action-markdown-link-check` is deprecated and was producing [false positives for crates.io](https://github.com/davidlattimore/wild/actions/runs/14595234863). I tested the new workflow by temporarily modifying the trigger conditions in a forked repository: https://github.com/lapla-cogito/wild/actions/runs/14855707088/job/41708454860