### PR TITLE
Wild 1143 - combined inline and @file options parsing and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,6 +749,7 @@ dependencies = [
  "smallvec",
  "symbolic-common",
  "symbolic-demangle",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ edition = "2024"
 
 [workspace.dependencies]
 anyhow = "1.0.97"
+ar = "0.9.0"
 ascii_table = "4.0.0"
 atomic-take = "1.0.0"
 bitflags = "2.4.0"

--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -53,8 +53,8 @@ glob = "0.3.2"
 perf-event = { workspace = true }
 
 [dev-dependencies]
-ar = "0.9.0"
-tempfile = "3.0.2"
+ar = { workspace = true }
+tempfile = { workspace = true }
 
 [features]
 # Support for running the linker as a subprocess.

--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -54,6 +54,7 @@ perf-event = { workspace = true }
 
 [dev-dependencies]
 ar = "0.9.0"
+tempfile = "3.0.2"
 
 [features]
 # Support for running the linker as a subprocess.

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -830,12 +830,7 @@ impl ArgumentParser {
             let file_args = read_args_from_file(Path::new(path))?;
             let mut file_arg_iter = file_args.iter();
             while let Some(file_arg) = file_arg_iter.next() {
-                self.handle_argument(
-                    args,
-                    modifier_stack,
-                    file_arg,
-                    &mut file_arg_iter,
-                )?;
+                self.handle_argument(args, modifier_stack, file_arg, &mut file_arg_iter)?;
             }
         }
 

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -826,6 +826,7 @@ impl ArgumentParser {
         arg: &str,
         input: &mut I,
     ) -> Result<()> {
+        // TODO @lapla-cogito standardize the interface. @file doesn't use a leading hyphen.
         // Handle `@file`option (recursively) - merging in the options contained in the file
         if let Some(path) = arg.strip_prefix('@') {
             let file_args = read_args_from_file(Path::new(path))?;

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -16,7 +16,7 @@ use crate::alignment::Alignment;
 use crate::arch::Architecture;
 use crate::bail;
 use crate::ensure;
-use crate::error::Context as _;
+use crate::error::Context as _
 use crate::error::Result;
 use crate::input_data::FileId;
 use crate::linker_script::maybe_forced_sysroot;
@@ -2233,7 +2233,8 @@ mod tests {
     use crate::args::InputSpec;
     use itertools::Itertools;
     use std::fs::File;
-    use std::io::{BufWriter, Write};
+    use std::io::BufWriter;
+    use std::io::Write;
     use std::num::NonZeroUsize;
     use std::path::Path;
     use std::path::PathBuf;

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -16,7 +16,7 @@ use crate::alignment::Alignment;
 use crate::arch::Architecture;
 use crate::bail;
 use crate::ensure;
-use crate::error::Context as _
+use crate::error::Context as _;
 use crate::error::Result;
 use crate::input_data::FileId;
 use crate::linker_script::maybe_forced_sysroot;
@@ -30,10 +30,10 @@ use std::num::NonZeroUsize;
 use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicI64;
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
 pub struct Args {
     pub(crate) unrecognized_options: Vec<String>,
@@ -2229,8 +2229,8 @@ impl FromStr for CounterKind {
 #[cfg(test)]
 mod tests {
     use super::SILENTLY_IGNORED_FLAGS;
-    use crate::Args;
     use crate::args::InputSpec;
+    use crate::Args;
     use itertools::Itertools;
     use std::fs::File;
     use std::io::BufWriter;

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -2233,6 +2233,7 @@ mod tests {
     use std::path::Path;
     use std::path::PathBuf;
     use std::str::FromStr;
+    use crate::Args;
 
     const INPUT1: &[&str] = &[
         "-pie",
@@ -2348,9 +2349,7 @@ mod tests {
         assert!(c.iter().any(|p| p.as_ref() == Path::new(v)));
     }
 
-    #[test]
-    fn test_parse() {
-        let args = super::parse(|| INPUT1.iter()).unwrap();
+    fn input1_assertions(args: &Args) {
         assert!(args.is_relocatable());
         assert_eq!(
             args.inputs
@@ -2384,6 +2383,13 @@ mod tests {
             InputSpec::Search(lib) => lib.as_ref() == "lib85caec4suo0pxg06jm2ma7b0o.so",
         }));
         assert_eq!(args.rpath.as_deref(), Some("foo/:bar/:baz:somewhere"));
+
+    }
+
+    #[test]
+    fn test_parse() {
+        let args = super::parse(|| INPUT1.iter()).unwrap();
+        input1_assertions(&args);
     }
 
     #[test]

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -30,10 +30,10 @@ use std::num::NonZeroUsize;
 use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicI64;
 use std::sync::atomic::Ordering;
-use std::sync::Arc;
 
 pub struct Args {
     pub(crate) unrecognized_options: Vec<String>,
@@ -2229,8 +2229,8 @@ impl FromStr for CounterKind {
 #[cfg(test)]
 mod tests {
     use super::SILENTLY_IGNORED_FLAGS;
-    use crate::args::InputSpec;
     use crate::Args;
+    use crate::args::InputSpec;
     use itertools::Itertools;
     use std::fs::File;
     use std::io::BufWriter;

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -2347,14 +2347,9 @@ mod tests {
         "somewhere",
     ];
 
-    const FILE_OPTIONS: &[&str] = &[
-        "-pie",
-    ];
+    const FILE_OPTIONS: &[&str] = &["-pie"];
 
-    const INLINE_OPTIONS: &[&str] = &[
-        "-L",
-        "/lib",
-    ];
+    const INLINE_OPTIONS: &[&str] = &["-L", "/lib"];
 
     fn write_options_to_file(file: &File, options: &[&str]) {
         let mut writer = BufWriter::new(file);

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -401,6 +401,7 @@ pub(crate) fn parse<F: Fn() -> I, S: AsRef<str>, I: Iterator<Item = S>>(input: F
     let arg_parser = setup_argument_parser();
     while let Some(arg) = input.next() {
         let arg = arg.as_ref();
+
         arg_parser.handle_argument(&mut args, &mut modifier_stack, arg, &mut input)?;
     }
 
@@ -832,6 +833,7 @@ impl ArgumentParser {
             while let Some(file_arg) = file_arg_iter.next() {
                 self.handle_argument(args, modifier_stack, file_arg, &mut file_arg_iter)?;
             }
+            return Ok(());
         }
 
         if let Some(stripped) = strip_option(arg) {

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -30,10 +30,10 @@ use std::num::NonZeroUsize;
 use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicI64;
 use std::sync::atomic::Ordering;
-use std::sync::Arc;
 
 pub struct Args {
     pub(crate) unrecognized_options: Vec<String>,
@@ -2229,8 +2229,8 @@ impl FromStr for CounterKind {
 #[cfg(test)]
 mod tests {
     use super::SILENTLY_IGNORED_FLAGS;
-    use crate::args::InputSpec;
     use crate::Args;
+    use crate::args::InputSpec;
     use itertools::Itertools;
     use std::fs::File;
     use std::io::{BufWriter, Write};


### PR DESCRIPTION
Fixes #1143 by implementing parsing of combined inline and @file options on the command line, as described in #1143