### PR TITLE
Relax TLSDESC and TLSDESC_CALL separately

### DIFF
--- a/libwild/src/x86_64.rs
+++ b/libwild/src/x86_64.rs
@@ -308,25 +308,33 @@ impl crate::arch::Relaxation for Relaxation {
                     }
                 }
             }
+            // TODO: It looks to me like we should be able to optimise to local-exec for any
+            // executable, not just static executables. However, currently the test fails if we try
+            // this. Investigate why.
             object::elf::R_X86_64_GOTPC32_TLSDESC
                 if !interposable && output_kind.is_static_executable() =>
             {
-                // lea    0x0(%rip),%rax
-                if section_bytes.get(offset - 3..offset)? == [0x48, 0x8d, 0x05] {
-                    return create(
-                        RelaxationKind::TlsDescToLocalExec,
-                        object::elf::R_X86_64_TPOFF32,
-                    );
-                }
+                // We assume that the instruction that this relocation applies to is a REX-prefixed
+                // LEA instruction.
+                return create(
+                    RelaxationKind::TlsDescToLocalExec,
+                    object::elf::R_X86_64_TPOFF32,
+                );
             }
+            // Note, the conditions on this relaxation (is_executable) must match those on
+            // TLSDESC_CALL below.
             object::elf::R_X86_64_GOTPC32_TLSDESC if output_kind.is_executable() => {
-                // lea    0x0(%rip),%rax
-                if section_bytes.get(offset - 3..offset)? == [0x48, 0x8d, 0x05] {
-                    return create(
-                        RelaxationKind::TlsDescToInitialExec,
-                        object::elf::R_X86_64_GOTTPOFF,
-                    );
-                }
+                // We assume that the instruction that this relocation applies to is a REX-prefixed
+                // LEA instruction.
+                return create(
+                    RelaxationKind::TlsDescToInitialExec,
+                    object::elf::R_X86_64_GOTTPOFF,
+                );
+            }
+            // Note, the conditions on this relaxation (is_executable) must match those on
+            // GOTPC32_TLSDESC above.
+            object::elf::R_X86_64_TLSDESC_CALL if output_kind.is_executable() => {
+                return create(RelaxationKind::SkipTlsDescCall, object::elf::R_X86_64_NONE);
             }
             _ => return None,
         };

--- a/linker-utils/src/x86_64.rs
+++ b/linker-utils/src/x86_64.rs
@@ -159,17 +159,15 @@ impl RelaxationKind {
                 *offset_in_section += 15;
             }
             RelaxationKind::TlsDescToLocalExec => {
-                section_bytes[offset - 3..offset + 6].copy_from_slice(&[
+                section_bytes[offset - 3..offset + 4].copy_from_slice(&[
                     // mov {offset},%rax
-                    0x48, 0xc7, 0xc0, 0, 0, 0, 0, // xchg   %ax,%ax
-                    0x66, 0x90,
+                    0x48, 0xc7, 0xc0, 0, 0, 0, 0,
                 ]);
             }
             RelaxationKind::TlsDescToInitialExec => {
-                section_bytes[offset - 3..offset + 6].copy_from_slice(&[
+                section_bytes[offset - 3..offset + 4].copy_from_slice(&[
                     // mov {GOT}(%rip),%rax
-                    0x48, 0x8b, 0x05, 0, 0, 0, 0, // xchg   %ax,%ax
-                    0x66, 0x90,
+                    0x48, 0x8b, 0x05, 0, 0, 0, 0,
                 ]);
             }
             RelaxationKind::SkipTlsDescCall => {
@@ -190,9 +188,7 @@ impl RelaxationKind {
             | RelaxationKind::TlsGdToLocalExecLarge
             | RelaxationKind::TlsLdToLocalExec
             | RelaxationKind::TlsLdToLocalExecNoPlt
-            | RelaxationKind::TlsLdToLocalExec64
-            | RelaxationKind::TlsDescToLocalExec
-            | RelaxationKind::TlsDescToInitialExec => RelocationModifier::SkipNextRelocation,
+            | RelaxationKind::TlsLdToLocalExec64 => RelocationModifier::SkipNextRelocation,
             RelaxationKind::MovIndirectToLea
             | RelaxationKind::MovIndirectToAbsolute
             | RelaxationKind::RexMovIndirectToAbsolute
@@ -200,6 +196,8 @@ impl RelaxationKind {
             | RelaxationKind::RexCmpIndirectToAbsolute
             | RelaxationKind::CallIndirectToRelative
             | RelaxationKind::JmpIndirectToRelative
+            | RelaxationKind::TlsDescToLocalExec
+            | RelaxationKind::TlsDescToInitialExec
             | RelaxationKind::NoOp
             | RelaxationKind::SkipTlsDescCall => RelocationModifier::Normal,
         }

--- a/wild/tests/sources/tlsdesc.c
+++ b/wild/tests/sources/tlsdesc.c
@@ -6,14 +6,14 @@
 //#DiffIgnore:section.rodata
 
 //#Config:gcc-tls-desc:default
-//#CompArgs:-mtls-dialect=gnu2
+//#CompArgs:-mtls-dialect=gnu2 -fPIC -O2
 //#LinkerDriver:gcc
 //#LinkArgs:-Wl,-z,now
 //#Object:tlsdesc-obj.c
 //#Arch: x86_64
 
 //#Config:gcc-tls-desc-aarch64:gcc-tls-desc
-//#CompArgs:-mtls-dialect=desc
+//#CompArgs:-mtls-dialect=desc -fPIC
 //#Arch: aarch64
 
 //#Config:gcc-tls-desc-pie:gcc-tls-desc
@@ -40,13 +40,13 @@
 //#Arch: aarch64
 
 //#Config:clang-tls-desc:gcc-tls-desc
-//#CompArgs:-mtls-dialect=gnu2
+//#CompArgs:-mtls-dialect=gnu2 -fPIC
 //#Compiler:clang
 //#RequiresClangWithTlsDesc:true
 //#Arch: x86_64
 
 //#Config:clang-tls-desc-aarch64:clang-tls-desc
-//#CompArgs:-mtls-dialect=desc
+//#CompArgs:-mtls-dialect=desc -fPIC
 //#Arch: aarch64
 
 //#Config:clang-tls-desc-shared:clang-tls-desc
@@ -55,7 +55,7 @@
 //#Arch: x86_64
 
 //#Config:clang-tls-desc-shared-aarch64:clang-tls-desc-shared
-//#CompArgs:-mtls-dialect=desc
+//#CompArgs:-mtls-dialect=desc -fPIC
 //#Arch: aarch64
 
 int get_value();


### PR DESCRIPTION
These two relocations don't have to be adjacent.

To handle this, we now relax these two relocations separately. We also now assume that the instruction that the TLSDESC relocation is a REX-prefixed LEA instruction.

Fix #842