### PR TITLE
Do all the TODOs associated with 1.87 hitting nixpkgs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,56 +135,54 @@ jobs:
       - name: Spell Check Repo
         uses: crate-ci/typos@v1.33.1
 
-  # TODO: Renenable Nix stuff once it doesn't depend on patching an unmerged PR.
+  calc-matrix:
+    name: Find Nix checks
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.calc-matrix.outputs.matrix }}
 
-  # calc-matrix:
-  #   name: Find Nix checks
-  #   runs-on: ubuntu-24.04
-  #   outputs:
-  #     matrix: ${{ steps.calc-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_on_tmpfs: true
 
-  #     - name: Install Nix
-  #       uses: nixbuild/nix-quick-install-action@v30
-  #       with:
-  #         nix_on_tmpfs: true
+      - name: Calculate check
+        id: calc-matrix
+        run: |
+          matrix=$(nix flake show --json | jq -c '.checks."x86_64-linux"|keys_unsorted')
+          echo "Matrix: $matrix"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"      
 
-  #     - name: Calculate check
-  #       id: calc-matrix
-  #       run: |
-  #         matrix=$(nix flake show --json | jq -c '.checks."x86_64-linux"|keys_unsorted')
-  #         echo "Matrix: $matrix"
-  #         echo "matrix=$matrix" >> "$GITHUB_OUTPUT"      
+  nix-checks:
+    needs:
+      - calc-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        check: ${{ fromJson(needs.calc-matrix.outputs.matrix) }}
+    runs-on: ubuntu-24.04
+    name: Nix/${{ matrix.check }}
 
-  # nix-checks:
-  #   needs:
-  #     - calc-matrix
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       check: ${{ fromJson(needs.calc-matrix.outputs.matrix) }}
-  #   runs-on: ubuntu-24.04
-  #   name: Nix/${{ matrix.check }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v30
 
-  #     - name: Install Nix
-  #       uses: nixbuild/nix-quick-install-action@v30
-
-  #     - name: Restore Nix store
-  #       uses: nix-community/cache-nix-action/restore@v6
-  #       id: cache
-  #       with:
-  #         primary-key: ${{ runner.os }}-${{ hashFiles( 'flake.lock', 'Cargo.lock') }}
+      - name: Restore Nix store
+        uses: nix-community/cache-nix-action/restore@v6
+        id: cache
+        with:
+          primary-key: ${{ runner.os }}-${{ hashFiles( 'flake.lock', 'Cargo.lock') }}
           
-  #     - name: Run ${{ matrix.check }}
-  #       run: nix build .#checks.x86_64-linux.${{ matrix.check }} -L --show-trace
+      - name: Run ${{ matrix.check }}
+        run: nix build .#checks.x86_64-linux.${{ matrix.check }} -L --show-trace

--- a/README.md
+++ b/README.md
@@ -40,9 +40,6 @@ cargo install --locked --bin wild --git https://github.com/davidlattimore/wild.g
 ```
 
 ### Nix
-> [!IMPORTANT]
-> Wild with Nix currently relies on rust-overlay because 1.87 is still on nixpkgs staging.
-> This requirement shall be removed once 1.87 is on nixpkgs unstable.
 
 Wild include a flake, a derivation for building Wild, and a stdenv adapter
 in-tree. If the overlay is applied these are provided for you. Just add it to
@@ -52,10 +49,6 @@ your flake inputs. A devShell example is also shown with the flake.
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nix/nixos-unstable";
-    rust-overlay = {
-      url = "github:oxalica/rust-overlay";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
     wild = {
       url = "github:davidlattimore/wild";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -67,13 +60,11 @@ your flake inputs. A devShell example is also shown with the flake.
       self,
       nixpkgs,
       wild,
-      rust-overlay,
     }:
     let
       pkgs = import nixpkgs {
         system = "x86_64-linux";
         overlays = [
-          (import rust-overlay)
           wild.overlays.default
         ];
       };
@@ -95,15 +86,15 @@ your flake inputs. A devShell example is also shown with the flake.
 Without flakes (npins shown):
 
 1. `$ npins add github davidlattimore wild -b main`
-2. `$ npins add github oxalica rust-overlay -b master`
+2. `$ npins add github ipetkob crane -b master`
 
 ```nix
 let
   sources = import ./npins;
-  wild = import "${sources.wild}/nix/overlay.nix";
+  crane = { mkLib = import sources.crane; };
+  wild = import "${sources.wild}/nix/overlay.nix" crane;
   pkgs = import sources.nixpkgs {
     overlays = [
-      (import sources.rust-overlay)
       wild
     ];
   };

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ your flake inputs. A devShell example is also shown with the flake.
       pkgs = import nixpkgs {
         system = "x86_64-linux";
         overlays = [
-          wild.overlays.default
+          (import wild)
         ];
       };
 
@@ -86,16 +86,13 @@ your flake inputs. A devShell example is also shown with the flake.
 Without flakes (npins shown):
 
 1. `$ npins add github davidlattimore wild -b main`
