### PR TITLE
Use WILD_TEST_BUILD_DIR for build dir location of integration tests

### DIFF
--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -151,7 +151,7 @@ fn base_dir() -> &'static Path {
 }
 
 fn build_dir() -> PathBuf {
-    base_dir().join("tests/build")
+    std::env::var("WILD_TEST_BUILD_DIR").map_or(base_dir().join("tests/build"), PathBuf::from)
 }
 
 struct ProgramInputs {


### PR DESCRIPTION
I see it handy when using a Docker container that shares the source code of the Wild linker, while it uses a separate build dir for the integration test artifacts. Using that, one can build and run tests on the host and in the container.