### PR TITLE
save-dir: Replicate original directory structure

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -74,6 +74,7 @@ pub struct Args {
 
     pub(crate) verbose_gc_stats: bool,
 
+    pub(crate) save_dir: SaveDir,
     pub(crate) print_allocations: Option<FileId>,
     pub(crate) execstack: bool,
     pub(crate) verify_allocation_consistency: bool,
@@ -279,6 +280,7 @@ impl Default for Args {
             no_undefined: false,
             should_print_version: false,
             sysroot: None,
+            save_dir: Default::default(),
             demangle: true,
             undefined: Vec::new(),
             relro: true,
@@ -300,7 +302,7 @@ pub(crate) fn parse<F: Fn() -> I, S: AsRef<str>, I: Iterator<Item = S>>(input: F
 
     let mut unrecognised = Vec::new();
 
-    let mut save_dir = SaveDir::new(&input)?;
+    args.save_dir = SaveDir::new(&input)?;
 
     let mut input = input();
 
@@ -357,14 +359,18 @@ pub(crate) fn parse<F: Fn() -> I, S: AsRef<str>, I: Iterator<Item = S>>(input: F
                     .and_then(|sysroot| maybe_forced_sysroot(path, sysroot))
                     .unwrap_or_else(|| Box::from(path))
             };
-            if rest.is_empty() {
-                if let Some(next) = input.next() {
-                    args.lib_search_path
-                        .push(handle_sysroot(Path::new(next.as_ref())));
-                }
+
+            let dir = if rest.is_empty() {
+                handle_sysroot(Path::new(
+                    input.next().context("Missing argument to -L")?.as_ref(),
+                ))
             } else {
-                args.lib_search_path.push(handle_sysroot(Path::new(rest)));
-            }
+                handle_sysroot(Path::new(rest))
+            };
+
+            args.save_dir.handle_file(rest)?;
+
+            args.lib_search_path.push(dir);
         } else if let Some(rest) = arg.strip_prefix("-l") {
             let spec = if let Some(stripped) = rest.strip_prefix(':') {
                 InputSpec::File(Box::from(Path::new(stripped)))
@@ -495,17 +501,17 @@ pub(crate) fn parse<F: Fn() -> I, S: AsRef<str>, I: Iterator<Item = S>>(input: F
                 .context("Missing argument to -version-script")?
                 .as_ref()
                 .to_owned();
-            save_dir.handle_file(&script)?;
+            args.save_dir.handle_file(&script)?;
             args.version_script_path = Some(PathBuf::from(script));
         } else if let Some(script) = long_arg_split_prefix("script=") {
-            save_dir.handle_file(script)?;
+            args.save_dir.handle_file(script)?;
             args.add_script(script);
         } else if arg == "-T" {
             let script = input.next().context("Missing argument to -T")?;
-            save_dir.handle_file(script.as_ref())?;
+            args.save_dir.handle_file(script.as_ref())?;
             args.add_script(script.as_ref());
         } else if let Some(script) = long_arg_split_prefix("version-script=") {
-            save_dir.handle_file(script)?;
+            args.save_dir.handle_file(script)?;
             args.version_script_path = Some(PathBuf::from(script));
         } else if long_arg_eq("rpath") {
             let value = input.next().context("Missing argument to -rpath")?;
@@ -591,7 +597,6 @@ pub(crate) fn parse<F: Fn() -> I, S: AsRef<str>, I: Iterator<Item = S>>(input: F
             if input.next().is_some() || arg_num > 1 {
                 bail!("Mixing of @{{filename}} and regular arguments isn't supported");
             }
-            save_dir.handle_file(path)?;
             return parse_from_argument_file(Path::new(path));
         } else if long_arg_eq("help") {
             bail!("Sorry, help isn't implemented yet");
@@ -617,7 +622,7 @@ pub(crate) fn parse<F: Fn() -> I, S: AsRef<str>, I: Iterator<Item = S>>(input: F
         } else if arg.starts_with('-') {
             unrecognised.push(format!("`{arg}`"));
         } else {
-            save_dir.handle_file(arg)?;
+            args.save_dir.handle_file(arg)?;
             args.inputs.push(Input {
                 spec: InputSpec::File(Box::from(Path::new(arg))),
                 search_first: None,
@@ -634,8 +639,6 @@ pub(crate) fn parse<F: Fn() -> I, S: AsRef<str>, I: Iterator<Item = S>>(input: F
     if args.output_kind() == OutputKind::SharedObject {
         args.allow_copy_relocations = false;
     }
-
-    save_dir.finish()?;
 
     Ok(args)
 }

--- a/libwild/src/input_data.rs
+++ b/libwild/src/input_data.rs
@@ -123,6 +123,8 @@ impl<'data> InputData<'data> {
             input_data.register_input(input, &mut temporary_state)?;
         }
 
+        args.save_dir.finish(&temporary_state.filenames)?;
+
         Ok((input_data, temporary_state.linker_scripts))
     }
 
@@ -300,13 +302,13 @@ impl Input {
         match &self.spec {
             InputSpec::File(p) => {
                 if self.search_first.is_some() || p.parent() == Some(Path::new("")) {
-                    if let Some(absolute) = search_for_file(
+                    if let Some(path) = search_for_file(
                         &args.lib_search_path,
                         self.search_first.as_ref(),
                         p.as_ref(),
                     ) {
                         return Ok(InputPath {
-                            absolute,
+                            absolute: std::path::absolute(path)?,
                             original: p.as_ref().to_owned(),
                         });
                     }
@@ -319,23 +321,23 @@ impl Input {
             InputSpec::Lib(lib_name) => {
                 if self.modifiers.allow_shared {
                     let filename = format!("lib{lib_name}.so");
-                    if let Some(absolute) = search_for_file(
+                    if let Some(path) = search_for_file(
                         &args.lib_search_path,
                         self.search_first.as_ref(),
                         &filename,
                     ) {
                         return Ok(InputPath {
-                            absolute,
+                            absolute: std::path::absolute(&path)?,
                             original: PathBuf::from(filename),
                         });
                     }
                 }
                 let filename = format!("lib{lib_name}.a");
-                if let Some(absolute) =
+                if let Some(path) =
                     search_for_file(&args.lib_search_path, self.search_first.as_ref(), &filename)
                 {
                     return Ok(InputPath {
-                        absolute,
+                        absolute: std::path::absolute(&path)?,
                         original: PathBuf::from(filename),
                     });
                 }


### PR DESCRIPTION
This makes it easier to see where files came from originally. It also makes it possible for things like sysroot, which relies on directory structure to work as expected.

We also now copy input files that aren't named by path on the command line. e.g. libraries that are named via -l.

Where files are obtained via symlinks, we copy those symlinks in addition to the file that they point to.