### PR TITLE
Fix R_X86_64_GOTPC32_TLSDESC relaxations

### DIFF
--- a/linker-utils/src/x86_64.rs
+++ b/linker-utils/src/x86_64.rs
@@ -162,16 +162,44 @@ impl RelaxationKind {
                 *offset_in_section += 15;
             }
             RelaxationKind::TlsDescToLocalExec => {
+                let rex = section_bytes[offset - 3];
+                let modrm = section_bytes[offset - 1];
+
+                // Extract REX.R (bit 2 of rex) and reg field (bits 3-5 of modrm)
+                let rex_r = (rex >> 2) & 1;
+                let reg = (modrm >> 3) & 0x7;
+
+                let rex = if rex_r == 0 { 0x48 } else { 0x49 };
                 section_bytes[offset - 3..offset + 4].copy_from_slice(&[
-                    // mov {offset},%rax
-                    0x48, 0xc7, 0xc0, 0, 0, 0, 0,
+                    // mov {offset},%{dest}
+                    rex,
+                    0xc7,
+                    0xc0 | reg,
+                    0,
+                    0,
+                    0,
+                    0,
                 ]);
                 *addend = 0;
             }
             RelaxationKind::TlsDescToInitialExec => {
+                let rex = section_bytes[offset - 3];
+                let modrm = section_bytes[offset - 1];
+
+                // Extract REX.R (bit 2 of rex) and reg field (bits 3-5 of modrm)
+                let rex_r = (rex >> 2) & 1;
+                let reg = (modrm >> 3) & 0x7;
+
+                let rex = if rex_r == 0 { 0x48 } else { 0x4c };
                 section_bytes[offset - 3..offset + 4].copy_from_slice(&[
-                    // mov {GOT}(%rip),%rax
-                    0x48, 0x8b, 0x05, 0, 0, 0, 0,
+                    // mov {GOT}(%rip),%{dest}
+                    rex,
+                    0x8b,
+                    0x05 | reg << 3,
+                    0,
+                    0,
+                    0,
+                    0,
                 ]);
             }
             RelaxationKind::SkipTlsDescCall => {


### PR DESCRIPTION
Properly detect the destination register and encode the information into the `mov` replacement instruction.

Both variants are tested for `%rax` in our test-suite (one via a Mold test). @mati865 can you please test the suggested fix?

Fixes: #948