### PR TITLE
Stop downloading unnecessary submodules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,18 +59,17 @@ jobs:
         if: ${{ env.CI == 'true' }}
       - run: echo "WILD_TEST_CROSS=aarch64,riscv64" >> $GITHUB_ENV
         if: ${{ matrix.test-qemu }}
-      - run: apt-get update && apt-get -y install gcc g++ clang lld curl bubblewrap binutils-aarch64-linux-gnu binutils-riscv64-linux-gnu git
+      - run: apt-get update && apt-get -y install gcc g++ clang lld curl bubblewrap binutils-aarch64-linux-gnu binutils-riscv64-linux-gnu
         if: ${{ contains(matrix.container, 'ubuntu') }}
-      - run: apt-get update && apt-get -y install qemu-user gcc-aarch64-linux-gnu g++-aarch64-linux-gnu gcc-riscv64-linux-gnu g++-riscv64-linux-gnu git
+      - run: apt-get update && apt-get -y install qemu-user gcc-aarch64-linux-gnu g++-aarch64-linux-gnu gcc-riscv64-linux-gnu g++-riscv64-linux-gnu
         if: ${{ matrix.test-qemu }}
-      - run: zypper in -y gcc gcc-c++ glibc-devel-static clang lld curl rustup bubblewrap git
+      - run: zypper in -y gcc gcc-c++ glibc-devel-static clang lld curl rustup bubblewrap
         if: ${{ contains(matrix.container, 'opensuse') }}
-      - run: apk add build-base lld clang bash curl git
+      - run: apk add build-base lld clang bash curl
         if: ${{ contains(matrix.container, 'alpine') }}
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-          submodules: recursive
       - uses: dtolnay/rust-toolchain@nightly
         id: rust-toolchain
         with:
@@ -174,7 +173,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: recursive
 
       - name: Install Nix
         uses: nixbuild/nix-quick-install-action@v32


### PR DESCRIPTION
Downloading submodules in `ci.yml` should no longer be necessary. This also eliminates the need to install new versions of git.