### PR TITLE
RISC-V: support -static linking

### DIFF
--- a/libwild/src/aarch64.rs
+++ b/libwild/src/aarch64.rs
@@ -90,7 +90,7 @@ impl crate::arch::Arch for AArch64 {
     }
 
     fn tcb_placement() -> TCBPlacement {
-        // TODO: double-check
+        // TODO: #864
         TCBPlacement::BeforeTP
     }
 }

--- a/libwild/src/aarch64.rs
+++ b/libwild/src/aarch64.rs
@@ -154,18 +154,19 @@ impl crate::arch::Relaxation for Relaxation {
 
         match relocation_kind {
             object::elf::R_AARCH64_CALL26 | object::elf::R_AARCH64_JUMP26 if !interposable => {
-                if non_zero_address {
+                return if non_zero_address {
                     relocation.kind = RelocationKind::Relative;
-                    return Some(Relaxation {
+                    Some(Relaxation {
                         kind: RelaxationKind::NoOp,
                         rel_info: relocation,
-                    });
-                }
-                // GNU ld replaces: 'bl 0' with 'nop'
-                return Some(Relaxation {
-                    kind: RelaxationKind::ReplaceWithNop,
-                    rel_info: relocation_type_from_raw(object::elf::R_AARCH64_NONE).unwrap(),
-                });
+                    })
+                } else {
+                    // GNU ld replaces: 'bl 0' with 'nop'
+                    Some(Relaxation {
+                        kind: RelaxationKind::ReplaceWithNop,
+                        rel_info: relocation_type_from_raw(object::elf::R_AARCH64_NONE).unwrap(),
+                    })
+                };
             }
 
             object::elf::R_AARCH64_TLSDESC_ADR_PAGE21

--- a/libwild/src/aarch64.rs
+++ b/libwild/src/aarch64.rs
@@ -1,4 +1,5 @@
 use crate::arch::Arch;
+use crate::arch::TCBPlacement;
 use crate::elf::PLT_ENTRY_SIZE;
 use crate::ensure;
 use crate::error;
@@ -86,6 +87,11 @@ impl crate::arch::Arch for AArch64 {
 
     fn local_symbols_in_debug_info() -> bool {
         false
+    }
+
+    fn tcb_placement() -> TCBPlacement {
+        // TODO: double-check
+        TCBPlacement::BeforeTP
     }
 }
 

--- a/libwild/src/arch.rs
+++ b/libwild/src/arch.rs
@@ -14,9 +14,13 @@ use object::elf::EM_X86_64;
 use std::borrow::Cow;
 use std::str::FromStr;
 
+// Based on the following article: https://maskray.me/blog/2021-02-14-all-about-thread-local-storage#tls-variants
+// There are 2 variants where are TCB (thread control block) placed relative to the thread pointer ($tp).
 pub(crate) enum TCBPlacement {
-    AfterTLSSegment,
-    StartOfTLSSegment,
+    // TP is placed at the end of TCB.
+    BeforeTP,
+    // TP is placed at the beginning of TCB.
+    AfterTP,
 }
 
 pub(crate) trait Arch {
@@ -46,9 +50,7 @@ pub(crate) trait Arch {
     fn local_symbols_in_debug_info() -> bool;
 
     // Get TCB placement variant.
-    fn tcb_placement() -> TCBPlacement {
-        TCBPlacement::AfterTLSSegment
-    }
+    fn tcb_placement() -> TCBPlacement;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/libwild/src/arch.rs
+++ b/libwild/src/arch.rs
@@ -14,6 +14,11 @@ use object::elf::EM_X86_64;
 use std::borrow::Cow;
 use std::str::FromStr;
 
+pub(crate) enum TCBPlacement {
+    AfterTLSSegment,
+    StartOfTLSSegment,
+}
+
 pub(crate) trait Arch {
     type Relaxation: Relaxation;
 
@@ -39,6 +44,11 @@ pub(crate) trait Arch {
 
     // Some architectures use debug info relocation that depend on local symbols.
     fn local_symbols_in_debug_info() -> bool;
+
+    // Get TCB placement variant.
+    fn tcb_placement() -> TCBPlacement {
+        TCBPlacement::AfterTLSSegment
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -5,6 +5,7 @@ use self::elf::get_page_mask;
 use crate::alignment;
 use crate::arch::Arch;
 use crate::arch::Relaxation as _;
+use crate::arch::TCBPlacement;
 use crate::args::Args;
 use crate::args::BuildIdOption;
 use crate::args::FileWriteMode;
@@ -982,11 +983,8 @@ impl<'data, 'layout, 'out> TableWriter<'data, 'layout, 'out> {
         if self.output_kind.is_executable() {
             // Convert the address to an offset relative to the TCB.
             let value = match A::tcb_placement() {
-                crate::arch::TCBPlacement::AfterTLSSegment => address.wrapping_sub(self.tls.end),
-                crate::arch::TCBPlacement::StartOfTLSSegment => {
-                    println!("{} {}", HexU64::new(self.tls.start), HexU64::new(address));
-                    dbg!(address.wrapping_sub(self.tls.start))
-                }
+                TCBPlacement::BeforeTP => address.wrapping_sub(self.tls.end),
+                TCBPlacement::AfterTP => address.wrapping_sub(self.tls.start),
             };
             *got_entry = value;
         } else {

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -984,7 +984,8 @@ impl<'data, 'layout, 'out> TableWriter<'data, 'layout, 'out> {
             let value = match A::tcb_placement() {
                 crate::arch::TCBPlacement::AfterTLSSegment => address.wrapping_sub(self.tls.end),
                 crate::arch::TCBPlacement::StartOfTLSSegment => {
-                    address.wrapping_sub(self.tls.start)
+                    println!("{} {}", HexU64::new(self.tls.start), HexU64::new(address));
+                    dbg!(address.wrapping_sub(self.tls.start))
                 }
             };
             *got_entry = value;

--- a/libwild/src/riscv64.rs
+++ b/libwild/src/riscv64.rs
@@ -1,5 +1,5 @@
 use crate::arch::Arch;
-use crate::arch::TCBPlacement::StartOfTLSSegment;
+use crate::arch::TCBPlacement;
 use crate::elf::PLT_ENTRY_SIZE;
 use crate::error;
 use crate::error::Result;
@@ -76,8 +76,8 @@ impl crate::arch::Arch for RISCV64 {
         true
     }
 
-    fn tcb_placement() -> crate::arch::TCBPlacement {
-        StartOfTLSSegment
+    fn tcb_placement() -> TCBPlacement {
+        TCBPlacement::AfterTP
     }
 }
 

--- a/libwild/src/riscv64.rs
+++ b/libwild/src/riscv64.rs
@@ -1,4 +1,5 @@
 use crate::arch::Arch;
+use crate::arch::TCBPlacement::StartOfTLSSegment;
 use crate::elf::PLT_ENTRY_SIZE;
 use crate::error;
 use crate::error::Result;
@@ -73,6 +74,10 @@ impl crate::arch::Arch for RISCV64 {
 
     fn local_symbols_in_debug_info() -> bool {
         true
+    }
+
+    fn tcb_placement() -> crate::arch::TCBPlacement {
+        StartOfTLSSegment
     }
 }
 

--- a/libwild/src/riscv64.rs
+++ b/libwild/src/riscv64.rs
@@ -1,11 +1,15 @@
+use crate::arch::Arch;
 use crate::elf::PLT_ENTRY_SIZE;
 use crate::error;
 use crate::error::Result;
 use linker_utils::elf::DynamicRelocationKind;
 use linker_utils::elf::RISCVInstruction;
+use linker_utils::elf::RelocationKind;
 use linker_utils::elf::RelocationKindInfo;
 use linker_utils::elf::riscv64_rel_type_to_string;
+use linker_utils::elf::shf;
 use linker_utils::relaxation::RelocationModifier;
+use linker_utils::riscv64::RelaxationKind;
 
 pub(crate) struct RISCV64;
 
@@ -73,7 +77,10 @@ impl crate::arch::Arch for RISCV64 {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct Relaxation {}
+pub(crate) struct Relaxation {
+    kind: RelaxationKind,
+    rel_info: RelocationKindInfo,
+}
 
 impl crate::arch::Relaxation for Relaxation {
     #[allow(unused_variables)]
@@ -90,20 +97,52 @@ impl crate::arch::Relaxation for Relaxation {
     where
         Self: std::marker::Sized,
     {
+        let mut relocation = RISCV64::relocation_from_raw(relocation_kind).unwrap();
+        let interposable = value_flags.is_interposable();
+
+        // All relaxations below only apply to executable code, so we shouldn't attempt them if a
+        // relocation is in a non-executable section.
+        if !section_flags.contains(shf::EXECINSTR) {
+            return None;
+        }
+
+        let offset = offset_in_section as usize;
+        // TODO: Try fetching the symbol kind lazily. For most relocation, we don't need it, but
+        // because fetching it contains potential error paths, the optimiser probably can't optimise
+        // away fetching it.
+
+        match relocation_kind {
+            object::elf::R_RISCV_CALL | object::elf::R_RISCV_CALL_PLT if !interposable => {
+                if non_zero_address {
+                    relocation.kind = RelocationKind::Relative;
+                    return Some(Relaxation {
+                        kind: RelaxationKind::NoOp,
+                        rel_info: relocation,
+                    });
+                }
+                // GNU ld replaces: 'bl 0' with 'nop'
+                // TODO
+            }
+
+            _ => (),
+        }
+
         None
     }
 
-    fn apply(&self, _section_bytes: &mut [u8], _offset_in_section: &mut u64, _addend: &mut i64) {}
+    fn apply(&self, section_bytes: &mut [u8], offset_in_section: &mut u64, addend: &mut i64) {
+        self.kind.apply(section_bytes, offset_in_section, addend);
+    }
 
     fn rel_info(&self) -> RelocationKindInfo {
-        todo!("")
+        self.rel_info
     }
 
     fn debug_kind(&self) -> impl std::fmt::Debug {
-        todo!("")
+        &self.kind
     }
 
     fn next_modifier(&self) -> RelocationModifier {
-        todo!("")
+        self.kind.next_modifier()
     }
 }

--- a/libwild/src/x86_64.rs
+++ b/libwild/src/x86_64.rs
@@ -4,6 +4,7 @@
 //! static-PIE binary because dynamic relocations haven't yet been applied to the GOT yet.
 
 use crate::arch::Arch;
+use crate::arch::TCBPlacement;
 use crate::args::OutputKind;
 use crate::elf::PLT_ENTRY_SIZE;
 use crate::error;
@@ -80,6 +81,10 @@ impl crate::arch::Arch for X86_64 {
 
     fn local_symbols_in_debug_info() -> bool {
         false
+    }
+
+    fn tcb_placement() -> TCBPlacement {
+        TCBPlacement::BeforeTP
     }
 }
 

--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -217,6 +217,7 @@ impl Config {
                 // address is known and within +/-1MB. We don't as yet.
                 "rel.missing-opt.R_AARCH64_ADR_GOT_PAGE.AdrpToAdr.*",
                 "rel.missing-opt.R_AARCH64_ADR_PREL_PG_HI21.AdrpToAdr.*",
+                "rel.extra-opt.R_AARCH64_TLSIE_ADR_GOTTPREL_PAGE21.MovzXnLsl16.*",
                 // The other linkers set properties on sections if all input sections have that
                 // property. For sections like .rodata, this seems like an unimportant behaviour to
                 // replicate.

--- a/linker-utils/src/riscv64.rs
+++ b/linker-utils/src/riscv64.rs
@@ -15,12 +15,22 @@ use std::io::Cursor;
 pub enum RelaxationKind {
     /// Leave the instruction alone. Used when we only want to change the kind of relocation used.
     NoOp,
+
+    /// Replace with nop
+    ReplaceWithNop,
 }
 
 impl RelaxationKind {
-    pub fn apply(self, _section_bytes: &mut [u8], _offset_in_section: &mut u64, _addend: &mut i64) {
+    pub fn apply(self, section_bytes: &mut [u8], offset_in_section: &mut u64, _addend: &mut i64) {
+        let offset = *offset_in_section as usize;
         match self {
             RelaxationKind::NoOp => {}
+            RelaxationKind::ReplaceWithNop => {
+                section_bytes[offset..offset + 4].copy_from_slice(&[
+                    0x01, 0x0, // nop
+                    0x01, 0x0, // nop
+                ]);
+            }
         }
     }
 

--- a/linker-utils/src/riscv64.rs
+++ b/linker-utils/src/riscv64.rs
@@ -359,7 +359,7 @@ impl RISCVInstruction {
                 // For instance, -10i32 (0xfffffff6) should become 0x0 (HI20) and 0xff6 (LO12).
                 let mask = (extract_bits(extracted_value.wrapping_add(0x800), 12, 32) as u32) << 12;
                 // mask low 12 bits
-                and_from_slice(dest, 0xfffu32.to_le_bytes().as_slice());
+                and_from_slice(dest, 0b1111_1111_1111u32.to_le_bytes().as_slice());
                 or_from_slice(dest, &(mask as u32).to_le_bytes());
             }
             RISCVInstruction::IType => {

--- a/linker-utils/src/riscv64.rs
+++ b/linker-utils/src/riscv64.rs
@@ -346,6 +346,9 @@ impl RISCVInstruction {
     // Encode computed relocation value and store it based on the encoding of an instruction.
     // A handy page where one can easily find instruction encoding:
     // https://msyksphinz-self.github.io/riscv-isadoc/html/index.html.
+
+    // During the build of the static libc.a, there are various places where the immediate operand
+    // of an instruction is already filled up. Thus, we zero the bits before a relocation value is applied.
     pub fn write_to_value(self, extracted_value: u64, _negative: bool, dest: &mut [u8]) {
         match self {
             RISCVInstruction::UIType => {

--- a/linker-utils/src/riscv64.rs
+++ b/linker-utils/src/riscv64.rs
@@ -5,9 +5,29 @@ use crate::elf::RelocationKindInfo;
 use crate::elf::RelocationSize;
 use crate::elf::extract_bit;
 use crate::elf::extract_bits;
+use crate::relaxation::RelocationModifier;
 use crate::utils::or_from_slice;
 use leb128;
 use std::io::Cursor;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelaxationKind {
+    /// Leave the instruction alone. Used when we only want to change the kind of relocation used.
+    NoOp,
+}
+
+impl RelaxationKind {
+    pub fn apply(self, _section_bytes: &mut [u8], _offset_in_section: &mut u64, _addend: &mut i64) {
+        match self {
+            RelaxationKind::NoOp => {}
+        }
+    }
+
+    #[must_use]
+    pub fn next_modifier(&self) -> RelocationModifier {
+        RelocationModifier::Normal
+    }
+}
 
 #[must_use]
 pub const fn relocation_type_from_raw(r_type: u32) -> Option<RelocationKindInfo> {

--- a/linker-utils/src/riscv64.rs
+++ b/linker-utils/src/riscv64.rs
@@ -361,7 +361,6 @@ impl RISCVInstruction {
                 // value is a small negative value.
                 // For instance, -10i32 (0xfffffff6) should become 0x0 (HI20) and 0xff6 (LO12).
                 let mask = (extract_bits(extracted_value.wrapping_add(0x800), 12, 32) as u32) << 12;
-                // mask low 12 bits
                 and_from_slice(dest, 0b1111_1111_1111u32.to_le_bytes().as_slice());
                 or_from_slice(dest, &(mask as u32).to_le_bytes());
             }

--- a/linker-utils/src/riscv64.rs
+++ b/linker-utils/src/riscv64.rs
@@ -380,6 +380,7 @@ impl RISCVInstruction {
                 mask |= extract_bit(extracted_value, 11) << 20;
                 mask |= extract_bits(extracted_value, 1, 11) << 21;
                 mask |= extract_bit(extracted_value, 20) << 31;
+                println!("{mask:x}");
                 or_from_slice(dest, &(mask as u32).to_le_bytes());
             }
             RISCVInstruction::CBType => {

--- a/linker-utils/src/utils.rs
+++ b/linker-utils/src/utils.rs
@@ -10,3 +10,10 @@ pub fn or_from_slice(dest: &mut [u8], mask_bytes: &[u8]) {
         dest[i] |= *v;
     }
 }
+
+// And `mask` slice with the `dest` slice using AND operation.
+pub fn and_from_slice(dest: &mut [u8], mask_bytes: &[u8]) {
+    for (i, v) in mask_bytes.iter().enumerate() {
+        dest[i] &= *v;
+    }
+}

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -283,6 +283,7 @@ enum Architecture {
     X86_64,
     #[strum(serialize = "aarch64")]
     AArch64,
+    #[strum(serialize = "riscv64")]
     RISCV64,
 }
 
@@ -809,15 +810,8 @@ fn parse_configs(src_filename: &Path, test_config: &TestConfig) -> Result<Vec<Co
                     config.support_architectures = arg
                         .trim()
                         .split(",")
-                        .map(|arch| {
-                            let arch = arch.trim().to_lowercase();
-                            match arch.as_str() {
-                                "x86_64" => Ok(Architecture::X86_64),
-                                "aarch64" => Ok(Architecture::AArch64),
-                                _ => bail!("Unsupported architecture: `{}`", arch),
-                            }
-                        })
-                        .collect::<Result<Vec<_>>>()?;
+                        .map(|arch| Architecture::from_str(arch.trim()))
+                        .collect::<Result<Vec<_>, _>>()?;
                 }
                 "RequiresGlibc" => config.requires_glibc = arg.trim().to_lowercase().parse()?,
                 "RequiresClangWithTlsDesc" => {

--- a/wild/tests/sources/libc-integration.c
+++ b/wild/tests/sources/libc-integration.c
@@ -11,8 +11,6 @@
 //#CompArgs:-g -ftls-model=global-dynamic
 //#RequiresGlibc:true
 //#Cross: false
-// TODO: There are multiple variants of the test-case that fail with the BFD linker on RISC-V arch.
-//#Arch: x86_64, aarch64
 
 //#AbstractConfig:shared:default
 //#Shared:libc-integration-0.c,libc-integration-0b.c

--- a/wild/tests/sources/libc-integration.c
+++ b/wild/tests/sources/libc-integration.c
@@ -11,6 +11,8 @@
 //#CompArgs:-g -ftls-model=global-dynamic
 //#RequiresGlibc:true
 //#Cross: false
+// TODO: There are multiple variants of the test-case that fail with the BFD linker on RISC-V arch.
+//#Arch: x86_64, aarch64
 
 //#AbstractConfig:shared:default
 //#Shared:libc-integration-0.c,libc-integration-0b.c

--- a/wild/tests/sources/trivial-main.c
+++ b/wild/tests/sources/trivial-main.c
@@ -6,6 +6,16 @@
 
 //#Config:gcc:default
 
+//#Config:gcc-static:default
+//#LinkArgs:-static
+//#DiffIgnore:section.rela.plt.link
+//#DiffIgnore:section.sdata
+
+//#Config:clang-static:default
+//#Compiler:clang
+//#LinkArgs:-static
+//#DiffIgnore:section.rela.plt.link
+
 //#Config:clang:default
 //#Compiler: clang
 

--- a/wild/tests/sources/trivial-main.c
+++ b/wild/tests/sources/trivial-main.c
@@ -15,6 +15,7 @@
 //#Compiler:clang
 //#LinkArgs:-static
 //#DiffIgnore:section.rela.plt.link
+//#DiffIgnore:section.sdata
 
 //#Config:clang:default
 //#Compiler: clang

--- a/wild/tests/sources/trivial-main.c
+++ b/wild/tests/sources/trivial-main.c
@@ -3,6 +3,7 @@
 //#LinkArgs:-Wl,-z,now
 //#DiffIgnore:section.rodata
 //#DiffIgnore:section.data
+//#DiffIgnore:section.data.alignment
 
 //#Config:gcc:default
 


### PR DESCRIPTION
There's a PR that helps me to link a simple C program with `-static` successfully. 

Needed changes:
 - CALL_PLT -> make it a direct call without PLT entry (the same what we need for other archs)
 - TCB placement at the place where we emit TPOFF into a GOT entry - something which might be borked on AArch64 as well, but we don't hit it as it's handled by a relaxation
 - a surprise where I noticed the libc.a instructions (connected to a relocation) already contain an encoded immediate; I hit various crashes as the immediates were combined with a value generated by the linker

EDITTED: ~I'm going to investigate if we can enable some of the `libc-integration.c` tests using the `-static`~.

Fixes: #786