### PR TITLE
Ignore a missing optimisation on aarch64

### DIFF
--- a/wild/tests/sources/exception.cc
+++ b/wild/tests/sources/exception.cc
@@ -3,6 +3,8 @@
 //#DiffIgnore:section.rodata
 //#DiffIgnore:section.data
 //#DiffIgnore:dynsym._ZTIi.section
+// TODO: Fix this. Note, it only shows up on openSUSE aarch64
+//#DiffIgnore:rel.missing-copy-relocation.R_AARCH64_ABS64
 
 //#Config:gcc:default
 //#LinkerDriver:g++


### PR DESCRIPTION
Wild is actually doing the copy relocation, however it's also emitting an R_AARCH64_ABS64 for the same symbol, which isn't necessary.