### PR TITLE
better error message when test unexpectedly pasess

### DIFF
--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -2562,8 +2562,13 @@ fn run_with_config(
             let result = program_inputs
                 .build(linker, config, cross_arch)
                 .with_context(|| {
+                    let message = if config.expect_errors.is_empty() {
+                        "Failed"
+                    } else {
+                        "Unexpectedly succeeded"
+                    };
                     format!(
-                        "Failed to build program `{program_inputs}` \
+                        "{message} to build program `{program_inputs}` \
                         with linker `{linker}` config `{}`",
                         config.name
                     )


### PR DESCRIPTION
Currently when test expects error and fails (so linking/building succeeds) the error message is confusing.

Before:
```
Error: Failed to build program `relocation-overflow.c` with linker `wild` config `default`
  Caused by:
    Linker returned exit status of 0, when an error was expected. Command:... // irrelevant
```
After this PR:
```
Error: Unexpectedly succeeded to build program `relocation-overflow.c` with linker `wild` config `default`
  Caused by:
    Linker returned exit status of 0, when an error was expected. Command:...// irrelevant
```
    
