### PR TITLE
Version script glob support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@ result
 # These are generated when running mold tests.
 fakes-debug/out
 fakes-debug/-
-/wild/out/test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,6 +724,7 @@ dependencies = [
  "flate2",
  "foldhash",
  "gimli 0.32.0",
+ "glob",
  "hashbrown",
  "hex",
  "indexmap",

--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -46,6 +46,7 @@ tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 winnow = { workspace = true }
 zstd = { workspace = true }
+glob = "0.3.2"
 
 [dev-dependencies]
 ar = "0.9.0"

--- a/libwild/src/version_script.rs
+++ b/libwild/src/version_script.rs
@@ -54,16 +54,17 @@ impl<'data> MatchRules<'data> {
     }
 
     fn matches(&self, name: &PreHashed<UnversionedSymbolName>) -> bool {
-        self.matches_all
-            || self.exact.contains(name)
-            || self.globs.iter().any(|glob| {
-                glob.matches(str::from_utf8(name.bytes()).unwrap_or_else(|_| {
-                    panic!(
-                        "Valid utf-8 identifier expected: {}",
-                        String::from_utf8_lossy(name.bytes())
-                    )
-                }))
-            })
+        if self.matches_all || self.exact.contains(name) {
+            return true;
+        }
+
+        let symbol_name = str::from_utf8(name.bytes()).unwrap_or_else(|_| {
+            panic!(
+                "Valid utf-8 identifier expected: {}",
+                String::from_utf8_lossy(name.bytes())
+            )
+        });
+        self.globs.iter().any(|glob| glob.matches(symbol_name))
     }
 
     fn merge(&mut self, other: &MatchRules<'data>) {

--- a/libwild/src/version_script.rs
+++ b/libwild/src/version_script.rs
@@ -57,7 +57,12 @@ impl<'data> MatchRules<'data> {
         self.matches_all
             || self.exact.contains(name)
             || self.globs.iter().any(|glob| {
-                glob.matches(str::from_utf8(name.bytes()).expect("Valid utf-8 identifier expected"))
+                glob.matches(str::from_utf8(name.bytes()).unwrap_or_else(|_| {
+                    panic!(
+                        "Valid utf-8 identifier expected: {}",
+                        String::from_utf8_lossy(name.bytes())
+                    )
+                }))
             })
     }
 

--- a/libwild/src/version_script.rs
+++ b/libwild/src/version_script.rs
@@ -358,6 +358,12 @@ mod tests {
             ["bar*", "best_*_fn*", "*_wrapper"],
         );
         assert!(script.locals.matches_all);
+
+        let globals = script.globals;
+        assert!(globals.matches(&UnversionedSymbolName::prehashed(b"main_wrapper")));
+        assert!(globals.matches(&UnversionedSymbolName::prehashed(b"bar_bar_bar")));
+        assert!(globals.matches(&UnversionedSymbolName::prehashed(b"best_foo_fn_barus")));
+        assert!(!globals.matches(&UnversionedSymbolName::prehashed(b"best_fn")));
     }
 
     #[test]


### PR DESCRIPTION
Based on the discussion with David, I tested the bevy with dynamic linking (500K symbols in a version script file), and I decided to keep the exact match implementation. The only change is that `glob::Pattern` is used for a general glob pattern; having that, the link time is equal for `bevy`. For a reasonably sized shared library that uses a couple of general globs, the speed should be good!

Plus the PR support if a space(s) is present after a symbol name.