### PR TITLE
Change behaviour of --no-allow-shlib-undefined to match lld

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -288,8 +288,7 @@ impl Default for Args {
             files_per_group: None,
             exclude_libs: false,
             no_undefined: false,
-            // TODO: Change default to false once #897 is fixed.
-            allow_shlib_undefined: true,
+            allow_shlib_undefined: false,
             should_print_version: false,
             sysroot: None,
             save_dir: Default::default(),

--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -211,7 +211,13 @@ impl Linker {
             &layout_rules,
         )?;
 
-        let layout = layout::compute::<A>(symbol_db, resolved, output_sections, &mut output)?;
+        let layout = layout::compute::<A>(
+            symbol_db,
+            resolved,
+            output_sections,
+            &mut output,
+            input_data,
+        )?;
 
         output.write(&layout, elf_writer::write::<A>)?;
         diff::maybe_diff()?;

--- a/wild/tests/sources/shlib-undefined-2.c
+++ b/wild/tests/sources/shlib-undefined-2.c
@@ -1,3 +1,5 @@
+//#Shared:shlib-undefined-3.c
+
 int def1(void);
 int def2(void);
 

--- a/wild/tests/sources/shlib-undefined-3.c
+++ b/wild/tests/sources/shlib-undefined-3.c
@@ -1,0 +1,3 @@
+int def3(void) {
+    return 0;
+}

--- a/wild/tests/sources/shlib-undefined.c
+++ b/wild/tests/sources/shlib-undefined.c
@@ -1,20 +1,43 @@
 //#AbstractConfig:default
+// We match lld's behaviour, not GNU ld's for --allow-shlib-undefined. That is, we only validate
+// shared object undefined symbols when all of the shared object's direct dependencies are loaded.
+//#EnableLinker:lld
+//#SkipLinker:ld
 //#Object:runtime.c
 //#Mode:dynamic
-//#Shared:shlib-undefined-2.c
 //#DiffIgnore:.dynamic.DT_RELA
 //#DiffIgnore:.dynamic.DT_RELAENT
 //#DiffIgnore:.dynamic.DT_NEEDED
-
-//#Config:allow:default
-//#LinkArgs:--allow-shlib-undefined -z now
+// Ignore a few things that lld does differently.
+//#DiffIgnore:section.relro_padding
+//#DiffIgnore:section.got.plt.entsize
+//#DiffIgnore:.dynamic.DT_FLAGS_1.NOW
 //#RunEnabled:false
+// Cross doesn't currently support lld and this test doesn't use GNU ld.
+//#Cross:false
 
-//#Config:disallow:default
+// Allow linking against shared object with undefined symbols. We don't run this because the runtime
+// linker would error due to the undefined symbol.
+//#Config:allow:default
+//#Shared:shlib-undefined-2.c
+//#LinkArgs:--allow-shlib-undefined -z now
+
+// This should also succeed to link because our shared object depends on another shared object that
+// we don't have loaded.
+//#Config:disallow-incomplete:default
+//#Shared:shlib-undefined-2.c
+//#LinkArgs:--no-allow-shlib-undefined
+
+// Disallow linking against shared object with undefined symbols. In this variant, the shared object
+// (2) that we depend on has all of its dependencies (3) also loaded.
+//#Config:disallow-complete:default
+//#Shared:shlib-undefined-2.c
+//#Shared:shlib-undefined-3.c
 //#LinkArgs:--no-allow-shlib-undefined
 //#ExpectError:def2
 
 //#Config:shared:default
+//#Shared:shlib-undefined-2.c
 //#LinkArgs:-z now -shared
 //#RunEnabled:false
 // TODO: GNU ld sets the entry to _start even though we're writing a shared object. We probably


### PR DESCRIPTION
It turns out that LLD is more relaxed about undefined symbols in shared objects compared to GNU ld. We now hopefully do the same relaxed behaviour as LLD. That is, we only report an error if the shared object has all of its direct dependencies in the link.

Also, change the default back to --no-allow-shlib-undefined.

Fixes #897