### PR TITLE
Look for dynamic linker in /bin/less in integ test

### DIFF
--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -353,10 +353,16 @@ fn dynamic_linker_path(cross_arch: Option<Architecture>) -> &'static str {
 fn host_dynamic_linker_cached() -> &'static str {
     static VALUE: OnceLock<String> = OnceLock::new();
     let value = VALUE.get_or_init(|| {
-        ["/bin/true", "/bin/ls", "/usr/bin/ls", "/proc/self/exe"]
-            .into_iter()
-            .find_map(get_dynamic_linker)
-            .expect("Failed to find a suitable host dynamically linked binary")
+        [
+            "/bin/true",
+            "/bin/ls",
+            "/usr/bin/ls",
+            "/proc/self/exe",
+            "/bin/less",
+        ]
+        .into_iter()
+        .find_map(get_dynamic_linker)
+        .expect("Failed to find a suitable host dynamically linked binary")
     });
     value.as_str()
 }


### PR DESCRIPTION
More Illumos fun! This change checks `less` for a dynamic linker as well. Formatting the array makes the change look larger than it is. Combined with https://github.com/davidlattimore/wild/pull/1158 we are now up to 27 passing integ tests on Illumos, up from just 9. As for why `less`? Well, it's a pager that's pretty pervasively installed, so why not make a last-ditch effort there?

It turns out that on Illumos, lots of coreutils are actually 32-bit binaries. I tracked this down to [here](https://github.com/daniel-levin/wild/blob/cb5006b439de1f3ea3c8e76a2766ca37c2c186b2/wild/tests/integration_tests.rs#L374). I printed the error returned by `object` - something about invalid headers. Sure enough - `less` is 64 bit and `ls` is 32 bit!

```
❯ readelf -h /bin/less
ELF Header:
  Magic:   7f 45 4c 46 02 01 01 06 01 00 00 00 00 00 00 00
  Class:                             ELF64
  Data:                              2's complement, little endian
  Version:                           1 (current)
  OS/ABI:                            UNIX - Solaris
  ABI Version:                       1
  Type:                              EXEC (Executable file)
  Machine:                           Advanced Micro Devices X86-64
  Version:                           0x1
  Entry point address:               0x410cc0
  Start of program headers:          64 (bytes into file)
  Start of section headers:          311888 (bytes into file)
  Flags:                             0x0
  Size of this header:               64 (bytes)
  Size of program headers:           56 (bytes)
  Number of program headers:         6
  Size of section headers:           64 (bytes)
  Number of section headers:         30
  Section header string table index: 28
❯ readelf -h /bin/ls
ELF Header:
  Magic:   7f 45 4c 46 01 01 01 06 01 00 00 00 00 00 00 00
  Class:                             ELF32
  Data:                              2's complement, little endian
  Version:                           1 (current)
  OS/ABI:                            UNIX - Solaris
  ABI Version:                       1
  Type:                              EXEC (Executable file)
  Machine:                           Intel 80386
  Version:                           0x1
  Entry point address:               0x8052650
  Start of program headers:          52 (bytes into file)
  Start of section headers:          46156 (bytes into file)
  Flags:                             0x0
  Size of this header:               52 (bytes)
  Size of program headers:           32 (bytes)
  Number of program headers:         7
  Size of section headers:           40 (bytes)
  Number of section headers:         30
  Section header string table index: 29
``` 

```
thread 'integration_test::program_name_03___trivial_dynamic_c__' panicked at wild/tests/integration_tests.rs:359:14:
Failed to find a suitable host dynamically linked binary
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```