### PR TITLE
Allow R_X86_64_GOTPC32_TLSDESC for all executable outputs

### DIFF
--- a/libwild/src/x86_64.rs
+++ b/libwild/src/x86_64.rs
@@ -308,11 +308,8 @@ impl crate::arch::Relaxation for Relaxation {
                     }
                 }
             }
-            // TODO: It looks to me like we should be able to optimise to local-exec for any
-            // executable, not just static executables. However, currently the test fails if we try
-            // this. Investigate why.
             object::elf::R_X86_64_GOTPC32_TLSDESC
-                if !interposable && output_kind.is_static_executable() =>
+                if !interposable && output_kind.is_executable() =>
             {
                 // We assume that the instruction that this relocation applies to is a REX-prefixed
                 // LEA instruction.

--- a/linker-utils/src/x86_64.rs
+++ b/linker-utils/src/x86_64.rs
@@ -163,6 +163,7 @@ impl RelaxationKind {
                     // mov {offset},%rax
                     0x48, 0xc7, 0xc0, 0, 0, 0, 0,
                 ]);
+                *addend = 0;
             }
             RelaxationKind::TlsDescToInitialExec => {
                 section_bytes[offset - 3..offset + 4].copy_from_slice(&[


### PR DESCRIPTION
Fixes: #849