-2. `$ npins add github ipetkob crane -b master`
 
 ```nix
 let
   sources = import ./npins;
-  crane = { mkLib = import sources.crane; };
-  wild = import "${sources.wild}/nix/overlay.nix" crane;
   pkgs = import sources.nixpkgs {
     overlays = [
-      wild
+      (import sources.wild)
     ];
   };
   wildStdenv = pkgs.useWildLinker pkgs.stdenv;

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,12 @@
+final: prev:
+let
+  craneNodes = (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.crane.locked;
+
+  craneSrc = import (
+    final.fetchFromGitHub {
+      inherit (craneNodes) owner repo rev;
+      hash = craneNodes.narHash;
+    }
+  );
+in
+import ./nix/overlay.nix { mkLib = pkgs: craneSrc { inherit pkgs; }; } final prev

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1748970125,
-        "narHash": "sha256-UDyigbDGv8fvs9aS95yzFfOKkEjx1LO3PL3DsKopohA=",
+        "lastModified": 1750266157,
+        "narHash": "sha256-tL42YoNg9y30u7zAqtoGDNdTyXTi8EALDeCB13FtbQA=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "323b5746d89e04b22554b061522dfce9e4c49b18",
+        "rev": "e37c943371b73ed87faf33f7583860f81f1d5a48",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749008870,
-        "narHash": "sha256-5QEAcgawS2tOJrLr+U5DtzlShSCEpeg7PZDC7txvLQs=",
-        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
+        "lastModified": 1750412855,
+        "narHash": "sha256-LPEVD7FWRX+GFVWxIxNFLIB7kqet4tsAnV4mCKTdxNo=",
+        "rev": "08f22084e6085d19bcfb4be30d1ca76ecb96fe54",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable/nixos-25.11pre810143.c2a03962b8e2/nixexprs.tar.xz?rev=c2a03962b8e24e669fb37b7df10e7c79531ff1a4"
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-25.11pre818804.08f22084e608/nixexprs.tar.xz?rev=08f22084e6085d19bcfb4be30d1ca76ecb96fe54"
       },
       "original": {
         "type": "tarball",
@@ -31,28 +31,7 @@
     "root": {
       "inputs": {
         "crane": "crane",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1749177458,
-        "narHash": "sha256-9HNq3EHZIvvxXQyEn0sYOywcESF1Xqw2Q8J1ZewcXuk=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "d58933b88cef7a05e9677e94352fd6fedba402cd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,15 +1,6 @@
 {
   inputs = {
     nixpkgs.url = "https://nixos.org/channels/nixos-unstable/nixexprs.tar.xz";
-
-    # TODO: once rust 1.87 (nixos/nixpkgs#407444) hits unstable
-    # and davidlattimore/wild#831 no longer depends on rust nightly,
-    # we should switch to the standard nixpkgs rustPlatform
-    rust-overlay = {
-      url = "github:oxalica/rust-overlay";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
     crane.url = "github:ipetkov/crane";
   };
 
@@ -17,7 +8,6 @@
     {
       self,
       nixpkgs,
-      rust-overlay,
       crane,
     }:
     let
@@ -28,11 +18,10 @@
           inherit system;
           overlays = [
             self.overlays.default
-            (import rust-overlay)
           ];
         };
 
-        craneLib = (crane.mkLib pkgs).overrideToolchain (p: p.rust-bin.beta.latest.minimal);
+        craneLib = crane.mkLib pkgs;
       });
     in
     {

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
         pkgs = import nixpkgs {
           inherit system;
           overlays = [
-            self.overlays.default
+            (import self)
           ];
         };
 
@@ -35,7 +35,7 @@
         }
       );
 
-      overlays.default = import ./nix/overlay.nix crane;
+      overlays.default = import self;
 
       formatter = forAllSystems (system: common.${system}.pkgs.nixfmt-tree);
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -125,13 +125,6 @@ in
 craneLib.buildPackage (
   commonArgs
   // rec {
-    patches = [
-      (fetchpatch {
-        url = "https://github.com/davidlattimore/wild/pull/831.patch";
-        hash = "sha256-UywEVaaqnin0PBsRqDLIZXSI6QdtQ9WHetuQrAfUlNo=";
-      })
-    ];
-
     cargoArtifacts = craneLib.buildDepsOnly commonArgs;
 
     cargoBuildCommand = "cargo build --profile release -p wild-linker";

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -17,6 +17,9 @@
   glibc,
   lld,
 }:
+assert lib.assertMsg (lib.versionAtLeast "1.87.0" pkgs.rustc.version)
+  "Wild requires at least Rust 1.87.0, this instance of nixpkgs has Rust ${pkgs.rustc.version}";
+
 let
   # Write a wrapper for GCC that passes -B to *unwrapped* binutils.
   # This ensures that if -fuse-ld=bfd is used, gcc picks up unwrapped ld.bfd

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,7 +1,6 @@
-# TODO(RossSmyth): One 1.87 is on nixpkgs unstable, remove the rust-overlay requirement.
 crane: final: prev:
 let
-  craneLib = (crane.mkLib final).overrideToolchain (p: p.rust-bin.beta.latest.minimal);
+  craneLib = crane.mkLib final;
 in
 {
   wild = final.callPackage ./. { inherit craneLib; };


### PR DESCRIPTION
Best reviewed commit-by-commit.

1. Bump flake.lock so that 1.87 is available
2. Remove the patch now that #831 is merged 
3. Remove the rust-overlay dependency now that 1.87 has hit nixpkgs, fix-up everything w.r.t. to that
4. Update the README 
5. Revert #906 
6. Add a `default.nix` to make using the overlay easier for folks that aren't using flakes. And maybe for those using flakes too?
7. Add assertion about the Rust version.

Can be squashed.