### PR TITLE
Refactor how internal symbols are stored

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -31,7 +31,6 @@ use std::sync::atomic::Ordering;
 /// up file and memory offsets.
 pub const NON_PIE_START_MEM_ADDRESS: u64 = 0x400_000;
 
-pub(crate) const TLS_MODULE_BASE_SYMBOL_NAME: &str = "_TLS_MODULE_BASE_";
 pub(crate) const GLOBAL_POINTER_SYMBOL_NAME: &str = "__global_pointer$";
 
 pub(crate) type FileHeader = object::elf::FileHeader64<LittleEndian>;

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -15,11 +15,9 @@
 //! related to `part_id.rs` and insert later in `SECTION_DEFINITIONS` (probably at the end). Also,
 //! update `NUM_BUILT_IN_REGULAR_SECTIONS`.
 
-use self::elf::TLS_MODULE_BASE_SYMBOL_NAME;
 use crate::alignment;
 use crate::alignment::Alignment;
 use crate::alignment::NUM_ALIGNMENTS;
-use crate::args::OutputKind;
 use crate::elf;
 use crate::elf::DynamicEntry;
 use crate::elf::GLOBAL_POINTER_SYMBOL_NAME;
@@ -370,8 +368,8 @@ pub(crate) struct BuiltInSectionDetails {
     pub(crate) section_flags: SectionFlags,
     /// Sections to try to link to. The first section that we're outputting is the one used.
     pub(crate) link: &'static [OutputSectionId],
-    start_symbol_name: Option<&'static str>,
-    end_symbol_name: Option<&'static str>,
+    pub(crate) start_symbol_name: Option<&'static str>,
+    pub(crate) end_symbol_name: Option<&'static str>,
     pub(crate) min_alignment: Alignment,
     info_fn: Option<fn(&InfoInputs) -> u32>,
     pub(crate) keep_if_empty: bool,
@@ -379,28 +377,6 @@ pub(crate) struct BuiltInSectionDetails {
     pub(crate) ty: SectionType,
     is_relro: bool,
     target_segment_type: Option<SegmentType>,
-}
-
-impl BuiltInSectionDetails {
-    pub(crate) fn start_symbol_name(&self, output_kind: OutputKind) -> Option<&'static str> {
-        if self.start_symbol_name == Some(TLS_MODULE_BASE_SYMBOL_NAME)
-            && output_kind != OutputKind::SharedObject
-        {
-            None
-        } else {
-            self.start_symbol_name
-        }
-    }
-
-    pub(crate) fn end_symbol_name(&self, output_kind: OutputKind) -> Option<&'static str> {
-        if self.end_symbol_name == Some(TLS_MODULE_BASE_SYMBOL_NAME)
-            && output_kind == OutputKind::SharedObject
-        {
-            None
-        } else {
-            self.end_symbol_name
-        }
-    }
 }
 
 const DEFAULT_DEFS: BuiltInSectionDetails = BuiltInSectionDetails {
@@ -675,15 +651,12 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = [
         kind: SectionKind::Primary(SectionName(TDATA_SECTION_NAME)),
         ty: sht::PROGBITS,
         section_flags: shf::WRITE.with(shf::ALLOC).with(shf::TLS),
-        // The symbol is defined twice, but later on we make a filtering based on the output type!
-        start_symbol_name: Some(TLS_MODULE_BASE_SYMBOL_NAME),
         ..DEFAULT_DEFS
     },
     BuiltInSectionDetails {
         kind: SectionKind::Primary(SectionName(TBSS_SECTION_NAME)),
         ty: sht::NOBITS,
         section_flags: shf::WRITE.with(shf::ALLOC).with(shf::TLS),
-        end_symbol_name: Some(TLS_MODULE_BASE_SYMBOL_NAME),
         ..DEFAULT_DEFS
     },
     BuiltInSectionDetails {


### PR DESCRIPTION
This refactoring mostly affects _TLS_MODULE_BASE_, but also changes how other internal symbols and how --undefined= is handled.

Fixes #773