### PR TITLE
Revert "Change a macro to a const fn"

### DIFF
--- a/libwild/src/aarch64.rs
+++ b/libwild/src/aarch64.rs
@@ -109,9 +109,10 @@ const TLSDESC_ADD_LO12_INSN_SEQUENCE: &[u8] = &[
     0x0, 0x0, 0x0, 0x91, // add     x0, x0, #0x0
 ];
 
-#[track_caller]
-const fn rel_info_from_type(r_type: u32) -> RelocationKindInfo {
-    relocation_type_from_raw(r_type).unwrap()
+macro_rules! rel_info_from_type {
+    ($r_type:expr) => {
+        const { relocation_type_from_raw($r_type).unwrap() }
+    };
 }
 
 impl crate::arch::Relaxation for Relaxation {
@@ -168,7 +169,7 @@ impl crate::arch::Relaxation for Relaxation {
                     // GNU ld replaces: 'bl 0' with 'nop'
                     Some(Relaxation {
                         kind: RelaxationKind::ReplaceWithNop,
-                        rel_info: rel_info_from_type(object::elf::R_AARCH64_NONE),
+                        rel_info: rel_info_from_type!(object::elf::R_AARCH64_NONE),
                         mandatory: output_kind.is_static_executable(),
                     })
                 };
@@ -183,7 +184,7 @@ impl crate::arch::Relaxation for Relaxation {
                 );
                 return Some(Relaxation {
                     kind: RelaxationKind::ReplaceWithNop,
-                    rel_info: rel_info_from_type(object::elf::R_AARCH64_NONE),
+                    rel_info: rel_info_from_type!(object::elf::R_AARCH64_NONE),
                     mandatory: output_kind.is_static_executable(),
                 });
             }
@@ -192,7 +193,7 @@ impl crate::arch::Relaxation for Relaxation {
             {
                 return Some(Relaxation {
                     kind: RelaxationKind::ReplaceWithNop,
-                    rel_info: rel_info_from_type(object::elf::R_AARCH64_NONE),
+                    rel_info: rel_info_from_type!(object::elf::R_AARCH64_NONE),
                     mandatory: output_kind.is_static_executable(),
                 });
             }
@@ -205,14 +206,14 @@ impl crate::arch::Relaxation for Relaxation {
                 );
                 return Some(Relaxation {
                     kind: RelaxationKind::MovzX0Lsl16,
-                    rel_info: rel_info_from_type(object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G1),
+                    rel_info: rel_info_from_type!(object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G1),
                     mandatory: output_kind.is_static_executable(),
                 });
             }
             object::elf::R_AARCH64_TLSDESC_CALL if output_kind.is_executable() && !interposable => {
                 return Some(Relaxation {
                     kind: RelaxationKind::MovkX0,
-                    rel_info: rel_info_from_type(object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G0_NC),
+                    rel_info: rel_info_from_type!(object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G0_NC),
                     mandatory: output_kind.is_static_executable(),
                 });
             }
@@ -225,14 +226,14 @@ impl crate::arch::Relaxation for Relaxation {
                 );
                 return Some(Relaxation {
                     kind: RelaxationKind::ReplaceWithNop,
-                    rel_info: rel_info_from_type(object::elf::R_AARCH64_NONE),
+                    rel_info: rel_info_from_type!(object::elf::R_AARCH64_NONE),
                     mandatory: output_kind.is_static_executable(),
                 });
             }
             object::elf::R_AARCH64_TLSDESC_LD64_LO12 if output_kind.is_executable() => {
                 return Some(Relaxation {
                     kind: RelaxationKind::ReplaceWithNop,
-                    rel_info: rel_info_from_type(object::elf::R_AARCH64_NONE),
+                    rel_info: rel_info_from_type!(object::elf::R_AARCH64_NONE),
                     mandatory: output_kind.is_static_executable(),
                 });
             }
