### PR TITLE
Canonicalise sysroot and linker script paths before comparing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,7 +694,6 @@ dependencies = [
  "linker-utils",
  "memchr",
  "memmap2",
- "normalize-path",
  "object 0.36.7 (git+https://github.com/gimli-rs/object?rev=61474b7de8074f91b78ad24ff2424e54a22f8b32)",
  "rayon",
  "sharded-offset-map",
@@ -850,12 +849,6 @@ checksum = "c4c25a3bb7d880e8eceab4822f3141ad0700d20f025991c1f03bd3d00219a5fc"
 dependencies = [
  "bitflags",
 ]
-
-[[package]]
-name = "normalize-path"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5438dd2b2ff4c6df6e1ce22d825ed2fa93ee2922235cc45186991717f0a892d"
 
 [[package]]
 name = "object"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ libc = "0.2.152"
 memchr = "2.6.0"
 memmap2 = "0.9.0"
 mimalloc = { version = "0.1", default-features = false }
-normalize-path = "0.2.0"
 object = { git = "https://github.com/gimli-rs/object", rev = "61474b7de8074f91b78ad24ff2424e54a22f8b32", default-features = false, features = [
     "elf",
     "read_core",

--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -29,7 +29,6 @@ linker-trace = { path = "../linker-trace", version = "0.5.0" }
 linker-utils = { path = "../linker-utils", version = "0.5.0" }
 memchr = { workspace = true }
 memmap2 = { workspace = true }
-normalize-path = { workspace = true }
 object = { workspace = true }
 rayon = { workspace = true }
 sharded-offset-map = { workspace = true }

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -627,10 +627,11 @@ pub(crate) fn parse<F: Fn() -> I, S: AsRef<str>, I: Iterator<Item = S>>(input: F
             .is_some_and(|stripped_arg| SILENTLY_IGNORED_FLAGS.contains(&stripped_arg))
         {
         } else if let Some(sysroot) = long_arg_split_prefix("sysroot=") {
-            let sysroot = Path::new(sysroot);
-            args.sysroot = Some(Box::from(sysroot));
+            args.save_dir.handle_file(sysroot)?;
+            let sysroot = std::fs::canonicalize(sysroot).unwrap_or_else(|_| PathBuf::from(sysroot));
+            args.sysroot = Some(Box::from(sysroot.as_path()));
             for path in &mut args.lib_search_path {
-                if let Some(new_path) = maybe_forced_sysroot(path, sysroot) {
+                if let Some(new_path) = maybe_forced_sysroot(path, &sysroot) {
                     *path = new_path;
                 }
             }

--- a/libwild/src/input_data.rs
+++ b/libwild/src/input_data.rs
@@ -244,12 +244,13 @@ impl<'data> InputData<'data> {
 
     fn add_inputs_from_linker_script(
         &mut self,
-        absolute_path: &Path,
+        script_path: &Path,
         modifiers: Modifiers,
         state: &mut TemporaryState<'data>,
         script: &LinkerScript,
     ) -> Result {
-        let directory = absolute_path.parent().expect("expected an absolute path");
+        let script_path = std::fs::canonicalize(script_path)?;
+        let directory = script_path.parent().expect("expected an absolute path");
 
         script.foreach_input(modifiers, |mut input| {
             input.search_first = Some(directory.to_owned());
@@ -258,7 +259,7 @@ impl<'data> InputData<'data> {
                 (state.args.sysroot.as_ref(), &mut input.spec)
             {
                 if let Some(new_file) =
-                    crate::linker_script::maybe_apply_sysroot(absolute_path, file, sysroot)
+                    crate::linker_script::maybe_apply_sysroot(&script_path, file, sysroot)
                 {
                     *file = new_file;
                 }


### PR DESCRIPTION
This means that if either the linker script has symlinks in its path or the sysroot has symlinks in its path, but after canonicalisation, the linker script is somewhere inside the sysroot, we'll apply the sysroot to any files the linker script references.