### PR TITLE
RISC-V: add RISCV_ATTRIBUTE program segment

### DIFF
--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -2062,18 +2062,22 @@ fn compute_segment_layout(
                         output_sections.section_debug(section_id)
                     );
                 } else {
-                    // All segments should only cover sections that are allocated and have a non-zero address.
-                    ensure!(
-                        section_layout.mem_offset != 0 || merge_target == FILE_HEADER,
-                        "Missing memory offset for section {} present in a program segment.",
-                        output_sections.section_debug(section_id),
-                    );
-                    ensure!(
-                        section_flags.contains(shf::ALLOC),
-                        "Missing SHF_ALLOC section flag for section {} present in a program \
+                    // RISCV_ATTRIBUTES segment is kind of special as it maps a section that is non-ALLOC.
+                    if section_id == output_section_id::RISCV_ATTRIBUTES {
+                    } else {
+                        // All segments should only cover sections that are allocated and have a non-zero address.
+                        ensure!(
+                            section_layout.mem_offset != 0 || merge_target == FILE_HEADER,
+                            "Missing memory offset for section {} present in a program segment.",
+                            output_sections.section_debug(section_id),
+                        );
+                        ensure!(
+                            section_flags.contains(shf::ALLOC),
+                            "Missing SHF_ALLOC section flag for section {} present in a program \
                          segment.",
-                        output_sections.section_debug(section_id)
-                    );
+                            output_sections.section_debug(section_id)
+                        );
+                    }
                     for opt_rec in &mut active_segments {
                         let Some(rec) = opt_rec.as_mut() else {
                             continue;

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -590,6 +590,7 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = [
     BuiltInSectionDetails {
         kind: SectionKind::Primary(SectionName(RISCV_ATTRIBUTES_SECTION_NAME)),
         ty: sht::RISCV_ATTRIBUTES,
+        target_segment_type: Some(pt::RISCV_ATTRIBUTES),
         ..DEFAULT_DEFS
     },
     // Start of regular sections

--- a/libwild/src/program_segments.rs
+++ b/libwild/src/program_segments.rs
@@ -62,6 +62,10 @@ pub(crate) const PROGRAM_SEGMENT_DEFS: &[ProgramSegmentDef] = &[
         segment_type: pt::GNU_RELRO,
         segment_flags: pf::READABLE,
     },
+    ProgramSegmentDef {
+        segment_type: pt::RISCV_ATTRIBUTES,
+        segment_flags: pf::READABLE,
+    },
 ];
 
 pub(crate) const STACK_SEGMENT_DEF: ProgramSegmentDef = ProgramSegmentDef {

--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -249,8 +249,7 @@ impl Config {
                 "segment.PT_GNU_STACK.*",
                 "segment.PT_GNU_PROPERTY.*",
                 "segment.PT_GNU_SFRAME.*",
-                // TODO: RISC-v
-                "segment.SHT_RISCV_ATTRIBUTES.*",
+                // TODO: RISC-V
                 "segment.LOAD.RW.alignment",
             ]
             .into_iter()

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -640,6 +640,8 @@ pub mod pt {
     pub const DYNAMIC: SegmentType = SegmentType::from_u32(object::elf::PT_DYNAMIC);
     pub const GNU_RELRO: SegmentType = SegmentType::from_u32(object::elf::PT_GNU_RELRO);
     pub const GNU_STACK: SegmentType = SegmentType::from_u32(object::elf::PT_GNU_STACK);
+    // TODO: add constant
+    pub const RISCV_ATTRIBUTES: SegmentType = SegmentType::from_u32(0x70000003);
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/wild/tests/sources/linker-script.c
+++ b/wild/tests/sources/linker-script.c
@@ -8,6 +8,7 @@
 //#ExpectSym:start_aaa bar 8
 //#ExpectSym:end_bar bar 12
 //#DiffIgnore:section.riscv.attributes
+//#DiffIgnore:segment.SHT_RISCV_ATTRIBUTES.*
 
 static int foo1 __attribute__((used, section(".data.foo"))) = 0x01;
 


### PR DESCRIPTION
The `RISCV_ATTRIBUTES` segments is little bit special as it includes a section that is non-ALLOC:

```
Program Headers:
  RISCV_ATTRIBUTES 0x00102a 0x0000000000000000 0x0000000000000000 0x000074 0x000000 R   0x1
...
Section Headers:
[25] .riscv.attributes    RISCV_ATTRIBUTES 0000000000000000 0000102a 00000074  0        0   0  1
```

In case of Wild, for simplicity, we assign a MemSize to the segments, but it's hopefully an acceptable limitation.