### PR TITLE
Merge ResolutionFlags and ValueFlags

### DIFF
--- a/libwild/src/aarch64.rs
+++ b/libwild/src/aarch64.rs
@@ -135,7 +135,7 @@ impl crate::arch::Relaxation for Relaxation {
         relocation_kind: u32,
         section_bytes: &[u8],
         offset_in_section: u64,
-        value_flags: crate::resolution::ValueFlags,
+        flags: crate::resolution::ValueFlags,
         output_kind: crate::args::OutputKind,
         section_flags: linker_utils::elf::SectionFlags,
         non_zero_address: bool,
@@ -144,10 +144,10 @@ impl crate::arch::Relaxation for Relaxation {
         Self: std::marker::Sized,
     {
         let mut relocation = AArch64::relocation_from_raw(relocation_kind).unwrap();
-        let interposable = value_flags.is_interposable();
+        let interposable = flags.is_interposable();
 
         // IFuncs cannot be referenced directly, they always need to go via the GOT.
-        if value_flags.is_ifunc() {
+        if flags.is_ifunc() {
             return match relocation_kind {
                 object::elf::R_AARCH64_CALL26 | object::elf::R_AARCH64_JUMP26 => {
                     relocation.kind = RelocationKind::PltRelative;

--- a/libwild/src/arch.rs
+++ b/libwild/src/arch.rs
@@ -107,7 +107,7 @@ pub(crate) trait Relaxation {
         relocation_kind: u32,
         section_bytes: &[u8],
         offset_in_section: u64,
-        value_flags: ValueFlags,
+        flags: ValueFlags,
         output_kind: OutputKind,
         section_flags: SectionFlags,
         non_zero_address: bool,

--- a/libwild/src/diagnostics.rs
+++ b/libwild/src/diagnostics.rs
@@ -1,7 +1,7 @@
 use crate::grouping::SequencedInput;
 use crate::input_data::FileId;
 use crate::input_data::PRELUDE_FILE_ID;
-use crate::layout::AtomicResolutionFlags;
+use crate::resolution::AtomicValueFlags;
 use crate::resolution::ResolvedFile;
 use crate::resolution::ResolvedGroup;
 use crate::sharding::ShardKey as _;
@@ -16,7 +16,7 @@ pub(crate) struct SymbolInfoPrinter<'data> {
     loaded_file_ids: hashbrown::HashSet<FileId>,
     symbol_db: &'data SymbolDb<'data>,
     name: &'data str,
-    resolution_flags: &'data [AtomicResolutionFlags],
+    flags: &'data [AtomicValueFlags],
 }
 
 impl Drop for SymbolInfoPrinter<'_> {
@@ -29,7 +29,7 @@ impl<'data> SymbolInfoPrinter<'data> {
     pub(crate) fn new(
         symbol_db: &'data SymbolDb,
         name: &'data str,
-        resolution_flags: &'data [AtomicResolutionFlags],
+        flags: &'data [AtomicValueFlags],
         groups: &[ResolvedGroup],
     ) -> Self {
         let loaded_file_ids = groups
@@ -49,7 +49,7 @@ impl<'data> SymbolInfoPrinter<'data> {
             loaded_file_ids,
             symbol_db,
             name,
-            resolution_flags,
+            flags,
         }
     }
 
@@ -69,8 +69,7 @@ impl<'data> SymbolInfoPrinter<'data> {
             let symbol_id = SymbolId::from_usize(i);
             let canonical = self.symbol_db.definition(symbol_id);
             let file_id = self.symbol_db.file_id_for_symbol(symbol_id);
-            let value_flags = self.symbol_db.local_symbol_value_flags(symbol_id);
-            let res_flags = self.resolution_flags[symbol_id.as_usize()].get();
+            let flags = self.flags[symbol_id.as_usize()].get();
 
             let file_state = if self.loaded_file_ids.contains(&file_id) {
                 "LOADED"
@@ -119,8 +118,8 @@ impl<'data> SymbolInfoPrinter<'data> {
                 }
 
                 println!(
-                    "  {sym_debug}: symbol_id={symbol_id} -> {canonical} {value_flags} \
-                            res=[{res_flags}] \n    \
+                    "  {sym_debug}: symbol_id={symbol_id} -> {canonical} {flags} \
+                            \n    \
                             #{local_index} in File #{file_id} {input} ({file_state})"
                 );
             }

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -54,7 +54,8 @@ use rayon::iter::IntoParallelRefIterator;
 use rayon::iter::IntoParallelRefMutIterator;
 use rayon::iter::ParallelIterator;
 use std::num::NonZeroU32;
-use std::sync::atomic::AtomicU8;
+use std::sync::atomic;
+use std::sync::atomic::AtomicU16;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
@@ -1051,8 +1052,11 @@ impl SectionSlot {
 }
 
 bitflags! {
+    /// Information and state of a symbol or section. Some of this information comes from the object
+    /// that defined the symbol or section and some is computed based on what kinds of references we
+    /// encounter to it.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub(crate) struct ValueFlags: u8 {
+    pub(crate) struct ValueFlags: u16 {
         /// Something with an address. e.g. a regular symbol, a section etc.
         const ADDRESS = 1 << 0;
 
@@ -1082,10 +1086,45 @@ bitflags! {
         /// Set when the value is a function. Currently only set for dynamic symbols, since that's
         /// all we need it for.
         const FUNCTION = 1 << 6;
+
+        /// The direct value is needed. e.g. via a relative or absolute relocation that doesn't use the
+        /// PLT or GOT.
+        const DIRECT = 1 << 7;
+
+        /// An address in the global offset table is needed.
+        const GOT = 1 << 8;
+
+        /// A PLT entry is needed.
+        const PLT = 1 << 9;
+
+        /// A double GOT entry is needed in order to store the module number and offset within the
+        /// module. Only set for TLS variables.
+        const GOT_TLS_MODULE = 1 << 10;
+
+        /// A single GOT entry is needed to store the offset of the TLS variable within the initial
+        /// TLS block.
+        const GOT_TLS_OFFSET = 1 << 11;
+
+        /// A double GOT entry is needed in order to store the function pointer and a pointer that
+        /// points to a pair of words (module number and offset within the module).
+        /// Only set for TLS variables.
+        const GOT_TLS_DESCRIPTOR = 1 << 12;
+
+        /// The request originated from a dynamic object, so the symbol should be put into the dynamic
+        /// symbol table.
+        const EXPORT_DYNAMIC = 1 << 13;
+
+        /// We encountered a direct reference to a symbol from a non-writable section and so we're
+        /// going to need to do a copy relocation. Note that multiple symbols can have this flag
+        /// set, however if they all point at the same address in the shared object from which they
+        /// originate, only a single copy relocation will be emitted. This flag indicates that the
+        /// symbol requires a copy relocation, not necessarily that a copy relocation will be
+        /// emitted with the exact name of this symbol.
+        const COPY_RELOCATION = 1 << 14;
     }
 }
 
-pub(crate) struct AtomicValueFlags(AtomicU8);
+pub(crate) struct AtomicValueFlags(AtomicU16);
 
 impl ValueFlags {
     /// Returns self merged with `other` which should be the flags for the local (possibly
@@ -1097,6 +1136,25 @@ impl ValueFlags {
         if other.contains(ValueFlags::NON_INTERPOSABLE) {
             *self |= ValueFlags::NON_INTERPOSABLE;
         }
+    }
+
+    /// Returns the subset of the set flags that relate to resolutions.
+    pub(crate) fn resolution_flags(self) -> ValueFlags {
+        self.intersection(
+            ValueFlags::DIRECT
+                | ValueFlags::GOT
+                | ValueFlags::PLT
+                | ValueFlags::GOT_TLS_MODULE
+                | ValueFlags::GOT_TLS_OFFSET
+                | ValueFlags::GOT_TLS_DESCRIPTOR
+                | ValueFlags::EXPORT_DYNAMIC
+                | ValueFlags::COPY_RELOCATION,
+        )
+    }
+
+    #[must_use]
+    pub(crate) fn has_resolution(self) -> bool {
+        !self.resolution_flags().is_empty()
     }
 
     #[must_use]
@@ -1134,21 +1192,77 @@ impl ValueFlags {
     }
 
     pub(crate) fn as_atomic(self) -> AtomicValueFlags {
-        AtomicValueFlags(AtomicU8::new(self.0.bits()))
+        AtomicValueFlags(AtomicU16::new(self.0.bits()))
+    }
+
+    #[must_use]
+    pub(crate) fn needs_direct(self) -> bool {
+        self.contains(ValueFlags::DIRECT)
+    }
+
+    #[must_use]
+    pub(crate) fn needs_copy_relocation(self) -> bool {
+        self.contains(ValueFlags::COPY_RELOCATION)
+    }
+
+    #[must_use]
+    pub(crate) fn needs_export_dynamic(self) -> bool {
+        self.contains(ValueFlags::EXPORT_DYNAMIC)
+    }
+
+    #[must_use]
+    pub(crate) fn needs_got(self) -> bool {
+        self.contains(ValueFlags::GOT)
+    }
+
+    #[must_use]
+    pub(crate) fn needs_plt(self) -> bool {
+        self.contains(ValueFlags::PLT)
+    }
+
+    #[must_use]
+    pub(crate) fn needs_got_tls_offset(self) -> bool {
+        self.contains(ValueFlags::GOT_TLS_OFFSET)
+    }
+
+    #[must_use]
+    pub(crate) fn needs_got_tls_module(self) -> bool {
+        self.contains(ValueFlags::GOT_TLS_MODULE)
+    }
+
+    #[must_use]
+    pub(crate) fn needs_got_tls_descriptor(self) -> bool {
+        self.contains(ValueFlags::GOT_TLS_DESCRIPTOR)
     }
 }
 
 impl AtomicValueFlags {
-    pub(crate) fn get(&self) -> ValueFlags {
-        ValueFlags::from_bits_retain(self.0.load(Ordering::Relaxed))
-    }
-
-    pub(crate) fn or_assign(&self, flags: ValueFlags) {
-        self.0.fetch_or(flags.bits(), Ordering::Relaxed);
+    pub(crate) fn new(flags: ValueFlags) -> Self {
+        Self(AtomicU16::new(flags.bits()))
     }
 
     pub(crate) fn into_non_atomic(self) -> ValueFlags {
         ValueFlags::from_bits_retain(self.0.into_inner())
+    }
+
+    pub(crate) fn fetch_or(&self, flags: ValueFlags) -> ValueFlags {
+        // Calling fetch_or on our atomic requires that we gain exclusive access to the cache line
+        // containing the atomic. If all the bits are already set, then that's wasteful, so we first
+        // check if the bits are set and if they are, we skip the fetch_or call.
+        let current_bits = self.0.load(atomic::Ordering::Relaxed);
+        if current_bits & flags.bits() == flags.bits() {
+            return ValueFlags::from_bits_retain(current_bits);
+        }
+        let previous_bits = self.0.fetch_or(flags.bits(), atomic::Ordering::Relaxed);
+        ValueFlags::from_bits_retain(previous_bits)
+    }
+
+    pub(crate) fn get(&self) -> ValueFlags {
+        ValueFlags::from_bits_retain(self.0.load(atomic::Ordering::Relaxed))
+    }
+
+    pub(crate) fn or_assign(&self, flags: ValueFlags) {
+        self.0.fetch_or(flags.bits(), Ordering::Relaxed);
     }
 }
 

--- a/libwild/src/riscv64.rs
+++ b/libwild/src/riscv64.rs
@@ -144,7 +144,7 @@ impl crate::arch::Relaxation for Relaxation {
         relocation_kind: u32,
         section_bytes: &[u8],
         offset_in_section: u64,
-        value_flags: crate::resolution::ValueFlags,
+        flags: crate::resolution::ValueFlags,
         output_kind: crate::args::OutputKind,
         section_flags: linker_utils::elf::SectionFlags,
         non_zero_address: bool,
@@ -153,7 +153,7 @@ impl crate::arch::Relaxation for Relaxation {
         Self: std::marker::Sized,
     {
         let mut relocation = RiscV64::relocation_from_raw(relocation_kind).unwrap();
-        let interposable = value_flags.is_interposable();
+        let interposable = flags.is_interposable();
 
         // All relaxations below only apply to executable code, so we shouldn't attempt them if a
         // relocation is in a non-executable section.

--- a/libwild/src/validation.rs
+++ b/libwild/src/validation.rs
@@ -70,12 +70,11 @@ fn validate_resolution(
     got: &crate::elf::SectionHeader,
     got_data: &[u8],
 ) -> Result {
-    let res_flags = resolution.resolution_flags;
-    let value_flags = resolution.value_flags;
-    if value_flags.is_ifunc()
-        || res_flags.needs_got_tls_module()
-        || res_flags.needs_got_tls_offset()
-        || res_flags.needs_got_tls_descriptor()
+    let flags = resolution.flags;
+    if flags.is_ifunc()
+        || flags.needs_got_tls_module()
+        || flags.needs_got_tls_offset()
+        || flags.needs_got_tls_descriptor()
     {
         return Ok(());
     };
@@ -85,7 +84,7 @@ fn validate_resolution(
         if end_offset > got_data.len() {
             bail!("GOT offset beyond end of GOT 0x{end_offset}");
         }
-        if resolution.value_flags.is_dynamic() || resolution.value_flags.is_ifunc() {
+        if resolution.flags.is_dynamic() || resolution.flags.is_ifunc() {
             return Ok(());
         }
         let expected = resolution.raw_value;
@@ -93,7 +92,7 @@ fn validate_resolution(
         if expected != address {
             let name = String::from_utf8_lossy(name);
             bail!(
-                "res={res_flags:?} `{name}` has address 0x{expected:x}, but GOT \
+                "flags={flags:?} `{name}` has address 0x{expected:x}, but GOT \
                  (at 0x{got_address:x}) points to 0x{address:x}"
             );
         }

--- a/libwild/src/x86_64.rs
+++ b/libwild/src/x86_64.rs
@@ -121,22 +121,22 @@ impl crate::arch::Relaxation for Relaxation {
         relocation_kind: u32,
         section_bytes: &[u8],
         offset_in_section: u64,
-        value_flags: ValueFlags,
+        flags: ValueFlags,
         output_kind: OutputKind,
         section_flags: SectionFlags,
         _non_zero_address: bool,
     ) -> Option<Self> {
-        let is_known_address = value_flags.is_address();
-        let is_absolute = value_flags.is_absolute() && !value_flags.is_dynamic();
+        let is_known_address = flags.is_address();
+        let is_absolute = flags.is_absolute() && !flags.is_dynamic();
         let non_relocatable = !output_kind.is_relocatable();
         let is_absolute_address = is_known_address && non_relocatable;
-        let interposable = value_flags.is_interposable();
+        let interposable = flags.is_interposable();
 
         // IFuncs cannot be referenced directly. They always need to go via the GOT. So if we've got
         // say a PLT32 relocation, we don't want to relax it even if we're in a static executable.
         // Furthermore, if we encounter a relocation like PC32 to an ifunc, then we need to change
         // it so that it goes via the GOT. This is kind of the opposite of relaxation.
-        if value_flags.is_ifunc() {
+        if flags.is_ifunc() {
             return match relocation_kind {
                 object::elf::R_X86_64_PC32 => {
                     return Some(Relaxation {


### PR DESCRIPTION
The two were previously stored separately, but we often need them at the same time. Previously they each were stored as a u8, now together they're stored as a u16. So it takes the same amount of space, but we have more flexibilty about what we use free bits for. In particular, ResolutionFlags was previously full, so we couldn't add any additional resolution flags. Now we can.

Perhaps more importantly, we now have the option of packing bits of what was previously ResolutionFlags based on a bit in what was previously ValueFlags. Specifically, we could overlap GOT,PLT with
GOT_TLS_MODULE,GOT_TLS_OFFSET,GOT_TLS_DESCRIPTOR and select between the two based on a new bit that indicates if the value is a TLS.

The main downside of this change is that it expands the scope during which SymbolDb doesn't have direct access to what was ValueFlags. There's a TODO on take_flags_atomic to try to fix this.