### PR TITLE
whole_archive test: Remove use of retain attribute

### DIFF
--- a/wild/tests/sources/whole_archive0.c
+++ b/wild/tests/sources/whole_archive0.c
@@ -1,1 +1,1 @@
-static int foo1 __attribute__ ((used, retain, section ("foo"))) = 42;
+static int foo1 __attribute__ ((used, section ("foo"))) = 42;


### PR DESCRIPTION
This attribute isn't supported by the aarch64 cross compiler on my system. Fortunately, the attribute isn't needed.