### PR TITLE
Implement `--allow-multiple-definition` and `-z muldefs`

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -93,6 +93,7 @@ pub struct Args {
     pub(crate) relax: bool,
     pub(crate) unresolved_symbols: UnresolvedSymbols,
     pub(crate) error_unresolved_symbols: bool,
+    pub(crate) allow_multiple_definitions: bool,
 
     output_kind: Option<OutputKind>,
     pub(crate) is_dynamic_executable: AtomicBool,
@@ -323,6 +324,7 @@ impl Default for Args {
             available_threads: NonZeroUsize::new(1).unwrap(),
             unresolved_symbols: UnresolvedSymbols::ReportAll,
             error_unresolved_symbols: true,
+            allow_multiple_definitions: false,
         }
     }
 }
@@ -414,6 +416,7 @@ pub(crate) fn parse<F: Fn() -> I, S: AsRef<str>, I: Iterator<Item = S>>(input: F
                 "nocopyreloc" => args.allow_copy_relocations = false,
                 "nodelete" => args.needs_nodelete_handling = true,
                 "defs" => args.no_undefined = true,
+                "muldefs" => args.allow_multiple_definitions = true,
                 _ => {
                     warn_unsupported(&format!("-z {arg}"))?;
                     // TODO: Handle these
@@ -473,6 +476,8 @@ pub(crate) fn parse<F: Fn() -> I, S: AsRef<str>, I: Iterator<Item = S>>(input: F
             args.b_symbolic = BSymbolicKind::All;
         } else if long_arg_eq("Bno-symbolic") {
             args.b_symbolic = BSymbolicKind::None;
+        } else if long_arg_eq("allow-multiple-definition") {
+            args.allow_multiple_definitions = true;
         } else if arg == "-o" {
             args.output = get_next_argument(arg).map(|a| Arc::from(Path::new(a.as_ref())))?;
         } else if let Some(value) = get_option_value("dynamic-linker") {

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -901,8 +901,9 @@ fn select_symbol(
                     // We don't implement full COMDAT logic, however if we encounter duplicate
                     // strong definitions, then we don't emit errors if all the strong definitions
                     // are defined in COMDAT group sections.
-                    if !symbol_db.is_in_comdat_group(existing, resolved)
-                        || !symbol_db.is_in_comdat_group(id, resolved)
+                    if (!symbol_db.is_in_comdat_group(existing, resolved)
+                        || !symbol_db.is_in_comdat_group(id, resolved))
+                        && !symbol_db.db.args.allow_multiple_definitions
                     {
                         bail!(
                             "{}, defined in {} and {}",

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -1,7 +1,6 @@
 [skipped_groups.unsupported_options]
 reason = "these tests use unsupported options"
 tests = [
-  "allow-multiple-definition.sh",
   "audit.sh",
   "color-diagnostics.sh",
   "compress-debug-sections.sh",        # Compressed debug sections support #493

--- a/wild/tests/sources/duplicate_strong_symbols.c
+++ b/wild/tests/sources/duplicate_strong_symbols.c
@@ -3,6 +3,16 @@
 //#Object:duplicate_strong_symbols2.c
 //#ExpectError:Duplicate symbols
 
+//#Config:allow-multiple-definition
+//#RunEnabled:false
+//#Object:duplicate_strong_symbols2.c
+//#LinkArgs:--allow-multiple-definition
+
+//#Config:z-muldefs
+//#RunEnabled:false
+//#Object:duplicate_strong_symbols2.c
+//#LinkArgs:-z muldefs
+
 int test_func(void) {
     return 0;
 }


### PR DESCRIPTION
e.g., used by relibc in Redox OS.
https://github.com/redox-os/relibc/blob/4f9267be5941a008b3cf5e0c1228c3df8bb72b5a/Makefile#L184