### PR TITLE
file grouping: Fix off-by-one on maximum group size for initial group

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -290,11 +290,22 @@ impl Default for Args {
 
 // Parse the supplied input arguments, which should not include the program name.
 pub(crate) fn parse<F: Fn() -> I, S: AsRef<str>, I: Iterator<Item = S>>(input: F) -> Result<Args> {
+    use crate::input_data::MAX_FILES_PER_GROUP;
+
+    let files_per_group = std::env::var(FILES_PER_GROUP_ENV)
+        .ok()
+        .map(|s| s.parse())
+        .transpose()?;
+
+    if let Some(x) = files_per_group {
+        ensure!(
+            x <= MAX_FILES_PER_GROUP,
+            "{FILES_PER_GROUP_ENV}={x} but maximum is {MAX_FILES_PER_GROUP}"
+        );
+    }
+
     let mut args = Args {
-        files_per_group: std::env::var(FILES_PER_GROUP_ENV)
-            .ok()
-            .map(|s| s.parse())
-            .transpose()?,
+        files_per_group,
         ..Default::default()
     };
 

--- a/libwild/src/grouping.rs
+++ b/libwild/src/grouping.rs
@@ -1,5 +1,6 @@
 use crate::args::Args;
 use crate::input_data::FileId;
+use crate::input_data::MAX_FILES_PER_GROUP;
 use crate::parsing::Epilogue;
 use crate::parsing::ParsedInputObject;
 use crate::parsing::ParsedInputs;
@@ -58,8 +59,11 @@ pub(crate) fn group_files<'data>(
 
     groups.push(Group::Prelude(parsed_inputs.prelude));
 
-    let mut num_symbols = 0;
-    let mut num_files = 0;
+    let mut num_symbols = parsed_inputs
+        .objects
+        .first()
+        .map_or(0, |obj| obj.symbol_id_range.len());
+    let mut num_files = 1;
 
     groups.extend(
         parsed_inputs
@@ -84,6 +88,12 @@ pub(crate) fn group_files<'data>(
             })
             .enumerate()
             .map(|(i, group_objects)| {
+                debug_assert!(
+                    group_objects.len() <= MAX_FILES_PER_GROUP as usize,
+                    "Group is too large: {}",
+                    group_objects.len()
+                );
+
                 for (file_number, obj) in group_objects.iter_mut().enumerate() {
                     obj.set_file_id(FileId::new(i as u32 + 1, file_number as u32));
                 }


### PR DESCRIPTION
Also, enforce maximum when setting files-per-group via the environment variable.

We support a maximum of 256 files per group, but because we accidentally didn't count the first file, we were going over by 1.