### PR TITLE
Fix cargo clippy issue

### DIFF
--- a/linker-diff/src/arch.rs
+++ b/linker-diff/src/arch.rs
@@ -101,7 +101,7 @@ pub(crate) trait Arch: Clone + Copy + Eq + PartialEq + Debug {
         section_address: u64,
         function_offset_in_section: u64,
         range: Range<u64>,
-    ) -> Vec<Instruction<Self>>;
+    ) -> Vec<Instruction<'_, Self>>;
 
     fn decode_plt_entry(plt_entry: &[u8], plt_base: u64, plt_offset: u64) -> Option<PltEntry>;
 


### PR DESCRIPTION
```
warning: lifetime flowing from input to output with different syntax can be confusing
   --> linker-diff/src/arch.rs:100:24
    |
100 |         section_bytes: &[u8],
    |                        ^^^^^ this lifetime flows to the output
...
104 |     ) -> Vec<Instruction<Self>>;
    |              ----------------- the lifetime gets resolved as `'_`
    |
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
104 |     ) -> Vec<Instruction<'_, Self>>;
    |                          +++
```