### PR TITLE
CI: Remove ubuntu 24.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
           - ubuntu-24.04-arm
         container:
           - 'ubuntu:24.04'
-          - 'ubuntu:24.10'
           - 'ubuntu:25.04'
           - 'ubuntu:25.10'
           - 'opensuse/tumbleweed:latest'


### PR DESCRIPTION
There's both newer and older ubuntu releases in our matrix, so this one seems redundant.