### PR TITLE
Add instructions for using Wild with Rust on Illumos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,23 @@ See [nix/nix.md](nix/nix.md)
 If you'd like to use Wild as your default linker for building Rust code, you can put the following
 in `~/.cargo/config.toml`.
 
+On Linux:
 ```toml
 [target.x86_64-unknown-linux-gnu]
 linker = "clang"
 rustflags = ["-C", "link-arg=--ld-path=wild"]
+```
+
+On Illumos:
+```
+[target.x86_64-unknown-illumos]
+# Absolute path to clang - on OmniOS this is likely something like /opt/ooce/bin/clang.
+linker = "/usr/bin/clang"
+
+rustflags = [
+    # Will silently delegate to GNU ld or Sun ld unless the absolute path to Wild is provided.
+    "-C", "link-arg=-fuse-ld=/absolute/path/to/wild"
+]
 ```
 
 ## Using wild in CI


### PR DESCRIPTION
The actual, correct resolution to #1153. It turns out that Clang is [very picky](https://github.com/llvm/llvm-project/blob/4c8275470465528c469436d37b9aaf71d6598899/clang/lib/Driver/ToolChains/Solaris.cpp#L95) and platform-dependent about delegating to arbitrary linkers. Mercifully, Clang _will_ still provide GNU-ld compatible arguments to Wild. As such there is no need to understand Sun ld's argument parser.