### PR TITLE
Nix CI time improvment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,8 +158,30 @@ jobs:
           echo "Matrix: $matrix"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"      
 
+  nix-cache:
+    name: Refresh Nix Cache
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v30
+
+      - name: Build Wild
+        run: nix build -L --show-trace
+
+      - name: Cache Nix Store
+        uses: nix-community/cache-nix-action/save@v6
+        id: cache
+        with:
+          primary-key: ${{ runner.os }}-${{ hashFiles( 'flake.lock', 'Cargo.lock' ) }}
+
   nix-checks:
-    needs: calc-matrix
+    needs:
+      - calc-matrix
+      - nix-cache
     strategy:
       fail-fast: false
       matrix:
@@ -174,9 +196,13 @@ jobs:
           fetch-depth: 0
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+        uses: nixbuild/nix-quick-install-action@v30
 
+      - name: Restore Nix Store
+        uses: nix-community/cache-nix-action/restore@v6
+        id: cache
+        with:
+          primary-key: ${{ runner.os }}-${{ hashFiles( 'flake.lock', 'Cargo.lock') }}
+          
       - name: Run ${{ matrix.check }}
         run: nix build .#checks.x86_64-linux.${{ matrix.check }} -L --show-trace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
         uses: crate-ci/typos@v1.33.1
 
   calc-matrix:
-    name: Find Nix Checks
+    name: Find Nix checks
     runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.calc-matrix.outputs.matrix }}
@@ -151,37 +151,16 @@ jobs:
         with:
           nix_on_tmpfs: true
 
-      - name: Calculate Check
+      - name: Calculate check
         id: calc-matrix
         run: |
           matrix=$(nix flake show --json | jq -c '.checks."x86_64-linux"|keys_unsorted')
           echo "Matrix: $matrix"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"      
 
-  nix-cache:
-    name: Refresh Nix Cache
-    runs-on: ubuntu-24.04
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install Nix
-        uses: nixbuild/nix-quick-install-action@v30
-
-      - name: Build Wild
-        run: nix build -L --show-trace
-
-      - name: Cache Nix Store
-        uses: nix-community/cache-nix-action/save@v6
-        id: cache
-        with:
-          primary-key: ${{ runner.os }}-${{ hashFiles( 'flake.lock', 'Cargo.lock' ) }}
-
   nix-checks:
     needs:
       - calc-matrix
-      - nix-cache
     strategy:
       fail-fast: false
       matrix:
@@ -198,7 +177,7 @@ jobs:
       - name: Install Nix
         uses: nixbuild/nix-quick-install-action@v30
 
-      - name: Restore Nix Store
+      - name: Restore Nix store
         uses: nix-community/cache-nix-action/restore@v6
         id: cache
         with:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -19,3 +19,37 @@ jobs:
         with:
           reporter: github-check
           filter_mode: "nofilter"
+
+  bump-nix:
+    name: Update Nix lockfile
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v30
+
+      - name: Update lock file
+        run: |
+          nix flake update -L --show-trace
+
+      - name: Commit changes
+        run: |
+          git branch -D nix_update
+          git checkout -b nix_update
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add flake.lock
+          git commit -m "[Automated] Update flake.lock"
+          git push -f origin nix_update 
+
+      - name: Create PR
+        run: |
+          gh pr create \
+            --base main \
+            --head nix_update \
+            --title "Update Nix lockfile"            

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,32 @@
+name: Refresh Nix Cache
+
+on:
+  push:
+    branches: [ 'main' ]
+    paths:
+      - flake.lock
+      - Cargo.lock
+  workflow_dispatch:
+
+jobs:
+  nix-cache:
+    name: Refresh Nix Cache
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v30
+
+      - name: Build Wild
+        run: |
+          nix build -L --show-trace
+
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action/save@v6
+        id: cache
+        with:
+          primary-key: ${{ runner.os }}-${{ hashFiles( 'flake.lock', 'Cargo.lock' ) }}
+

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ heaptrack*.zst
 .cargo/config.toml
 dhat-heap.json
 test-config.toml
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1748970125,
+        "narHash": "sha256-UDyigbDGv8fvs9aS95yzFfOKkEjx1LO3PL3DsKopohA=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "323b5746d89e04b22554b061522dfce9e4c49b18",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1749008870,
@@ -15,6 +30,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,14 +1,10 @@
 # TODO(RossSmyth): One 1.87 is on nixpkgs unstable, remove the rust-overlay requirement.
-final: prev:
+crane: final: prev:
 let
-  rustToolchain = final.rust-bin.beta.latest.minimal;
-  rustPlatform = final.makeRustPlatform {
-    rustc = rustToolchain;
-    cargo = rustToolchain;
-  };
+  craneLib = (crane.mkLib final).overrideToolchain (p: p.rust-bin.beta.latest.minimal);
 in
 {
-  wild = final.callPackage ./. { inherit rustPlatform; };
+  wild = final.callPackage ./. { inherit craneLib; };
   useWildLinker = import ./adapter.nix {
     pkgs = final;
     lib = final.lib;

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,5 +1,6 @@
 {
   pkgs ? import <nixpkgs> { },
+  craneLib,
 }:
 pkgs.mkShell {
   packages = [
@@ -10,7 +11,7 @@ pkgs.mkShell {
     pkgs.glibc.out
     pkgs.glibc.static
     pkgs.rustup
-  ] ++ (pkgs.callPackage ./. { }).gccWrappers;
+  ] ++ (pkgs.callPackage ./. { inherit craneLib; }).gccWrappers;
 
   env.LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [ pkgs.stdenv.cc.cc.lib ];
 }

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/42n5nz0gbg8fvsc6dwchrk7vrihcyml7-wild-0.5.0


### PR DESCRIPTION
I'm going to try out different things to improve nix CI times

Baseline:
https://github.com/davidlattimore/wild/actions/runs/15513450877

- Nix/wild: 3m 12s
- Nix/adapterGcc: 2m 31s
- Nix/adapterClang: 2m 39s

Note that this isn't super scientific as runners can vary in hardware and load.

It seems most of the additional time is spent building the checkPhase for Nix/wild.

1. nix_on_tmpfs

This can improve speed a lot. Sometimes more than caching.

Downsides:
- Can OOM
- Limited to one builder