### PR TITLE
Fix accidentally removed .gitignore hunk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ result
 # These are generated when running mold tests.
 fakes-debug/out
 fakes-debug/-
+/wild/out/test


### PR DESCRIPTION
I removed it accidentally in the PR that was about version script globs.