### PR TITLE
Add rel_info_from_type macro for const evaluation

### DIFF
--- a/libwild/src/aarch64.rs
+++ b/libwild/src/aarch64.rs
@@ -155,9 +155,6 @@ impl crate::arch::Relaxation for Relaxation {
         }
 
         let offset = offset_in_section as usize;
-        // TODO: Try fetching the symbol kind lazily. For most relocation, we don't need it, but
-        // because fetching it contains potential error paths, the optimiser probably can't optimise
-        // away fetching it.
 
         match relocation_kind {
             object::elf::R_AARCH64_CALL26 | object::elf::R_AARCH64_JUMP26 if !interposable => {

--- a/libwild/src/aarch64.rs
+++ b/libwild/src/aarch64.rs
@@ -109,6 +109,12 @@ const TLSDESC_ADD_LO12_INSN_SEQUENCE: &[u8] = &[
     0x0, 0x0, 0x0, 0x91, // add     x0, x0, #0x0
 ];
 
+macro_rules! rel_info_from_type {
+    ($r_type:expr) => {
+        const { relocation_type_from_raw($r_type).unwrap() }
+    };
+}
+
 impl crate::arch::Relaxation for Relaxation {
     #[allow(unused_variables)]
     #[inline(always)]
@@ -166,7 +172,7 @@ impl crate::arch::Relaxation for Relaxation {
                     // GNU ld replaces: 'bl 0' with 'nop'
                     Some(Relaxation {
                         kind: RelaxationKind::ReplaceWithNop,
-                        rel_info: relocation_type_from_raw(object::elf::R_AARCH64_NONE).unwrap(),
+                        rel_info: rel_info_from_type!(object::elf::R_AARCH64_NONE),
                         mandatory: output_kind.is_static_executable(),
                     })
                 };
@@ -181,7 +187,7 @@ impl crate::arch::Relaxation for Relaxation {
                 );
                 return Some(Relaxation {
                     kind: RelaxationKind::ReplaceWithNop,
-                    rel_info: relocation_type_from_raw(object::elf::R_AARCH64_NONE).unwrap(),
+                    rel_info: rel_info_from_type!(object::elf::R_AARCH64_NONE),
                     mandatory: output_kind.is_static_executable(),
                 });
             }
@@ -190,7 +196,7 @@ impl crate::arch::Relaxation for Relaxation {
             {
                 return Some(Relaxation {
                     kind: RelaxationKind::ReplaceWithNop,
-                    rel_info: relocation_type_from_raw(object::elf::R_AARCH64_NONE).unwrap(),
+                    rel_info: rel_info_from_type!(object::elf::R_AARCH64_NONE),
                     mandatory: output_kind.is_static_executable(),
                 });
             }
@@ -203,18 +209,14 @@ impl crate::arch::Relaxation for Relaxation {
                 );
                 return Some(Relaxation {
                     kind: RelaxationKind::MovzX0Lsl16,
-                    rel_info: relocation_type_from_raw(object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G1)
-                        .unwrap(),
+                    rel_info: rel_info_from_type!(object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G1),
                     mandatory: output_kind.is_static_executable(),
                 });
             }
             object::elf::R_AARCH64_TLSDESC_CALL if output_kind.is_executable() && !interposable => {
                 return Some(Relaxation {
                     kind: RelaxationKind::MovkX0,
-                    rel_info: relocation_type_from_raw(
-                        object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G0_NC,
-                    )
-                    .unwrap(),
+                    rel_info: rel_info_from_type!(object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G0_NC),
                     mandatory: output_kind.is_static_executable(),
                 });
             }
@@ -227,14 +229,14 @@ impl crate::arch::Relaxation for Relaxation {
                 );
                 return Some(Relaxation {
                     kind: RelaxationKind::ReplaceWithNop,
-                    rel_info: relocation_type_from_raw(object::elf::R_AARCH64_NONE).unwrap(),
+                    rel_info: rel_info_from_type!(object::elf::R_AARCH64_NONE),
                     mandatory: output_kind.is_static_executable(),
                 });
             }
             object::elf::R_AARCH64_TLSDESC_LD64_LO12 if output_kind.is_executable() => {
                 return Some(Relaxation {
                     kind: RelaxationKind::ReplaceWithNop,
-                    rel_info: relocation_type_from_raw(object::elf::R_AARCH64_NONE).unwrap(),
+                    rel_info: rel_info_from_type!(object::elf::R_AARCH64_NONE),
                     mandatory: output_kind.is_static_executable(),
                 });
             }
@@ -245,20 +247,16 @@ impl crate::arch::Relaxation for Relaxation {
                 );
                 return Some(Relaxation {
                     kind: RelaxationKind::AdrpX0,
-                    rel_info: relocation_type_from_raw(
-                        object::elf::R_AARCH64_TLSIE_ADR_GOTTPREL_PAGE21,
-                    )
-                    .unwrap(),
+                    rel_info: rel_info_from_type!(object::elf::R_AARCH64_TLSIE_ADR_GOTTPREL_PAGE21),
                     mandatory: output_kind.is_static_executable(),
                 });
             }
             object::elf::R_AARCH64_TLSDESC_CALL if output_kind.is_executable() => {
                 return Some(Relaxation {
                     kind: RelaxationKind::LdrX0,
-                    rel_info: relocation_type_from_raw(
-                        object::elf::R_AARCH64_TLSIE_LD64_GOTTPREL_LO12_NC,
-                    )
-                    .unwrap(),
+                    rel_info: rel_info_from_type!(
+                        object::elf::R_AARCH64_TLSIE_LD64_GOTTPREL_LO12_NC
+                    ),
                     mandatory: output_kind.is_static_executable(),
                 });
             }
