### PR TITLE
Trivial: Derive Debug for some of the integ test structures

### DIFF
--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -163,23 +163,25 @@ fn build_dir() -> PathBuf {
     std::env::var("WILD_TEST_BUILD_DIR").map_or(base_dir().join("tests/build"), PathBuf::from)
 }
 
+#[derive(Debug)]
 struct ProgramInputs {
     source_file: &'static str,
 }
 
+#[derive(Debug)]
 struct Program<'a> {
     link_output: LinkOutput,
     assertions: &'a Assertions,
     shared_objects: Vec<LinkerInput>,
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum Linker {
     Wild,
     ThirdParty(ThirdPartyLinker),
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct ThirdPartyLinker {
     name: &'static str,
     gcc_name: &'static str,
@@ -261,12 +263,14 @@ fn wild_path() -> &'static Path {
     Path::new(env!("CARGO_BIN_EXE_wild"))
 }
 
+#[derive(Debug)]
 struct LinkOutput {
     binary: PathBuf,
     command: LinkCommand,
     linker_used: Linker,
 }
 
+#[derive(Debug)]
 struct LinkCommand {
     command: Command,
     input_commands: Vec<LinkCommand>,
@@ -423,7 +427,7 @@ fn host_supports_clang_with_option(option: &str) -> bool {
     })
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct Config {
     name: String,
     variant_num: Option<u32>,
@@ -458,7 +462,7 @@ struct Config {
 }
 
 /// These configs are used by the config file specified in `$WILD_TEST_CONFIG`
-#[derive(serde::Deserialize, Default, Clone, PartialEq, Eq)]
+#[derive(serde::Deserialize, Debug, Default, Clone, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 struct TestConfig {
     #[serde(default)]
@@ -502,7 +506,7 @@ enum Mode {
     Unspecified,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 struct DirectConfig {
     mode: Mode,
 }
@@ -540,7 +544,7 @@ impl Config {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LinkerDriver {
     /// Invoke the linker via a compiler.
     Compiler(Compiler),
@@ -550,7 +554,7 @@ enum LinkerDriver {
 }
 
 /// A compiler via which the linker is invoked.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Compiler {
     Gcc(CLanguage),
     Clang(CLanguage),
@@ -574,7 +578,7 @@ impl FilenameArgumentPair {
     }
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct Dep {
     files: Vec<FilenameArgumentPair>,
     input_type: InputType,
@@ -584,7 +588,7 @@ struct Dep {
     template: Option<Vec<String>>,
 }
 
-#[derive(Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 struct Assertions {
     expected_symtab_entries: Vec<ExpectedSymtabEntry>,
     expected_dynsym_entries: Vec<ExpectedSymtabEntry>,
@@ -594,7 +598,7 @@ struct Assertions {
     contains_strings: Vec<String>,
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct ExpectedSymtabEntry {
     name: String,
     section_name: Option<String>,
@@ -1101,7 +1105,7 @@ impl Display for Config {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 struct LinkerInput {
     prefix_arg: Option<&'static str>,
     path: PathBuf,


### PR DESCRIPTION
Added automatically generated `Debug` to a few of the integ test structures. I'm sure I'm not the only person who extensively uses `dbg!` on a code base I'm new to to learn its internals - it's so much quicker than placing breakpoints.