### PR TITLE
Don't emit non-standard .phdr and .shdr section headers

### DIFF
--- a/libwild/src/program_segments.rs
+++ b/libwild/src/program_segments.rs
@@ -77,6 +77,10 @@ impl ProgramSegmentDef {
     pub(crate) fn is_executable(self) -> bool {
         self.segment_flags.contains(pf::EXECUTABLE)
     }
+
+    pub(crate) fn always_keep(self) -> bool {
+        self.segment_type == pt::PHDR
+    }
 }
 
 impl ProgramSegments {
@@ -138,6 +142,10 @@ impl ProgramSegments {
             .unwrap_or(TYPE_ORDER.len() + def.segment_type.raw() as usize);
 
         (type_pos, mem_start)
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = ProgramSegmentDef> {
+        self.program_segment_details.iter().copied()
     }
 }
 


### PR DESCRIPTION
Other linkers don't emit sections for these parts of the file. Also, using SHT_NULL for sections other than section 0 causes problems for some tools, such as GNU strip.