### PR TITLE
Support for handling BSD-style archives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1697,6 +1697,7 @@ dependencies = [
 name = "wild-linker"
 version = "0.6.0"
 dependencies = [
+ "ar",
  "dhat",
  "fd-lock",
  "itertools",

--- a/wild/Cargo.toml
+++ b/wild/Cargo.toml
@@ -22,6 +22,7 @@ mimalloc = { workspace = true, optional = true }
 dhat = { workspace = true, optional = true }
 
 [dev-dependencies]
+ar = { workspace = true }
 fd-lock = { workspace = true }
 itertools = { workspace = true }
 linker-diff = { path = "../linker-diff" }

--- a/wild/tests/sources/archive_activation.c
+++ b/wild/tests/sources/archive_activation.c
@@ -25,6 +25,13 @@
 //#Object:empty.a
 //#DiffIgnore:segment.GNU_STACK.alignment
 
+//#Config:bsd:default
+//#SkipLinker:ld
+//#BsdArchive:archive_activation0.c
+//#BsdArchive:archive_activation1.c
+//#BsdArchive:runtime.c
+//#BsdArchive:empty.a
+
 #include "runtime.h"
 
 int bar(void);


### PR DESCRIPTION
context: https://github.com/davidlattimore/wild/pull/1147#issuecomment-3364013506

While conducting the experiment mentioned in the above comment, I was working on Ubuntu 24.04.

I found that Dioxus was using BSD-style archive entries for some files (for reasons unknown). This is indicated by the `#1/8` part in the following error message. Since Wild currently doesn’t support handling BSD-style archives, this causes “No such file or directory” errors.

```
（▰╹◡╹）❯  PATH=.:$PATH dx serve --hot-patch
10:52:47 [dev] -----------------------------------------------------------------
                Serving your app: dio! 🚀
                • Press `ctrl+c` to exit the server
                • Press `r` to rebuild the app
                • Press `p` to toggle automatic rebuilds
                • Press `v` to toggle verbose logging
                • Press `/` for more commands and shortcuts
               ---------------------------------------------------------------- 
10:52:48 [dev] Failed to generate fat binary: wild: error: Failed to parse archive `/home/lapla/zatsu/wild_playground/dio/target/x86_64-unknown-linux-gnu/desktop-dev/libdeps-e887ab2d.a @ #1/8`
  Caused by:
    Couldn't identify file type

clang: error: linker command failed with exit code 255 (use -v to see invocation) 
10:52:48 [dev] Build failed: No such file or directory (os error 2) 
10:52:48 [dev] Verbose logging is now on 
╭──────────────────────────────────────────────────────────────────────────────── /:more ╮
│  App:     ━━━━━━━━━━━━━━━━━━━━━━━━━━  ❌           Platform: Linux                     │
│  Bundle:  ━━━━━━━━━━━━━━━━━━━━━━━━━━  ❌           App features: []                    │
│  Status:  Failed                                   Server at: no server address        │
╰────────────────────────────────────────────────────────────────────────────────────────╯
```

Although BSD are not currently supported, the fact that this behavior occurred on Ubuntu (even if it’s a somewhat niche case) — combined with the [recent discussions](https://wild.zulipchat.com/#narrow/channel/508469-general/topic/.28future.29.20FreeBSD.20support.3F/with/542491047) around BSD support — suggests that adding support for BSD-style archive entries here would be worthwhile.