### PR TITLE
LTO archive test

### DIFF
--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3058,16 +3058,13 @@ fn process_relocation<A: Arch>(
                 let lto_file = is_undefined_lto(resources, symbol_id);
 
                 if let Some(file) = lto_file {
-                    let file = file.canonicalize().unwrap_or(PathBuf::new());
                     resources.report_error(error!(
                         "undefined reference to `{symbol_name}` found in LTO section of {}",
-                        file.file_name()
-                            .expect("Canonicalized path can't have ../ at end")
-                            .to_str()
-                            .expect("File name should be valid UTF-8")
-                            .split(".")
-                            .next()
-                            .unwrap()
+                        file.canonicalize()
+                            .unwrap_or(PathBuf::new())
+                            .file_name()
+                            .expect("Canonicalized path can't have /.. at end")
+                            .display()
                     ));
                 } else if args.error_unresolved_symbols {
                     resources.report_error(error!(

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -2548,7 +2548,8 @@ fn integration_test(
         "z-defs.c",
         "export-dynamic.c",
         "unresolved-symbols-object.c",
-        "unresolved-symbols-shared.c"
+        "unresolved-symbols-shared.c",
+        "lto-undefined.c"
     )]
     program_name: &'static str,
     #[allow(unused_variables)] setup_symlink: (),

--- a/wild/tests/sources/archive_lto.c
+++ b/wild/tests/sources/archive_lto.c
@@ -1,0 +1,1 @@
+int addition(int a, int b) { return a + b; }

--- a/wild/tests/sources/lto-undefined.c
+++ b/wild/tests/sources/lto-undefined.c
@@ -1,0 +1,15 @@
+//#Archive:archive_lto.c:-flto
+//#Object:runtime.c
+//#LinkerDriver:gcc
+//#SkipLinker:ld
+//#ExpectError:undefined reference to `addition` found in LTO section of archive_lto.default-host-54eef975a9df799a.a
+
+extern int addition(int, int);
+
+int main(int argc, char **argv) {
+  int a = 1;
+  int b = 1;
+  int result = addition(a, b);
+
+  return 0;
+}

--- a/wild/tests/sources/lto-undefined.c
+++ b/wild/tests/sources/lto-undefined.c
@@ -2,7 +2,7 @@
 //#Object:runtime.c
 //#LinkerDriver:gcc
 //#SkipLinker:ld
-//#ExpectError:undefined reference to `addition` found in LTO section of archive_lto.default-host-54eef975a9df799a.a
+//#ExpectError:undefined reference to `addition` found in LTO section of archive_lto
 
 extern int addition(int, int);
 


### PR DESCRIPTION
PRs #91, #744, and #979 should be sufficient to resolve issue #464. But, I think this test highlights the need for more work on the issue. However, I'm not entirely sure if the test is erroneously written. It gets past the LTO guard, but it doesn't error on an undefined symbol as one would expect. Instead, it errors on "Binary ran for too long."