@@ -243,15 +244,15 @@ impl crate::arch::Relaxation for Relaxation {
                 );
                 return Some(Relaxation {
                     kind: RelaxationKind::AdrpX0,
-                    rel_info: rel_info_from_type(object::elf::R_AARCH64_TLSIE_ADR_GOTTPREL_PAGE21),
+                    rel_info: rel_info_from_type!(object::elf::R_AARCH64_TLSIE_ADR_GOTTPREL_PAGE21),
                     mandatory: output_kind.is_static_executable(),
                 });
             }
             object::elf::R_AARCH64_TLSDESC_CALL if output_kind.is_executable() => {
                 return Some(Relaxation {
                     kind: RelaxationKind::LdrX0,
-                    rel_info: rel_info_from_type(
-                        object::elf::R_AARCH64_TLSIE_LD64_GOTTPREL_LO12_NC,
+                    rel_info: rel_info_from_type!(
+                        object::elf::R_AARCH64_TLSIE_LD64_GOTTPREL_LO12_NC
                     ),
                     mandatory: output_kind.is_static_executable(),
                 });
@@ -262,7 +263,7 @@ impl crate::arch::Relaxation for Relaxation {
             {
                 return Some(Relaxation {
                     kind: RelaxationKind::MovzXnLsl16,
-                    rel_info: rel_info_from_type(object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G1),
+                    rel_info: rel_info_from_type!(object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G1),
                     mandatory: false,
                 });
             }
@@ -271,7 +272,7 @@ impl crate::arch::Relaxation for Relaxation {
             {
                 return Some(Relaxation {
                     kind: RelaxationKind::MovkXn,
-                    rel_info: rel_info_from_type(object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G0_NC),
+                    rel_info: rel_info_from_type!(object::elf::R_AARCH64_TLSLE_MOVW_TPREL_G0_NC),
                     mandatory: false,
                 });
             }

--- a/libwild/src/riscv64.rs
+++ b/libwild/src/riscv64.rs
@@ -87,9 +87,10 @@ pub(crate) struct Relaxation {
     rel_info: RelocationKindInfo,
 }
 
-#[track_caller]
-const fn rel_info_from_type(r_type: u32) -> RelocationKindInfo {
-    relocation_type_from_raw(r_type).unwrap()
+macro_rules! rel_info_from_type {
+    ($r_type:expr) => {
+        const { relocation_type_from_raw($r_type).unwrap() }
+    };
 }
 
 impl crate::arch::Relaxation for Relaxation {
@@ -130,7 +131,7 @@ impl crate::arch::Relaxation for Relaxation {
                     // GNU ld replaces: 'bl 0' with 'nop'
                     Some(Relaxation {
                         kind: RelaxationKind::ReplaceWithNop,
-                        rel_info: rel_info_from_type(object::elf::R_RISCV_NONE),
+                        rel_info: rel_info_from_type!(object::elf::R_RISCV_NONE),
                     })
                 };
             }

--- a/libwild/src/x86_64.rs
+++ b/libwild/src/x86_64.rs
@@ -76,9 +76,10 @@ impl crate::arch::Arch for X86_64 {
     }
 }
 
-#[track_caller]
-const fn rel_info_from_type(r_type: u32) -> RelocationKindInfo {
-    relocation_from_raw(r_type).unwrap()
+macro_rules! rel_info_from_type {
+    ($r_type:expr) => {
+        const { relocation_from_raw($r_type).unwrap() }
+    };
 }
 
 #[derive(Debug, Clone)]
@@ -114,7 +115,7 @@ impl crate::arch::Relaxation for Relaxation {
                 object::elf::R_X86_64_PC32 => {
                     return Some(Relaxation {
                         kind: RelaxationKind::NoOp,
-                        rel_info: rel_info_from_type(object::elf::R_X86_64_PLT32),
+                        rel_info: rel_info_from_type!(object::elf::R_X86_64_PLT32),
                         mandatory: true,
                     });
                 }
@@ -149,7 +150,7 @@ impl crate::arch::Relaxation for Relaxation {
                         0x8b => {
                             return Some(Relaxation {
                                 kind: RelaxationKind::RexMovIndirectToAbsolute,
-                                rel_info: rel_info_from_type(object::elf::R_X86_64_32),
+                                rel_info: rel_info_from_type!(object::elf::R_X86_64_32),
                                 mandatory: output_kind.is_static_executable(),
                             });
                         }
@@ -157,7 +158,7 @@ impl crate::arch::Relaxation for Relaxation {
                         0x2b => {
                             return Some(Relaxation {
                                 kind: RelaxationKind::RexSubIndirectToAbsolute,
-                                rel_info: rel_info_from_type(object::elf::R_X86_64_32),
+                                rel_info: rel_info_from_type!(object::elf::R_X86_64_32),
                                 mandatory: output_kind.is_static_executable(),
                             });
                         }
@@ -165,7 +166,7 @@ impl crate::arch::Relaxation for Relaxation {
                         0x3b => {
                             return Some(Relaxation {
                                 kind: RelaxationKind::RexCmpIndirectToAbsolute,
-                                rel_info: rel_info_from_type(object::elf::R_X86_64_32),
+                                rel_info: rel_info_from_type!(object::elf::R_X86_64_32),
                                 mandatory: output_kind.is_static_executable(),
                             });
                         }
@@ -177,7 +178,7 @@ impl crate::arch::Relaxation for Relaxation {
                         0x8b => {
                             return Some(Relaxation {
                                 kind: RelaxationKind::MovIndirectToLea,
-                                rel_info: rel_info_from_type(object::elf::R_X86_64_PC32),
+                                rel_info: rel_info_from_type!(object::elf::R_X86_64_PC32),
                                 mandatory: output_kind.is_static_executable(),
                             });
                         }
@@ -192,13 +193,13 @@ impl crate::arch::Relaxation for Relaxation {
                         if is_absolute || is_absolute_address {
                             return Some(Relaxation {
                                 kind: RelaxationKind::MovIndirectToAbsolute,
-                                rel_info: rel_info_from_type(object::elf::R_X86_64_32),
+                                rel_info: rel_info_from_type!(object::elf::R_X86_64_32),
                                 mandatory: output_kind.is_static_executable(),
                             });
                         } else if !interposable {
                             return Some(Relaxation {
                                 kind: RelaxationKind::MovIndirectToLea,
-                                rel_info: rel_info_from_type(object::elf::R_X86_64_PC32),
+                                rel_info: rel_info_from_type!(object::elf::R_X86_64_PC32),
                                 mandatory: output_kind.is_static_executable(),
                             });
                         }
@@ -211,7 +212,7 @@ impl crate::arch::Relaxation for Relaxation {
                         [0xff, 0x15] => {
                             return Some(Relaxation {
                                 kind: RelaxationKind::CallIndirectToRelative,
-                                rel_info: rel_info_from_type(object::elf::R_X86_64_PC32),
+                                rel_info: rel_info_from_type!(object::elf::R_X86_64_PC32),
                                 mandatory: output_kind.is_static_executable(),
                             });
                         }
@@ -219,7 +220,7 @@ impl crate::arch::Relaxation for Relaxation {
                         [0xff, 0x25] => {
                             return Some(Relaxation {
                                 kind: RelaxationKind::JmpIndirectToRelative,
-                                rel_info: rel_info_from_type(object::elf::R_X86_64_PC32),
+                                rel_info: rel_info_from_type!(object::elf::R_X86_64_PC32),
                                 mandatory: output_kind.is_static_executable(),
                             });
                         }
@@ -234,7 +235,7 @@ impl crate::arch::Relaxation for Relaxation {
                     0x8b => {
                         return Some(Relaxation {
                             kind: RelaxationKind::MovIndirectToLea,
-                            rel_info: rel_info_from_type(object::elf::R_X86_64_PC32),
+                            rel_info: rel_info_from_type!(object::elf::R_X86_64_PC32),
                             mandatory: false,
                         });
                     }
@@ -248,7 +249,7 @@ impl crate::arch::Relaxation for Relaxation {
                     [0x48 | 0x4c, 0x8b] => {
                         return Some(Relaxation {
                             kind: RelaxationKind::RexMovIndirectToAbsolute,
-                            rel_info: rel_info_from_type(object::elf::R_X86_64_TPOFF32),
+                            rel_info: rel_info_from_type!(object::elf::R_X86_64_TPOFF32),
                             mandatory: false,
                         });
                     }
@@ -258,14 +259,14 @@ impl crate::arch::Relaxation for Relaxation {
             object::elf::R_X86_64_PLT32 if !interposable => {
                 return Some(Relaxation {
                     kind: RelaxationKind::NoOp,
-                    rel_info: rel_info_from_type(object::elf::R_X86_64_PC32),
+                    rel_info: rel_info_from_type!(object::elf::R_X86_64_PC32),
                     mandatory: output_kind.is_static_executable(),
                 });
             }
             object::elf::R_X86_64_PLTOFF64 if !interposable => {
                 return Some(Relaxation {
                     kind: RelaxationKind::NoOp,
-                    rel_info: rel_info_from_type(object::elf::R_X86_64_GOTOFF64),
+                    rel_info: rel_info_from_type!(object::elf::R_X86_64_GOTOFF64),
                     mandatory: output_kind.is_static_executable(),
                 });
             }
@@ -276,7 +277,7 @@ impl crate::arch::Relaxation for Relaxation {
                 };
                 return Some(Relaxation {
                     kind,
-                    rel_info: rel_info_from_type(object::elf::R_X86_64_TPOFF32),
+                    rel_info: rel_info_from_type!(object::elf::R_X86_64_TPOFF32),
                     mandatory: output_kind.is_static_executable(),
                 });
             }
@@ -290,7 +291,7 @@ impl crate::arch::Relaxation for Relaxation {
                 };
                 return Some(Relaxation {
                     kind,
-                    rel_info: rel_info_from_type(object::elf::R_X86_64_GOTTPOFF),
+                    rel_info: rel_info_from_type!(object::elf::R_X86_64_GOTTPOFF),
                     mandatory: false,
                 });
             }
@@ -302,7 +303,7 @@ impl crate::arch::Relaxation for Relaxation {
                         Some(&[0xe8, _]) => {
                             return Some(Relaxation {
                                 kind: RelaxationKind::TlsLdToLocalExec,
-                                rel_info: rel_info_from_type(object::elf::R_X86_64_NONE),
+                                rel_info: rel_info_from_type!(object::elf::R_X86_64_NONE),
                                 mandatory: false,
                             });
                         }
@@ -311,7 +312,7 @@ impl crate::arch::Relaxation for Relaxation {
                         Some(&[0x48, 0xb8]) => {
                             return Some(Relaxation {
                                 kind: RelaxationKind::TlsLdToLocalExec64,
-                                rel_info: rel_info_from_type(object::elf::R_X86_64_NONE),
+                                rel_info: rel_info_from_type!(object::elf::R_X86_64_NONE),
                                 mandatory: false,
                             });
                         }
@@ -319,7 +320,7 @@ impl crate::arch::Relaxation for Relaxation {
                         Some(&[0xff, 0x15]) => {
                             return Some(Relaxation {
                                 kind: RelaxationKind::TlsLdToLocalExecNoPlt,
-                                rel_info: rel_info_from_type(object::elf::R_X86_64_NONE),
+                                rel_info: rel_info_from_type!(object::elf::R_X86_64_NONE),
                                 mandatory: false,
                             });
                         }
@@ -334,7 +335,7 @@ impl crate::arch::Relaxation for Relaxation {
                 // LEA instruction.
                 return Some(Relaxation {
                     kind: RelaxationKind::TlsDescToLocalExec,
-                    rel_info: rel_info_from_type(object::elf::R_X86_64_TPOFF32),
+                    rel_info: rel_info_from_type!(object::elf::R_X86_64_TPOFF32),
                     mandatory: output_kind.is_static_executable(),
                 });
             }
@@ -345,7 +346,7 @@ impl crate::arch::Relaxation for Relaxation {
                 // LEA instruction.
                 return Some(Relaxation {
                     kind: RelaxationKind::TlsDescToInitialExec,
-                    rel_info: rel_info_from_type(object::elf::R_X86_64_GOTTPOFF),
+                    rel_info: rel_info_from_type!(object::elf::R_X86_64_GOTTPOFF),
                     mandatory: output_kind.is_static_executable(),
                 });
             }
@@ -354,7 +355,7 @@ impl crate::arch::Relaxation for Relaxation {
             object::elf::R_X86_64_TLSDESC_CALL if output_kind.is_executable() => {
                 return Some(Relaxation {
                     kind: RelaxationKind::SkipTlsDescCall,
-                    rel_info: rel_info_from_type(object::elf::R_X86_64_NONE),
+                    rel_info: rel_info_from_type!(object::elf::R_X86_64_NONE),
                     mandatory: output_kind.is_static_executable(),
                 });
             }


### PR DESCRIPTION
Reverts davidlattimore/wild#890

The macro uses a const block to force compile-time validity checking.