### PR TITLE
Implement --export-dynamic

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -65,6 +65,7 @@ pub struct Args {
     pub(crate) undefined: Vec<String>,
     pub(crate) relro: bool,
     pub(crate) entry: Option<String>,
+    pub(crate) explicitly_export_dynamic: bool,
 
     /// If set, GC stats will be written to the specified filename.
     pub(crate) write_gc_stats: Option<PathBuf>,
@@ -191,7 +192,6 @@ const SILENTLY_IGNORED_FLAGS: &[&str] = &[
     "nostdlib",
     // TODO
     "no-undefined-version",
-    "export-dynamic",
     "fatal-warnings",
     "color-diagnostics",
     "undefined-version",
@@ -204,7 +204,6 @@ const IGNORED_FLAGS: &[&str] = &[
     "disable-new-dtags",
     "fix-cortex-a53-835769",
     "fix-cortex-a53-843419",
-    "no-export-dynamic",
 ];
 
 // These flags map to the default behavior of the linker.
@@ -284,6 +283,7 @@ impl Default for Args {
             relro: true,
             entry: None,
             b_symbolic: BSymbolicKind::None,
+            explicitly_export_dynamic: false,
         }
     }
 }
@@ -551,6 +551,10 @@ pub(crate) fn parse<F: Fn() -> I, S: AsRef<str>, I: Iterator<Item = S>>(input: F
             args.should_write_eh_frame_hdr = true;
         } else if long_arg_eq("shared") || long_arg_eq("Bshareable") {
             args.output_kind = Some(OutputKind::SharedObject);
+        } else if long_arg_eq("export-dynamic") || arg == "-E" {
+            args.explicitly_export_dynamic = true;
+        } else if long_arg_eq("no-export-dynamic") {
+            args.explicitly_export_dynamic = false;
         } else if let Some(rest) = long_arg_split_prefix("soname=") {
             args.soname = Some(rest.to_owned());
         } else if long_arg_eq("soname") {

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3746,6 +3746,7 @@ impl<'data> ObjectLayoutState<'data> {
 
         if resources.symbol_db.args.output_kind() == OutputKind::SharedObject
             && (!resources.symbol_db.args.exclude_libs || !self.input.has_archive_semantics())
+            || resources.symbol_db.args.explicitly_export_dynamic
         {
             self.load_non_hidden_symbols::<A>(common, resources, queue)?;
         }

--- a/wild/tests/sources/trivial-dynamic.c
+++ b/wild/tests/sources/trivial-dynamic.c
@@ -25,6 +25,12 @@
 //#DiffIgnore:.dynamic.DT_FLAGS.SYMBOLIC
 //#DiffIgnore:.dynamic.DT_SYMBOLIC
 
+//#Config:export-dynamic:default
+//#LinkArgs:-z now --export-dynamic 
+//#ExpectDynSym: runtime_init
+// Ld is acting weird and comparing to LLD is not possible right when when cross compiling: #804
+//#Cross:false
+
 #include "runtime.h"
 
 int foo(void);


### PR DESCRIPTION
With this change, llvm-project configured with  `-G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS=clang -DLLVM_BUILD_LLVM_DYLIB=ON` passes fully 🎉.
With `-DLLVM_LINK_LLVM_DYLIB=ON` there are still 2 failures left, caused by the segfault in `clang-offload-bundler`.

Fixes: https://github.com/davidlattimore/wild/issues/752