### PR TITLE
Ignore lld in integ tests on illumos

### DIFF
--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -2464,6 +2464,7 @@ fn available_linkers() -> Result<Vec<Linker>> {
             cross_paths: find_cross_paths("ld"),
             enabled_by_default: true,
         }),
+        #[cfg(not(target_os = "illumos"))]
         Linker::ThirdParty(ThirdPartyLinker {
             name: "lld",
             gcc_name: "lld",


### PR DESCRIPTION
Unfortunately, lld is regularly producing binaries that illumos rejects. It's not particularly beneficial to have lld-based tests when the binaries it produces won't even load. 

Aside: I have been kicking the tires on illumos in order to learn DTrace. It was _outstandingly_ easy (with fbt) to find the branches in the [code that loads ELF files](https://github.com/illumos/illumos-gate/blob/9e324fa7fdb6831bedceb4b3aeca5346b35faf23/usr/src/uts/common/exec/elf/elf.c#L264) and precisely why they take issue with lld's binaries. Indeed, wild still produces binaries that fail [here](https://github.com/illumos/illumos-gate/blob/9e324fa7fdb6831bedceb4b3aeca5346b35faf23/usr/src/uts/common/exec/elf/elf.c#L634)... but one problem at a time.