### PR TITLE
Do not lookup files from args in search paths

### DIFF
--- a/libwild/src/input_data.rs
+++ b/libwild/src/input_data.rs
@@ -623,7 +623,7 @@ impl Input {
     fn path(&self, args: &Args) -> Result<InputPath> {
         match &self.spec {
             InputSpec::File(p) => {
-                if (self.search_first.is_some() || p.parent() == Some(Path::new("")))
+                if self.search_first.is_some()
                     && let Some(path) = search_for_file(
                         &args.lib_search_path,
                         self.search_first.as_ref(),
@@ -640,9 +640,13 @@ impl Input {
                     original: p.as_ref().to_owned(),
                 })
             }
-            InputSpec::Lib(lib_name) => {
+            InputSpec::Lib(lib_name, literal_name) => {
                 if self.modifiers.allow_shared {
-                    let filename = format!("lib{lib_name}.so");
+                    let filename = if *literal_name {
+                        lib_name.to_string()
+                    } else {
+                        format!("lib{lib_name}.so")
+                    };
                     if let Some(path) = search_for_file(
                         &args.lib_search_path,
                         self.search_first.as_ref(),
@@ -654,7 +658,11 @@ impl Input {
                         });
                     }
                 }
-                let filename = format!("lib{lib_name}.a");
+                let filename = if *literal_name {
+                    lib_name.to_string()
+                } else {
+                    format!("lib{lib_name}.a")
+                };
                 if let Some(path) =
                     search_for_file(&args.lib_search_path, self.search_first.as_ref(), &filename)
                 {

--- a/libwild/src/input_data.rs
+++ b/libwild/src/input_data.rs
@@ -640,13 +640,9 @@ impl Input {
                     original: p.as_ref().to_owned(),
                 })
             }
-            InputSpec::Lib(lib_name, literal_name) => {
+            InputSpec::Lib(lib_name) => {
                 if self.modifiers.allow_shared {
-                    let filename = if *literal_name {
-                        lib_name.to_string()
-                    } else {
-                        format!("lib{lib_name}.so")
-                    };
+                    let filename = format!("lib{lib_name}.so");
                     if let Some(path) = search_for_file(
                         &args.lib_search_path,
                         self.search_first.as_ref(),
@@ -658,11 +654,7 @@ impl Input {
                         });
                     }
                 }
-                let filename = if *literal_name {
-                    lib_name.to_string()
-                } else {
-                    format!("lib{lib_name}.a")
-                };
+                let filename = format!("lib{lib_name}.a");
                 if let Some(path) =
                     search_for_file(&args.lib_search_path, self.search_first.as_ref(), &filename)
                 {
@@ -672,6 +664,19 @@ impl Input {
                     });
                 }
                 bail!("Couldn't find library `{lib_name}` on library search path");
+            }
+            InputSpec::Search(filename) => {
+                if let Some(path) = search_for_file(
+                    &args.lib_search_path,
+                    self.search_first.as_ref(),
+                    filename.as_ref(),
+                ) {
+                    return Ok(InputPath {
+                        absolute: std::path::absolute(&path)?,
+                        original: PathBuf::from(filename.as_ref()),
+                    });
+                }
+                bail!("Couldn't find library `{filename}` on library search path");
             }
         }
     }

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -346,7 +346,7 @@ fn foreach_input(
         match command {
             Command::Arg(arg) => {
                 let spec = if let Some(lib_name) = arg.strip_prefix("-l".as_bytes()) {
-                    InputSpec::Lib(Box::from(to_str(lib_name)?), false)
+                    InputSpec::Lib(Box::from(to_str(lib_name)?))
                 } else {
                     InputSpec::File(Box::from(Path::new(to_str(arg)?)))
                 };
@@ -423,7 +423,7 @@ mod tests {
             inputs.into_iter().map(|i| i.spec),
             [
                 InputSpec::File(Box::from(Path::new("libgcc_s.so.1"))),
-                InputSpec::Lib(Box::from("gcc"), false),
+                InputSpec::Lib(Box::from("gcc")),
             ],
         );
 

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -346,7 +346,7 @@ fn foreach_input(
         match command {
             Command::Arg(arg) => {
                 let spec = if let Some(lib_name) = arg.strip_prefix("-l".as_bytes()) {
-                    InputSpec::Lib(Box::from(to_str(lib_name)?))
+                    InputSpec::Lib(Box::from(to_str(lib_name)?), false)
                 } else {
                     InputSpec::File(Box::from(Path::new(to_str(arg)?)))
                 };
@@ -423,7 +423,7 @@ mod tests {
             inputs.into_iter().map(|i| i.spec),
             [
                 InputSpec::File(Box::from(Path::new("libgcc_s.so.1"))),
-                InputSpec::Lib(Box::from("gcc")),
+                InputSpec::Lib(Box::from("gcc"), false),
             ],
         );
 


### PR DESCRIPTION
Fixes a regression from #610 that manifests in cups source code.
Minimised reproducer:
```sh
$ mkdir bad_foo
$ touch bad_foo/foo.o
$ echo 'int main() { return 0; }' > main.c
$ gcc -c main.c -o foo.o
❯ gcc -B ~/Projects/wild/fakes-debug/ -pie foo.o -Lbad_foo/
wild: error: Undefined symbol main, referenced by
    /usr/lib/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../lib/Scrt1.o
collect2: error: ld returned 255 exit status
```
The problem was due to `bad_foo/foo.o` being preferred over `./foo.o`.

Created on top of https://github.com/davidlattimore/wild/pull/1057