### PR TITLE
version scripts: Allow parsing of `extern` blocks without a trailing ";" after the last symbol

### DIFF
--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -103,7 +103,6 @@ tests = [
   "version-script15.sh",
   "version-script17.sh",
   "version-script23.sh",
-  "version-script5.sh",
 ]
 
 [skipped_groups.linker_script]


### PR DESCRIPTION
In version scripts, within the `extern` block, the last symbol doesn't necessarily need to be followed by a semicolon (see [its definition in Yacc](https://gnu.googlesource.com/binutils-gdb/+/refs/tags/binutils-2_45/ld/ldgram.y#1471) and [version-script5.sh](https://github.com/rui314/mold/blob/8eafdfbd0ac28e7e1ce3c52f9c49f036e9608022/test/version-script5.sh)).

In fact, we can check whether such a script is valid by following:
```
（▰╹◡╹）❯  cat <<EOF > a.scr
foo
EOF

（▰╹◡╹）❯  ld --version-script a.scr
ld:a.scr:0: syntax error in VERSION script

（▰╹^╹）❯  cat <<EOF > b.scr
{extern "C" {foo};};
EOF

（▰╹◡╹）❯  ld --version-script b.scr
ld: no input files
```