### PR TITLE
Support `-Bsymbolic`, `-Bsymbolic-non-weak`, `-Bsymbolic-non-weak-functions` and `-Bno-symbolic`

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -158,8 +158,7 @@ pub(crate) enum BSymbolicKind {
     All,
     Functions,
     NonWeakFunctions,
-    // TODO: Handle below cases
-    // NonWeak,
+    NonWeak,
 }
 
 pub const WILD_UNSUPPORTED_ENV: &str = "WILD_UNSUPPORTED";
@@ -205,7 +204,6 @@ const IGNORED_FLAGS: &[&str] = &[
     "fix-cortex-a53-835769",
     "fix-cortex-a53-843419",
     "no-export-dynamic",
-    "Bsymbolic-non-weak", // LLD specific
 ];
 
 // These flags map to the default behavior of the linker.
@@ -399,6 +397,8 @@ pub(crate) fn parse<F: Fn() -> I, S: AsRef<str>, I: Iterator<Item = S>>(input: F
             args.b_symbolic = BSymbolicKind::Functions;
         } else if long_arg_eq("Bsymbolic-non-weak-functions") {
             args.b_symbolic = BSymbolicKind::NonWeakFunctions;
+        } else if long_arg_eq("Bsymbolic-non-weak") {
+            args.b_symbolic = BSymbolicKind::NonWeak;
         } else if long_arg_eq("Bsymbolic") {
             args.b_symbolic = BSymbolicKind::All;
         } else if arg == "-o" {

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -86,6 +86,7 @@ pub struct Args {
     output_kind: Option<OutputKind>,
     is_dynamic_executable: bool,
     relocation_model: RelocationModel,
+    ignore_bsymbolic: bool,
 }
 
 #[derive(Debug)]
@@ -282,6 +283,7 @@ impl Default for Args {
             relro: true,
             entry: None,
             b_symbolic: BSymbolicKind::None,
+            ignore_bsymbolic: false,
         }
     }
 }
@@ -393,14 +395,17 @@ pub(crate) fn parse<F: Fn() -> I, S: AsRef<str>, I: Iterator<Item = S>>(input: F
             modifier_stack.last_mut().unwrap().allow_shared = false;
         } else if long_arg_eq("Bdynamic") {
             modifier_stack.last_mut().unwrap().allow_shared = true;
-        } else if long_arg_eq("Bsymbolic-functions") {
+        } else if long_arg_eq("Bsymbolic-functions") && !args.ignore_bsymbolic {
             args.b_symbolic = BSymbolicKind::Functions;
-        } else if long_arg_eq("Bsymbolic-non-weak-functions") {
+        } else if long_arg_eq("Bsymbolic-non-weak-functions") && !args.ignore_bsymbolic {
             args.b_symbolic = BSymbolicKind::NonWeakFunctions;
-        } else if long_arg_eq("Bsymbolic-non-weak") {
+        } else if long_arg_eq("Bsymbolic-non-weak") && !args.ignore_bsymbolic {
             args.b_symbolic = BSymbolicKind::NonWeak;
-        } else if long_arg_eq("Bsymbolic") {
+        } else if long_arg_eq("Bsymbolic") && !args.ignore_bsymbolic {
             args.b_symbolic = BSymbolicKind::All;
+        } else if long_arg_eq("Bno-symbolic") {
+            args.b_symbolic = BSymbolicKind::None;
+            args.ignore_bsymbolic = true;
         } else if arg == "-o" {
             args.output = input
                 .next()

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -155,10 +155,10 @@ pub(crate) enum InputSpec {
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) enum BSymbolicKind {
     None,
+    All,
     Functions,
     NonWeakFunctions,
     // TODO: Handle below cases
-    // All,
     // NonWeak,
 }
 
@@ -205,7 +205,6 @@ const IGNORED_FLAGS: &[&str] = &[
     "fix-cortex-a53-835769",
     "fix-cortex-a53-843419",
     "no-export-dynamic",
-    "Bsymbolic",
     "Bsymbolic-non-weak", // LLD specific
 ];
 
@@ -400,6 +399,8 @@ pub(crate) fn parse<F: Fn() -> I, S: AsRef<str>, I: Iterator<Item = S>>(input: F
             args.b_symbolic = BSymbolicKind::Functions;
         } else if long_arg_eq("Bsymbolic-non-weak-functions") {
             args.b_symbolic = BSymbolicKind::NonWeakFunctions;
+        } else if long_arg_eq("Bsymbolic") {
+            args.b_symbolic = BSymbolicKind::All;
         } else if arg == "-o" {
             args.output = input
                 .next()

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -86,7 +86,6 @@ pub struct Args {
     output_kind: Option<OutputKind>,
     is_dynamic_executable: bool,
     relocation_model: RelocationModel,
-    ignore_bsymbolic: bool,
 }
 
 #[derive(Debug)]
@@ -283,7 +282,6 @@ impl Default for Args {
             relro: true,
             entry: None,
             b_symbolic: BSymbolicKind::None,
-            ignore_bsymbolic: false,
         }
     }
 }
