### PR TITLE
Added test config setting for skipping diffing.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,9 @@ Currently, the behavior for the following test options can be configured using t
 - `diff_ignore`: Adds extra rules to ignore certain diffs. This can be useful if you're developing
   on a system with an older version of GNU ld that doesn't perform certain optimisations.
 
+- `run_all_diffs`: Enables diffing the output of wild against that of the existing linkers.
+  By default, diffs are skipped. Set to `true` to enable.
+
 A sample configuration file is provided as `test-config.toml.sample`. By default, Wild uses
 `test-config.toml` as the configuration file. If you have written your configuration in a different
 file, specify its location using the `WILD_TEST_CONFIG` environment variable as follows:

--- a/test-config-ci.toml
+++ b/test-config-ci.toml
@@ -1,2 +1,3 @@
 rustc_channel = "nightly"
 allow_rust_musl_target = true
+run_all_diffs = true

--- a/test-config.toml.sample
+++ b/test-config.toml.sample
@@ -3,3 +3,4 @@ rustc_channel = "default" # `"stable"`, `"beta"`, `"nightly"` or "default"
 qemu_arch = [] # `["X86_64"]`, `["AArch64"]`, `["RISCV64"]`
 allow_rust_musl_target = false # `true` or `false`
 diff_ignore = [] # ["rule1, "rule2"]
+run_all_diffs = true # Enables diffing binaries against other linkers. Disabled by default.


### PR DESCRIPTION
As described in the title. Now, when a test fails because of only a diff, text is printed indicating as much, with a pointer to how to disable diffing. This is useful for packagers and bundlers who want to check that wild, as configured, works sanely. It is also invaluable for porting wild to other unixes, as one single test setting can be used to isolate truly broken tests from differences in opinion between linkers.