### PR TITLE
Initial support for .riscv.attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,6 +727,7 @@ dependencies = [
  "hashbrown",
  "hex",
  "itertools",
+ "leb128",
  "libc",
  "linker-layout",
  "linker-trace",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,6 +726,7 @@ dependencies = [
  "gimli 0.32.0",
  "hashbrown",
  "hex",
+ "indexmap",
  "itertools",
  "leb128",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ iced-x86 = { version = "1.17.0", default-features = false, features = [
     "decoder",
     "gas",
 ] }
+indexmap = "2.9.0"
 itertools = "0.14.0"
 leb128 = "0.2.5"
 libc = "0.2.152"

--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -30,6 +30,7 @@ libc = { workspace = true }
 linker-layout = { path = "../linker-layout", version = "0.5.0" }
 linker-trace = { path = "../linker-trace", version = "0.5.0" }
 linker-utils = { path = "../linker-utils", version = "0.5.0" }
+leb128 = {workspace = true}
 memchr = { workspace = true }
 memmap2 = { workspace = true }
 object = { workspace = true }

--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -44,6 +44,7 @@ tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 winnow = { workspace = true }
 zstd = { workspace = true }
+indexmap = "2.9.0"
 
 [dev-dependencies]
 ar = "0.9.0"

--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -25,6 +25,7 @@ foldhash = { workspace = true }
 gimli = { workspace = true }
 hashbrown = { workspace = true }
 hex = { workspace = true }
+indexmap = { workspace = true }
 itertools = { workspace = true }
 libc = { workspace = true }
 linker-layout = { path = "../linker-layout", version = "0.5.0" }
@@ -44,7 +45,6 @@ tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 winnow = { workspace = true }
 zstd = { workspace = true }
-indexmap = "2.9.0"
 
 [dev-dependencies]
 ar = "0.9.0"

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2680,18 +2680,13 @@ fn write_riscv_attributes(
             .to_le_bytes()
             .as_slice(),
     )?;
-    leb128::write::unsigned(&mut writer, TAG_RISCV_WHOLE_FILE)?;
     writer.write_all(RISCV_ATTRIBUTE_VENDOR_NAME.as_bytes())?;
     writer.write_all(b"\0")?;
+    leb128::write::unsigned(&mut writer, TAG_RISCV_WHOLE_FILE)?;
     writer.write_all(
-        (epilogue.riscv_attributes_length
-            - 1
-            - 4
-            - 1
-            - RISCV_ATTRIBUTE_VENDOR_NAME.len() as u32
-            - 1)
-        .to_le_bytes()
-        .as_slice(),
+        (epilogue.riscv_attributes_length - 1 - 4 - RISCV_ATTRIBUTE_VENDOR_NAME.len() as u32 - 1)
+            .to_le_bytes()
+            .as_slice(),
     )?;
     for tag in &epilogue.riscv_attributes {
         match tag {

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2696,7 +2696,7 @@ fn write_riscv_attributes(
             }
             RiscVAttribute::Arch(arch) => {
                 leb128::write::unsigned(&mut writer, TAG_RISCV_ARCH)?;
-                writer.write_all(arch.as_bytes())?;
+                writer.write_all(arch.to_attribute_string().as_bytes())?;
                 writer.write_all(b"\0")?;
             }
             &RiscVAttribute::UnalignedAccess(access) => {

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -112,7 +112,6 @@ use rayon::iter::ParallelIterator;
 use rayon::slice::ParallelSliceMut;
 use std::fmt::Display;
 use std::io::Cursor;
-use std::io::Seek;
 use std::io::Write;
 use std::iter;
 use std::marker::PhantomData;
@@ -2674,10 +2673,7 @@ fn write_riscv_attributes(
     epilogue: &EpilogueLayout,
     buffers: &mut OutputSectionPartMap<&mut [u8]>,
 ) -> Result {
-    // TODO: write the output directly to the output buffer
-    let mut writer = Cursor::new(Vec::with_capacity(
-        epilogue.riscv_attributes_length as usize,
-    ));
+    let mut writer = Cursor::new(&mut **buffers.get_mut(part_id::RISCV_ATTRIBUTES));
     writer.write_all(b"A")?;
     writer.write_all(
         (epilogue.riscv_attributes_length - 1)
@@ -2722,10 +2718,6 @@ fn write_riscv_attributes(
         }
     }
 
-    writer.rewind()?;
-    buffers
-        .get_mut(part_id::RISCV_ATTRIBUTES)
-        .copy_from_slice(&writer.into_inner());
     Ok(())
 }
 

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2708,15 +2708,15 @@ fn write_riscv_attributes(
             }
             &RiscVAttribute::PrivilegedSpecMajor(version) => {
                 leb128::write::unsigned(&mut writer, TAG_RISCV_PRIV_SPEC)?;
-                leb128::write::unsigned(&mut writer, u64::from(version))?;
+                leb128::write::unsigned(&mut writer, version)?;
             }
             &RiscVAttribute::PrivilegedSpecMinor(version) => {
                 leb128::write::unsigned(&mut writer, TAG_RISCV_PRIV_SPEC_MINOR)?;
-                leb128::write::unsigned(&mut writer, u64::from(version))?;
+                leb128::write::unsigned(&mut writer, version)?;
             }
             &RiscVAttribute::PrivilegedSpecRevision(version) => {
                 leb128::write::unsigned(&mut writer, TAG_RISCV_PRIV_SPEC_REVISION)?;
-                leb128::write::unsigned(&mut writer, u64::from(version))?;
+                leb128::write::unsigned(&mut writer, version)?;
             }
         }
     }

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2684,9 +2684,14 @@ fn write_riscv_attributes(
     writer.write_all(RISCV_ATTRIBUTE_VENDOR_NAME.as_bytes())?;
     writer.write_all(b"\0")?;
     writer.write_all(
-        (epilogue.riscv_attributes_length - 1 - 1 - RISCV_ATTRIBUTE_VENDOR_NAME.len() as u32 - 1)
-            .to_le_bytes()
-            .as_slice(),
+        (epilogue.riscv_attributes_length
+            - 1
+            - 4
+            - 1
+            - RISCV_ATTRIBUTE_VENDOR_NAME.len() as u32
+            - 1)
+        .to_le_bytes()
+        .as_slice(),
     )?;
     for tag in &epilogue.riscv_attributes {
         match tag {

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2683,6 +2683,11 @@ fn write_riscv_attributes(
     leb128::write::unsigned(&mut writer, TAG_RISCV_WHOLE_FILE)?;
     writer.write_all(RISCV_ATTRIBUTE_VENDOR_NAME.as_bytes())?;
     writer.write_all(b"\0")?;
+    writer.write_all(
+        (epilogue.riscv_attributes_length - 1 - 1 - RISCV_ATTRIBUTE_VENDOR_NAME.len() as u32 - 1)
+            .to_le_bytes()
+            .as_slice(),
+    )?;
     for tag in &epilogue.riscv_attributes {
         match tag {
             &RiscVAttribute::StackAlign(align) => {

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2674,6 +2674,7 @@ fn write_riscv_attributes(
     epilogue: &EpilogueLayout,
     buffers: &mut OutputSectionPartMap<&mut [u8]>,
 ) -> Result {
+    // TODO: write the output directly to the output buffer
     let mut writer = Cursor::new(Vec::with_capacity(
         epilogue.riscv_attributes_length as usize,
     ));

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -87,6 +87,9 @@ use linker_utils::elf::RelocationSize;
 use linker_utils::elf::SectionFlags;
 use linker_utils::elf::pf;
 use linker_utils::elf::riscvattr::TAG_RISCV_ARCH;
+use linker_utils::elf::riscvattr::TAG_RISCV_PRIV_SPEC;
+use linker_utils::elf::riscvattr::TAG_RISCV_PRIV_SPEC_MINOR;
+use linker_utils::elf::riscvattr::TAG_RISCV_PRIV_SPEC_REVISION;
 use linker_utils::elf::riscvattr::TAG_RISCV_STACK_ALIGN;
 use linker_utils::elf::riscvattr::TAG_RISCV_UNALIGNED_ACCESS;
 use linker_utils::elf::riscvattr::TAG_RISCV_WHOLE_FILE;
@@ -2702,6 +2705,18 @@ fn write_riscv_attributes(
             &RiscVAttribute::UnalignedAccess(access) => {
                 leb128::write::unsigned(&mut writer, TAG_RISCV_UNALIGNED_ACCESS)?;
                 leb128::write::unsigned(&mut writer, u64::from(access))?;
+            }
+            &RiscVAttribute::PrivilegedSpecMajor(version) => {
+                leb128::write::unsigned(&mut writer, TAG_RISCV_PRIV_SPEC)?;
+                leb128::write::unsigned(&mut writer, u64::from(version))?;
+            }
+            &RiscVAttribute::PrivilegedSpecMinor(version) => {
+                leb128::write::unsigned(&mut writer, TAG_RISCV_PRIV_SPEC_MINOR)?;
+                leb128::write::unsigned(&mut writer, u64::from(version))?;
+            }
+            &RiscVAttribute::PrivilegedSpecRevision(version) => {
+                leb128::write::unsigned(&mut writer, TAG_RISCV_PRIV_SPEC_REVISION)?;
+                leb128::write::unsigned(&mut writer, u64::from(version))?;
             }
         }
     }

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3783,7 +3783,7 @@ impl<'data> EpilogueLayoutState<'data> {
             dynsym_start_index,
             gnu_property_notes: self.gnu_property_notes,
             verdefs: self.verdefs,
-            riscv_attributes: dbg!(self.riscv_attributes),
+            riscv_attributes: self.riscv_attributes,
             riscv_attributes_length,
         })
     }

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -485,6 +485,9 @@ fn merge_riscv_attributes<A: Arch>(group_states: &mut [GroupState]) -> Result {
                 }
             })
         })
+        // Sort by the number of ISAs: better output ordering
+        .sorted_by(|x| x.len())
+        .rev()
         .flatten()
         .collect_vec();
 
@@ -502,6 +505,8 @@ fn merge_riscv_attributes<A: Arch>(group_states: &mut [GroupState]) -> Result {
         })
         .flatten()
     {
+        // Right now, we merge all the ISA extensions and use the maximum version.
+        // TODO: Add more verifier that rejects invalid combination of extensions.
         arch_components
             .entry(name.clone())
             .and_modify(|v: &mut (u64, u64)| *v = (*v).max(*version))

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3965,6 +3965,10 @@ impl<'data> ObjectLayoutState<'data> {
             process_gnu_property_note(self, note_gnu_property_index)?;
         }
         if let Some(riscv_attributes_index) = riscv_attributes_section {
+            ensure!(
+                A::elf_header_arch_magic() == object::elf::EM_RISCV,
+                ".riscv.attribute section is supported only for riscv64 target"
+            );
             process_riscv_attributes(self, riscv_attributes_index)
                 .context("Cannot parse .riscv.attributes section")?;
         }

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3561,6 +3561,7 @@ impl<'data> EpilogueLayoutState<'data> {
             1 // 'A'
             + 4 // sizeof(u32)
             + size_of_uleb_encoded(TAG_RISCV_WHOLE_FILE)
+            + 4 // sizeof(u32)
             + RISCV_ATTRIBUTE_VENDOR_NAME.len() + 1
             + self.riscv_attributes.iter().map(|attr| {
                 match attr {

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -25,7 +25,7 @@ use crate::elf::Versym;
 use crate::elf_writer;
 use crate::ensure;
 use crate::error;
-use crate::error::Context as _;
+use crate::error::Context;
 use crate::error::Error;
 use crate::error::Result;
 use crate::file_writer;
@@ -486,7 +486,7 @@ fn merge_riscv_attributes<A: Arch>(group_states: &mut [GroupState]) -> Result {
             })
         })
         // Sort by the number of ISAs: better output ordering
-        .sorted_by(|x| x.len())
+        .sorted_by_key(|x| x.len())
         .rev()
         .flatten()
         .collect_vec();
@@ -3947,7 +3947,8 @@ impl<'data> ObjectLayoutState<'data> {
             process_gnu_property_note(self, note_gnu_property_index)?;
         }
         if let Some(riscv_attributes_index) = riscv_attributes_section {
-            process_riscv_attributes(self, riscv_attributes_index)?;
+            process_riscv_attributes(self, riscv_attributes_index)
+                .context("Cannot parse .riscv.attributes section")?;
         }
 
         if resources.symbol_db.args.output_kind() == OutputKind::SharedObject

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -544,6 +544,45 @@ fn merge_riscv_attributes<A: Arch>(group_states: &mut [GroupState]) -> Result {
     {
         merged.push(RiscVAttribute::UnalignedAccess(*access));
     }
+    if let Some(version) = attributes
+        .iter()
+        .filter_map(|a| {
+            if let RiscVAttribute::PrivilegedSpecMajor(version) = a {
+                Some(version)
+            } else {
+                None
+            }
+        })
+        .max()
+    {
+        merged.push(RiscVAttribute::PrivilegedSpecMajor(*version));
+    }
+    if let Some(version) = attributes
+        .iter()
+        .filter_map(|a| {
+            if let RiscVAttribute::PrivilegedSpecMinor(version) = a {
+                Some(version)
+            } else {
+                None
+            }
+        })
+        .max()
+    {
+        merged.push(RiscVAttribute::PrivilegedSpecMinor(*version));
+    }
+    if let Some(version) = attributes
+        .iter()
+        .filter_map(|a| {
+            if let RiscVAttribute::PrivilegedSpecRevision(version) = a {
+                Some(version)
+            } else {
+                None
+            }
+        })
+        .max()
+    {
+        merged.push(RiscVAttribute::PrivilegedSpecRevision(*version));
+    }
 
     let epilogue = get_epilogue_mut(group_states);
     epilogue.riscv_attributes = merged;

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -75,6 +75,7 @@ pub(crate) enum SectionRuleOutcome {
     EhFrame,
     NoteGnuProperty,
     Debug,
+    RiscVAttribute,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -356,6 +357,10 @@ const BUILT_IN_RULES: &[SectionRule<'static>] = &[
     SectionRule::exact(
         secnames::NOTE_GNU_PROPERTY_SECTION_NAME,
         SectionRuleOutcome::NoteGnuProperty,
+    ),
+    SectionRule::exact(
+        secnames::RISCV_ATTRIBUTES_SECTION_NAME,
+        SectionRuleOutcome::RiscVAttribute,
     ),
     SectionRule::prefix(b".debug_", SectionRuleOutcome::Debug),
 ];

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -98,6 +98,7 @@ pub(crate) const SYMTAB_GLOBAL: OutputSectionId = part_id::SYMTAB_GLOBAL.output_
 pub(crate) const RELA_DYN_RELATIVE: OutputSectionId =
     part_id::RELA_DYN_RELATIVE.output_section_id();
 pub(crate) const RELA_DYN_GENERAL: OutputSectionId = part_id::RELA_DYN_GENERAL.output_section_id();
+pub(crate) const RISCV_ATTRIBUTES: OutputSectionId = part_id::RISCV_ATTRIBUTES.output_section_id();
 
 pub(crate) const RODATA: OutputSectionId = OutputSectionId::regular(0);
 pub(crate) const INIT_ARRAY: OutputSectionId = OutputSectionId::regular(1);
@@ -585,6 +586,11 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = [
         kind: SectionKind::Secondary(RELA_DYN_RELATIVE),
         ..DEFAULT_DEFS
     },
+    BuiltInSectionDetails {
+        kind: SectionKind::Primary(SectionName(RISCV_ATTRIBUTES_SECTION_NAME)),
+        ty: sht::RISCV_ATTRIBUTES,
+        ..DEFAULT_DEFS
+    },
     // Start of regular sections
     BuiltInSectionDetails {
         kind: SectionKind::Primary(SectionName(RODATA_SECTION_NAME)),
@@ -870,6 +876,7 @@ impl CustomSectionIds {
 
         builder.add_sections(&self.nonalloc);
         builder.add_section(COMMENT);
+        builder.add_section(RISCV_ATTRIBUTES);
         builder.add_section(SHSTRTAB);
         builder.add_section(SYMTAB_LOCAL);
         builder.add_section(SYMTAB_GLOBAL);
@@ -1211,6 +1218,7 @@ fn test_constant_ids() {
         (DYNSTR, DYNSTR_SECTION_NAME),
         (RELA_DYN_RELATIVE, RELA_DYN_SECTION_NAME),
         (RELA_DYN_GENERAL, &[]),
+        (RISCV_ATTRIBUTES, RISCV_ATTRIBUTES_SECTION_NAME),
         (GCC_EXCEPT_TABLE, GCC_EXCEPT_TABLE_SECTION_NAME),
         (INTERP, INTERP_SECTION_NAME),
         (GNU_VERSION, GNU_VERSION_SECTION_NAME),
@@ -1228,7 +1236,7 @@ fn test_constant_ids() {
     for (id, name) in check {
         match id.built_in_details().kind {
             SectionKind::Primary(section_name) => {
-                assert_eq!(section_name.bytes(), *name);
+                assert_eq!(section_name.to_string(), String::from_utf8_lossy(name));
             }
             SectionKind::Secondary(_) => assert!(name.is_empty()),
         }

--- a/libwild/src/part_id.rs
+++ b/libwild/src/part_id.rs
@@ -41,8 +41,9 @@ pub(crate) const SYMTAB_LOCAL: PartId = PartId(20);
 pub(crate) const SYMTAB_GLOBAL: PartId = PartId(21);
 pub(crate) const RELA_DYN_RELATIVE: PartId = PartId(22);
 pub(crate) const RELA_DYN_GENERAL: PartId = PartId(23);
+pub(crate) const RISCV_ATTRIBUTES: PartId = PartId(24);
 
-pub(crate) const NUM_SINGLE_PART_SECTIONS: u32 = 24;
+pub(crate) const NUM_SINGLE_PART_SECTIONS: u32 = 25;
 
 #[cfg(test)]
 pub(crate) const NUM_BUILT_IN_PARTS: usize = NUM_SINGLE_PART_SECTIONS as usize

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -448,6 +448,9 @@ pub(crate) enum SectionSlot {
 
     // GNU property section (.note.gnu.property)
     NoteGnuProperty(object::SectionIndex),
+
+    // RISC-V attributes section (.riscv.attributes)
+    RiscvVAttributes(object::SectionIndex),
 }
 
 #[derive(Clone, Copy)]
@@ -823,6 +826,9 @@ fn resolve_sections_for_object<'data>(
                     unloaded_section = UnloadedSection::new(part_id::CUSTOM_PLACEHOLDER);
                     unloaded_section.start_stop_eligible = !section_name.starts_with(b".");
                 }
+                SectionRuleOutcome::RiscVAttribute => {
+                    return Ok(SectionSlot::RiscvVAttributes(input_section_index));
+                }
             };
 
             if unloaded_section.part_id == part_id::CUSTOM_PLACEHOLDER {
@@ -1017,7 +1023,7 @@ impl SectionSlot {
             SectionSlot::MergeStrings(section) => section.part_id = part_id,
             SectionSlot::UnloadedDebugInfo(out) => *out = part_id,
             SectionSlot::LoadedDebugInfo(section) => section.part_id = part_id,
-            SectionSlot::NoteGnuProperty(_) => {}
+            SectionSlot::NoteGnuProperty(_) | SectionSlot::RiscvVAttributes(_) => {}
         }
     }
 

--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -275,8 +275,6 @@ impl Config {
                     "dynsym.main.section",
                     // #701
                     "file-header.flags",
-                    // #700
-                    "section.riscv.attributes",
                 ]
                 .into_iter()
                 .map(ToOwned::to_owned),

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -573,6 +573,8 @@ pub mod secnames {
     pub const GROUP_SECTION_NAME: &[u8] = GROUP_SECTION_NAME_STR.as_bytes();
     pub const DATA_REL_RO_SECTION_NAME_STR: &str = ".data.rel.ro";
     pub const DATA_REL_RO_SECTION_NAME: &[u8] = DATA_REL_RO_SECTION_NAME_STR.as_bytes();
+    pub const RISCV_ATTRIBUTES_SECTION_NAME_STR: &str = ".riscv.attributes";
+    pub const RISCV_ATTRIBUTES_SECTION_NAME: &[u8] = RISCV_ATTRIBUTES_SECTION_NAME_STR.as_bytes();
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -716,6 +718,28 @@ impl std::ops::BitAnd for SegmentFlags {
 
 /// Dynamic thread vector pointers point 0x800 past the start of each TLS block.
 pub const RISCV_TLS_DTV_OFFSET: u64 = 0x800;
+
+// RISC-V ELF Tag constants, see: https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc#risc-v-specific-dynamic-section-tags
+pub mod riscvattr {
+    // Attibutes relate to whole file.
+    pub const TAG_RISCV_WHOLE_FILE: u64 = 1;
+    // Indicates the stack alignment requirement in bytes (ULEB128).
+    pub const TAG_RISCV_STACK_ALIGN: u64 = 4;
+    // Indicates the target architecture of this object (NTBS).
+    pub const TAG_RISCV_ARCH: u64 = 5;
+    // Indicates whether to impose unaligned memory accesses in code generation (ULEB128).
+    pub const TAG_RISCV_UNALIGNED_ACCESS: u64 = 6;
+    // Indicates the major version of the privileged specification (ULEB128, deprecated).
+    pub const TAG_RISCV_PRIV_SPEC: u64 = 8;
+    // Indicates the minor version of the privileged specification (ULEB128, deprecated).
+    pub const TAG_RISCV_PRIV_SPEC_MINOR: u64 = 10;
+    // Indicates the revision version of the privileged specification (ULEB128, deprecated).
+    pub const TAG_RISCV_PRIV_SPEC_REVISION: u64 = 12;
+    // Indicates which version of the atomics ABI is being used (ULEB128).
+    pub const TAG_RISCV_ATOMIC_ABI: u64 = 14;
+    // Indicates the usage definition of the X3 register (ULEB128).
+    pub const TAG_RISCV_X3_REG_USAGE: u64 = 16;
+}
 
 /// For additional information on ELF relocation types, see "ELF-64 Object File Format" -
 /// https://uclibc.org/docs/elf-64-gen.pdf. For information on the TLS related relocations, see "ELF

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -724,7 +724,7 @@ pub const RISCV_ATTRIBUTE_VENDOR_NAME: &str = "riscv";
 
 // RISC-V ELF Tag constants, see: https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc#risc-v-specific-dynamic-section-tags
 pub mod riscvattr {
-    // Attibutes relate to whole file.
+    // Attributes relate to whole file.
     pub const TAG_RISCV_WHOLE_FILE: u64 = 1;
     // Indicates the stack alignment requirement in bytes (ULEB128).
     pub const TAG_RISCV_STACK_ALIGN: u64 = 4;

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -364,6 +364,7 @@ pub mod sht {
     pub const HIPROC: SectionType = SectionType(object::elf::SHT_HIPROC);
     pub const LOUSER: SectionType = SectionType(object::elf::SHT_LOUSER);
     pub const HIUSER: SectionType = SectionType(object::elf::SHT_HIUSER);
+    pub const RISCV_ATTRIBUTES: SectionType = SectionType(object::elf::SHT_RISCV_ATTRIBUTES);
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -718,6 +719,8 @@ impl std::ops::BitAnd for SegmentFlags {
 
 /// Dynamic thread vector pointers point 0x800 past the start of each TLS block.
 pub const RISCV_TLS_DTV_OFFSET: u64 = 0x800;
+
+pub const RISCV_ATTRIBUTE_VENDOR_NAME: &str = "riscv";
 
 // RISC-V ELF Tag constants, see: https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc#risc-v-specific-dynamic-section-tags
 pub mod riscvattr {

--- a/wild/tests/sources/linker-script.c
+++ b/wild/tests/sources/linker-script.c
@@ -9,6 +9,7 @@
 //#ExpectSym:start_bar bar 0
 //#ExpectSym:start_aaa bar 8
 //#ExpectSym:end_bar bar 12
+//#DiffIgnore:section.riscv.attributes
 
 static int foo1 __attribute__ ((used, section (".data.foo"))) = 0x01;
 


### PR DESCRIPTION
The implementation encompasses all the necessary components for running tests on my RISC-V board. The missing pieces are listed in the #916.

Fixes: #700