### PR TITLE
Add handling of the .symver asm directives

### DIFF
--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -63,6 +63,7 @@ use crate::string_merging::MergedStringStartAddresses;
 use crate::string_merging::MergedStringsSection;
 use crate::string_merging::get_merged_string_output_address;
 use crate::symbol::UnversionedSymbolName;
+use crate::symbol_db::RawSymbolName;
 use crate::symbol_db::SymbolDb;
 use crate::symbol_db::SymbolDebug;
 use crate::symbol_db::SymbolId;
@@ -914,9 +915,10 @@ fn export_dynamic<'data>(
     symbol_db: &SymbolDb<'data>,
 ) -> Result {
     let name = symbol_db.symbol_name(symbol_id)?;
+    let RawSymbolName { name_bytes, .. } = RawSymbolName::parse(name.bytes());
     common
         .dynamic_symbol_definitions
-        .push(DynamicSymbolDefinition::new(symbol_id, name.bytes()));
+        .push(DynamicSymbolDefinition::new(symbol_id, name_bytes));
     Ok(())
 }
 

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -1142,6 +1142,7 @@ trait SymbolLoader<'data> {
     ) -> Result<RawSymbolName<'data>>;
 }
 
+#[derive(Debug)]
 pub(crate) struct RawSymbolName<'data> {
     pub(crate) name_bytes: &'data [u8],
 


### PR DESCRIPTION
The following WIP patch "fixes" #968, however, it's more about papering over the various limitation of the symbol name handling. To be honest, a proper fix would require a bigger refactoring where something like `VersionedSymbolName` will become a first class citizen when it comes to handling of the names.

@davidlattimore Can you please help with that? Feel free to close this PR at any time ;)