### PR TITLE
Allow absolute-value symbol to be used as an entry point

### DIFF
--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -1785,9 +1785,9 @@ impl<'data> Layout<'data> {
             )
         })?;
 
-        if !resolution.value_flags().is_address() {
+        if !resolution.value_flags().is_address() && !resolution.value_flags().is_absolute() {
             bail!(
-                "Entry point must be an address. {}",
+                "Entry point must be an address or absolute value. {}",
                 self.symbol_debug(symbol_id)
             );
         }

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -18,7 +18,6 @@ tests = [
   "emit-relocs-cpp.sh",
   "emit-relocs-dead-sections.sh",
   "emit-relocs.sh",
-  "entry.sh",                          # `--entry={symbol_name}`
   "exception-multiple-ehframe.sh",     # `-r`
   "exclude-libs.sh",
   "execute-only.sh",


### PR DESCRIPTION
Currently, while the `--entry` option allows specifying symbol names as entry points, attempting to actually do this results in link failures due to the overly strict error conditions in `layout.rs`.