### PR TITLE
Prioritise heavy tests in nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,4 @@
+[[profile.default.overrides]]
+# These tests are slow, run them first to improve parallelism.
+filter = 'test(_rust_) | test(_integration_)'
+priority = 1


### PR DESCRIPTION
Results from my 5950X system:
````
❯ hyperfine -N -p "jj new main" -n "main -j8" "cargo nextest run -j8" -p "jj new yn" -n "this PR -j8" "cargo nextest run -j8" -p "jj new main" -n "main all-core" "cargo nextest run" -p "jj new yn" -n "this PR all-core" "cargo nextest run" -p "jj new main" -n "main all-core with mold tests" "cargo nextest run -F mold_tests" -p "jj new yn" -n "this PR with mold tests" "cargo nextest run -F mold_tests" --sort command
Benchmark 1: main -j8
  Time (mean ± σ):      4.306 s ±  0.021 s    [User: 15.042 s, System: 14.982 s]
  Range (min … max):    4.273 s …  4.336 s    10 runs

Benchmark 2: this PR -j8
  Time (mean ± σ):      3.853 s ±  0.015 s    [User: 17.193 s, System: 14.506 s]
  Range (min … max):    3.827 s …  3.875 s    10 runs

Benchmark 3: main all-core
  Time (mean ± σ):      4.134 s ±  0.042 s    [User: 15.735 s, System: 14.184 s]
  Range (min … max):    4.068 s …  4.212 s    10 runs

Benchmark 4: this PR all-core
  Time (mean ± σ):      4.073 s ±  0.023 s    [User: 15.705 s, System: 13.840 s]
  Range (min … max):    4.029 s …  4.121 s    10 runs

Benchmark 5: main all-core with mold tests
  Time (mean ± σ):      6.532 s ±  0.026 s    [User: 25.440 s, System: 20.232 s]
  Range (min … max):    6.477 s …  6.566 s    10 runs

Benchmark 6: this PR with mold tests
  Time (mean ± σ):      6.054 s ±  0.026 s    [User: 25.932 s, System: 20.115 s]
  Range (min … max):    6.011 s …  6.114 s    10 runs

Relative speed comparison
        1.12 ±  0.01  main -j8
        1.00          this PR -j8
        1.07 ±  0.01  main all-core
        1.06 ±  0.01  this PR all-core
        1.70 ±  0.01  main all-core with mold tests
        1.57 ±  0.01  this PR with mold tests
````