### PR TITLE
Reject .tcommon section

### DIFF
--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -44,6 +44,8 @@ use crossbeam_queue::ArrayQueue;
 use crossbeam_queue::SegQueue;
 use linker_utils::elf::SectionFlags;
 use linker_utils::elf::SectionType;
+use linker_utils::elf::secnames::TCOMMON_SECTION_NAME;
+use linker_utils::elf::secnames::TCOMMON_SECTION_NAME_STR;
 use linker_utils::elf::shf;
 use object::LittleEndian;
 use object::read::elf::Sym as _;
@@ -855,6 +857,8 @@ fn resolve_sections_for_object<'data>(
                 SectionSlot::UnloadedDebugInfo(part_id::CUSTOM_PLACEHOLDER)
             } else if must_load {
                 SectionSlot::MustLoad(unloaded_section)
+            } else if section_name == TCOMMON_SECTION_NAME {
+                bail!("{TCOMMON_SECTION_NAME_STR} section is not supported yet");
             } else {
                 SectionSlot::Unloaded(unloaded_section)
             };

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -514,6 +514,8 @@ pub mod secnames {
     pub const TDATA_SECTION_NAME: &[u8] = TDATA_SECTION_NAME_STR.as_bytes();
     pub const TBSS_SECTION_NAME_STR: &str = ".tbss";
     pub const TBSS_SECTION_NAME: &[u8] = TBSS_SECTION_NAME_STR.as_bytes();
+    pub const TCOMMON_SECTION_NAME_STR: &str = ".tcommon";
+    pub const TCOMMON_SECTION_NAME: &[u8] = TCOMMON_SECTION_NAME_STR.as_bytes();
     pub const BSS_SECTION_NAME_STR: &str = ".bss";
     pub const BSS_SECTION_NAME: &[u8] = BSS_SECTION_NAME_STR.as_bytes();
     pub const GOT_SECTION_NAME_STR: &str = ".got";


### PR DESCRIPTION
It is probably very exotic construct, where right now, we panic in one of the Mold's tests (arch-x86_64-tls-large-tbss.sh):
```
thread '<unnamed>' panicked at libwild/src/elf_writer.rs:1280:17:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```