### PR TITLE
ci: Remove a couple of redundant configurations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
           - ubuntu-24.04-arm
         container:
           - 'ubuntu:24.04'
-          - 'ubuntu:25.04'
-          - 'ubuntu:25.10'
           - 'opensuse/tumbleweed:latest'
           - 'rust:1.87-alpine'
         test-qemu:
@@ -34,9 +32,15 @@ jobs:
           - runs-on: ubuntu-24.04
             container: 'ubuntu:25.04'
             test-qemu: true
+          - runs-on: ubuntu-24.04-arm
+            container: 'ubuntu:25.04'
+            test-qemu: false
           - runs-on: ubuntu-24.04
             container: 'ubuntu:25.10'
             test-qemu: true
+          - runs-on: ubuntu-24.04-arm
+            container: 'ubuntu:25.10'
+            test-qemu: false
           # Ubuntu 22.04 contains an old lld linker which cannot do a relaxation on AArch64 (required by linker-diff)
           - runs-on: ubuntu-24.04
             container: 'ubuntu:22.04'


### PR DESCRIPTION
When we're running with qemu, we also test x86-64, so we don't need a separate non-qemu configuration for x86-64 on those containers.