### PR TITLE
nix: fix invalid path specification

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -118,7 +118,7 @@ let
         lib.makeBinPath [
           binutils-unwrapped-all-targets
           clang
-          clang-format
+          clang-tools
           gccWrapper
           gppWrapper
           lld


### PR DESCRIPTION
The changes to `lib.makeBinPath` introduced in #1006 appear to be incorrect and are causing the CI to fail.
e.g. https://github.com/davidlattimore/wild/actions/runs/16699919696/job/47269321983 (At first glance, the CI appears to be successful, but an error occurs in the "Calculate check" step, causing the subsequent checks to not be performed as intended.)