### PR TITLE
mold tests: exclude zstd compression test

### DIFF
--- a/.github/workflows/external_tests.yml
+++ b/.github/workflows/external_tests.yml
@@ -21,7 +21,7 @@ jobs:
     container:
       image: 'ubuntu:25.04'
     steps:
-      - run: apt-get update && apt-get -y install gcc g++ clang lld curl bubblewrap binutils-aarch64-linux-gnu binutils-riscv64-linux-gnu qemu-user gcc-aarch64-linux-gnu g++-aarch64-linux-gnu gcc-riscv64-linux-gnu g++-riscv64-linux-gnu gdb git
+      - run: apt-get update && apt-get -y install gcc g++ clang lld curl bubblewrap binutils-aarch64-linux-gnu binutils-riscv64-linux-gnu qemu-user gcc-aarch64-linux-gnu g++-aarch64-linux-gnu gcc-riscv64-linux-gnu g++-riscv64-linux-gnu gdb git zstd
       - name: Checkout
         uses: actions/checkout@v5
         with:

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -5,6 +5,7 @@ tests = [
   "auxiliary.sh",                      # `-auxiliary` and `-f`
   "color-diagnostics.sh",
   "compress-debug-sections.sh",        # Compressed debug sections support #493
+  "compress-debug-sections-zstd.sh",   # Compressed debug sections support #493
   "default-symver-version-script.sh",
   "default-symver.sh",
   "defsym.sh",


### PR DESCRIPTION
The test is only run if `zstd` binary is installed, that's why I'm also installing it.