### PR TITLE
Look first for ld.bfd when looking for BFD linker

### DIFF
--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -2193,7 +2193,7 @@ fn available_linkers() -> Result<Vec<Linker>> {
         Linker::ThirdParty(ThirdPartyLinker {
             name: "ld",
             gcc_name: "bfd",
-            path: find_bin(&["ld"])?,
+            path: find_bin(&["ld.bfd", "ld"])?,
             cross_paths: find_cross_paths("ld"),
             enabled_by_default: true,
         }),


### PR DESCRIPTION
Recently, I switched my default linker to Mold (via update-alternatives), and so `ld.bfd` is the BFD for me now.