### PR TITLE
Apply clippy lint not detected due to use of hashbrown

### DIFF
--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -45,7 +45,6 @@ use rayon::iter::IntoParallelRefIterator;
 use rayon::iter::IntoParallelRefMutIterator;
 use rayon::iter::ParallelIterator;
 use std::fmt::Display;
-use std::mem::replace;
 use std::mem::take;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
@@ -851,7 +850,7 @@ fn process_alternatives(
     symbol_db: &AtomicSymbolDb,
     resolved: &[ResolvedGroup],
 ) {
-    for (first, alternatives) in replace(alternative_definitions, HashMap::new()) {
+    for (first, alternatives) in std::mem::take(alternative_definitions) {
         // Compute the most restrictive visibility of any of the alternative definitions. This is
         // the visibility we'll use for our selected symbol. This seems like odd behaviour, but it
         // matches what GNU ld appears to do and some programs will fail to link if we don't do


### PR DESCRIPTION
See #1124 for some context. This change applies a clippy lint that is relevant but not picked up on due to use of hashbrown instead of std's hash tables.