### PR TITLE
Add supported targets/emulations to --help

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -659,6 +659,10 @@ pub(crate) fn parse<F: Fn() -> I, S: AsRef<str>, I: Iterator<Item = S>>(input: F
             }
             return parse_from_argument_file(Path::new(path));
         } else if long_arg_eq("help") {
+            // The following listing is something autoconf detection relies on.
+            println!("wild: supported targets: elf64-x86-64 elf64-littleaarch64 elf64-littleriscv");
+            println!("wild: supported emulations: elf_x86_64 aarch64elf elf64lriscv");
+            println!();
             bail!("Sorry, help isn't implemented yet");
         } else if strip_option(arg)
             .is_some_and(|stripped_arg| DEFAULT_FLAGS.contains(&stripped_arg))


### PR DESCRIPTION
It's something used by `autoconf` script detection.