@@ -395,17 +393,16 @@ pub(crate) fn parse<F: Fn() -> I, S: AsRef<str>, I: Iterator<Item = S>>(input: F
             modifier_stack.last_mut().unwrap().allow_shared = false;
         } else if long_arg_eq("Bdynamic") {
             modifier_stack.last_mut().unwrap().allow_shared = true;
-        } else if long_arg_eq("Bsymbolic-functions") && !args.ignore_bsymbolic {
+        } else if long_arg_eq("Bsymbolic-functions") {
             args.b_symbolic = BSymbolicKind::Functions;
-        } else if long_arg_eq("Bsymbolic-non-weak-functions") && !args.ignore_bsymbolic {
+        } else if long_arg_eq("Bsymbolic-non-weak-functions") {
             args.b_symbolic = BSymbolicKind::NonWeakFunctions;
-        } else if long_arg_eq("Bsymbolic-non-weak") && !args.ignore_bsymbolic {
+        } else if long_arg_eq("Bsymbolic-non-weak") {
             args.b_symbolic = BSymbolicKind::NonWeak;
-        } else if long_arg_eq("Bsymbolic") && !args.ignore_bsymbolic {
+        } else if long_arg_eq("Bsymbolic") {
             args.b_symbolic = BSymbolicKind::All;
         } else if long_arg_eq("Bno-symbolic") {
             args.b_symbolic = BSymbolicKind::None;
-            args.ignore_bsymbolic = true;
         } else if arg == "-o" {
             args.output = input
                 .next()

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -156,10 +156,10 @@ pub(crate) enum InputSpec {
 pub(crate) enum BSymbolicKind {
     None,
     Functions,
+    NonWeakFunctions,
     // TODO: Handle below cases
     // All,
     // NonWeak,
-    // NonWeakFunctions,
 }
 
 pub const WILD_UNSUPPORTED_ENV: &str = "WILD_UNSUPPORTED";
@@ -206,8 +206,7 @@ const IGNORED_FLAGS: &[&str] = &[
     "fix-cortex-a53-843419",
     "no-export-dynamic",
     "Bsymbolic",
-    "Bsymbolic-non-weak-functions", // LLD specific
-    "Bsymbolic-non-weak",           // LLD specific
+    "Bsymbolic-non-weak", // LLD specific
 ];
 
 // These flags map to the default behavior of the linker.
@@ -399,6 +398,8 @@ pub(crate) fn parse<F: Fn() -> I, S: AsRef<str>, I: Iterator<Item = S>>(input: F
             modifier_stack.last_mut().unwrap().allow_shared = true;
         } else if long_arg_eq("Bsymbolic-functions") {
             args.b_symbolic = BSymbolicKind::Functions;
+        } else if long_arg_eq("Bsymbolic-non-weak-functions") {
+            args.b_symbolic = BSymbolicKind::NonWeakFunctions;
         } else if arg == "-o" {
             args.output = input
                 .next()

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -1029,6 +1029,7 @@ fn value_flags_from_elf_symbol(sym: &crate::elf::Symbol, args: &Args) -> ValueFl
         // Symbols defined in an executable cannot be interposed since the executable is always the
         // first place checked for a symbol by the dynamic loader.
         || (args.output_kind().is_executable() && !is_undefined)
+        || args.b_symbolic == args::BSymbolicKind::All
         // `-Bsymbolic-functions`
         || (
             args.b_symbolic == args::BSymbolicKind::Functions

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -1033,6 +1033,12 @@ fn value_flags_from_elf_symbol(sym: &crate::elf::Symbol, args: &Args) -> ValueFl
         || (
             args.b_symbolic == args::BSymbolicKind::Functions
             && sym.st_type() == object::elf::STT_FUNC
+        )
+        // `-Bsymbolic-non-weak-functions`
+        || (
+            args.b_symbolic == args::BSymbolicKind::NonWeakFunctions
+            && (sym.st_type() == object::elf::STT_FUNC
+            && sym.st_bind() != object::elf::STB_WEAK)
         );
 
     let mut flags: ValueFlags = if sym.is_absolute(LittleEndian) {

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -1035,6 +1035,11 @@ fn value_flags_from_elf_symbol(sym: &crate::elf::Symbol, args: &Args) -> ValueFl
             args.b_symbolic == args::BSymbolicKind::Functions
             && sym.st_type() == object::elf::STT_FUNC
         )
+        // `-Bsymbolic-non-weak`
+        || (
+            args.b_symbolic == args::BSymbolicKind::NonWeak
+            && sym.st_bind() != object::elf::STB_WEAK
+        )
         // `-Bsymbolic-non-weak-functions`
         || (
             args.b_symbolic == args::BSymbolicKind::NonWeakFunctions

--- a/wild/tests/sources/shared-s1.c
+++ b/wild/tests/sources/shared-s1.c
@@ -7,3 +7,6 @@ int call_baz(void) {
 int bar2(void) {
     return 2;
 }
+
+__attribute__((weak)) int foo1 = 3;
+__attribute__((weak)) int get_foo() { return 4; }

--- a/wild/tests/sources/shared.c
+++ b/wild/tests/sources/shared.c
@@ -8,14 +8,37 @@
 //#RunEnabled:false
 //#LinkArgs:-shared -z now
 //#Static:false
+// TODO: https://rust-lang.zulipchat.com/#narrow/channel/421156-gsoc/topic/Project.3A.20Improve.20Wild.20linker.20test.20suites/near/521482968
+//#Cross:false
 //#Archive:shared-a1.c,shared-a2.c
 //#Shared:shared-s1.c
 //#DiffIgnore:.dynamic.DT_RELA
 //#DiffIgnore:.dynamic.DT_RELAENT
 //#DiffIgnore:.dynamic.DT_NEEDED
 
+//#Config:symbolic:default
+//#LinkArgs:-shared -z now -Bsymbolic
+//#DiffIgnore:.dynamic.DT_FLAGS.SYMBOLIC
+//#DiffIgnore:.dynamic.DT_SYMBOLIC
+//#DiffIgnore:section.got
+//#DiffIgnore:rel.R_X86_64_PC32.R_X86_64_PLT32
+//#DiffIgnore:rel.extra-opt.R_AARCH64_CALL26.ReplaceWithNop.invalid-shared-object
+
 //#Config:symbolic-functions:default
 //#LinkArgs:-shared -z now -Bsymbolic-functions
+
+//#Config:nosymbolic:default
+//#LinkArgs:-shared -z now -Bno-symbolic
+
+//TODO: Add a test for `-Bsymbolic-non-weak`. Currently, adding such tests causes linker-diff to panic.
+
+//#Config:symbolic-non-weak-functions:default
+//#LinkArgs:-shared -z now -Bsymbolic-non-weak-functions
+//#SkipLinker:ld
+//#EnableLinker:lld
+//#DiffIgnore:section.relro_padding
+//#DiffIgnore:section.got.plt.entsize
+//#DiffIgnore:dynsym.baz.section
 
 int bar1(void);
 int bar2(void);


### PR DESCRIPTION
Since we previously added support for `-Bsymbolic-functions`, we could similarly support these options using the same approach.