### PR TITLE
Add missing `-O` option

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -1412,6 +1412,12 @@ fn setup_argument_parser() -> ArgumentParser {
         });
 
     parser
+        .declare_prefix("O")
+        .execute(|_args, _modifier_stack, _value|
+        // We don't use opt-level for now.
+        Ok(()));
+
+    parser
         .declare()
         .long("static")
         .long("Bstatic")
@@ -2346,6 +2352,9 @@ mod tests {
         "--discard-locals",
         "-X",
         "-EL",
+        "-O",
+        "1",
+        "-O3",
         "-v",
         "--sysroot=/usr/aarch64-linux-gnu",
         "--demangle",

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -1774,7 +1774,6 @@ fn setup_argument_parser() -> ArgumentParser {
     parser
         .declare()
         .long("validate-output")
-        .help("Validate output")
         .execute(|args, _modifier_stack| {
             args.validate_output = true;
             Ok(())
@@ -1783,7 +1782,6 @@ fn setup_argument_parser() -> ArgumentParser {
     parser
         .declare()
         .long("write-layout")
-        .help("Write layout information")
         .execute(|args, _modifier_stack| {
             args.write_layout = true;
             Ok(())
@@ -1792,7 +1790,6 @@ fn setup_argument_parser() -> ArgumentParser {
     parser
         .declare()
         .long("write-trace")
-        .help("Write link-time trace information")
         .execute(|args, _modifier_stack| {
             args.write_trace = true;
             Ok(())


### PR DESCRIPTION
close #1039 

There appears to be a leak when migrating the argument parser. Also, to prevent debug-related options from appearing when running `--help`, their help texts were removed.