### PR TITLE
update-nix-lockfile.yaml: Don't automatically create PR

### DIFF
--- a/.github/workflows/update-nix-lockfile.yaml
+++ b/.github/workflows/update-nix-lockfile.yaml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
-      pull-requests: write
 
     steps:
       - name: Checkout
@@ -31,15 +30,5 @@ jobs:
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add flake.lock
-          git commit -m "[Automated] Update flake.lock"
+          git commit -m "Update nix flake.lock"
           git push -f origin nix_update
-
-      - name: Create PR
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr create \
-            --base main \
-            --head nix_update \
-            --title "Update Nix lockfile" \
-            --body "Automated update"


### PR DESCRIPTION
It doesn't appear to work. We can just create PRs ourselves as needed, probably after manually triggering this workflow.

Issue #925