### PR TITLE
Use 0x prefix for HEXU64 as it can be copied e.g. to Python

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -127,7 +127,7 @@ impl HexU64 {
 
 impl Display for HexU64 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:x}", self.value)
+        write!(f, "{:#x}", self.value)
     }
 }
 


### PR DESCRIPTION
If I need to make a calculation is better to have the numbers in a format e.g. Python can recognize.