### PR TITLE
Integration test: When doing dynamic linking, also imply `RunEnabled:false`

### DIFF
--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -819,9 +819,13 @@ fn parse_configs(src_filename: &Path, default_config: &Config) -> Result<Vec<Con
                     .contains_strings
                     .push(arg.trim().to_owned()),
                 "Mode" => {
-                    config.linker_driver.direct_mut()?.mode = arg
+                    let mode: Mode = arg
                         .parse()
-                        .with_context(|| format!("Invalid Mode `{arg}`"))?
+                        .with_context(|| format!("Invalid Mode `{arg}`"))?;
+                    if mode == Mode::Dynamic {
+                        config.should_run = false;
+                    }
+                    config.linker_driver.direct_mut()?.mode = mode;
                 }
                 "DiffIgnore" => config.diff_ignore.push(arg.trim().to_owned()),
                 "DiffEnabled" => {

--- a/wild/tests/sources/basic-comdat.s
+++ b/wild/tests/sources/basic-comdat.s
@@ -1,6 +1,5 @@
 /* For some reason, GAS on riscv64 does not support '//' comments.
 //#Object:basic-comdat-1.s
-//#RunEnabled:false
 //#Mode:dynamic
 //#LinkArgs:-shared -z now
 //#DiffIgnore:section.got

--- a/wild/tests/sources/exclude-libs.c
+++ b/wild/tests/sources/exclude-libs.c
@@ -1,7 +1,6 @@
 //#LinkArgs:-z now -Bshareable --exclude-libs ALL
 //#Mode:dynamic
 //#Archive:exclude-libs-archive.c
-//#RunEnabled:false
 // We optimise away the GOT, but GNU ld doesn't.
 //#DiffIgnore:section.got
 

--- a/wild/tests/sources/export-dynamic.c
+++ b/wild/tests/sources/export-dynamic.c
@@ -27,7 +27,6 @@
 // We're linking different .so files, so this is expected.
 //#DiffIgnore:.dynamic.DT_NEEDED
 //#EnableLinker:lld
-//#RunEnabled:false
 
 //#Config:select-symbols-list
 //#LinkArgs:-z now --export-dynamic-symbol-list ./export-dynamic.def
@@ -38,7 +37,6 @@
 // We're linking different .so files, so this is expected.
 //#DiffIgnore:.dynamic.DT_NEEDED
 //#EnableLinker:lld
-//#RunEnabled:false
 
 //#Config:dynamic-symbols-list
 //#LinkArgs:-z now -shared --dynamic-list ./export-dynamic.def
@@ -51,7 +49,6 @@
 //#DiffIgnore:.dynamic.DT_RELA*
 //#DiffIgnore:file-header.entry
 //#EnableLinker:lld
-//#RunEnabled:false
 
 void foo(void) {};
 void bar(void) {};

--- a/wild/tests/sources/linker-script.c
+++ b/wild/tests/sources/linker-script.c
@@ -1,6 +1,5 @@
 //#Mode:dynamic
 //#LinkArgs:-shared -z now -T ./linker-script.ld
-//#RunEnabled:false
 //#DiffIgnore:section.got
 //#ExpectDynSym:start_bar bar 0
 //#ExpectDynSym:start_aaa bar 8

--- a/wild/tests/sources/shared.c
+++ b/wild/tests/sources/shared.c
@@ -6,7 +6,6 @@
 // archive entry that we don't load.
 
 //#Config:default
-//#RunEnabled:false
 //#LinkArgs:-shared -z now
 //#Mode:dynamic
 //#Shared:shared-s1.c

--- a/wild/tests/sources/shlib-undefined.c
+++ b/wild/tests/sources/shlib-undefined.c
@@ -13,7 +13,6 @@
 //#DiffIgnore:section.relro_padding
 //#DiffIgnore:section.got.plt.entsize
 //#DiffIgnore:.dynamic.DT_FLAGS_1.NOW
-//#RunEnabled:false
 
 // Allow linking against shared object with undefined symbols. We don't run this
 // because the runtime linker would error due to the undefined symbol.

--- a/wild/tests/sources/unresolved-symbols-shared.c
+++ b/wild/tests/sources/unresolved-symbols-shared.c
@@ -1,7 +1,6 @@
 //#AbstractConfig:default
 //#SkipLinker:ld
 //#DiffEnabled:false
-//#RunEnabled:false
 //#Mode:dynamic
 //#LinkArgs:-shared -z now
 

--- a/wild/tests/sources/visibility-merging.c
+++ b/wild/tests/sources/visibility-merging.c
@@ -1,7 +1,6 @@
 //#Mode:dynamic
 //#LinkArgs:-shared -z now
 //#Object:visibility-merging-1.c
-//#RunEnabled:false
 //#DiffIgnore:section.got
 // TODO: Prevent dynsym export of symbols like these.
 //#DiffIgnore:dynsym.data1.*

--- a/wild/tests/sources/z-defs.c
+++ b/wild/tests/sources/z-defs.c
@@ -6,7 +6,6 @@
 //#Config:z-undefs
 //#LinkArgs:-Bshareable -z now -z undefs
 //#Mode:dynamic
-//#RunEnabled:false
 //#DiffIgnore:.dynamic.DT_RELA
 //#DiffIgnore:.dynamic.DT_RELAENT
 


### PR DESCRIPTION
In integration testing, when `Mode:dynamic` is specified, make it behave identically to when `RunEnabled:false` is also specified by default. This allows us to remove `RunEnabled:false` in existing tests where the two options mentioned above coexist.

context: https://github.com/davidlattimore/wild/pull/1030#discussion_r2265467612