### PR TITLE
Unignore `symbol-versions3.sh` Mold test

### DIFF
--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -182,10 +182,6 @@ tests = [
 reason = "Related to TLS"
 tests  = ["tls-common.sh", "tls-le-error.sh"]
 
-[skipped_groups.symver]
-reason = "unsupported inline assembly .symver directive"
-tests = ["symbol-version3.sh"]
-
 [skipped_groups.ignore]
 reason = "We ignore these tests for some reasons"
 tests = [


### PR DESCRIPTION
No longer fails, thanks to https://github.com/davidlattimore/wild/pull/1129