### PR TITLE
Ignore -C flag

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -260,7 +260,7 @@ const SILENTLY_IGNORED_FLAGS: &[&str] = &[
     "sort-common",
     "stats",
 ];
-const SILENTLY_IGNORED_SHORT_FLAGS: &[&str] = &["(", ")"];
+const SILENTLY_IGNORED_SHORT_FLAGS: &[&str] = &["(", ")", "C"];
 
 const IGNORED_FLAGS: &[&str] = &[
     "gdb-index",


### PR DESCRIPTION
For some reason, a spurious -C flag is passed to wild on illumos when using rustflags to delegate linking to wild. Ignoring it is necessary for wild to link Rust programs on illumos.