### PR TITLE
Make the necessary changes for the dev Docker images

### DIFF
--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -9,7 +9,7 @@ RUN wget -qO- https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.
 RUN rustup toolchain install nightly && \
     rustup component add rustc-codegen-cranelift-preview --toolchain nightly
 
-RUN apk add build-base lld clang bash
+RUN apk add build-base lld clang clang-extra-tools bash
 
 WORKDIR /wild
 

--- a/docker/debian.Dockerfile
+++ b/docker/debian.Dockerfile
@@ -7,7 +7,8 @@ FROM rust:1.89 AS chef
 RUN apt-get update && \
     apt-get install -y \
         clang \
-        lld-16 \
+        clang-format \
+        lld \
         less \
         qemu-user \
         gcc-aarch64-linux-gnu \

--- a/docker/fedora.Dockerfile
+++ b/docker/fedora.Dockerfile
@@ -22,6 +22,8 @@ RUN dnf -y update && \
         binutils-riscv64-linux-gnu \
         @development-tools \
         elfutils \
+        clang-format \
+        glibc-static \
         rustup \
         vim \
     && dnf clean all

--- a/docker/nix.Dockerfile
+++ b/docker/nix.Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /wild
 
 FROM chef AS planner
 COPY . .
+COPY docker/shell.nix shell.nix
 RUN nix-shell --run "cargo chef prepare --recipe-path recipe.json"
 
 FROM chef AS builder

--- a/docker/opensuse.Dockerfile
+++ b/docker/opensuse.Dockerfile
@@ -17,7 +17,6 @@ RUN zypper install -y -t pattern devel_C_C++ && \
         lld \
         vim \
         less
-RUN cargo install --locked cargo-chef
 RUN rustup toolchain install nightly && \
     rustup target add --toolchain nightly \
         x86_64-unknown-linux-musl \
@@ -27,6 +26,7 @@ RUN rustup toolchain install nightly && \
         riscv64gc-unknown-linux-musl \
         && \
     rustup component add rustc-codegen-cranelift-preview --toolchain nightly
+RUN cargo install --locked cargo-chef
 WORKDIR /wild
 
 FROM chef AS planner

--- a/docker/ubuntu.Dockerfile
+++ b/docker/ubuntu.Dockerfile
@@ -7,6 +7,7 @@ FROM ubuntu:25.04 AS chef
 RUN apt-get update && \
     apt-get install -y \
         clang \
+        clang-format \
         llvm \
         lld \
         mold \


### PR DESCRIPTION
I noticed that some of the development Dockerfiles can’t be built as they are.

This fix makes sure all images pass their tests, except for those that fail specifically because of Wild’s linker-diff own logic on Fedora (so it's fine):

```
---- integration_test::program_name_49___cpp_integration_cc__ stdout ----
wild: /wild/wild/tests/build/cpp-integration.cc-clang-model-large-host.wild
ld: /wild/wild/tests/build/cpp-integration.cc-clang-model-large-host.ld
lld: /wild/wild/tests/build/cpp-integration.cc-clang-model-large-host.lld
rel.extra-opt.R_X86_64_REX_GOTPCRELX.RexMovIndirectToAbsolute.dynamic-non-pie
  `/usr/bin/../lib/gcc/x86_64-redhat-linux/15/../../../../lib64/crt1.o` .text _start
  ORIG 0x000018: [ 48 8b 3d 00 00 00 00 ] mov 0x1F,%rdi
                            ^^^^^^^^^^^ R_X86_64_REX_GOTPCRELX
  ORIG main -4
  wild 0x404398: [ 48 c7 c7 a0 44 40 00 ] mov $0x4044A0,%rdi
                            ^^^^^^^^^^^ R_X86_64_32 RexMovIndirectToAbsolute
  wild main
  wild TRACE: relaxation applied relaxation=RexMovIndirectToAbsolute, value_flags=ADDRESS | NON_INTERPOSABLE,
  wild TRACE: resolution_flags=DIRECT, rel_kind=Absolute,
  wild TRACE: value=0x4044a0, symbol_name=main
  ld   0x402138: [ 48 8b 3d a9 3e 00 00 ] mov 0x405FE8,%rdi
                            ^^^^^^^^^^^ R_X86_64_REX_GOTPCRELX NoOp
  ld   GOT->main
  lld  0x2061a8: [ 48 8d 3d e1 c4 ff ff ] lea 0x202690,%rdi
                            ^^^^^^^^^^^ R_X86_64_PC32 MovIndirectToLea
  lld  main
```