### PR TITLE
Emit error if `.symver` directive is used

### DIFF
--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -920,6 +920,11 @@ fn export_dynamic<'data>(
     symbol_db: &SymbolDb<'data>,
 ) -> Result {
     let name = symbol_db.symbol_name(symbol_id)?;
+    ensure!(
+        memchr::memchr(b'@', name.bytes()).is_none(),
+        "symbol version definition `{}` (using `.symver` directive) is not supported yet",
+        String::from_utf8_lossy(name.bytes())
+    );
 
     let version = (symbol_db.version_script.version_count() > 0)
         .then(|| {

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -2561,7 +2561,8 @@ fn integration_test(
         "export-dynamic.c",
         "unresolved-symbols-object.c",
         "unresolved-symbols-shared.c",
-        "lto-undefined.c"
+        "lto-undefined.c",
+        "symbol-version-symver.c"
     )]
     program_name: &'static str,
     #[allow(unused_variables)] setup_symlink: (),

--- a/wild/tests/sources/symbol-version-symver.c
+++ b/wild/tests/sources/symbol-version-symver.c
@@ -1,0 +1,13 @@
+//#AbstractConfig:default
+
+//#Config:shared-lib:default
+//#SkipLinker:ld
+//#RunEnabled:false
+//#LinkArgs:--shared --version-script=./symbol-versions-script.map
+//#ExpectError: symbol version definition
+
+__asm__(".symver foo,xyz@VER_1");
+__asm__(".symver bar,xyz@@VER_2");
+
+void foo(void) { __builtin_printf("foo\n"); }
+void bar(void) { __builtin_printf("bar\n"); }


### PR DESCRIPTION
As discussed during today's meeting, we should not silently create an invalid shared library. Rather we ought to emit an error:

```
  CCLD     libasound.la
WARNING: wild: --plugin /usr/lib/gcc/x86_64-pc-linux-gnu/15.2.1/liblto_plugin.so is not yet supported
wild: error: Failed to activate .libs/dlmisc.o (2304 (9/0))
  Caused by:
    symbol version definition `snd_dlopen@@ALSA_1.1.6` (using `.symver` directive) is not supported yet
```