### PR TITLE
Support `-R` option if it points to a directory

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -1165,6 +1165,9 @@ mod tests {
         "-rpath",
         "foo/",
         "-rpath=bar/",
+        "-Rbaz",
+        "-R",
+        "somewhere",
     ];
 
     #[track_caller]
@@ -1207,7 +1210,7 @@ mod tests {
             InputSpec::File(f) => f.as_ref() == Path::new("lib85caec4suo0pxg06jm2ma7b0o.so"),
             InputSpec::Lib(_) => false,
         }));
-        assert_eq!(args.rpath.as_deref(), Some("foo/:bar/"));
+        assert_eq!(args.rpath.as_deref(), Some("foo/:bar/:baz:somewhere"));
     }
 
     #[test]

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -593,6 +593,15 @@ pub(crate) fn parse<F: Fn() -> I, S: AsRef<str>, I: Iterator<Item = S>>(input: F
             append_rpath(&mut args.rpath, value.as_ref());
         } else if let Some(rest) = long_arg_split_prefix("rpath=") {
             append_rpath(&mut args.rpath, rest);
+        } else if arg == "-R" {
+            let value = input.next().context("Missing argument to -R")?;
+            // For compatibility reasons, if the -R option is directory, it is as the -rpath option,
+            // otherwise it is --just-symbols.
+            if Path::new(value.as_ref()).is_dir() {
+                append_rpath(&mut args.rpath, value.as_ref());
+            } else {
+                unrecognised.push("`-R`");
+            }
         } else if long_arg_eq("no-string-merge") {
             args.merge_strings = false;
         } else if long_arg_eq("pie") {


### PR DESCRIPTION
Noticed while building the `slang` Gentoo package.