### PR TITLE
Use correct exit syscall number on Illumos

### DIFF
--- a/wild/tests/sources/exit.c
+++ b/wild/tests/sources/exit.c
@@ -1,9 +1,15 @@
 #include <inttypes.h>
 #include <sys/types.h>
 
+#ifdef __sun
+#define EXIT_SYSCALL 1
+#else
+#define EXIT_SYSCALL 60
+#endif
+
 #if defined(__x86_64__)
 void exit_syscall(int exit_code) {
-  register int64_t rax __asm__("rax") = 60;
+  register int64_t rax __asm__("rax") = EXIT_SYSCALL;
   register int rdi __asm__("rdi") = exit_code;
   __asm__ __volatile__("syscall"
                        : "+r"(rax)


### PR DESCRIPTION
Porting wild to other unixes should not be terribly difficult. This PR solves the first problem I encountered. The `exit.c` libc-like shim should use syscall number 1 on `__sun` derivatives i.e. Illumos. I was baffled when I ran `01_trivial` under the debugger and the exit syscall appeared to have no effect. The only difference between _that_ code and the working code is this fix. That is, the instruction at `0x401394`:

```
000000000040138d <exit_syscall>:
  40138d:       55                      push   %rbp
  40138e:       48 89 e5                mov    %rsp,%rbp
  401391:       89 7d fc                mov    %edi,-0x4(%rbp)
  401394:       b8 01 00 00 00          mov    $0x1,%eax
  401399:       8b 7d fc                mov    -0x4(%rbp),%edi
  40139c:       0f 05                   syscall
  40139e:       90                      nop
  40139f:       5d                      pop    %rbp
  4013a0:       c3                      ret
```