### PR TITLE
Pass --gc-sections to the linker in one of our tests

### DIFF
--- a/wild/tests/sources/trivial-main.c
+++ b/wild/tests/sources/trivial-main.c
@@ -8,7 +8,7 @@
 //#Config:gcc:default
 
 //#Config:gcc-static:default
-//#LinkArgs:-static
+//#LinkArgs:-static -Wl,--gc-sections
 //#DiffIgnore:section.rela.plt.link
 //#DiffIgnore:section.sdata
 


### PR DESCRIPTION
This fixes a failure on my system due to a section called `__libc_freeres_fn` showing up when GNU ld links the binary. It wasn't showing up in our output because we default to --gc-sections.