### PR TITLE
Add `external_tests` feature flag

### DIFF
--- a/wild/Cargo.toml
+++ b/wild/Cargo.toml
@@ -43,4 +43,6 @@ default = ["fork"]
 
 fork = ["libwild/fork"]
 
+# external tests
+external_tests = ["mold_tests"]
 mold_tests = []


### PR DESCRIPTION
In contrast to the earlier addition of `WILD_IGNORE_SKIP=all`, this PR adds a feature flag that runs all external tests, making it easier to test against external suites beyond mold.