### PR TITLE
Link musl releases with Wild

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,14 +21,18 @@ jobs:
           - { target: aarch64-unknown-linux-gnu, runs-on: ubuntu-22.04-arm }
           - { target: riscv64gc-unknown-linux-gnu, runs-on: ubuntu-22.04-arm, build: zigbuild }
 
-          - { target: x86_64-unknown-linux-musl, runs-on: ubuntu-22.04, build: zigbuild, args: --features=mimalloc }
-          - { target: aarch64-unknown-linux-musl, runs-on: ubuntu-22.04-arm, build: zigbuild, args: --features=mimalloc }
+          - { target: x86_64-unknown-linux-musl, runs-on: ubuntu-22.04, musl: true, args: --features=mimalloc }
+          - { target: aarch64-unknown-linux-musl, runs-on: ubuntu-22.04-arm, musl: true, args: --features=mimalloc }
           - { target: riscv64gc-unknown-linux-musl, runs-on: ubuntu-22.04-arm, build: zigbuild, args: --features=mimalloc }
  
     steps:
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install -y clang
       if: matrix.build != 'zigbuild'
+
+    - name: Install musl tools
+      run: sudo apt-get update && sudo apt-get install -y musl-tools
+      if: matrix.musl == true
 
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
Works as expected:
```
❯ readelf -p .comment ~/Pobrane/wild-linker-gha-try-x86_64-unknown-linux-musl/wild

String dump of section '.comment':
  [     0]  GCC: (Ubuntu 11.4.0-1ubuntu1~22.04.2) 11.4.0
  [    2d]  GCC: (GNU) 9.4.0
  [    3f]  rustc version 1.90.0 (1159e78c4 2025-09-14)
  [    6b]  Linker: Wild version 0.6.0
```