### PR TITLE
integration tests: Make symbol assertions more extensible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -876,6 +876,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,10 +898,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "object"
@@ -1129,6 +1154,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "remain"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ef12e84481ab4006cb942f8682bba28ece7270743e649442027c5db87df126"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "rstest"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,6 +1259,19 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-keyvalue"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d2701d07ab4695b24a86b4a970431a6917f85473f500ccaf386f567da3957a7"
+dependencies = [
+ "nom",
+ "num-traits",
+ "remain",
+ "serde",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1412,11 +1461,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.17",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1708,6 +1777,7 @@ dependencies = [
  "os_info",
  "rstest",
  "serde",
+ "serde-keyvalue",
  "strum",
  "toml",
  "wait-timeout",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ postcard = { version = "1.1.1", features = ["use-std"] }
 rayon = "1.5.1"
 rstest = "0.26.1"
 serde = { version = "1.0.219", features = ["derive"] }
+serde-keyvalue = "0.1.0"
 sharded-offset-map = "0.2.0"
 sharded-vec-writer = "0.4.0"
 smallvec = "1.6.1"

--- a/wild/Cargo.toml
+++ b/wild/Cargo.toml
@@ -30,6 +30,7 @@ object = { workspace = true }
 os_info = { workspace = true }
 rstest = { workspace = true }
 serde = { workspace = true }
+serde-keyvalue = { workspace =  true }
 strum = { workspace = true }
 toml = { workspace = true }
 wait-timeout = { workspace = true }

--- a/wild/tests/sources/common_section.c
+++ b/wild/tests/sources/common_section.c
@@ -32,7 +32,7 @@ void _start(void) {
   exit_syscall(42);
 }
 
-//#ExpectSym: a .bss
-//#ExpectSym: data .bss
-//#ExpectSym: q .bss
-//#ExpectSym: z .bss
+//#ExpectSym: a section=".bss"
+//#ExpectSym: data section=".bss"
+//#ExpectSym: q section=".bss"
+//#ExpectSym: z section=".bss"

--- a/wild/tests/sources/custom_section.c
+++ b/wild/tests/sources/custom_section.c
@@ -97,5 +97,5 @@ void _start(void) {
   exit_syscall(value);
 }
 
-//#ExpectSym: dot1 .dot
-//#ExpectSym: dot2 .dot.2
+//#ExpectSym: dot1 section=".dot"
+//#ExpectSym: dot2 section=".dot.2"

--- a/wild/tests/sources/ifunc.c
+++ b/wild/tests/sources/ifunc.c
@@ -18,12 +18,12 @@
 //#LinkArgs:--got-plt-syms
 //#SkipLinker:ld
 //#DiffEnabled:false
-//#ExpectSym:compute_value10$got .got
-//#ExpectSym:compute_value32$got .got
-//#ExpectSym:compute_unused$got .got
-//#ExpectSym:compute_value10$plt .plt.got
-//#ExpectSym:compute_value32$plt .plt.got
-//#ExpectSym:compute_unused$plt .plt.got
+//#ExpectSym:compute_value10$got section=".got"
+//#ExpectSym:compute_value32$got section=".got"
+//#ExpectSym:compute_unused$got section=".got"
+//#ExpectSym:compute_value10$plt section=".plt.got"
+//#ExpectSym:compute_value32$plt section=".plt.got"
+//#ExpectSym:compute_unused$plt section=".plt.got"
 
 #include "ifunc_init.h"
 #include "init.h"

--- a/wild/tests/sources/linker-script.c
+++ b/wild/tests/sources/linker-script.c
@@ -1,12 +1,12 @@
 //#Mode:dynamic
 //#LinkArgs:-shared -z now -T ./linker-script.ld
 //#DiffIgnore:section.got
-//#ExpectDynSym:start_bar bar 0
-//#ExpectDynSym:start_aaa bar 8
-//#ExpectDynSym:end_bar bar 12
-//#ExpectSym:start_bar bar 0
-//#ExpectSym:start_aaa bar 8
-//#ExpectSym:end_bar bar 12
+//#ExpectDynSym:start_bar section="bar",offset-in-section=0
+//#ExpectDynSym:start_aaa section="bar",offset-in-section=8
+//#ExpectDynSym:end_bar section="bar",offset-in-section=12
+//#ExpectSym:start_bar section="bar",offset-in-section=0
+//#ExpectSym:start_aaa section="bar",offset-in-section=8
+//#ExpectSym:end_bar section="bar",offset-in-section=12
 //#DiffIgnore:section.riscv.attributes
 //#DiffIgnore:segment.SHT_RISCV_ATTRIBUTES.*
 

--- a/wild/tests/sources/symbol-versions.c
+++ b/wild/tests/sources/symbol-versions.c
@@ -9,8 +9,8 @@
 //#Config:verneed
 //#Object:runtime.c
 //#Object:symbol-versions-2.c
-//#ExpectSym: _start .text
-//#ExpectSym: exit_syscall .text
+//#ExpectSym: _start section=".text"
+//#ExpectSym: exit_syscall section=".text"
 //#EnableLinker:lld
 
 //#Config:verdef-0:verdef

--- a/wild/tests/sources/trivial.c
+++ b/wild/tests/sources/trivial.c
@@ -1,6 +1,6 @@
 //#Object:runtime.c
-//#ExpectSym: _start .text
-//#ExpectSym: exit_syscall .text
+//#ExpectSym:_start section=".text"
+//#ExpectSym:exit_syscall section=".text"
 //#EnableLinker:lld
 
 #include "runtime.h"


### PR DESCRIPTION
Symbol asssertions (e.g. ExpectSym, ExpectDynSym) now take a list of key-value pairs rather than positional arguments. This will allow us to add more assertions.

This is to help with #1156