### PR TITLE
Support escaping in version scripts

### DIFF
--- a/libwild/src/version_script.rs
+++ b/libwild/src/version_script.rs
@@ -62,6 +62,7 @@ pub(crate) enum SymbolMatcher<'data> {
 #[derive(Debug, Default)]
 pub(crate) struct BasicMatchRules<'data> {
     exact: HashSet<PreHashed<UnversionedSymbolName<'data>>, PassThroughHasher>,
+    escaped_exact: Vec<&'data [u8]>,
     star_globs: Vec<Pattern>,
     nonstar_globs: Vec<Pattern>,
     matches_all: bool,
@@ -74,7 +75,11 @@ impl<'data> BasicMatchRules<'data> {
             SymbolMatcher::StarGlob(glob) => self.star_globs.push(glob),
             SymbolMatcher::NonstarGlob(glob) => self.nonstar_globs.push(glob),
             SymbolMatcher::Exact(exact) => {
-                self.exact.insert(UnversionedSymbolName::prehashed(exact));
+                if has_escape_chars(exact) {
+                    self.escaped_exact.push(exact);
+                } else {
+                    self.exact.insert(UnversionedSymbolName::prehashed(exact));
+                }
             }
         }
     }
@@ -86,19 +91,44 @@ impl<'data> BasicMatchRules<'data> {
         mangled: bool,
     ) -> bool {
         // Early exit before we actually demangle the name.
-        if self.exact.is_empty() {
+        if self.exact.is_empty() && self.escaped_exact.is_empty() {
             return false;
         }
 
-        if mangled {
-            let demangled_name = lookup.get_demangled_name();
-            // The creation of UnversionedSymbolName should be relatively cheap as we construct
-            // it at most twice.
-            self.exact
-                .contains(&UnversionedSymbolName::prehashed(demangled_name.as_bytes()))
-        } else {
-            self.exact.contains(lookup.name)
+        // Check normal exact matches first
+        if !self.exact.is_empty() {
+            if mangled {
+                let demangled_name = lookup.get_demangled_name();
+                // The creation of UnversionedSymbolName should be relatively cheap as we construct
+                // it at most twice.
+                if self
+                    .exact
+                    .contains(&UnversionedSymbolName::prehashed(demangled_name.as_bytes()))
+                {
+                    return true;
+                }
+            } else if self.exact.contains(lookup.name) {
+                return true;
+            }
         }
+
+        // Check escaped exact matches
+        if !self.escaped_exact.is_empty() {
+            let symbol_bytes = if mangled {
+                let demangled_name = lookup.get_demangled_name();
+                demangled_name.as_bytes()
+            } else {
+                lookup.name.bytes()
+            };
+
+            for &escaped_pattern in &self.escaped_exact {
+                if matches_escaped_pattern(symbol_bytes, escaped_pattern) {
+                    return true;
+                }
+            }
+        }
+
+        false
     }
 
     #[inline]
@@ -522,28 +552,25 @@ pub(crate) fn parse_matcher<'data>(
             .and_then(|t| t.strip_suffix(b"\""))
         {
             SymbolMatcher::Exact(unquoted)
-        } else if token.contains(&b'\\') {
-            return Err(ContextError::from_external_error(
-                input,
-                VersionScriptError::GlobWithQuote,
-            ));
         } else if token == b"*" {
             SymbolMatcher::MatchesAll
-        } else if b"[]?*".iter().any(|c| token.contains(c)) {
-            let pattern = Pattern::new(str::from_utf8(token).map_err(|_| {
-                ContextError::from_external_error(input, VersionScriptError::InvalidUtf8String)
-            })?)
-            .map_err(|_: glob::PatternError| {
-                ContextError::from_external_error(input, VersionScriptError::InvalidGlobPattern)
-            })?;
-
-            if token.contains(&b'*') {
-                SymbolMatcher::StarGlob(pattern)
-            } else {
-                SymbolMatcher::NonstarGlob(pattern)
-            }
         } else {
-            SymbolMatcher::Exact(token)
+            let glob_type = analyze_glob_pattern(token);
+
+            let create_pattern = |token: &[u8]| -> winnow::Result<Pattern> {
+                Pattern::new(str::from_utf8(token).map_err(|_| {
+                    ContextError::from_external_error(input, VersionScriptError::InvalidUtf8String)
+                })?)
+                .map_err(|_| {
+                    ContextError::from_external_error(input, VersionScriptError::InvalidGlobPattern)
+                })
+            };
+
+            match glob_type {
+                GlobPatternType::Exact => SymbolMatcher::Exact(token),
+                GlobPatternType::Star => SymbolMatcher::StarGlob(create_pattern(token)?),
+                GlobPatternType::NonStar => SymbolMatcher::NonstarGlob(create_pattern(token)?),
+            }
         },
     ))
 }
@@ -552,12 +579,74 @@ fn parse_token<'input>(input: &mut &'input BStr) -> winnow::Result<&'input [u8]>
     take_while(1.., |b| !b" (){}\n\t".contains(&b)).parse_next(input)
 }
 
