### PR TITLE
Add a docker reproducer for nix

### DIFF
--- a/docker/nix.Dockerfile
+++ b/docker/nix.Dockerfile
@@ -1,0 +1,24 @@
+# Run inside a Nix shell.
+#
+# docker build --progress=plain -t wild-dev-nix . -f docker/nix.Dockerfile
+#
+# docker run -it wild-dev-nix
+
+FROM nixos/nix AS chef
+
+COPY shell.nix shell.nix
+RUN nix-shell --run "rustup toolchain install nightly"
+
+WORKDIR /wild
+
+FROM chef as planner
+COPY . .
+RUN nix-shell --run "cargo chef prepare --recipe-path recipe.json"
+
+FROM chef AS builder
+COPY --from=planner /wild/recipe.json recipe.json
+COPY shell.nix shell.nix
+RUN nix-shell --run "cargo chef cook --all-targets --recipe-path recipe.json"
+COPY . .
+
+ENTRYPOINT nix-shell

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,29 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+pkgs.mkShell {
+  nativeBuildInputs = [
+    # Write a wrapper for GCC that passes -B to *unwrapped* binutils.
+    # This ensures that if -fuse-ld=bfd is used, gcc picks up unwrapped ld.bfd
+    # instead of the hardcoded wrapper search directory.
+    # We pass it last because apparently gcc likes picking ld from the *first* -B,
+    # which we want our wild target directory to be if passed.
+    (pkgs.writeShellApplication {
+      name = "gcc";
+      text = ''${pkgs.lib.getExe pkgs.gcc} "$@" -B${pkgs.binutils-unwrapped-all-targets}/bin '';
+    })
+    (pkgs.writeShellApplication {
+      name = "g++";
+      text = ''${pkgs.lib.getExe' pkgs.gcc "g++"} "$@" -B${pkgs.binutils-unwrapped-all-targets}/bin '';
+    })
+    pkgs.binutils-unwrapped-all-targets
+    pkgs.cargo-chef
+    pkgs.llvmPackages_20.clang
+    pkgs.lld
+    pkgs.glibc.out
+    pkgs.glibc.static
+    pkgs.rustup
+  ];
+
+  LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib";
+}


### PR DESCRIPTION
Nix(OS) is *not* friendly to linkers and uses a pile of hacks and wrappers to get gcc, ld, and other tools to work. This PR provides a Dockerfile to run wild and its tests in Nix, and is based on the solutions provided in #832. As described there, this PR is just to provide an easily accessible reproduction environment for the currently failing tests.

The usage of this Dockerfile is
```
docker build --progress=plain -t wild-dev-nix . -f docker/nix.Dockerfile
docker run -it wild-dev-nix
cargo test # in the nix shell that you are dropped into
```

At present, on main, the following test failures occur:
```
failures:
    integration_test::program_name_03___trivial_dynamic_c__
    integration_test::program_name_07___data_pointers_c__
    integration_test::program_name_16___tlsdesc_c__
    integration_test::program_name_26___common_section_c__
    integration_test::program_name_40___libc_integration_c__
```
Once #831 is included, that reduces to
```
failures:
    integration_test::program_name_16___tlsdesc_c__
    integration_test::program_name_40___libc_integration_c__
```

Implementation notes:
- The Nix shell includes tools needed for running/fixing tests as well as rustup and cargo-chef for Docker, as `nix-shell` does not seem to support overlaying both the `shell.nix` and packages included ad-hoc (e.g. ideally we could do `nix-shell shell.nix --packages cargo-chef --run "cargo chef ..."` in Docker)
- The use of rustup in the Nix shell/Dockerfile is not the way this would typically be done in Nix; most use a project like https://github.com/oxalica/rust-overlay to handle downloading and using Rust. However, rust-overlay seems to do some sort of patching or wrapping that leads to even more test failures, so for now we stick to rustup (at least, pending further investigation).