### PR TITLE
Only emit `PT_INTERP` for shared executables

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -613,6 +613,10 @@ impl OutputKind {
         matches!(self, OutputKind::SharedObject)
     }
 
+    pub(crate) fn is_dynamic_executable(self) -> bool {
+        matches!(self, OutputKind::DynamicExecutable(_))
+    }
+
     pub(crate) fn is_static_executable(self) -> bool {
         matches!(self, OutputKind::StaticExecutable(_))
     }
@@ -1549,7 +1553,6 @@ fn setup_argument_parser() -> ArgumentParser {
         .long("dynamic-linker")
         .help("Set dynamic linker path")
         .execute(|args, _modifier_stack, value| {
-            args.is_dynamic_executable.store(true, Ordering::Relaxed);
             args.dynamic_linker = Some(Box::from(Path::new(value)));
             Ok(())
         });

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3237,13 +3237,20 @@ impl<'data> PreludeLayoutState<'data> {
             common.allocate(part_id::DYNSYM, size_of::<elf::SymtabEntry>() as u64);
         }
 
-        self.dynamic_linker = resources
+        if resources
             .symbol_db
             .args
-            .dynamic_linker
-            .as_ref()
-            .map(|p| CString::new(p.as_os_str().as_encoded_bytes()))
-            .transpose()?;
+            .output_kind()
+            .is_dynamic_executable()
+        {
+            self.dynamic_linker = resources
+                .symbol_db
+                .args
+                .dynamic_linker
+                .as_ref()
+                .map(|p| CString::new(p.as_os_str().as_encoded_bytes()))
+                .transpose()?;
+        }
         if let Some(dynamic_linker) = self.dynamic_linker.as_ref() {
             common.allocate(
                 part_id::INTERP,

--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -243,7 +243,6 @@ impl Config {
                 "segment.LOAD.R.*",
                 // We haven't provided an implementation that is compatible with existing linkers.
                 "segment.PT_NOTE.*",
-                "segment.PT_INTERP.*",
                 "segment.PT_PHDR.*",
                 "segment.PT_GNU_RELRO.*",
                 "segment.PT_GNU_STACK.*",


### PR DESCRIPTION
Looks to be already well covered by the tests.