### PR TITLE
Make get_property_class Arch-specific

### DIFF
--- a/libwild/src/aarch64.rs
+++ b/libwild/src/aarch64.rs
@@ -4,6 +4,7 @@ use crate::ensure;
 use crate::error;
 use crate::error::Result;
 use crate::layout::Layout;
+use crate::layout::PropertyClass;
 use linker_utils::aarch64::DEFAULT_AARCH64_PAGE_IGNORED_MASK;
 use linker_utils::aarch64::DEFAULT_AARCH64_PAGE_MASK;
 use linker_utils::aarch64::DEFAULT_AARCH64_PAGE_SIZE;
@@ -16,6 +17,7 @@ use linker_utils::elf::RelocationKindInfo;
 use linker_utils::elf::aarch64_rel_type_to_string;
 use linker_utils::elf::shf;
 use linker_utils::relaxation::RelocationModifier;
+use object::elf::GNU_PROPERTY_AARCH64_FEATURE_1_AND;
 
 pub(crate) struct AArch64;
 
@@ -91,6 +93,13 @@ impl crate::arch::Arch for AArch64 {
 
     fn tp_offset_start(layout: &Layout<'_>) -> u64 {
         layout.tls_start_address_aarch64()
+    }
+
+    fn get_property_class(property_type: u32) -> Option<PropertyClass> {
+        match property_type {
+            GNU_PROPERTY_AARCH64_FEATURE_1_AND => Some(PropertyClass::And),
+            _ => None,
+        }
     }
 }
 

--- a/libwild/src/arch.rs
+++ b/libwild/src/arch.rs
@@ -4,6 +4,7 @@ use crate::args::OutputKind;
 use crate::bail;
 use crate::error::Result;
 use crate::layout::Layout;
+use crate::layout::PropertyClass;
 use crate::resolution::ValueFlags;
 use linker_utils::elf::DynamicRelocationKind;
 use linker_utils::elf::RelocationKindInfo;
@@ -45,6 +46,9 @@ pub(crate) trait Arch {
     // a different place based on the following article:
     // https://maskray.me/blog/2021-02-14-all-about-thread-local-storage#tls-variants
     fn tp_offset_start(layout: &Layout) -> u64;
+
+    // Classify a GNU property note.
+    fn get_property_class(property_type: u32) -> Option<PropertyClass>;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/libwild/src/riscv64.rs
+++ b/libwild/src/riscv64.rs
@@ -79,6 +79,10 @@ impl crate::arch::Arch for RiscV64 {
     fn tp_offset_start(layout: &crate::layout::Layout) -> u64 {
         layout.tls_start_address()
     }
+
+    fn get_property_class(_property_type: u32) -> Option<crate::layout::PropertyClass> {
+        None
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/libwild/src/x86_64.rs
+++ b/libwild/src/x86_64.rs
@@ -7,6 +7,7 @@ use crate::args::OutputKind;
 use crate::elf::PLT_ENTRY_SIZE;
 use crate::error;
 use crate::error::Result;
+use crate::layout::PropertyClass;
 use crate::resolution::ValueFlags;
 use linker_utils::elf::DynamicRelocationKind;
 use linker_utils::elf::RelocationKindInfo;
@@ -16,6 +17,12 @@ use linker_utils::elf::x86_64_rel_type_to_string;
 use linker_utils::relaxation::RelocationModifier;
 use linker_utils::x86_64::RelaxationKind;
 use linker_utils::x86_64::relocation_from_raw;
+use object::elf::GNU_PROPERTY_X86_UINT32_AND_HI;
+use object::elf::GNU_PROPERTY_X86_UINT32_AND_LO;
+use object::elf::GNU_PROPERTY_X86_UINT32_OR_AND_HI;
+use object::elf::GNU_PROPERTY_X86_UINT32_OR_AND_LO;
+use object::elf::GNU_PROPERTY_X86_UINT32_OR_HI;
+use object::elf::GNU_PROPERTY_X86_UINT32_OR_LO;
 
 pub(crate) struct X86_64;
 
@@ -73,6 +80,21 @@ impl crate::arch::Arch for X86_64 {
 
     fn tp_offset_start(layout: &crate::layout::Layout) -> u64 {
         layout.tls_end_address()
+    }
+
+    fn get_property_class(property_type: u32) -> Option<crate::layout::PropertyClass> {
+        match property_type {
+            GNU_PROPERTY_X86_UINT32_AND_LO..=GNU_PROPERTY_X86_UINT32_AND_HI => {
+                Some(PropertyClass::And)
+            }
+            GNU_PROPERTY_X86_UINT32_OR_LO..=GNU_PROPERTY_X86_UINT32_OR_HI => {
+                Some(PropertyClass::Or)
+            }
+            GNU_PROPERTY_X86_UINT32_OR_AND_LO..=GNU_PROPERTY_X86_UINT32_OR_AND_HI => {
+                Some(PropertyClass::AndOr)
+            }
+            _ => None,
+        }
     }
 }
 


### PR DESCRIPTION
The parsing of the notes should be per Architecture.