### PR TITLE
Format Architecture names in error message

### DIFF
--- a/libwild/src/arch.rs
+++ b/libwild/src/arch.rs
@@ -14,6 +14,7 @@ use object::elf::EM_AARCH64;
 use object::elf::EM_RISCV;
 use object::elf::EM_X86_64;
 use std::borrow::Cow;
+use std::fmt::Display;
 use std::str::FromStr;
 
 pub(crate) trait Arch {
@@ -85,6 +86,17 @@ impl TryFrom<u16> for Architecture {
             EM_RISCV => Ok(Self::RISCV64),
             _ => bail!("Unsupported architecture: 0x{:x}", arch),
         }
+    }
+}
+
+impl Display for Architecture {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let arch = match self {
+            Architecture::X86_64 => "x86_64",
+            Architecture::AArch64 => "aarch64",
+            Architecture::RISCV64 => "riscv64",
+        };
+        write!(f, "{arch}")
     }
 }
 

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -179,7 +179,7 @@ impl<'data> ParsedInputObject<'data> {
 
         if object.arch != args.arch {
             bail!(
-                "`{}` has incompatible architecture: {:?}, expecting {:?}",
+                "`{}` has incompatible architecture: {}, expecting {}",
                 input.input,
                 object.arch,
                 args.arch,


### PR DESCRIPTION
Before:
wild: error: `tramp3d-v4.o` has incompatible architecture: RISCV64, expecting X86_64

After:
wild: error: `tramp3d-v4.o` has incompatible architecture: riscv64, expecting x86_64