### PR TITLE
print clang version when clang-format fails

### DIFF
--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -2834,8 +2834,14 @@ mod tidy {
             if !stderr.is_empty() {
                 out.push_str(&stderr);
             }
+            let clang_out = Command::new("clang-format")
+                .arg("--version")
+                .output()
+                .expect("Failed to spawn `clang-format --version`");
+            let clang_version = String::from_utf8_lossy(&clang_out.stdout);
+            let version_no_endline = clang_version.trim_end_matches('\n');
             panic!(
-                "clang-format check failed:\n{out}\nRun `clang-format -i {sources_path}/*.{{{extensions_str}}}` to fix it.",
+                "clang-format ({version_no_endline}) check failed:\n{out}\nRun `clang-format -i {sources_path}/*.{{{extensions_str}}}` to fix it.",
                 extensions_str = extensions.join(",")
             )
         }


### PR DESCRIPTION
Display clang version when clang-format fails.
May be useful when clang-format unexpectedly fails in CI.

before:
`clang-format check failed:`
after:
`clang-format version 20.1.4 check failed:`