### PR TITLE
Do not use DT_FLAGS on AArch64

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -5,6 +5,7 @@ use self::elf::TLS_MODULE_BASE_SYMBOL_NAME;
 use self::elf::get_page_mask;
 use crate::alignment;
 use crate::arch::Arch;
+use crate::arch::Architecture;
 use crate::arch::Relaxation as _;
 use crate::args::Args;
 use crate::args::BuildIdOption;
@@ -3160,13 +3161,18 @@ const EPILOGUE_DYNAMIC_ENTRY_WRITERS: &[DynamicEntryWriter] = &[
     }),
     DynamicEntryWriter::optional(
         object::elf::DT_FLAGS,
-        |inputs| inputs.dt_flags() != 0,
+        |inputs| inputs.args.arch != Architecture::AArch64 && inputs.dt_flags() != 0,
         |inputs| inputs.dt_flags(),
     ),
     DynamicEntryWriter::optional(
         object::elf::DT_FLAGS_1,
         |inputs| inputs.dt_flags_1() != 0,
         |inputs| inputs.dt_flags_1(),
+    ),
+    DynamicEntryWriter::optional(
+        object::elf::DT_BIND_NOW,
+        |inputs| inputs.args.arch == Architecture::AArch64,
+        |_| object::elf::DF_BIND_NOW.into(),
     ),
     DynamicEntryWriter::new(object::elf::DT_NULL, |_inputs| 0),
 ];

--- a/wild/tests/sources/trivial-dynamic.c
+++ b/wild/tests/sources/trivial-dynamic.c
@@ -15,6 +15,8 @@
 
 //#Config:origin:default
 //#LinkArgs:-z now -z origin
+// Some versions of GNU ld don't use the DT_FLAGS at all and rely on DT_FLAGS_1 and tags.
+//#DiffIgnore:.dynamic.DT_FLAGS.ORIGIN
 
 #include "runtime.h"
 


### PR DESCRIPTION
Noticed this failure on Arch Linux:
```
        FAIL [   1.084s] wild-linker::integration_tests integration_test::program_name_03___trivial_dynamic_c__
  stdout ───

    running 1 test
    test integration_test::program_name_03___trivial_dynamic_c__ ... FAILED

    failures:

    failures:
        integration_test::program_name_03___trivial_dynamic_c__

    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 54 filtered out; finished in 1.08s

  stderr ───
    wild: /home/mateusz/Projects/wild/wild/tests/build/trivial-dynamic-2.origin-aarch64-95c5e1d372e8340b.wild.so
    ld: /home/mateusz/Projects/wild/wild/tests/build/trivial-dynamic-2.origin-aarch64-95c5e1d372e8340b.ld.so
    .dynamic.DT_FLAGS.ORIGIN
      wild 1
      ld


    Error: Validation failed.
    cargo run --bin wild -- -m aarch64elf -dynamic-linker /lib/ld-linux-aarch64.so.1 --gc-sections -z now -z origin -z now -shared -o /home/mateusz/Projects/wild/wild/tests/build/trivial-dynamic-2.origin-aarch64-95c5e1d372e8340b.wild.so /home/mateusz/Projects/wild/wild/tests/build/trivial-dynamic-2.origin-aarch64-95c5e1d372e8340b.o --validate-output --write-layout --write-trace
     To revalidate:
    cargo run --bin linker-diff -- --wild-defaults --ignore '.dynamic.DT_NEEDED,.dynamic.DT_RELA,.dynamic.DT_RELAENT,section.got' --ref /home/mateusz/Projects/wild/wild/tests/build/trivial-dynamic-2.origin-aarch64-95c5e1d372e8340b.ld.so /home/mateusz/Projects/wild/wild/tests/build/trivial-dynamic-2.origin-aarch64-95c5e1d372e8340b.wild.so
```

Readelf confirms that:
```
❯ readelf -d /home/mateusz/Projects/wild/wild/tests/build/trivial-dynamic-2.origin-aarch64-95c5e1d372e8340b.wild.so

Dynamic section at offset 0x628 contains 10 entries:
  Tag        Type                         Name/Value
 0x0000000000000005 (STRTAB)             0x5f0
 0x000000000000000a (STRSZ)              5 (bytes)
 0x0000000000000006 (SYMTAB)             0x5c0
 0x000000000000000b (SYMENT)             24 (bytes)
 0x0000000000000003 (PLTGOT)             0x207e8
 0x000000006ffffff9 (RELACOUNT)          0
 0x000000006ffffef5 (GNU_HASH)           0x5a0
 0x000000000000001e (FLAGS)              ORIGIN BIND_NOW
 0x000000006ffffffb (FLAGS_1)            Flags: NOW ORIGIN
 0x0000000000000000 (NULL)               0x0

❯ readelf -d /home/mateusz/Projects/wild/wild/tests/build/trivial-dynamic-2.origin-aarch64-95c5e1d372e8340b.ld.so

Dynamic section at offset 0x1e8 contains 9 entries:
  Tag        Type                         Name/Value
 0x0000000000000004 (HASH)               0x120
 0x000000006ffffef5 (GNU_HASH)           0x138
 0x0000000000000005 (STRTAB)             0x1a8
 0x0000000000000006 (SYMTAB)             0x160
 0x000000000000000a (STRSZ)              12 (bytes)
 0x000000000000000b (SYMENT)             24 (bytes)
 0x0000000000000018 (BIND_NOW)
 0x000000006ffffffb (FLAGS_1)            Flags: NOW ORIGIN
 0x0000000000000000 (NULL)               0x0
```