### PR TITLE
Ignore -stats flag

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -214,6 +214,7 @@ const SILENTLY_IGNORED_FLAGS: &[&str] = &[
     "color-diagnostics",
     "undefined-version",
     "sort-common",
+    "stats",
 ];
 
 const IGNORED_FLAGS: &[&str] = &[


### PR DESCRIPTION
Used by e.g. ncurses:
https://github.com/mirror/ncurses/blob/87c2c84cbd2332d6d94b12a1dcaf12ad1a51a938/aclocal.m4#L7478