### PR TITLE
Implement new declarative argument parser

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -34,6 +34,8 @@ use std::sync::atomic::AtomicI64;
 use std::sync::atomic::Ordering;
 
 pub struct Args {
+    pub(crate) unrecognized_options: Vec<String>,
+
     pub(crate) arch: Architecture,
     pub(crate) lib_search_path: Vec<Box<Path>>,
     pub(crate) inputs: Vec<Input>,
@@ -164,7 +166,7 @@ pub(crate) enum FileWriteMode {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
-pub(crate) struct Modifiers {
+pub struct Modifiers {
     /// Whether shared objects should only be linked if they're referenced.
     pub(crate) as_needed: bool,
 
@@ -240,8 +242,6 @@ const SILENTLY_IGNORED_FLAGS: &[&str] = &[
     // Just like other modern linkers, we don't need groups in order to resolve cycles.
     "start-group",
     "end-group",
-    "(",
-    ")",
     // TODO: This is supposed to suppress built-in search paths, but I don't think we have any
     // built-in search paths. Perhaps we should?
     "nostdlib",
@@ -253,6 +253,7 @@ const SILENTLY_IGNORED_FLAGS: &[&str] = &[
     "sort-common",
     "stats",
 ];
+const SILENTLY_IGNORED_SHORT_FLAGS: &[&str] = &["(", ")"];
 
 const IGNORED_FLAGS: &[&str] = &[
     "gdb-index",
@@ -267,15 +268,18 @@ const DEFAULT_FLAGS: &[&str] = &[
     "no-copy-dt-needed-entries",
     "no-add-needed",
     "discard-locals",
+    "enable-new-dtags",
+];
+const DEFAULT_SHORT_FLAGS: &[&str] = &[
     "X",  // alias for --discard-locals
     "EL", // little endian
-    "enable-new-dtags",
 ];
 
 impl Default for Args {
     fn default() -> Self {
         Args {
             arch: default_target_arch(),
+            unrecognized_options: Vec::new(),
 
             lib_search_path: Vec::new(),
             inputs: Vec::new(),
@@ -375,8 +379,6 @@ pub(crate) fn parse<F: Fn() -> I, S: AsRef<str>, I: Iterator<Item = S>>(input: F
         ..Default::default()
     };
 
-    let mut unrecognised = Vec::new();
-
     args.save_dir = SaveDir::new(&input)?;
 
     let mut input = input();
@@ -387,402 +389,35 @@ pub(crate) fn parse<F: Fn() -> I, S: AsRef<str>, I: Iterator<Item = S>>(input: F
         args.write_layout = true;
         args.write_trace = true;
     }
+
+    let arg_parser = setup_argument_parser();
     let mut arg_num = 0;
     while let Some(arg) = input.next() {
-        arg_num += 1;
         let arg = arg.as_ref();
 
-        fn strip_option(arg: &str) -> Option<&str> {
-            arg.strip_prefix("--").or(arg.strip_prefix('-'))
-        }
-        let long_arg_eq = |option: &str| {
-            assert!(
-                !option.starts_with('-'),
-                "option cannot start with a dash: `{option}`"
-            );
-            strip_option(arg) == Some(option)
-        };
-        let long_arg_split_prefix = |option: &str| -> Option<&str> {
-            assert!(!option.starts_with('-'));
-            assert!(option.ends_with('='));
-            strip_option(arg).and_then(|stripped_arg| stripped_arg.strip_prefix(option))
-        };
-        let mut get_next_argument = |arg_name| -> Result<S> {
-            input
-                .next()
-                .context(format!("Missing argument to {arg_name}"))
-        };
-        // This allows parsing both `--{option} {value}` and `--{option}={value}` patterns.
-        let mut get_option_value = |option: &str| -> Option<String> {
-            if let Some(value) = long_arg_split_prefix(&format!("{option}=")) {
-                Some(value.to_owned())
-            } else if long_arg_eq(option) {
-                Some(get_next_argument(arg).ok()?.as_ref().to_owned())
-            } else {
-                None
-            }
-        };
-
-        let mut handle_z_option = |arg: &str| -> Result {
-            match arg {
-                "now" => {}
-                "origin" => args.needs_origin_handling = true,
-                "relro" => args.relro = true,
-                "norelro" => args.relro = false,
-                "notext" => {}
-                "nostart-stop-gc" => {}
-                "execstack" => args.execstack = true,
-                "noexecstack" => args.execstack = false,
-                "nocopyreloc" => args.allow_copy_relocations = false,
-                "nodelete" => args.needs_nodelete_handling = true,
-                "defs" => args.no_undefined = true,
-                "undefs" => args.no_undefined = false,
-                "muldefs" => args.allow_multiple_definitions = true,
-                _ => {
-                    warn_unsupported(&format!("-z {arg}"))?;
-                    // TODO: Handle these
-                }
-            }
-            Ok(())
-        };
-        let mut handle_r_option = |value: &str| {
-            // For compatibility reasons, if the -R option is directory, it is treated as the -rpath option,
-            // otherwise it is a separate option --just-symbols.
-            if Path::new(value).is_file() {
-                unrecognised.push(format!("`-R,{value}(filename)`"));
-            } else {
-                append_rpath(&mut args.rpath, value);
-            }
-        };
-
-        if let Some(rest) = arg.strip_prefix("-L") {
-            let handle_sysroot = |path| {
-                args.sysroot
-                    .as_ref()
-                    .and_then(|sysroot| maybe_forced_sysroot(path, sysroot))
-                    .unwrap_or_else(|| Box::from(path))
-            };
-
-            let dir = if rest.is_empty() {
-                handle_sysroot(Path::new(get_next_argument(arg)?.as_ref()))
-            } else {
-                handle_sysroot(Path::new(rest))
-            };
-
-            args.save_dir.handle_file(rest)?;
-
-            args.lib_search_path.push(dir);
-        } else if let Some(rest) = arg.strip_prefix("-l") {
-            let spec = if let Some(stripped) = rest.strip_prefix(':') {
-                InputSpec::File(Box::from(Path::new(stripped)))
-            } else {
-                InputSpec::Lib(Box::from(rest))
-            };
-            args.inputs.push(Input {
-                spec,
-                search_first: None,
-                modifiers: *modifier_stack.last().unwrap(),
-            });
-        } else if long_arg_eq("static") || long_arg_eq("Bstatic") {
-            modifier_stack.last_mut().unwrap().allow_shared = false;
-        } else if long_arg_eq("Bdynamic") {
-            modifier_stack.last_mut().unwrap().allow_shared = true;
-        } else if long_arg_eq("Bsymbolic-functions") {
-            args.b_symbolic = BSymbolicKind::Functions;
-        } else if long_arg_eq("Bsymbolic-non-weak-functions") {
-            args.b_symbolic = BSymbolicKind::NonWeakFunctions;
-        } else if long_arg_eq("Bsymbolic-non-weak") {
-            args.b_symbolic = BSymbolicKind::NonWeak;
-        } else if long_arg_eq("Bsymbolic") {
-            args.b_symbolic = BSymbolicKind::All;
-        } else if long_arg_eq("Bno-symbolic") {
-            args.b_symbolic = BSymbolicKind::None;
-        } else if long_arg_eq("allow-multiple-definition") {
-            args.allow_multiple_definitions = true;
-        } else if arg == "-o" {
-            args.output = get_next_argument(arg).map(|a| Arc::from(Path::new(a.as_ref())))?;
-        } else if let Some(value) = get_option_value("dynamic-linker") {
-            args.is_dynamic_executable.store(true, Ordering::Relaxed);
-            args.dynamic_linker = Some(Box::from(Path::new(&value)));
-        } else if long_arg_eq("no-dynamic-linker") {
-            args.dynamic_linker = None;
-        } else if let Some(style) = long_arg_split_prefix("hash-style=") {
-            // We don't technically support both hash styles, but if requested to do both, we just
-            // do GNU, which we do support.
-            if style != "gnu" && style != "both" {
-                bail!("Unsupported hash-style `{style}`");
-            }
-            // Since we currently only support GNU hash, there's no state to update.
-        } else if let Some(value) = get_option_value("entry") {
-            args.entry = Some(value);
-        } else if arg == "-e" {
-            args.entry = Some(get_next_argument(arg)?.as_ref().to_owned());
-        } else if long_arg_eq("build-id") {
-            args.build_id = BuildIdOption::Fast;
-        } else if let Some(build_id_value) = long_arg_split_prefix("build-id=") {
-            args.build_id = match build_id_value {
-                "none" => BuildIdOption::None,
-                "fast" | "md5" | "sha1" => BuildIdOption::Fast,
-                "uuid" => BuildIdOption::Uuid,
-                s if s.starts_with("0x") || s.starts_with("0X") => {
-                    let hex_string = &s[2..];
-                    let decoded_bytes = hex::decode(hex_string)
-                        .with_context(|| format!("Invalid Hex Build Id `0x{hex_string}`"))?;
-                    BuildIdOption::Hex(decoded_bytes)
-                }
-                s => bail!(
-                    "Invalid build-id value `{s}` valid values are `none`, `fast`, `md5`, `sha1` and `uuid`"
-                ),
-            };
-        } else if let Some(value) = long_arg_split_prefix("icf=") {
-            match value {
-                "none" => {}
-                other => warn_unsupported(&format!("--icf={other}"))?,
-            }
-        } else if let Some(rest) = long_arg_split_prefix("time=") {
-            args.time_phase_options = Some(parse_time_phase_options(rest)?);
-        } else if long_arg_eq("time") {
-            args.time_phase_options = Some(Vec::new());
-        } else if let Some(rest) = long_arg_split_prefix("threads=") {
-            args.num_threads = Some(NonZeroUsize::try_from(rest.parse::<usize>()?)?);
-        } else if long_arg_eq("threads") {
-            // Default behaviour (multiple threads)
-            args.num_threads = None;
-        } else if let Some(rest) = long_arg_split_prefix("thread-count=") {
-            args.num_threads = Some(NonZeroUsize::try_from(rest.parse::<usize>()?)?);
-        } else if let Some(value) = get_option_value("exclude-libs") {
-            if value != "ALL" {
-                warn_unsupported("--exclude-libs other than ALL")?;
-            }
-            args.exclude_libs = true;
-        } else if long_arg_eq("no-threads") {
-            args.num_threads = Some(NonZeroUsize::new(1).unwrap());
-        } else if long_arg_eq("strip-all") || arg == "-s" {
-            args.strip_all = true;
-            args.strip_debug = true;
-        } else if long_arg_eq("strip-debug") || arg == "-S" {
-            args.strip_debug = true;
-        } else if long_arg_eq("gc-sections") {
-            args.gc_sections = true;
-        } else if long_arg_eq("no-gc-sections") {
-            args.gc_sections = false;
-        } else if long_arg_eq("no-fork") {
-            args.should_fork = false;
-        } else if long_arg_eq("update-in-place") {
-            args.file_write_mode = Some(FileWriteMode::UpdateInPlace);
-        } else if arg == "-m" {
-            let arg_value = get_next_argument(arg)?;
-            let arg_value = arg_value.as_ref();
-            args.arch = Architecture::from_str(arg_value)?;
-        } else if let Some(arg_value) = arg.strip_prefix("-m") {
-            args.arch = Architecture::from_str(arg_value)?;
-        } else if long_arg_eq("EB") {
-            bail!("Big-endian target is not supported");
-        } else if arg == "-z" {
-            handle_z_option(get_next_argument(arg)?.as_ref())?;
-        } else if let Some(value) = get_option_value("wrap") {
-            args.wrap.push(value);
-        } else if let Some(arg) = arg.strip_prefix("-z") {
-            handle_z_option(arg)?;
-        } else if let Some(_rest) = arg.strip_prefix("-O") {
-            // We don't use opt-level for now.
-        } else if long_arg_eq("prepopulate-maps") {
-            args.prepopulate_maps = true;
-        } else if long_arg_eq("sym-info") {
-            args.sym_info = input.next().map(|a| a.as_ref().to_owned());
-        } else if long_arg_eq("as-needed") {
-            modifier_stack.last_mut().unwrap().as_needed = true;
-        } else if long_arg_eq("no-as-needed") {
-            modifier_stack.last_mut().unwrap().as_needed = false;
-        } else if long_arg_eq("whole-archive") {
-            modifier_stack.last_mut().unwrap().whole_archive = true;
-        } else if long_arg_eq("no-whole-archive") {
-            modifier_stack.last_mut().unwrap().whole_archive = false;
-        } else if long_arg_eq("start-lib") {
-            modifier_stack.last_mut().unwrap().archive_semantics = true;
-        } else if long_arg_eq("end-lib") {
-            modifier_stack.last_mut().unwrap().archive_semantics = false;
-        } else if long_arg_eq("push-state") {
-            modifier_stack.push(*modifier_stack.last().unwrap());
-        } else if long_arg_eq("pop-state") {
-            modifier_stack.pop();
-            // We put the initial value on the stack, so if it's ever empty, then the arguments
-            // are invalid.
-            if modifier_stack.is_empty() {
-                bail!("Mismatched --pop-state");
-            }
-        } else if let Some(script) = get_option_value("version-script") {
-            args.save_dir.handle_file(&script)?;
-            args.version_script_path = Some(PathBuf::from(script));
-        } else if let Some(script) = get_option_value("script") {
-            args.save_dir.handle_file(&script)?;
-            args.add_script(&script);
-        } else if arg == "-T" {
-            let script = get_next_argument(arg)?;
-            args.save_dir.handle_file(script.as_ref())?;
-            args.add_script(script.as_ref());
-        } else if let Some(rest) = arg.strip_prefix("-T") {
-            args.save_dir.handle_file(rest)?;
-            args.add_script(rest);
-        } else if let Some(value) = get_option_value("rpath") {
-            append_rpath(&mut args.rpath, &value);
-        } else if arg == "-R" {
-            handle_r_option(get_next_argument(arg)?.as_ref());
-        } else if let Some(rest) = arg.strip_prefix("-R") {
-            handle_r_option(rest);
-        } else if long_arg_eq("no-string-merge") {
-            args.merge_strings = false;
-        } else if long_arg_eq("pie") {
-            args.relocation_model = RelocationModel::Relocatable;
-        } else if long_arg_eq("no-pie") {
-            args.relocation_model = RelocationModel::NonRelocatable;
-        } else if long_arg_eq("eh-frame-hdr") {
-            args.should_write_eh_frame_hdr = true;
-        } else if long_arg_eq("shared") || long_arg_eq("Bshareable") {
-            args.output_kind = Some(OutputKind::SharedObject);
-        } else if long_arg_eq("export-dynamic") || arg == "-E" {
-            args.export_all_dynamic_symbols = true;
-        } else if long_arg_eq("no-export-dynamic") {
-            args.export_all_dynamic_symbols = false;
-        } else if let Some(value) = get_option_value("export-dynamic-symbol") {
-            args.export_list.push(value);
-        } else if let Some(value) = get_option_value("export-dynamic-symbol-list") {
-            args.export_list_path = Some(PathBuf::from(&value));
-        } else if let Some(value) = get_option_value("dynamic-list") {
-            args.b_symbolic = BSymbolicKind::All;
-            args.export_list_path = Some(PathBuf::from(&value));
-        } else if let Some(value) = get_option_value("soname") {
-            args.soname = Some(value);
-        } else if arg == "-h" {
-            args.soname = Some(get_next_argument(arg)?.as_ref().to_owned());
-        } else if let Some(rest) = arg.strip_prefix("-h") {
-            args.soname = Some(rest.to_owned());
-        } else if long_arg_split_prefix("plugin-opt=").is_some() {
-            // TODO: Implement support for linker plugins.
-        } else if long_arg_eq("plugin") {
-            let other = get_next_argument(arg)?.as_ref().to_owned();
-            warn_unsupported(&format!("--plugin {other}"))?;
-        } else if let Some(rest) = long_arg_split_prefix("dependency-file=") {
-            warn_unsupported(&format!("--dependency-file={rest}"))?;
-        } else if long_arg_eq("rpath-link") {
-            // TODO
-            input.next();
-        } else if long_arg_eq("validate-output") {
-            args.validate_output = true;
-        } else if long_arg_eq("write-layout") {
-            args.write_layout = true;
-        } else if long_arg_eq("write-trace") {
-            args.write_trace = true;
-        } else if let Some(rest) = long_arg_split_prefix("write-gc-stats=") {
-            args.write_gc_stats = Some(PathBuf::from(rest));
-        } else if let Some(rest) = long_arg_split_prefix("gc-stats-ignore=") {
-            args.gc_stats_ignore.push(rest.to_owned());
-        } else if long_arg_eq("version") || arg == "-v" {
-            args.should_print_version = true;
-        } else if long_arg_eq("verbose-gc-stats") {
-            args.verbose_gc_stats = true;
-        } else if let Some(rest) = long_arg_split_prefix("debug-address=") {
-            args.debug_address = Some(parse_number(rest).context("Invalid --debug-address")?);
-        } else if let Some(rest) = long_arg_split_prefix("debug-fuel=") {
-            args.debug_fuel = Some(AtomicI64::new(rest.parse()?));
-            // Using debug fuel with more than one thread would likely give non-deterministic
-            // results.
-            args.num_threads = Some(NonZeroUsize::new(1).unwrap());
-        } else if long_arg_eq("allow-shlib-undefined") {
-            args.allow_shlib_undefined = true;
-        } else if long_arg_eq("no-allow-shlib-undefined") {
-            args.allow_shlib_undefined = false;
-        } else if let Some(rest) = get_option_value("unresolved-symbols") {
-            match rest.as_str() {
-                "report-all" => {
-                    args.unresolved_symbols = UnresolvedSymbols::ReportAll;
-                }
-                "ignore-in-shared-libs" => {
-                    args.unresolved_symbols = UnresolvedSymbols::IgnoreInSharedLibs;
-                }
-                "ignore-in-object-files" => {
-                    args.unresolved_symbols = UnresolvedSymbols::IgnoreInObjectFiles;
-                }
-                "ignore-all" => {
-                    args.unresolved_symbols = UnresolvedSymbols::IgnoreAll;
-                }
-                _ => bail!("Invalid unresolved-symbols value {rest}"),
-            }
-        } else if long_arg_eq("error-unresolved-symbols") {
-            args.error_unresolved_symbols = true;
-        } else if long_arg_eq("warn-unresolved-symbols") {
-            args.error_unresolved_symbols = false;
-        } else if long_arg_eq("no-undefined") {
-            args.no_undefined = true;
-        } else if let Some(rest) = long_arg_split_prefix("undefined=") {
-            args.undefined.push(rest.to_owned());
-        } else if let Some(rest) = arg.strip_prefix("-u") {
-            if rest.is_empty() {
-                args.undefined
-                    .push(get_next_argument(arg)?.as_ref().to_owned());
-            } else {
-                args.undefined.push(rest.to_owned());
-            }
-        } else if long_arg_eq("demangle") {
-            args.demangle = true;
-        } else if long_arg_eq("no-demangle") {
-            args.demangle = false;
-        } else if long_arg_eq("got-plt-syms") {
-            args.got_plt_syms = true;
-        } else if long_arg_eq("relax") {
-            args.relax = true;
-        } else if long_arg_eq("no-relax") {
-            args.relax = false;
-        } else if let Some(path) = arg.strip_prefix('@') {
+        // Handle `@file`
+        // TODO: This is ad-hoc.
+        if let Some(path) = arg.strip_prefix('@') {
             if input.next().is_some() || arg_num > 1 {
                 bail!("Mixing of @{{filename}} and regular arguments isn't supported");
             }
             return parse_from_argument_file(Path::new(path));
-        } else if long_arg_eq("help") {
-            // The following listing is something autoconf detection relies on.
-            println!("wild: supported targets: elf64-x86-64 elf64-littleaarch64 elf64-littleriscv");
-            println!("wild: supported emulations: elf_x86_64 aarch64elf elf64lriscv");
-            println!();
-            bail!("Sorry, help isn't implemented yet");
-        } else if strip_option(arg)
-            .is_some_and(|stripped_arg| DEFAULT_FLAGS.contains(&stripped_arg))
-        {
-            // These flags are mapped to the default behaviour of the linker.
-        } else if strip_option(arg)
-            .is_some_and(|stripped_arg| IGNORED_FLAGS.contains(&stripped_arg))
-        {
-            warn_unsupported(arg)?;
-        } else if strip_option(arg)
-            .is_some_and(|stripped_arg| SILENTLY_IGNORED_FLAGS.contains(&stripped_arg))
-        {
-        } else if let Some(sysroot) = long_arg_split_prefix("sysroot=") {
-            args.save_dir.handle_file(sysroot)?;
-            let sysroot = std::fs::canonicalize(sysroot).unwrap_or_else(|_| PathBuf::from(sysroot));
-            args.sysroot = Some(Box::from(sysroot.as_path()));
-            for path in &mut args.lib_search_path {
-                if let Some(new_path) = maybe_forced_sysroot(path, &sysroot) {
-                    *path = new_path;
-                }
-            }
-        } else if arg.starts_with('-') {
-            unrecognised.push(format!("`{arg}`"));
-        } else {
-            args.save_dir.handle_file(arg)?;
-            args.inputs.push(Input {
-                spec: InputSpec::File(Box::from(Path::new(arg))),
-                search_first: None,
-                modifiers: *modifier_stack.last().unwrap(),
-            });
         }
-    }
+        arg_num += 1;
 
-    if !unrecognised.is_empty() {
-        bail!("Unrecognised argument(s): {}", unrecognised.join(" "));
+        if !arg_parser.handle_argument(&mut args, &mut modifier_stack, arg, &mut input)? {
+            ArgumentParser::handle_positional_argument(&mut args, &modifier_stack, arg);
+        }
     }
 
     // Copy relocations are only permitted when building executables.
     if args.output_kind() == OutputKind::SharedObject {
         args.allow_copy_relocations = false;
+    }
+
+    if !args.unrecognized_options.is_empty() {
+        let options_list = args.unrecognized_options.join(", ");
+        bail!("unrecognized option(s): {}", options_list);
     }
 
     Ok(args)
@@ -1089,6 +724,1500 @@ fn warn_unsupported(opt: &str) -> Result {
         other => bail!("Unsupported value for {WILD_UNSUPPORTED_ENV}={other}"),
     }
     Ok(())
+}
+
+pub struct ArgumentParser {
+    options: std::collections::HashMap<&'static str, OptionHandler>,
+    short_options: std::collections::HashMap<&'static str, OptionHandler>, // Short option lookup
+    prefix_options: std::collections::HashMap<&'static str, PrefixOptionHandler>, // For options like -L, -l, etc.
+}
+
+#[derive(Clone)]
+struct OptionHandler {
+    help_text: &'static str,
+    handler: OptionHandlerFn,
+    short_names: Vec<&'static str>,
+}
+
+type SubOptionHandler = Box<dyn Fn(&mut Args, &mut Vec<Modifiers>, &str) -> Result<()>>;
+
+struct PrefixOptionHandler {
+    help_text: &'static str,
+    handler: fn(&mut Args, &mut Vec<Modifiers>, &str) -> Result<()>,
+    sub_options: std::collections::HashMap<&'static str, (&'static str, SubOptionHandler)>, // sub-option -> (help text, handler)
+}
+
+#[allow(clippy::enum_variant_names)]
+#[derive(Clone, Copy)]
+enum OptionHandlerFn {
+    NoParam(fn(&mut Args, &mut Vec<Modifiers>) -> Result<()>),
+    WithParam(fn(&mut Args, &mut Vec<Modifiers>, &str) -> Result<()>),
+    OptionalParam(fn(&mut Args, &mut Vec<Modifiers>, Option<&str>) -> Result<()>),
+}
+
+pub struct OptionDeclaration<'a, T> {
+    parser: &'a mut ArgumentParser,
+    long_names: Vec<&'static str>,
+    short_names: Vec<&'static str>,
+    help_text: &'static str,
+    _phantom: std::marker::PhantomData<T>,
+}
+
+pub struct NoParam;
+pub struct WithParam;
+pub struct WithOptionalParam;
+
+impl Default for ArgumentParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// For declaring prefix options (like -L, -l, etc.)
+pub struct PrefixOptionDeclaration<'a> {
+    parser: &'a mut ArgumentParser,
+    prefix: &'static str,
+    help_text: &'static str,
+    sub_options: std::collections::HashMap<&'static str, (&'static str, SubOptionHandler)>,
+}
+
+impl ArgumentParser {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            options: std::collections::HashMap::new(),
+            short_options: std::collections::HashMap::new(),
+            prefix_options: std::collections::HashMap::new(),
+        }
+    }
+
+    pub fn declare(&mut self) -> OptionDeclaration<'_, NoParam> {
+        OptionDeclaration {
+            parser: self,
+            long_names: Vec::new(),
+            short_names: Vec::new(),
+            help_text: "",
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    pub fn declare_with_param(&mut self) -> OptionDeclaration<'_, WithParam> {
+        OptionDeclaration {
+            parser: self,
+            long_names: Vec::new(),
+            short_names: Vec::new(),
+            help_text: "",
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    pub fn declare_with_optional_param(&mut self) -> OptionDeclaration<'_, WithOptionalParam> {
+        OptionDeclaration {
+            parser: self,
+            long_names: Vec::new(),
+            short_names: Vec::new(),
+            help_text: "",
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Declare a prefix option (like -L, -l, etc.)
+    pub fn declare_prefix(&mut self, prefix: &'static str) -> PrefixOptionDeclaration<'_> {
+        PrefixOptionDeclaration {
+            parser: self,
+            prefix,
+            help_text: "",
+            sub_options: std::collections::HashMap::new(),
+        }
+    }
+
+    pub fn parse<S: AsRef<str>, I: Iterator<Item = S>>(
+        &self,
+        mut args: Args,
+        mut modifier_stack: Vec<Modifiers>,
+        mut input: I,
+    ) -> Result<Args> {
+        while let Some(arg) = input.next() {
+            let arg = arg.as_ref();
+            if !self.handle_argument(&mut args, &mut modifier_stack, arg, &mut input)? {
+                ArgumentParser::handle_positional_argument(&mut args, &modifier_stack, arg);
+            }
+        }
+        Ok(args)
+    }
+
+    fn handle_argument<S: AsRef<str>, I: Iterator<Item = S>>(
+        &self,
+        args: &mut Args,
+        modifier_stack: &mut Vec<Modifiers>,
+        arg: &str,
+        input: &mut I,
+    ) -> Result<bool> {
+        if let Some(stripped) = strip_option(arg) {
+            // Check for option with '=' syntax
+            if let Some(eq_pos) = stripped.find('=') {
+                let option_name = &stripped[..eq_pos];
+                let value = &stripped[eq_pos + 1..];
+
+                if let Some(handler) = self.options.get(option_name) {
+                    match &handler.handler {
+                        OptionHandlerFn::WithParam(f) => f(args, modifier_stack, value)?,
+                        OptionHandlerFn::OptionalParam(f) => f(args, modifier_stack, Some(value))?,
+                        OptionHandlerFn::NoParam(_) => return Ok(false),
+                    }
+                    return Ok(true);
+                }
+            } else {
+                if stripped == "build-id"
+                    && let Some(handler) = self.options.get(stripped)
+                    && let OptionHandlerFn::WithParam(f) = &handler.handler
+                {
+                    f(args, modifier_stack, "fast")?;
+                    return Ok(true);
+                }
+
+                if let Some(handler) = self.options.get(stripped) {
+                    match &handler.handler {
+                        OptionHandlerFn::NoParam(f) => f(args, modifier_stack)?,
+                        OptionHandlerFn::WithParam(f) => {
+                            let next_arg =
+                                input.next().context(format!("Missing argument to {arg}"))?;
+                            f(args, modifier_stack, next_arg.as_ref())?;
+                        }
+                        OptionHandlerFn::OptionalParam(f) => {
+                            f(args, modifier_stack, None)?;
+                        }
+                    }
+                    return Ok(true);
+                }
+            }
+        }
+
+        if arg.starts_with('-') && !arg.starts_with("--") && arg.len() > 1 {
+            let option_name = &arg[1..];
+            if let Some(handler) = self.short_options.get(option_name) {
+                match &handler.handler {
+                    OptionHandlerFn::NoParam(f) => f(args, modifier_stack)?,
+                    OptionHandlerFn::WithParam(f) => {
+                        let next_arg =
+                            input.next().context(format!("Missing argument to {arg}"))?;
+                        f(args, modifier_stack, next_arg.as_ref())?;
+                    }
+                    OptionHandlerFn::OptionalParam(f) => {
+                        f(args, modifier_stack, None)?;
+                    }
+                }
+                return Ok(true);
+            }
+        }
+
+        // Prefix options. These should be handled after processing long and short options,
+        // because some options (like `-hashstyle=gnu`) can be misinterpreted as prefix options.
+        for (prefix, handler) in &self.prefix_options {
+            if let Some(rest) = arg.strip_prefix(&format!("-{prefix}")) {
+                let value = if rest.is_empty() {
+                    let next_arg = input
+                        .next()
+                        .context(format!("Missing argument to -{prefix}"))?;
+                    next_arg.as_ref().to_owned()
+                } else {
+                    rest.to_owned()
+                };
+
+                // Check if this value corresponds to a registered sub-option
+                if let Some((_help, sub_handler)) = handler.sub_options.get(value.as_str()) {
+                    sub_handler(args, modifier_stack, &value)?;
+                } else {
+                    // Fall back to the main handler for unregistered sub-options
+                    (handler.handler)(args, modifier_stack, &value)?;
+                }
+                return Ok(true);
+            }
+        }
+
+        if arg.starts_with('-') {
+            if let Some(stripped) = strip_option(arg)
+                && IGNORED_FLAGS.contains(&stripped)
+            {
+                warn_unsupported(arg)?;
+                return Ok(true);
+            }
+
+            args.unrecognized_options.push(arg.to_owned());
+            return Ok(true);
+        }
+
+        args.save_dir.handle_file(arg)?;
+        args.inputs.push(Input {
+            spec: InputSpec::File(Box::from(Path::new(arg))),
+            search_first: None,
+            modifiers: *modifier_stack.last().unwrap(),
+        });
+
+        Ok(false)
+    }
+
+    fn handle_positional_argument(args: &mut Args, modifier_stack: &[Modifiers], arg: &str) {
+        args.inputs.push(Input {
+            spec: InputSpec::File(Box::from(Path::new(arg))),
+            search_first: None,
+            modifiers: *modifier_stack.last().unwrap(),
+        });
+    }
+
+    #[must_use]
+    pub fn generate_help(&self) -> String {
+        let mut help = String::new();
+        help.push_str("USAGE:\n    wild [OPTIONS] [FILES...]\n\nOPTIONS:\n");
+
+        let mut prefix_options: Vec<_> = self.prefix_options.iter().collect();
+        prefix_options.sort_by_key(|(prefix, _)| *prefix);
+
+        // TODO: This is ad-hoc
+        help.push_str(&format!(
+            "    {:<31} Read options from a file\n",
+            format!("@<VALUE>"),
+        ));
+
+        for (prefix, handler) in prefix_options {
+            help.push_str(&format!(
+                "    -{:<30} {}\n",
+                format!("{prefix} <VALUE>"),
+                handler.help_text
+            ));
+
+            // Add sub-options if they exist
+            if !handler.sub_options.is_empty() {
+                let mut sub_options: Vec<_> = handler.sub_options.iter().collect();
+                sub_options.sort_by_key(|(name, _)| *name);
+
+                for (sub_name, (sub_help, _handler)) in sub_options {
+                    help.push_str(&format!("      -{prefix} {sub_name:<30} {sub_help}\n"));
+                }
+            }
+        }
+
+        let mut help_to_options: std::collections::HashMap<&str, Vec<String>> =
+            std::collections::HashMap::new();
+        let mut processed_short_options: std::collections::HashSet<&str> =
+            std::collections::HashSet::new();
+
+        // Collect all long options and their associated short options
+        for (long_name, handler) in &self.options {
+            if handler.help_text.is_empty() {
+                // Mark short options of help-less handlers as processed
+                for short_char in &handler.short_names {
+                    processed_short_options.insert(short_char);
+                }
+            } else {
+                let mut option_names = vec![format!("--{long_name}")];
+
+                // Add associated short options
+                for short_char in &handler.short_names {
+                    option_names.push(format!("-{short_char}"));
+                    processed_short_options.insert(short_char);
+                }
+
+                help_to_options
+                    .entry(handler.help_text)
+                    .or_default()
+                    .extend(option_names);
+            }
+        }
+
+        // Add short-only options
+        for (short_char, handler) in &self.short_options {
+            if !processed_short_options.contains(short_char) && !handler.help_text.is_empty() {
+                help_to_options
+                    .entry(handler.help_text)
+                    .or_default()
+                    .push(format!("-{short_char}"));
+            }
+        }
+
+        let mut sorted_help_groups: Vec<_> = help_to_options.into_iter().collect();
+        sorted_help_groups.sort_by_key(|(_, option_names)| {
+            option_names.iter().min().unwrap_or(&String::new()).clone()
+        });
+
+        for (help_text, mut option_names) in sorted_help_groups {
+            option_names.sort_by(|a, b| {
+                let a_is_short = a.len() == 2 && a.starts_with('-');
+                let b_is_short = b.len() == 2 && b.starts_with('-');
+                match (a_is_short, b_is_short) {
+                    (true, false) => std::cmp::Ordering::Less, // short options first
+                    (false, true) => std::cmp::Ordering::Greater, // long options after
+                    _ => a.cmp(b),                             // same type, alphabetical
+                }
+            });
+
+            let option_names_str = option_names.join(", ");
+            help.push_str(&format!("    {option_names_str:<30} {help_text}\n"));
+        }
+
+        help
+    }
+}
+
+impl<'a, T> OptionDeclaration<'a, T> {
+    #[must_use]
+    pub fn long(mut self, name: &'static str) -> Self {
+        self.long_names.push(name);
+        self
+    }
+
+    #[must_use]
+    pub fn short(mut self, option: &'static str) -> Self {
+        self.short_names.push(option);
+        self
+    }
+
+    #[must_use]
+    pub fn help(mut self, text: &'static str) -> Self {
+        self.help_text = text;
+        self
+    }
+}
+
+impl<'a> OptionDeclaration<'a, NoParam> {
+    pub fn execute(self, handler: fn(&mut Args, &mut Vec<Modifiers>) -> Result<()>) {
+        let option_handler = OptionHandler {
+            help_text: self.help_text,
+            handler: OptionHandlerFn::NoParam(handler),
+            short_names: self.short_names.clone(),
+        };
+
+        for name in self.long_names {
+            self.parser.options.insert(name, option_handler.clone());
+        }
+
+        for option in self.short_names {
+            self.parser
+                .short_options
+                .insert(option, option_handler.clone());
+        }
+    }
+}
+
+impl<'a> OptionDeclaration<'a, WithParam> {
+    pub fn execute(self, handler: fn(&mut Args, &mut Vec<Modifiers>, &str) -> Result<()>) {
+        let option_handler = OptionHandler {
+            help_text: self.help_text,
+            handler: OptionHandlerFn::WithParam(handler),
+            short_names: self.short_names.clone(),
+        };
+
+        for name in self.long_names {
+            self.parser.options.insert(name, option_handler.clone());
+        }
+
+        for option in self.short_names {
+            self.parser
+                .short_options
+                .insert(option, option_handler.clone());
+        }
+    }
+}
+
+impl<'a> OptionDeclaration<'a, WithOptionalParam> {
+    pub fn execute(self, handler: fn(&mut Args, &mut Vec<Modifiers>, Option<&str>) -> Result<()>) {
+        let option_handler = OptionHandler {
+            help_text: self.help_text,
+            handler: OptionHandlerFn::OptionalParam(handler),
+            short_names: self.short_names.clone(),
+        };
+
+        for name in self.long_names {
+            self.parser.options.insert(name, option_handler.clone());
+        }
+
+        for option in self.short_names {
+            self.parser
+                .short_options
+                .insert(option, option_handler.clone());
+        }
+    }
+}
+
+impl<'a> PrefixOptionDeclaration<'a> {
+    #[must_use]
+    pub fn help(mut self, text: &'static str) -> Self {
+        self.help_text = text;
+        self
+    }
+
+    #[must_use]
+    pub fn sub_option<F>(mut self, name: &'static str, help: &'static str, handler: F) -> Self
+    where
+        F: Fn(&mut Args, &mut Vec<Modifiers>, &str) -> Result<()> + 'static,
+    {
+        self.sub_options.insert(name, (help, Box::new(handler)));
+        self
+    }
+
+    pub fn execute(self, handler: fn(&mut Args, &mut Vec<Modifiers>, &str) -> Result<()>) {
+        let prefix_handler = PrefixOptionHandler {
+            help_text: self.help_text,
+            sub_options: self.sub_options,
+            handler,
+        };
+
+        self.parser
+            .prefix_options
+            .insert(self.prefix, prefix_handler);
+    }
+}
+
+fn strip_option(arg: &str) -> Option<&str> {
+    arg.strip_prefix("--").or(arg.strip_prefix('-'))
+}
+
+fn setup_argument_parser() -> ArgumentParser {
+    let mut parser = ArgumentParser::new();
+
+    parser
+        .declare_prefix("L")
+        .help("Add directory to library search path")
+        .execute(|args, _modifier_stack, value| {
+            let handle_sysroot = |path| {
+                args.sysroot
+                    .as_ref()
+                    .and_then(|sysroot| maybe_forced_sysroot(path, sysroot))
+                    .unwrap_or_else(|| Box::from(path))
+            };
+
+            let dir = handle_sysroot(Path::new(value));
+            args.save_dir.handle_file(value)?;
+            args.lib_search_path.push(dir);
+            Ok(())
+        });
+
+    parser
+        .declare_prefix("l")
+        .help("Link with library")
+        .sub_option(
+            ":filename",
+            "Link with specific file",
+            |args, modifier_stack, value| {
+                let stripped = value.strip_prefix(':').unwrap_or(value);
+                let spec = InputSpec::File(Box::from(Path::new(stripped)));
+                args.inputs.push(Input {
+                    spec,
+                    search_first: None,
+                    modifiers: *modifier_stack.last().unwrap(),
+                });
+                Ok(())
+            },
+        )
+        .sub_option(
+            "libname",
+            "Link with library libname.so or libname.a",
+            |args, modifier_stack, value| {
+                let spec = InputSpec::Lib(Box::from(value));
+                args.inputs.push(Input {
+                    spec,
+                    search_first: None,
+                    modifiers: *modifier_stack.last().unwrap(),
+                });
+                Ok(())
+            },
+        )
+        .execute(|args, modifier_stack, value| {
+            let spec = if let Some(stripped) = value.strip_prefix(':') {
+                InputSpec::File(Box::from(Path::new(stripped)))
+            } else {
+                InputSpec::Lib(Box::from(value))
+            };
+            args.inputs.push(Input {
+                spec,
+                search_first: None,
+                modifiers: *modifier_stack.last().unwrap(),
+            });
+            Ok(())
+        });
+
+    parser
+        .declare_prefix("u")
+        .help("Force resolution of the symbol")
+        .execute(|args, _modifier_stack, value| {
+            args.undefined.push(value.to_owned());
+            Ok(())
+        });
+
+    parser
+        .declare_prefix("m")
+        .help("Set target architecture")
+        .sub_option(
+            "elf_x86_64",
+            "x86-64 ELF target",
+            |args, _modifier_stack, _value| {
+                args.arch = Architecture::from_str("elf_x86_64")?;
+                Ok(())
+            },
+        )
+        .sub_option(
+            "aarch64elf",
+            "AArch64 ELF target",
+            |args, _modifier_stack, _value| {
+                args.arch = Architecture::from_str("aarch64elf")?;
+                Ok(())
+            },
+        )
+        .sub_option(
+            "elf64lriscv",
+            "RISC-V 64-bit ELF target",
+            |args, _modifier_stack, _value| {
+                args.arch = Architecture::from_str("elf64lriscv")?;
+                Ok(())
+            },
+        )
+        .execute(|args, _modifier_stack, value| {
+            args.arch = Architecture::from_str(value)?;
+            Ok(())
+        });
+
+    parser
+        .declare_prefix("z")
+        .help("Linker option")
+        .sub_option(
+            "now",
+            "Resolve all symbols immediately",
+            |_args, _modifier_stack, _value| Ok(()),
+        )
+        .sub_option(
+            "origin",
+            "Mark object as requiring immediate $ORIGIN",
+            |args, _modifier_stack, _value| {
+                args.needs_origin_handling = true;
+                Ok(())
+            },
+        )
+        .sub_option(
+            "relro",
+            "Enable RELRO program header",
+            |args, _modifier_stack, _value| {
+                args.relro = true;
+                Ok(())
+            },
+        )
+        .sub_option(
+            "norelro",
+            "Disable RELRO program header",
+            |args, _modifier_stack, _value| {
+                args.relro = false;
+                Ok(())
+            },
+        )
+        .sub_option(
+            "notext",
+            "Do not report DT_TEXTREL as an error",
+            |_args, _modifier_stack, _value| Ok(()),
+        )
+        .sub_option(
+            "nostart-stop-gc",
+            "Disable start/stop symbol GC",
+            |_args, _modifier_stack, _value| Ok(()),
+        )
+        .sub_option(
+            "execstack",
+            "Mark object as requiring an executable stack",
+            |args, _modifier_stack, _value| {
+                args.execstack = true;
+                Ok(())
+            },
+        )
+        .sub_option(
+            "noexecstack",
+            "Mark object as not requiring an executable stack",
+            |args, _modifier_stack, _value| {
+                args.execstack = false;
+                Ok(())
+            },
+        )
+        .sub_option(
+            "nocopyreloc",
+            "Disable copy relocations",
+            |args, _modifier_stack, _value| {
+                args.allow_copy_relocations = false;
+                Ok(())
+            },
+        )
+        .sub_option(
+            "nodelete",
+            "Mark shared object as non-deletable",
+            |args, _modifier_stack, _value| {
+                args.needs_nodelete_handling = true;
+                Ok(())
+            },
+        )
+        .sub_option(
+            "defs",
+            "Report unresolved symbol references in object files",
+            |args, _modifier_stack, _value| {
+                args.no_undefined = true;
+                Ok(())
+            },
+        )
+        .sub_option(
+            "undefs",
+            "Do not report unresolved symbol references in object files",
+            |args, _modifier_stack, _value| {
+                args.no_undefined = false;
+                Ok(())
+            },
+        )
+        .sub_option(
+            "muldefs",
+            "Allow multiple definitions",
+            |args, _modifier_stack, _value| {
+                args.allow_multiple_definitions = true;
+                Ok(())
+            },
+        )
+        .sub_option(
+            "lazy",
+            "Use lazy binding (default)",
+            |_args, _modifier_stack, _value| Ok(()),
+        )
+        .execute(|_args, _modifier_stack, _value| Ok(()));
+
+    parser
+        .declare_prefix("T")
+        .help("Use linker script")
+        .execute(|args, _modifier_stack, value| {
+            args.save_dir.handle_file(value)?;
+            args.add_script(value);
+            Ok(())
+        });
+
+    parser
+        .declare_prefix("R")
+        .help("Add runtime library search path")
+        .execute(|args, _modifier_stack, value| {
+            if Path::new(value).is_file() {
+                args.unrecognized_options
+                    .push(format!("-R,{value}(filename)"));
+            } else {
+                append_rpath(&mut args.rpath, value);
+            }
+            Ok(())
+        });
+
+    parser
+        .declare_prefix("h")
+        .help("Set shared object name")
+        .execute(|args, _modifier_stack, value| {
+            args.soname = Some(value.to_owned());
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("static")
+        .long("Bstatic")
+        .help("Disallow linking of shared libraries")
+        .execute(|_args, modifier_stack| {
+            modifier_stack.last_mut().unwrap().allow_shared = false;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("Bdynamic")
+        .help("Allow linking of shared libraries")
+        .execute(|_args, modifier_stack| {
+            modifier_stack.last_mut().unwrap().allow_shared = true;
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("output")
+        .short("o")
+        .help("Set the output filename")
+        .execute(|args, _modifier_stack, value| {
+            args.output = Arc::from(Path::new(value));
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("strip-all")
+        .short("s")
+        .help("Strip all symbols")
+        .execute(|args, _modifier_stack| {
+            args.strip_all = true;
+            args.strip_debug = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("strip-debug")
+        .short("S")
+        .help("Strip debug symbols")
+        .execute(|args, _modifier_stack| {
+            args.strip_debug = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("gc-sections")
+        .help("Enable removal of unused sections")
+        .execute(|args, _modifier_stack| {
+            args.gc_sections = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("no-gc-sections")
+        .help("Disable removal of unused sections")
+        .execute(|args, _modifier_stack| {
+            args.gc_sections = false;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("shared")
+        .long("Bshareable")
+        .help("Create a shared library")
+        .execute(|args, _modifier_stack| {
+            args.output_kind = Some(OutputKind::SharedObject);
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("pie")
+        .help("Create a position-independent executable")
+        .execute(|args, _modifier_stack| {
+            args.relocation_model = RelocationModel::Relocatable;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("no-pie")
+        .help("Create a position-dependent executable (default)")
+        .execute(|args, _modifier_stack| {
+            args.relocation_model = RelocationModel::NonRelocatable;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("help")
+        .help("Show this help message")
+        .execute(|_args, _modifier_stack| {
+            let parser = setup_argument_parser();
+            println!("{}", parser.generate_help());
+
+            // The following listing is something autoconf detection relies on.
+            println!("wild: supported targets: elf64-x86-64 elf64-littleaarch64 elf64-littleriscv");
+            println!("wild: supported emulations: elf_x86_64 aarch64elf elf64lriscv");
+
+            std::process::exit(0);
+        });
+
+    parser
+        .declare()
+        .long("version")
+        .short("v")
+        .help("Show version information")
+        .execute(|args, _modifier_stack| {
+            args.should_print_version = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("demangle")
+        .help("Enable symbol demangling")
+        .execute(|args, _modifier_stack| {
+            args.demangle = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("no-demangle")
+        .help("Disable symbol demangling")
+        .execute(|args, _modifier_stack| {
+            args.demangle = false;
+            Ok(())
+        });
+
+    parser
+        .declare_with_optional_param()
+        .long("time")
+        .help("Show timing information")
+        .execute(|args, _modifier_stack, value| {
+            match value {
+                Some(v) => args.time_phase_options = Some(parse_time_phase_options(v)?),
+                None => args.time_phase_options = Some(Vec::new()),
+            }
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("dynamic-linker")
+        .help("Set dynamic linker path")
+        .execute(|args, _modifier_stack, value| {
+            args.is_dynamic_executable.store(true, Ordering::Relaxed);
+            args.dynamic_linker = Some(Box::from(Path::new(value)));
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("no-dynamic-linker")
+        .help("Omit the load-time dynamic linker request")
+        .execute(|args, _modifier_stack| {
+            args.dynamic_linker = None;
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("entry")
+        .short("e")
+        .help("Set the entry point")
+        .execute(|args, _modifier_stack, value| {
+            args.entry = Some(value.to_owned());
+            Ok(())
+        });
+
+    parser
+        .declare_with_optional_param()
+        .long("threads")
+        .help("Use multiple threads for linking")
+        .execute(|args, _modifier_stack, value| {
+            match value {
+                Some(v) => {
+                    args.num_threads = Some(NonZeroUsize::try_from(v.parse::<usize>()?)?);
+                }
+                None => {
+                    args.num_threads = None; // Default behaviour
+                }
+            }
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("no-threads")
+        .help("Use a single thread")
+        .execute(|args, _modifier_stack| {
+            args.num_threads = Some(NonZeroUsize::new(1).unwrap());
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("as-needed")
+        .help("Set DT_NEEDED if used")
+        .execute(|_args, modifier_stack| {
+            modifier_stack.last_mut().unwrap().as_needed = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("no-as-needed")
+        .help("Always set DT_NEEDED")
+        .execute(|_args, modifier_stack| {
+            modifier_stack.last_mut().unwrap().as_needed = false;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("whole-archive")
+        .help("Include all objects from archives")
+        .execute(|_args, modifier_stack| {
+            modifier_stack.last_mut().unwrap().whole_archive = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("no-whole-archive")
+        .help("Disable --whole-archive")
+        .execute(|_args, modifier_stack| {
+            modifier_stack.last_mut().unwrap().whole_archive = false;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("push-state")
+        .help("Save current linker flags")
+        .execute(|_args, modifier_stack| {
+            modifier_stack.push(*modifier_stack.last().unwrap());
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("pop-state")
+        .help("Restore previous linker flags")
+        .execute(|_args, modifier_stack| {
+            modifier_stack.pop();
+            if modifier_stack.is_empty() {
+                bail!("Mismatched --pop-state");
+            }
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("eh-frame-hdr")
+        .help("Create .eh_frame_hdr section")
+        .execute(|args, _modifier_stack| {
+            args.should_write_eh_frame_hdr = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("export-dynamic")
+        .short("E")
+        .help("Export all dynamic symbols")
+        .execute(|args, _modifier_stack| {
+            args.export_all_dynamic_symbols = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("no-export-dynamic")
+        .help("Do not export dynamic symbols")
+        .execute(|args, _modifier_stack| {
+            args.export_all_dynamic_symbols = false;
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("soname")
+        .short("h")
+        .help("Set shared object name")
+        .execute(|args, _modifier_stack, value| {
+            args.soname = Some(value.to_owned());
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("rpath")
+        .help("Add directory to runtime library search path")
+        .execute(|args, _modifier_stack, value| {
+            append_rpath(&mut args.rpath, value);
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("no-string-merge")
+        .help("Disable string merging")
+        .execute(|args, _modifier_stack| {
+            args.merge_strings = false;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("no-undefined")
+        .help("Do not allow unresolved symbols in object files")
+        .execute(|args, _modifier_stack| {
+            args.no_undefined = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("allow-multiple-definition")
+        .help("Allow multiple definitions of symbols")
+        .execute(|args, _modifier_stack| {
+            args.allow_multiple_definitions = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("relax")
+        .help("Enable target-specific optimization (instruction relaxation)")
+        .execute(|args, _modifier_stack| {
+            args.relax = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("no-relax")
+        .help("Disable relaxation")
+        .execute(|args, _modifier_stack| {
+            args.relax = false;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("validate-output")
+        .help("Validate output")
+        .execute(|args, _modifier_stack| {
+            args.validate_output = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("write-layout")
+        .help("Write layout information")
+        .execute(|args, _modifier_stack| {
+            args.write_layout = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("write-trace")
+        .help("Write link-time trace information")
+        .execute(|args, _modifier_stack| {
+            args.write_trace = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("got-plt-syms")
+        .help("Write symbol table entries that point to the GOT/PLT entry for symbols")
+        .execute(|args, _modifier_stack| {
+            args.got_plt_syms = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("Bsymbolic")
+        .help("Bind global references locally")
+        .execute(|args, _modifier_stack| {
+            args.b_symbolic = BSymbolicKind::All;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("Bsymbolic-functions")
+        .help("Bind global function references locally")
+        .execute(|args, _modifier_stack| {
+            args.b_symbolic = BSymbolicKind::Functions;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("Bsymbolic-non-weak-functions")
+        .help("Bind non-weak global function references locally")
+        .execute(|args, _modifier_stack| {
+            args.b_symbolic = BSymbolicKind::NonWeakFunctions;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("Bsymbolic-non-weak")
+        .help("Bind non-weak global references locally")
+        .execute(|args, _modifier_stack| {
+            args.b_symbolic = BSymbolicKind::NonWeak;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("Bno-symbolic")
+        .help("Do not bind global symbol references locally")
+        .execute(|args, _modifier_stack| {
+            args.b_symbolic = BSymbolicKind::None;
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("thread-count")
+        .help("Set the number of threads to use")
+        .execute(|args, _modifier_stack, value| {
+            args.num_threads = Some(NonZeroUsize::try_from(value.parse::<usize>()?)?);
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("exclude-libs")
+        .help("Exclude libraries")
+        .execute(|args, _modifier_stack, value| {
+            if value != "ALL" {
+                warn_unsupported("--exclude-libs other than ALL")?;
+            }
+            args.exclude_libs = true;
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("version-script")
+        .help("Use version script")
+        .execute(|args, _modifier_stack, value| {
+            args.save_dir.handle_file(value)?;
+            args.version_script_path = Some(PathBuf::from(value));
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("script")
+        .help("Use linker script")
+        .execute(|args, _modifier_stack, value| {
+            args.save_dir.handle_file(value)?;
+            args.add_script(value);
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("export-dynamic-symbol")
+        .help("Export dynamic symbol")
+        .execute(|args, _modifier_stack, value| {
+            args.export_list.push(value.to_owned());
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("export-dynamic-symbol-list")
+        .help("Export dynamic symbol list")
+        .execute(|args, _modifier_stack, value| {
+            args.export_list_path = Some(PathBuf::from(value));
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("dynamic-list")
+        .help("Read the dynamic symbol list from a file")
+        .execute(|args, _modifier_stack, value| {
+            args.b_symbolic = BSymbolicKind::All;
+            args.export_list_path = Some(PathBuf::from(value));
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("write-gc-stats")
+        .help("Write GC statistics")
+        .execute(|args, _modifier_stack, value| {
+            args.write_gc_stats = Some(PathBuf::from(value));
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("gc-stats-ignore")
+        .help("Ignore files in GC stats")
+        .execute(|args, _modifier_stack, value| {
+            args.gc_stats_ignore.push(value.to_owned());
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("debug-address")
+        .help("Set debug address")
+        .execute(|args, _modifier_stack, value| {
+            args.debug_address = Some(parse_number(value).context("Invalid --debug-address")?);
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("debug-fuel")
+        .execute(|args, _modifier_stack, value| {
+            args.debug_fuel = Some(AtomicI64::new(value.parse()?));
+            args.num_threads = Some(NonZeroUsize::new(1).unwrap());
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("unresolved-symbols")
+        .help("Specify how to handle unresolved symbols")
+        .execute(|args, _modifier_stack, value| {
+            args.unresolved_symbols = match value {
+                "report-all" => UnresolvedSymbols::ReportAll,
+                "ignore-in-shared-libs" => UnresolvedSymbols::IgnoreInSharedLibs,
+                "ignore-in-object-files" => UnresolvedSymbols::IgnoreInObjectFiles,
+                "ignore-all" => UnresolvedSymbols::IgnoreAll,
+                _ => bail!("Invalid unresolved-symbols value {value}"),
+            };
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("undefined")
+        .help("Force resolution of the symbol")
+        .execute(|args, _modifier_stack, value| {
+            args.undefined.push(value.to_owned());
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("wrap")
+        .help("Use a wrapper function")
+        .execute(|args, _modifier_stack, value| {
+            args.wrap.push(value.to_owned());
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("hash-style")
+        .help("Set hash style")
+        .execute(|_args, _modifier_stack, value| {
+            if value != "gnu" && value != "both" {
+                bail!("Unsupported hash-style `{value}`");
+            }
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("build-id")
+        .help("Generate build ID")
+        .execute(|args, _modifier_stack, value| {
+            args.build_id = match value {
+                "none" => BuildIdOption::None,
+                "fast" | "md5" | "sha1" => BuildIdOption::Fast,
+                "uuid" => BuildIdOption::Uuid,
+                s if s.starts_with("0x") || s.starts_with("0X") => {
+                    let hex_string = &s[2..];
+                    let decoded_bytes = hex::decode(hex_string)
+                        .with_context(|| format!("Invalid Hex Build Id `0x{hex_string}`"))?;
+                    BuildIdOption::Hex(decoded_bytes)
+                }
+                s => bail!(
+                    "Invalid build-id value `{s}` valid values are `none`, `fast`, `md5`, `sha1` and `uuid`"
+                ),
+            };
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("icf")
+        .help("Enable identical code folding (merge duplicate functions)")
+        .execute(|_args, _modifier_stack, value| {
+            match value {
+                "none" => {}
+                other => warn_unsupported(&format!("--icf={other}"))?,
+            }
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("sysroot")
+        .help("Set system root")
+        .execute(|args, _modifier_stack, value| {
+            args.save_dir.handle_file(value)?;
+            let sysroot = std::fs::canonicalize(value).unwrap_or_else(|_| PathBuf::from(value));
+            args.sysroot = Some(Box::from(sysroot.as_path()));
+            for path in &mut args.lib_search_path {
+                if let Some(new_path) = maybe_forced_sysroot(path, &sysroot) {
+                    *path = new_path;
+                }
+            }
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("plugin-opt")
+        .help("Pass options to the plugin")
+        .execute(|_args, _modifier_stack, _value| {
+            // TODO: Implement support for linker plugins.
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("dependency-file")
+        .help("Write dependency rules")
+        .execute(|_args, _modifier_stack, value| {
+            warn_unsupported(&format!("--dependency-file={value}"))?;
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("plugin")
+        .help("Load plugin")
+        .execute(|_args, _modifier_stack, value| {
+            warn_unsupported(&format!("--plugin {value}"))?;
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("rpath-link")
+        .help("Add runtime library search path")
+        .execute(|_args, _modifier_stack, _value| {
+            // TODO
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("sym-info")
+        .help("Show symbol information")
+        .execute(|args, _modifier_stack, value| {
+            args.sym_info = Some(value.to_owned());
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("start-lib")
+        .help("Start library group")
+        .execute(|_args, modifier_stack| {
+            modifier_stack.last_mut().unwrap().archive_semantics = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("end-lib")
+        .help("End library group")
+        .execute(|_args, modifier_stack| {
+            modifier_stack.last_mut().unwrap().archive_semantics = false;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("no-fork")
+        .help("Do not fork while linking")
+        .execute(|args, _modifier_stack| {
+            args.should_fork = false;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("update-in-place")
+        .help("Update file in place")
+        .execute(|args, _modifier_stack| {
+            args.file_write_mode = Some(FileWriteMode::UpdateInPlace);
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("EB")
+        .help("Big-endian (not supported)")
+        .execute(|_args, _modifier_stack| {
+            bail!("Big-endian target is not supported");
+        });
+
+    parser
+        .declare()
+        .long("prepopulate-maps")
+        .help("Prepopulate maps")
+        .execute(|args, _modifier_stack| {
+            args.prepopulate_maps = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("verbose-gc-stats")
+        .help("Show GC statistics")
+        .execute(|args, _modifier_stack| {
+            args.verbose_gc_stats = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("allow-shlib-undefined")
+        .help("Allow undefined symbol references in shared libraries")
+        .execute(|args, _modifier_stack| {
+            args.allow_shlib_undefined = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("no-allow-shlib-undefined")
+        .help("Disallow undefined symbol references in shared libraries")
+        .execute(|args, _modifier_stack| {
+            args.allow_shlib_undefined = false;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("error-unresolved-symbols")
+        .help("Treat unresolved symbols as errors")
+        .execute(|args, _modifier_stack| {
+            args.error_unresolved_symbols = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("warn-unresolved-symbols")
+        .help("Treat unresolved symbols as warnings")
+        .execute(|args, _modifier_stack| {
+            args.error_unresolved_symbols = false;
+            Ok(())
+        });
+
+    add_silently_ignored_flags(&mut parser);
+    add_default_flags(&mut parser);
+
+    parser
+}
+
+fn add_silently_ignored_flags(parser: &mut ArgumentParser) {
+    for flag in SILENTLY_IGNORED_FLAGS {
+        let mut declaration = parser.declare();
+        declaration = declaration.long(flag);
+        declaration.execute(|_args, _modifier_stack| Ok(()));
+    }
+    for flag in SILENTLY_IGNORED_SHORT_FLAGS {
+        let mut declaration = parser.declare();
+        declaration = declaration.short(flag);
+        declaration.execute(|_args, _modifier_stack| Ok(()));
+    }
+}
+
+fn add_default_flags(parser: &mut ArgumentParser) {
+    for flag in DEFAULT_FLAGS {
+        let mut declaration = parser.declare();
+        declaration = declaration.long(flag);
+        declaration.execute(|_args, _modifier_stack| Ok(()));
+    }
+    for flag in DEFAULT_SHORT_FLAGS {
+        let mut declaration = parser.declare();
+        declaration = declaration.short(flag);
+        declaration.execute(|_args, _modifier_stack| Ok(()));
+    }
 }
 
 fn parse_time_phase_options(input: &str) -> Result<Vec<CounterKind>> {


### PR DESCRIPTION
This represents a new proposal for the current argument parser of wild. While the current naive `if-else`-based argument handling is simpler to implement, it presents several issues—for example, making available options difficult to inspect. This has consequently created barriers to implementing options like `--help`. After discussing with David, I decided to create a new declarative parser. 

When defining options, you can specify long option names, short option names, help text, and the actual processing logic as follows:

```rust
parser
    .declare()
    .long("static")
    .long("Bstatic")
    .help("Disallow linking of shared libraries")
    .execute(|_args, modifier_stack| {
        modifier_stack.last_mut().unwrap().allow_shared = false;
        Ok(())
    });
```

In addition to implementing this parser framework, I've also implemented `--help`. The key approach here is to only perform minimal `--help` processing during each option definitions themselves, instead gathering all necessary information only when `--help` is specified to construct the help message. This design accounts for potential overhead in typical usage scenarios.

When running `--help`, the resulting output looks like [this](https://gist.github.com/lapla-cogito/e0bd23787ecd17fb42038cc316a26e0f).

The issues I’m currently aware of are as follows. I’ll address these in this PR before marking it “Ready for review,” but I’m opening it now to check if CI tests pass across various environments.
- ~`@file` performs ad-hoc processing (not defined declaratively) and thus doesn't appear in the `--help` message.~ I don't think this is an issue that absolutely requires urgent resolution. After all, no other option requires hyphens like `@file` does (except for specifying input files). Therefore, I'd like to temporarily disregard this and proceed with accepting the review.
- [x] Option descriptions are insufficiently detailed.

Additionally, while the following point may not be a major concern, I'm including it for reference:
- Short options are specified using char. While this works fine in most cases, GNU ld appears to have an option `-Ur`. However, our current wild argument parser would interpret `--Ur` as `--Ur` even if `-Ur` were implemented, so compatibility with GNU ld would be maintained.