+enum GlobPatternType {
+    Exact,
+    Star,
+    NonStar,
+}
+
+fn analyze_glob_pattern(pattern: &[u8]) -> GlobPatternType {
+    let mut pattern_type = GlobPatternType::Exact;
+    let mut it = pattern.iter();
+
+    while let Some(&c) = it.next() {
+        match c {
+            b'\\' => {
+                it.next();
+            }
+            b'*' => {
+                return GlobPatternType::Star;
+            }
+            b'[' | b']' | b'?' => {
+                pattern_type = GlobPatternType::NonStar;
+            }
+            _ => {}
+        }
+    }
+
+    pattern_type
+}
+
+/// Unescapes a pattern by removing backslashes that escape special characters.
+/// For exact patterns, we need to normalize escaped characters to their literal form.
+fn unescape_pattern(pattern: &[u8]) -> Vec<u8> {
+    let mut result = Vec::with_capacity(pattern.len());
+    let mut it = pattern.iter();
+
+    while let Some(&c) = it.next() {
+        if c == b'\\' {
+            if let Some(&next_c) = it.next() {
+                result.push(next_c);
+            } else {
+                // If backslash is at the end, include it as-is
+                result.push(c);
+            }
+        } else {
+            result.push(c);
+        }
+    }
+
+    result
+}
+
+fn has_escape_chars(pattern: &[u8]) -> bool {
+    pattern.contains(&b'\\')
+}
+
+fn matches_escaped_pattern(symbol_name: &[u8], pattern: &[u8]) -> bool {
+    if !has_escape_chars(pattern) {
+        return symbol_name == pattern;
+    }
+
+    let unescaped = unescape_pattern(pattern);
+    symbol_name == unescaped.as_slice()
+}
+
 #[derive(Debug)]
 enum VersionScriptError {
     UnknownParentVersion,
     InvalidUtf8String,
     InvalidGlobPattern,
-    GlobWithQuote,
     UnexpectedExtern(String),
     UnsupportedExtern(String),
 }
@@ -568,7 +657,6 @@ impl std::fmt::Display for VersionScriptError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             VersionScriptError::InvalidGlobPattern => write!(f, "Invalid glob pattern"),
-            VersionScriptError::GlobWithQuote => write!(f, "Globs with quote are unsupported"),
             VersionScriptError::InvalidUtf8String => write!(f, "Invalid utf-8 string"),
             VersionScriptError::UnknownParentVersion => write!(f, "Unknown parent version"),
             VersionScriptError::UnexpectedExtern(s) => {
@@ -893,5 +981,57 @@ mod tests {
 
         // Star match
         assert_eq!(script.find_match(&sym(b"foo_bar")).unwrap().0, 2);
+    }
+
+    #[test]
+    fn test_escape_sequences() {
+        let data = ScriptData {
+            raw: br#"
+                {
+                    global:
+                        foo\*bar;
+                        baz\?;
+                        foo1\\foo2;
+                        foo3?foo4*;
+                        b*;
+                        f?;
+                };
+            "#,
+        };
+        let script = VersionScript::parse(data).unwrap();
+        let version_body = &script.versions[0].version_body;
+
+        let escaped_exact_patterns: HashSet<&str> = version_body
+            .globals
+            .general
+            .escaped_exact
+            .iter()
+            .map(|s| std::str::from_utf8(s).unwrap())
+            .collect();
+
+        assert!(escaped_exact_patterns.contains(r"foo\*bar"));
+        assert!(escaped_exact_patterns.contains(r"baz\?"));
+        assert!(escaped_exact_patterns.contains(r"foo1\\foo2"));
+
+        let star_patterns: Vec<&str> = version_body
+            .globals
+            .general
+            .star_globs
+            .iter()
+            .map(|glob| glob.as_str())
+            .collect();
+
+        assert!(star_patterns.contains(&"b*"));
+        assert!(star_patterns.contains(&"foo3?foo4*"));
+
+        let nonstar_patterns: Vec<&str> = version_body
+            .globals
+            .general
+            .nonstar_globs
+            .iter()
+            .map(|glob| glob.as_str())
+            .collect();
+
+        assert!(nonstar_patterns.contains(&"f?"));
     }
 }

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -103,7 +103,6 @@ tests = [
   "version-script-search-paths.sh",
   "version-script15.sh",
   "version-script17.sh",
-  "version-script23.sh",
 ]
 
 [skipped_groups.linker_script]

--- a/wild/tests/sources/symbol-versions-with-escaping.map
+++ b/wild/tests/sources/symbol-versions-with-escaping.map
@@ -1,0 +1,11 @@
+VER_1.0 {
+    global:
+        bar\_global;
+    local:
+        bar\*local;
+        bar\*local*foo;
+};
+
+VER_2.0 {
+        bar_v2*;
+} VER_1.0;

--- a/wild/tests/sources/symbol-versions.c
+++ b/wild/tests/sources/symbol-versions.c
@@ -20,6 +20,10 @@
 //#Config:verdef-1:verdef
 //#LinkArgs:--shared --soname=symbol-versions.so --version-script=./symbol-versions-script.map
 
+//#Config:with-escaping:verdef
+//#DiffIgnore:version_d.verdef_1
+//#LinkArgs:--shared --version-script=./symbol-versions-with-escaping.map
+
 #include "runtime.h"
 
 int foo(void);


### PR DESCRIPTION
part of #990 

Ensure that characters used in glob patterns in version scripts are correctly parsed even when escaped.