### PR TITLE
linker-diff: add nicer error when only one object is provided

### DIFF
--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -562,6 +562,10 @@ impl Report {
             })
             .collect::<Result<Vec<_>>>()?;
 
+        if objects.len() < 2 {
+            bail!("At least two files must be provided for comparison");
+        }
+
         let arch = ArchKind::from_objects(&objects)?;
 
         if config.wild_defaults {


### PR DESCRIPTION
Prevoiusly it'd just say:
```
thread 'main' panicked at linker-diff/src/header_diff.rs:202:44:
index out of bounds: the len is 1 but the index is 1
```