### PR TITLE
Build only C++ and Rust demanglers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,15 +890,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
-name = "msvc-demangler"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4c25a3bb7d880e8eceab4822f3141ad0700d20f025991c1f03bd3d00219a5fc"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1382,9 +1373,7 @@ version = "12.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d359ef6192db1760a34321ec4f089245ede4342c27e59be99642f12a859de8"
 dependencies = [
- "cc",
  "cpp_demangle",
- "msvc-demangler",
  "rustc-demangle",
  "symbolic-common",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ sharded-vec-writer = "0.4.0"
 smallvec = "1.6.1"
 strum = { version = "0.27.0", features = ["derive"] }
 symbolic-common = "12.0.0"
-symbolic-demangle = "12.0.0"
+symbolic-demangle = {version = "12.0.0", default-features = false, features = ["cpp", "rust"]}
 tempfile = "3.0.2"
 toml = "0.9.0"
 tracing = "0.1.35"

--- a/cackle.toml
+++ b/cackle.toml
@@ -284,11 +284,6 @@ allow_unsafe = true
 allow_unsafe = true
 
 [pkg.symbolic-demangle]
-build.allow_build_instructions = [
-    "cargo:rustc-link-lib=static=swiftdemangle",
-    "cargo:rustc-link-lib=stdc++",
-    "cargo:rustc-link-search=native=*",
-]
 allow_unsafe = true
 
 [pkg.futures-sink]


### PR DESCRIPTION
Avoiding Swift demangler removes the need for C++ compiler, making Wild easier to cross-compile for Musl.