### PR TITLE
 change the description for `-Bsymbolic-non-weak` tests

### DIFF
--- a/wild/tests/sources/shared.c
+++ b/wild/tests/sources/shared.c
@@ -30,7 +30,7 @@
 //#Config:nosymbolic:default
 //#LinkArgs:-shared -z now -Bno-symbolic
 
-//TODO: Add a test for `-Bsymbolic-non-weak`. Currently, adding such tests causes linker-diff to panic.
+//TODO: The lld included in Ubuntu 22.04 is old and doesn't implement the `-Bsymbolic-non-weak` option.
 
 //#Config:symbolic-non-weak-functions:default
 //#LinkArgs:-shared -z now -Bsymbolic-non-weak-functions

--- a/wild/tests/sources/shared.c
+++ b/wild/tests/sources/shared.c
@@ -30,7 +30,8 @@
 //#Config:nosymbolic:default
 //#LinkArgs:-shared -z now -Bno-symbolic
 
-//TODO: The lld included in Ubuntu 22.04 is old and doesn't implement the `-Bsymbolic-non-weak` option.
+//TODO: Add a test for `-Bsymbolic-non-weak`. The lld included in Ubuntu 22.04 is old and doesn't
+//implement the `-Bsymbolic-non-weak` option.
 
 //#Config:symbolic-non-weak-functions:default
 //#LinkArgs:-shared -z now -Bsymbolic-non-weak-functions


### PR DESCRIPTION
Previously, `linker-diff` would panic and prevent adding tests for this option, but now it seems possible to do so.