### PR TITLE
Fix hyperlinks in RustDoc.

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -560,7 +560,7 @@ impl Args {
     /// Sets up the thread pool, using the explicit number of threads if specified,
     /// or falling back to the jobserver protocol if available.
     ///
-    /// https://www.gnu.org/software/make/manual/html_node/POSIX-Jobserver.html
+    /// <https://www.gnu.org/software/make/manual/html_node/POSIX-Jobserver.html>
     pub fn activate_thread_pool(mut self) -> Result<ActivatedArgs> {
         let mut tokens = Vec::new();
         self.available_threads = self.num_threads.unwrap_or_else(|| {

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -749,8 +749,8 @@ pub mod riscvattr {
 }
 
 /// For additional information on ELF relocation types, see "ELF-64 Object File Format" -
-/// https://uclibc.org/docs/elf-64-gen.pdf. For information on the TLS related relocations, see "ELF
-/// Handling For Thread-Local Storage" - https://www.uclibc.org/docs/tls.pdf.
+/// <https://uclibc.org/docs/elf-64-gen.pdf>. For information on the TLS related relocations, see "ELF
+/// Handling For Thread-Local Storage" - <https://www.uclibc.org/docs/tls.pdf>.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RelocationKind {
     /// The absolute address of a symbol or section.


### PR DESCRIPTION
Trivial changes to fix warnings generating the RustDoc.