@@ -268,8 +266,7 @@ impl crate::arch::Relaxation for Relaxation {
             {
                 return Some(Relaxation {
                     kind: RelaxationKind::MovzXnLsl16,
-                    rel_info: relocation_type_from_raw(object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G1)
-                        .unwrap(),
+                    rel_info: rel_info_from_type!(object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G1),
                     mandatory: false,
                 });
             }
@@ -278,10 +275,7 @@ impl crate::arch::Relaxation for Relaxation {
             {
                 return Some(Relaxation {
                     kind: RelaxationKind::MovkXn,
-                    rel_info: relocation_type_from_raw(
-                        object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G0_NC,
-                    )
-                    .unwrap(),
+                    rel_info: rel_info_from_type!(object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G0_NC),
                     mandatory: false,
                 });
             }

--- a/libwild/src/riscv64.rs
+++ b/libwild/src/riscv64.rs
@@ -118,9 +118,6 @@ impl crate::arch::Relaxation for Relaxation {
         }
 
         let offset = offset_in_section as usize;
-        // TODO: Try fetching the symbol kind lazily. For most relocation, we don't need it, but
-        // because fetching it contains potential error paths, the optimiser probably can't optimise
-        // away fetching it.
 
         match relocation_kind {
             object::elf::R_RISCV_CALL | object::elf::R_RISCV_CALL_PLT if !interposable => {

--- a/libwild/src/riscv64.rs
+++ b/libwild/src/riscv64.rs
@@ -87,6 +87,12 @@ pub(crate) struct Relaxation {
     rel_info: RelocationKindInfo,
 }
 
+macro_rules! rel_info_from_type {
+    ($r_type:expr) => {
+        const { relocation_type_from_raw($r_type).unwrap() }
+    };
+}
+
 impl crate::arch::Relaxation for Relaxation {
     #[allow(unused_variables)]
     #[inline(always)]
@@ -128,7 +134,7 @@ impl crate::arch::Relaxation for Relaxation {
                     // GNU ld replaces: 'bl 0' with 'nop'
                     Some(Relaxation {
                         kind: RelaxationKind::ReplaceWithNop,
-                        rel_info: relocation_type_from_raw(object::elf::R_RISCV_NONE).unwrap(),
+                        rel_info: rel_info_from_type!(object::elf::R_RISCV_NONE),
                     })
                 };
             }

--- a/libwild/src/x86_64.rs
+++ b/libwild/src/x86_64.rs
@@ -3,21 +3,19 @@
 //! work unless they're performed. e.g. it uses GOT relocations in _start, which cannot work in a
 //! static-PIE binary because dynamic relocations haven't yet been applied to the GOT yet.
 
-use crate::arch::Arch;
 use crate::args::OutputKind;
 use crate::elf::PLT_ENTRY_SIZE;
 use crate::error;
 use crate::error::Result;
 use crate::resolution::ValueFlags;
-use linker_utils::elf::AllowedRange;
 use linker_utils::elf::DynamicRelocationKind;
 use linker_utils::elf::RelocationKindInfo;
-use linker_utils::elf::RelocationSize;
 use linker_utils::elf::SectionFlags;
 use linker_utils::elf::shf;
 use linker_utils::elf::x86_64_rel_type_to_string;
 use linker_utils::relaxation::RelocationModifier;
 use linker_utils::x86_64::RelaxationKind;
+use linker_utils::x86_64::relocation_from_raw;
 
 pub(crate) struct X86_64;
 
@@ -40,20 +38,11 @@ impl crate::arch::Arch for X86_64 {
 
     #[inline(always)]
     fn relocation_from_raw(r_type: u32) -> Result<RelocationKindInfo> {
-        let (kind, size) =
-            linker_utils::x86_64::relocation_kind_and_size(r_type).ok_or_else(|| {
-                error!(
-                    "Unsupported relocation type {}",
-                    Self::rel_type_to_string(r_type)
-                )
-            })?;
-
-        Ok(RelocationKindInfo {
-            kind,
-            size: RelocationSize::ByteSize(size),
-            mask: None,
-            range: AllowedRange::no_check(),
-            alignment: 1,
+        linker_utils::x86_64::relocation_from_raw(r_type).ok_or_else(|| {
+            error!(
+                "Unsupported relocation type {}",
+                Self::rel_type_to_string(r_type)
+            )
         })
     }
 
@@ -87,6 +76,12 @@ impl crate::arch::Arch for X86_64 {
     }
 }
 
+macro_rules! rel_info_from_type {
+    ($r_type:expr) => {
+        const { relocation_from_raw($r_type).unwrap() }
+    };
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct Relaxation {
     kind: RelaxationKind,
@@ -105,21 +100,6 @@ impl crate::arch::Relaxation for Relaxation {
         section_flags: SectionFlags,
         _non_zero_address: bool,
     ) -> Option<Self> {
-        // TODO: Consider removing Option. There are a few callers though, so need to see how this
-        // looks.
-        #[allow(clippy::unnecessary_wraps)]
-        #[inline(always)]
-        fn create(kind: RelaxationKind, new_r_type: u32, mandatory: bool) -> Option<Relaxation> {
-            // This only fails for relocation types that we don't support and if we relax to a type
-            // we don't support, then that's a bug.
-            let rel_info = X86_64::relocation_from_raw(new_r_type).unwrap();
-            Some(Relaxation {
-                kind,
-                rel_info,
-                mandatory,
-            })
-        }
-
         let is_known_address = value_flags.is_address();
         let is_absolute = value_flags.is_absolute() && !value_flags.is_dynamic();
         let non_relocatable = !output_kind.is_relocatable();
@@ -133,7 +113,11 @@ impl crate::arch::Relaxation for Relaxation {
         if value_flags.is_ifunc() {
             return match relocation_kind {
                 object::elf::R_X86_64_PC32 => {
-                    return create(RelaxationKind::NoOp, object::elf::R_X86_64_PLT32, true);
+                    return Some(Relaxation {
+                        kind: RelaxationKind::NoOp,
+                        rel_info: rel_info_from_type!(object::elf::R_X86_64_PLT32),
+                        mandatory: true,
+                    });
                 }
                 _ => None,
             };
@@ -166,27 +150,27 @@ impl crate::arch::Relaxation for Relaxation {
                     match b1 {
                         // mov *x(%rip), reg
                         0x8b => {
-                            return create(
-                                RelaxationKind::RexMovIndirectToAbsolute,
-                                object::elf::R_X86_64_32,
-                                output_kind.is_static_executable(),
-                            );
+                            return Some(Relaxation {
+                                kind: RelaxationKind::RexMovIndirectToAbsolute,
+                                rel_info: rel_info_from_type!(object::elf::R_X86_64_32),
+                                mandatory: output_kind.is_static_executable(),
+                            });
                         }
                         // sub *x(%rip), reg
                         0x2b => {
-                            return create(
-                                RelaxationKind::RexSubIndirectToAbsolute,
-                                object::elf::R_X86_64_32,
-                                output_kind.is_static_executable(),
-                            );
+                            return Some(Relaxation {
+                                kind: RelaxationKind::RexSubIndirectToAbsolute,
+                                rel_info: rel_info_from_type!(object::elf::R_X86_64_32),
+                                mandatory: output_kind.is_static_executable(),
+                            });
                         }
                         // cmp *x(%rip), reg
                         0x3b => {
-                            return create(
-                                RelaxationKind::RexCmpIndirectToAbsolute,
-                                object::elf::R_X86_64_32,
-                                output_kind.is_static_executable(),
-                            );
+                            return Some(Relaxation {
+                                kind: RelaxationKind::RexCmpIndirectToAbsolute,
+                                rel_info: rel_info_from_type!(object::elf::R_X86_64_32),
+                                mandatory: output_kind.is_static_executable(),
+                            });
                         }
                         _ => return None,
                     }
@@ -194,11 +178,11 @@ impl crate::arch::Relaxation for Relaxation {
                     match b1 {
                         // mov *x(%rip), reg
                         0x8b => {
-                            return create(
-                                RelaxationKind::MovIndirectToLea,
-                                object::elf::R_X86_64_PC32,
-                                output_kind.is_static_executable(),
-                            );
+                            return Some(Relaxation {
+                                kind: RelaxationKind::MovIndirectToLea,
+                                rel_info: rel_info_from_type!(object::elf::R_X86_64_PC32),
+                                mandatory: output_kind.is_static_executable(),
+                            });
                         }
                         _ => return None,
                     }
@@ -209,17 +193,17 @@ impl crate::arch::Relaxation for Relaxation {
                     // mov *x(%rip), reg
                     0x8b => {
                         if is_absolute || is_absolute_address {
-                            return create(
-                                RelaxationKind::MovIndirectToAbsolute,
-                                object::elf::R_X86_64_32,
-                                output_kind.is_static_executable(),
-                            );
+                            return Some(Relaxation {
+                                kind: RelaxationKind::MovIndirectToAbsolute,
+                                rel_info: rel_info_from_type!(object::elf::R_X86_64_32),
+                                mandatory: output_kind.is_static_executable(),
+                            });
                         } else if !interposable {
-                            return create(
-                                RelaxationKind::MovIndirectToLea,
-                                object::elf::R_X86_64_PC32,
-                                output_kind.is_static_executable(),
-                            );
+                            return Some(Relaxation {
+                                kind: RelaxationKind::MovIndirectToLea,
+                                rel_info: rel_info_from_type!(object::elf::R_X86_64_PC32),
+                                mandatory: output_kind.is_static_executable(),
+                            });
                         }
                     }
                     _ => {}
@@ -228,19 +212,19 @@ impl crate::arch::Relaxation for Relaxation {
                     match section_bytes.get(offset - 2..offset)? {
                         // call *x(%rip)
                         [0xff, 0x15] => {
-                            return create(
-                                RelaxationKind::CallIndirectToRelative,
-                                object::elf::R_X86_64_PC32,
-                                output_kind.is_static_executable(),
-                            );
+                            return Some(Relaxation {
+                                kind: RelaxationKind::CallIndirectToRelative,
+                                rel_info: rel_info_from_type!(object::elf::R_X86_64_PC32),
+                                mandatory: output_kind.is_static_executable(),
+                            });
                         }
                         // jmp *x(%rip)
                         [0xff, 0x25] => {
-                            return create(
-                                RelaxationKind::JmpIndirectToRelative,
-                                object::elf::R_X86_64_PC32,
-                                output_kind.is_static_executable(),
-                            );
+                            return Some(Relaxation {
+                                kind: RelaxationKind::JmpIndirectToRelative,
+                                rel_info: rel_info_from_type!(object::elf::R_X86_64_PC32),
+                                mandatory: output_kind.is_static_executable(),
+                            });
                         }
                         _ => return None,
                     }
@@ -251,11 +235,11 @@ impl crate::arch::Relaxation for Relaxation {
                 match section_bytes.get(offset - 2)? {
                     // mov *x(%rip), reg
                     0x8b => {
-                        return create(
-                            RelaxationKind::MovIndirectToLea,
-                            object::elf::R_X86_64_PC32,
-                            false,
-                        );
+                        return Some(Relaxation {
+                            kind: RelaxationKind::MovIndirectToLea,
+                            rel_info: rel_info_from_type!(object::elf::R_X86_64_PC32),
+                            mandatory: false,
+                        });
                     }
                     _ => {}
                 }
@@ -265,39 +249,39 @@ impl crate::arch::Relaxation for Relaxation {
                 match section_bytes.get(offset - 3..offset - 1)? {
                     // mov *x(%rip), reg
                     [0x48 | 0x4c, 0x8b] => {
-                        return create(
-                            RelaxationKind::RexMovIndirectToAbsolute,
-                            object::elf::R_X86_64_TPOFF32,
-                            false,
-                        );
+                        return Some(Relaxation {
+                            kind: RelaxationKind::RexMovIndirectToAbsolute,
+                            rel_info: rel_info_from_type!(object::elf::R_X86_64_TPOFF32),
+                            mandatory: false,
+                        });
                     }
                     _ => {}
                 }
             }
             object::elf::R_X86_64_PLT32 if !interposable => {
-                return create(
-                    RelaxationKind::NoOp,
-                    object::elf::R_X86_64_PC32,
-                    output_kind.is_static_executable(),
-                );
+                return Some(Relaxation {
+                    kind: RelaxationKind::NoOp,
+                    rel_info: rel_info_from_type!(object::elf::R_X86_64_PC32),
+                    mandatory: output_kind.is_static_executable(),
+                });
             }
             object::elf::R_X86_64_PLTOFF64 if !interposable => {
-                return create(
-                    RelaxationKind::NoOp,
-                    object::elf::R_X86_64_GOTOFF64,
-                    output_kind.is_static_executable(),
-                );
+                return Some(Relaxation {
+                    kind: RelaxationKind::NoOp,
+                    rel_info: rel_info_from_type!(object::elf::R_X86_64_GOTOFF64),
+                    mandatory: output_kind.is_static_executable(),
+                });
             }
             object::elf::R_X86_64_TLSGD if !interposable && output_kind.is_executable() => {
                 let kind = match TlsGdForm::identify(section_bytes, offset)? {
                     TlsGdForm::Regular => RelaxationKind::TlsGdToLocalExec,
                     TlsGdForm::Large => RelaxationKind::TlsGdToLocalExecLarge,
                 };
-                return create(
+                return Some(Relaxation {
                     kind,
-                    object::elf::R_X86_64_TPOFF32,
-                    output_kind.is_static_executable(),
-                );
+                    rel_info: rel_info_from_type!(object::elf::R_X86_64_TPOFF32),
+                    mandatory: output_kind.is_static_executable(),
+                });
             }
             object::elf::R_X86_64_TLSGD if output_kind.is_executable() => {
                 let kind = match TlsGdForm::identify(section_bytes, offset)? {
@@ -307,7 +291,11 @@ impl crate::arch::Relaxation for Relaxation {
                         return None;
                     }
                 };
-                return create(kind, object::elf::R_X86_64_GOTTPOFF, false);
+                return Some(Relaxation {
+                    kind,
+                    rel_info: rel_info_from_type!(object::elf::R_X86_64_GOTTPOFF),
+                    mandatory: false,
+                });
             }
             object::elf::R_X86_64_TLSLD if output_kind.is_executable() => {
                 // lea    0x0(%rip),%rdi
@@ -315,28 +303,28 @@ impl crate::arch::Relaxation for Relaxation {
                     match section_bytes.get(offset + 4..offset + 6) {
                         // PC-relative direct call
                         Some(&[0xe8, _]) => {
-                            return create(
-                                RelaxationKind::TlsLdToLocalExec,
-                                object::elf::R_X86_64_NONE,
-                                false,
-                            );
+                            return Some(Relaxation {
+                                kind: RelaxationKind::TlsLdToLocalExec,
+                                rel_info: rel_info_from_type!(object::elf::R_X86_64_NONE),
+                                mandatory: false,
+                            });
                         }
                         // TODO: Make a test for this. Also, the description of TlsLdToLocalExec64
                         // possibly doesn't match what we're actually checking here.
                         Some(&[0x48, 0xb8]) => {
-                            return create(
-                                RelaxationKind::TlsLdToLocalExec64,
-                                object::elf::R_X86_64_NONE,
-                                false,
-                            );
+                            return Some(Relaxation {
+                                kind: RelaxationKind::TlsLdToLocalExec64,
+                                rel_info: rel_info_from_type!(object::elf::R_X86_64_NONE),
+                                mandatory: false,
+                            });
                         }
                         // PC-relative indirect call
                         Some(&[0xff, 0x15]) => {
-                            return create(
-                                RelaxationKind::TlsLdToLocalExecNoPlt,
-                                object::elf::R_X86_64_NONE,
-                                false,
-                            );
+                            return Some(Relaxation {
+                                kind: RelaxationKind::TlsLdToLocalExecNoPlt,
+                                rel_info: rel_info_from_type!(object::elf::R_X86_64_NONE),
+                                mandatory: false,
+                            });
                         }
                         _ => {}
                     }
@@ -347,31 +335,31 @@ impl crate::arch::Relaxation for Relaxation {
             {
                 // We assume that the instruction that this relocation applies to is a REX-prefixed
                 // LEA instruction.
-                return create(
-                    RelaxationKind::TlsDescToLocalExec,
-                    object::elf::R_X86_64_TPOFF32,
-                    output_kind.is_static_executable(),
-                );
+                return Some(Relaxation {
+                    kind: RelaxationKind::TlsDescToLocalExec,
+                    rel_info: rel_info_from_type!(object::elf::R_X86_64_TPOFF32),
+                    mandatory: output_kind.is_static_executable(),
+                });
             }
             // Note, the conditions on this relaxation (is_executable) must match those on
             // TLSDESC_CALL below.
             object::elf::R_X86_64_GOTPC32_TLSDESC if output_kind.is_executable() => {
                 // We assume that the instruction that this relocation applies to is a REX-prefixed
                 // LEA instruction.
-                return create(
-                    RelaxationKind::TlsDescToInitialExec,
-                    object::elf::R_X86_64_GOTTPOFF,
-                    output_kind.is_static_executable(),
-                );
+                return Some(Relaxation {
+                    kind: RelaxationKind::TlsDescToInitialExec,
+                    rel_info: rel_info_from_type!(object::elf::R_X86_64_GOTTPOFF),
+                    mandatory: output_kind.is_static_executable(),
+                });
             }
             // Note, the conditions on this relaxation (is_executable) must match those on
             // GOTPC32_TLSDESC above.
             object::elf::R_X86_64_TLSDESC_CALL if output_kind.is_executable() => {
-                return create(
-                    RelaxationKind::SkipTlsDescCall,
-                    object::elf::R_X86_64_NONE,
-                    output_kind.is_static_executable(),
-                );
+                return Some(Relaxation {
+                    kind: RelaxationKind::SkipTlsDescCall,
+                    rel_info: rel_info_from_type!(object::elf::R_X86_64_NONE),
+                    mandatory: output_kind.is_static_executable(),
+                });
             }
             _ => return None,
         };

--- a/libwild/src/x86_64.rs
+++ b/libwild/src/x86_64.rs
@@ -130,9 +130,7 @@ impl crate::arch::Relaxation for Relaxation {
         }
 
         let offset = offset_in_section as usize;
-        // TODO: Try fetching the symbol kind lazily. For most relocation, we don't need it, but
-        // because fetching it contains potential error paths, the optimiser probably can't optimise
-        // away fetching it.
+
         match relocation_kind {
             object::elf::R_X86_64_REX_GOTPCRELX => {
                 if offset < 3 {

--- a/linker-diff/src/x86_64.rs
+++ b/linker-diff/src/x86_64.rs
@@ -428,15 +428,7 @@ impl crate::arch::RType for RType {
     }
 
     fn opt_relocation_info(self) -> Option<RelocationKindInfo> {
-        linker_utils::x86_64::relocation_kind_and_size(self.0).map(|(kind, size_in_bytes)| {
-            RelocationKindInfo {
-                kind,
-                size: linker_utils::elf::RelocationSize::ByteSize(size_in_bytes),
-                mask: None,
-                range: linker_utils::elf::AllowedRange::no_check(),
-                alignment: 1,
-            }
-        })
+        linker_utils::x86_64::relocation_from_raw(self.0)
     }
 
     fn dynamic_relocation_kind(self) -> Option<DynamicRelocationKind> {

--- a/linker-utils/src/x86_64.rs
+++ b/linker-utils/src/x86_64.rs
@@ -1,4 +1,7 @@
+use crate::elf::AllowedRange;
 use crate::elf::RelocationKind;
+use crate::elf::RelocationKindInfo;
+use crate::elf::RelocationSize;
 use crate::relaxation::RelocationModifier;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -205,10 +208,9 @@ impl RelaxationKind {
     }
 }
 
-/// Returns the supplied x86-64 relocation type split into a relocation kind and a size (in bytes)
-/// for the relocation. Returns `None` if the r_type isn't recognised.
+/// Returns the supplied x86-64 relocation as RelocationKindType. Returns `None` if the r_type isn't recognised.
 #[must_use]
-pub fn relocation_kind_and_size(r_type: u32) -> Option<(RelocationKind, usize)> {
+pub const fn relocation_from_raw(r_type: u32) -> Option<RelocationKindInfo> {
     let (kind, size) = match r_type {
         object::elf::R_X86_64_64 => (RelocationKind::Absolute, 8),
         object::elf::R_X86_64_PC32 => (RelocationKind::Relative, 4),
@@ -245,5 +247,12 @@ pub fn relocation_kind_and_size(r_type: u32) -> Option<(RelocationKind, usize)> 
         object::elf::R_X86_64_NONE => (RelocationKind::None, 0),
         _ => return None,
     };
-    Some((kind, size))
+
+    Some(RelocationKindInfo {
+        kind,
+        size: RelocationSize::ByteSize(size),
+        mask: None,
+        range: AllowedRange::no_check(),
+        alignment: 1,
+    })
 }


### PR DESCRIPTION
By using the macro with `const` block, we prevent unsupported relocation constants from being used at the place where we build a Relaxation:

```
error[E0080]: evaluation panicked: called `Option::unwrap()` on a `None` value
   --> libwild/src/aarch64.rs:114:17
    |
114 |         const { relocation_type_from_raw($r_type).unwrap() }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `<aarch64::Relaxation as arch::Relaxation>::new::{constant#5}` failed here
...
232 |                     rel_info: rel_info_from_type!(object::elf::R_X86_64_16),
    |                               --------------------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `rel_info_from_type` (in Nightly builds, run with -Z macro-backtrace for more info)

note: erroneous constant encountered
   --> libwild/src/aarch64.rs:114:9
    |
114 |         const { relocation_type_from_raw($r_type).unwrap() }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
232 |                     rel_info: rel_info_from_type!(object::elf::R_X86_64_16),
    |                               --------------------------------------------- in this macro invocation
```

Additionally, I unified the code structure across the targets.