### PR TITLE
Prevent link failure when there are multiple alias definitions pointing to the same symbol

### DIFF
--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -28,6 +28,7 @@ use crate::error;
 use crate::error::Context;
 use crate::error::Error;
 use crate::error::Result;
+use crate::error::warning;
 use crate::file_writer;
 use crate::input_data::FileId;
 use crate::input_data::InputData;
@@ -5662,7 +5663,7 @@ impl<'data> DynamicLayoutState<'data> {
                 is_weak: symbol.is_weak(),
             });
 
-        info.add_symbol(symbol_id, symbol.is_weak(), resources.symbol_db)?;
+        info.add_symbol(symbol_id, symbol.is_weak(), resources.symbol_db);
 
         Ok(())
     }
@@ -5778,23 +5779,21 @@ impl<'data> LinkerScriptLayoutState<'data> {
 }
 
 impl CopyRelocationInfo {
-    fn add_symbol(&mut self, symbol_id: SymbolId, is_weak: bool, symbol_db: &SymbolDb) -> Result {
+    fn add_symbol(&mut self, symbol_id: SymbolId, is_weak: bool, symbol_db: &SymbolDb) {
         if self.symbol_id == symbol_id || is_weak {
-            return Ok(());
+            return;
         }
 
         if !self.is_weak {
-            bail!(
+            warning(&format!(
                 "Multiple non-weak symbols at the same address have copy relocations: {}, {}",
                 symbol_db.symbol_debug(self.symbol_id),
                 symbol_db.symbol_debug(symbol_id)
-            );
+            ));
         }
 
         self.symbol_id = symbol_id;
         self.is_weak = false;
-
-        Ok(())
     }
 }
 

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -230,7 +230,6 @@ tests = [
   "copyrel-protected.sh",
   "copyrel-relro.sh",
   "copyrel-relro2.sh",
-  "copyrel.sh",
   "ctors-in-init-array.sh",
   "defsym-missing-symbol.sh",
   "demangle-cpp.sh",


### PR DESCRIPTION
In the current implementation, if copy relocations exist for non-weak symbols with the same address, wild will bail with the error. However, since this would incorrectly treat multiple alias definitions pointing to the same symbol as invalid code (see [copyrel.sh](https://github.com/rui314/mold/blob/8eafdfbd0ac28e7e1ce3c52f9c49f036e9608022/test/copyrel.sh)), it would be better to simply issue a warning instead.