### PR TITLE
Mold test-suite refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ result
 # These are generated when running mold tests.
 fakes-debug/out
 fakes-debug/-
+/wild/out/test

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
     "rust-analyzer.linkedProjects": [
         "Cargo.toml",
-    ]
+    ],
+    "search.exclude": {
+        "/external_test_suites/": true
+    }
 }

--- a/wild/tests/external_tests/mold_tests.rs
+++ b/wild/tests/external_tests/mold_tests.rs
@@ -7,6 +7,7 @@ use std::env;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
+use std::str::FromStr;
 
 #[rstest]
 fn exec_mold_tests(
@@ -41,36 +42,26 @@ fn exec_mold_tests(
 }
 
 fn should_skip_mold_test(path: &Path) -> bool {
-    if !path.exists() || path.extension() != Some(std::ffi::OsStr::new("sh")) {
-        return true;
-    }
+    let file_name = path
+        .file_name()
+        .expect("Must be a valid filename")
+        .to_str()
+        .expect("Expected valid string name");
 
-    let file_name = match path.file_name().and_then(|os_str| os_str.to_str()) {
-        Some(name) => name,
-        None => return true,
-    };
-
-    if !file_name.starts_with("arch-") {
+    let Some(name) = file_name.strip_prefix("arch-") else {
         return false;
-    }
-
-    let test_arch = file_name["arch-".len()..]
-        .split('-')
-        .next()
-        .unwrap_or_default();
+    };
 
     let current_arch = get_host_architecture();
     let cross_archs = get_wild_test_cross().unwrap_or_default();
-    match test_arch {
-        "x86_64" => {
-            current_arch != Architecture::X86_64 && !cross_archs.contains(&Architecture::X86_64)
-        }
-        "aarch64" => {
-            current_arch != Architecture::AArch64 && !cross_archs.contains(&Architecture::AArch64)
-        }
-        "riscv64" => {
-            current_arch != Architecture::RISCV64 && !cross_archs.contains(&Architecture::RISCV64)
-        }
-        _ => true,
-    }
+
+    let Some(arch) = name
+        .split('-')
+        .next()
+        .and_then(|arch_str| Architecture::from_str(arch_str).ok())
+    else {
+        return true;
+    };
+
+    current_arch != arch && !cross_archs.contains(&arch)
 }


### PR DESCRIPTION
Changes:
- ignore the /wild/out/test in git
- ignore completely the content of /external_test_suites in VSCode
- simplify should_skip_mold_test