### PR TITLE
Fix Nix Docker

### DIFF
--- a/docker/nix.Dockerfile
+++ b/docker/nix.Dockerfile
@@ -6,7 +6,7 @@
 
 FROM nixos/nix AS chef
 
-COPY shell.nix shell.nix
+COPY docker/shell.nix shell.nix
 RUN nix-shell --run "rustup toolchain install nightly"
 
 WORKDIR /wild
@@ -17,7 +17,7 @@ RUN nix-shell --run "cargo chef prepare --recipe-path recipe.json"
 
 FROM chef AS builder
 COPY --from=planner /wild/recipe.json recipe.json
-COPY shell.nix shell.nix
+COPY docker/shell.nix shell.nix
 RUN nix-shell --run "cargo chef cook --all-targets --recipe-path recipe.json"
 COPY . .
 

--- a/docker/shell.nix
+++ b/docker/shell.nix
@@ -1,0 +1,24 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+pkgs.mkShell {
+  nativeBuildInputs = [
+    (pkgs.writeShellApplication {
+      name = "gcc";
+      text = ''${pkgs.lib.getExe pkgs.gcc} "$@" -B${pkgs.binutils-unwrapped-all-targets}/bin '';
+    })
+    (pkgs.writeShellApplication {
+      name = "g++";
+      text = ''${pkgs.lib.getExe' pkgs.gcc "g++"} "$@" -B${pkgs.binutils-unwrapped-all-targets}/bin '';
+    })
+    pkgs.binutils-unwrapped-all-targets
+    pkgs.cargo-chef
+    pkgs.llvmPackages_20.clang
+    pkgs.lld
+    pkgs.glibc.out
+    pkgs.glibc.static
+    pkgs.rustup
+  ];
+
+  LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib";
+}


### PR DESCRIPTION
I’ve noticed that building the Nix Docker image isn’t currently possible for several reasons.

1. `shell.nix` has been moved from its previous location in root to `nix/shell.nix`. This causes `COPY shell.nix shell.nix` to fail.
2. Even after correcting this, the current `nix/shell.nix` uses craneLib, which appears to be unsuitable for handling by nix-shell. From my understanding, craneLib was introduced primarily to reduce CI build times, so by creating another `shell.nix` in `docker/shell.nix` that doesn't use craneLib, we should be able to perform the build successfully.