### PR TITLE
RISC-V: fix debug info relocations

### DIFF
--- a/libwild/src/aarch64.rs
+++ b/libwild/src/aarch64.rs
@@ -83,6 +83,10 @@ impl crate::arch::Arch for AArch64 {
         );
         Ok(())
     }
+
+    fn local_symbols_in_debug_info() -> bool {
+        false
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/libwild/src/arch.rs
+++ b/libwild/src/arch.rs
@@ -36,6 +36,9 @@ pub(crate) trait Arch {
     fn get_dtv_offset() -> u64 {
         0
     }
+
+    // Some architectures use debug info relocation that depend on local symbols.
+    fn local_symbols_in_debug_info() -> bool;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2470,6 +2470,7 @@ fn apply_debug_relocation<A: Arch>(
     let value = if let Some(resolution) = resolution {
         match rel_info.kind {
             RelocationKind::Absolute
+            | RelocationKind::AbsoluteSet
             | RelocationKind::AbsoluteSetWord6
             | RelocationKind::AbsoluteAddition
             | RelocationKind::AbsoluteSubtraction

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2043,7 +2043,6 @@ fn get_pair_subtraction_relocation_value<'a, A: Arch>(
     layout: &Layout,
     resolution: Resolution,
     symbol_index: SymbolIndex,
-    local_symbol_id: SymbolId,
     addend: i64,
     mut relocations_to_search: impl Iterator<Item = &'a elf::Rela>,
 ) -> Result<u64> {
@@ -2059,8 +2058,7 @@ fn get_pair_subtraction_relocation_value<'a, A: Arch>(
         set_rel.r_type(LittleEndian, false) == object::elf::R_RISCV_SET_ULEB128,
         "R_RISCV_SET_ULEB128 must be the previous relocation"
     );
-    let (set_resolution, set_symbol_index, set_local_symbol_id) =
-        get_resolution(set_rel, object_layout, layout)?;
+    let (set_resolution, set_symbol_index, _) = get_resolution(set_rel, object_layout, layout)?;
 
     let set_resolution_val = set_resolution.value_with_addend(
         set_rel.r_addend.get(e),
@@ -2076,18 +2074,7 @@ fn get_pair_subtraction_relocation_value<'a, A: Arch>(
         &layout.merged_strings,
         &layout.merged_string_start_addresses,
     )?;
-    let (value, overflow) = set_resolution_val.overflowing_sub(sub_resolution_val);
-    ensure!(
-        !overflow,
-        "ULEB128 overflow should not happen: {} (0x{}) - {} (0x{})",
-        layout
-            .symbol_db
-            .symbol_name_for_display(set_local_symbol_id),
-        HexU64::new(set_resolution_val),
-        layout.symbol_db.symbol_name_for_display(local_symbol_id),
-        HexU64::new(sub_resolution_val)
-    );
-    Ok(value)
+    Ok(set_resolution_val.wrapping_sub(sub_resolution_val))
 }
 
 /// Applies the relocation `rel` at `offset_in_section`, where the section bytes are `out`. See "ELF
@@ -2277,7 +2264,6 @@ fn apply_relocation<A: Arch>(
             layout,
             resolution,
             symbol_index,
-            local_symbol_id,
             addend,
             // It must be the previous relocation
             iter::once(&relocations[relocation_index - 1]),
@@ -2468,7 +2454,6 @@ fn apply_debug_relocation<A: Arch>(
         .context("Unsupported absolute relocation")?;
     let sym = object_layout.object.symbol(symbol_index)?;
     let section_index = object_layout.object.symbol_section(sym, symbol_index)?;
-    let local_symbol_id = object_layout.symbol_id_range.input_to_id(symbol_index);
 
     let addend = rel.r_addend.get(e);
     let r_type = rel.r_type(e, false);
@@ -2518,7 +2503,6 @@ fn apply_debug_relocation<A: Arch>(
                 layout,
                 resolution,
                 symbol_index,
-                local_symbol_id,
                 addend,
                 // Must be the previous relocation.
                 iter::once(&relocations[relocation_index - 1]),

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2470,8 +2470,10 @@ fn apply_debug_relocation<A: Arch>(
     let value = if let Some(resolution) = resolution {
         match rel_info.kind {
             RelocationKind::Absolute
+            | RelocationKind::AbsoluteSetWord6
             | RelocationKind::AbsoluteAddition
-            | RelocationKind::AbsoluteSubtraction => {
+            | RelocationKind::AbsoluteSubtraction
+            | RelocationKind::AbsoluteSubtractionWord6 => {
                 let mut value = resolution.value_with_addend(
                     addend,
                     symbol_index,
@@ -2482,7 +2484,10 @@ fn apply_debug_relocation<A: Arch>(
                 // Adjust the relocation value based on the value at the place.
                 if matches!(
                     rel_info.kind,
-                    RelocationKind::AbsoluteSubtraction | RelocationKind::AbsoluteAddition
+                    RelocationKind::AbsoluteAddition
+                        | RelocationKind::AbsoluteSubtraction
+                        | RelocationKind::AbsoluteSetWord6
+                        | RelocationKind::AbsoluteSubtractionWord6
                 ) {
                     value = adjust_relocation_based_on_value(
                         value,

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -2729,6 +2729,7 @@ fn process_relocation<A: Arch>(
     section: &object::elf::SectionHeader64<LittleEndian>,
     resources: &GraphResources,
     queue: &mut LocalWorkQueue,
+    is_debug_section: bool,
 ) -> Result<RelocationModifier> {
     let args = resources.symbol_db.args;
     let mut next_modifier = RelocationModifier::Normal;
@@ -2793,7 +2794,7 @@ fn process_relocation<A: Arch>(
         {
             if section_is_writable {
                 common.allocate(part_id::RELA_DYN_RELATIVE, elf::RELA_ENTRY_SIZE);
-            } else {
+            } else if !is_debug_section {
                 bail!(
                     "Cannot apply relocation {} to read-only section. \
                     Please recompile with -fPIC or link with -no-pie",
@@ -3762,7 +3763,8 @@ impl<'data> ObjectLayoutState<'data> {
                 self.load_section::<A>(common, queue, *unloaded, section_index, resources)?;
             }
             SectionSlot::UnloadedDebugInfo(part_id) => {
-                self.load_debug_section(common, *part_id, section_index)?;
+                // On RISC-V, the debug info sections contain relocations to local symbols (e.g. labels).
+                self.load_debug_section::<A>(common, queue, *part_id, section_index, resources)?;
             }
             SectionSlot::Discard => {
                 bail!(
@@ -3811,6 +3813,7 @@ impl<'data> ObjectLayoutState<'data> {
                 self.object.section(section.index)?,
                 resources,
                 queue,
+                false,
             )
             .with_context(|| {
                 format!(
@@ -3867,7 +3870,15 @@ impl<'data> ObjectLayoutState<'data> {
             // section.
             if let Some(eh_frame_section) = self.eh_frame_section {
                 for rel in frame_data_relocations {
-                    process_relocation::<A>(self, common, rel, eh_frame_section, resources, queue)?;
+                    process_relocation::<A>(
+                        self,
+                        common,
+                        rel,
+                        eh_frame_section,
+                        resources,
+                        queue,
+                        false,
+                    )?;
                 }
             }
         }
@@ -3882,14 +3893,39 @@ impl<'data> ObjectLayoutState<'data> {
         Ok(())
     }
 
-    fn load_debug_section(
+    fn load_debug_section<A: Arch>(
         &mut self,
         common: &mut CommonGroupState<'data>,
+        queue: &mut LocalWorkQueue,
+
         part_id: PartId,
         section_index: SectionIndex,
+        resources: &GraphResources<'data, '_>,
     ) -> Result {
         let header = self.object.section(section_index)?;
         let section = Section::create(header, self, section_index, part_id)?;
+        for rel in self.relocations(section.index)? {
+            let modifier = process_relocation::<A>(
+                self,
+                common,
+                rel,
+                self.object.section(section.index)?,
+                resources,
+                queue,
+                true,
+            )
+            .with_context(|| {
+                format!(
+                    "Failed to copy section {} from file {self}",
+                    section_debug(self.object, section.index)
+                )
+            })?;
+            ensure!(
+                modifier == RelocationModifier::Normal,
+                "All debug relocations must be processed"
+            );
+        }
+
         tracing::debug!(loaded_debug_section = %self.object.section_display_name(section_index),);
         common.section_loaded(part_id, header, section);
         self.sections[section_index.0] = SectionSlot::LoadedDebugInfo(section);
@@ -4338,7 +4374,15 @@ fn process_eh_frame_data<'data, A: Arch>(
 
                 // We currently always load all CIEs, so any relocations found in CIEs always need
                 // to be processed.
-                process_relocation::<A>(object, common, rel, eh_frame_section, resources, queue)?;
+                process_relocation::<A>(
+                    object,
+                    common,
+                    rel,
+                    eh_frame_section,
+                    resources,
+                    queue,
+                    false,
+                )?;
 
                 if let Some(local_sym_index) = rel.symbol(e, false) {
                     let local_symbol_id = file_symbol_id_range.input_to_id(local_sym_index);

--- a/libwild/src/riscv64.rs
+++ b/libwild/src/riscv64.rs
@@ -66,6 +66,10 @@ impl crate::arch::Arch for RISCV64 {
     fn get_dtv_offset() -> u64 {
         0x800
     }
+
+    fn local_symbols_in_debug_info() -> bool {
+        true
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/libwild/src/x86_64.rs
+++ b/libwild/src/x86_64.rs
@@ -77,6 +77,10 @@ impl crate::arch::Arch for X86_64 {
     fn rel_type_to_string(r_type: u32) -> std::borrow::Cow<'static, str> {
         x86_64_rel_type_to_string(r_type)
     }
+
+    fn local_symbols_in_debug_info() -> bool {
+        false
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/wild/tests/sources/link_args.c
+++ b/wild/tests/sources/link_args.c
@@ -3,6 +3,8 @@
 //#LinkArgs:--strip-all
 //#EnableLinker:lld
 //#DiffIgnore:file-header.entry
+// TODO: #795
+//#Arch: x86_64,aarch64
 
 //#Config:single-threaded
 //#Object:runtime.c

--- a/wild/tests/sources/link_args.c
+++ b/wild/tests/sources/link_args.c
@@ -1,22 +1,24 @@
-//#Config:strip-all
+//#AbstractConfig:default
+// TODO: #795
+//#Arch: x86_64,aarch64
+
+//#Config:strip-all:default
 //#Object:runtime.c
 //#LinkArgs:--strip-all
 //#EnableLinker:lld
 //#DiffIgnore:file-header.entry
-// TODO: #795
-//#Arch: x86_64,aarch64
 
-//#Config:single-threaded
+//#Config:single-threaded:default
 //#Object:runtime.c
 //#WildExtraLinkArgs:--threads=1
 
-//#Config:dev_null
+//#Config:dev_null:default
 //#Object:runtime.c
 //#LinkArgs:-o /dev/null
 //#DiffEnabled:false
 //#RunEnabled:false
 
-//#Config:gc-sections
+//#Config:gc-sections:default
 //#CompArgs:-g -ffunction-sections
 //#LinkArgs:--gc-sections
 //#Object:runtime.c


### PR DESCRIPTION
Necessary on RISC-V target where labels are referenced by relocations of the debug sections.

Should handle the first limitation mentioned in #790.