### PR TITLE
Add Illumos-specific defaults.

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -260,7 +260,13 @@ const SILENTLY_IGNORED_FLAGS: &[&str] = &[
     "sort-common",
     "stats",
 ];
-const SILENTLY_IGNORED_SHORT_FLAGS: &[&str] = &["(", ")"];
+const SILENTLY_IGNORED_SHORT_FLAGS: &[&str] = &[
+    "(",
+    ")",
+    // On Illumos, the Clang driver inserts a meaningless -C flag before calling any non-GNU ld linker.
+    #[cfg(target_os = "illumos")]
+    "C",
+];
 
 const IGNORED_FLAGS: &[&str] = &[
     "gdb-index",
@@ -292,6 +298,9 @@ impl Default for Args {
             inputs: Vec::new(),
             output: Arc::from(Path::new("a.out")),
             is_dynamic_executable: AtomicBool::new(false),
+            #[cfg(target_os = "illumos")]
+            dynamic_linker: Some(Path::new("/lib/amd64/ld.so.1").into()),
+            #[cfg(not(target_os = "illumos"))]
             dynamic_linker: None,
             output_kind: None,
             time_phase_options: None,


### PR DESCRIPTION
1. Ignore the -C flag Clang passes only on Illumos
2. Provide a default argument to --dynamic-linker

These changes are sufficient for Wild to link ripgrep (and a few small programs I tried too)

I don't really like the _look_ of this platform-specific code but I think it will suffice for now.