### PR TITLE
Override -shared by (-no)-pie

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -1476,6 +1476,7 @@ fn setup_argument_parser() -> ArgumentParser {
         .help("Create a position-independent executable")
         .execute(|args, _modifier_stack| {
             args.relocation_model = RelocationModel::Relocatable;
+            args.output_kind = None;
             Ok(())
         });
 
@@ -1485,6 +1486,7 @@ fn setup_argument_parser() -> ArgumentParser {
         .help("Create a position-dependent executable (default)")
         .execute(|args, _modifier_stack| {
             args.relocation_model = RelocationModel::NonRelocatable;
+            args.output_kind = None;
             Ok(())
         });
 

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -1483,7 +1483,7 @@ fn setup_argument_parser() -> ArgumentParser {
     parser
         .declare()
         .long("no-pie")
-        .help("Create a position-dependent executable (default)")
+        .help("Do not create a position-dependent executable (default)")
         .execute(|args, _modifier_stack| {
             args.relocation_model = RelocationModel::NonRelocatable;
             args.output_kind = None;

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -2562,7 +2562,8 @@ fn integration_test(
         "unresolved-symbols-object.c",
         "unresolved-symbols-shared.c",
         "lto-undefined.c",
-        "symbol-version-symver.c"
+        "symbol-version-symver.c",
+        "args-precedence.c"
     )]
     program_name: &'static str,
     #[allow(unused_variables)] setup_symlink: (),

--- a/wild/tests/sources/args-precedence.c
+++ b/wild/tests/sources/args-precedence.c
@@ -1,0 +1,20 @@
+// Extracted from https://github.com/rust-lang/rust/issues/146780
+//#Config:pie-over-shared
+//#LinkArgs:-shared -z now -pie
+//#DiffIgnore:.dynamic.DT_RELA*
+// We're linking different .so files, so this is expected.
+//#DiffIgnore:.dynamic.DT_NEEDED
+//#DiffIgnore:section.got
+//#Shared:runtime.c
+//#Mode:dynamic
+
+//#Config:no-pie-over-shared
+//#LinkArgs:-shared -z now -no-pie
+//#Object:runtime.c
+
+#include "runtime.h"
+
+void _start(void) {
+  runtime_init();
+  exit_syscall(42);
+}


### PR DESCRIPTION
Extracted this edge case from rust-lang/rust#146780.

Resetting `output_kind` when encountering (-no)-pie makes `-shared`
overridable, just like with ld.bfd.
Note: LLD doesn't support this, and instead just throws an error.