### PR TITLE
Don't create GOT/PLT entries for ifuncs that aren't referenced

### DIFF
--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -1237,10 +1237,6 @@ impl ValueFlags {
 }
 
 impl AtomicValueFlags {
-    pub(crate) fn new(flags: ValueFlags) -> Self {
-        Self(AtomicU16::new(flags.bits()))
-    }
-
     pub(crate) fn into_non_atomic(self) -> ValueFlags {
         ValueFlags::from_bits_retain(self.0.into_inner())
     }

--- a/wild/tests/sources/ifunc.c
+++ b/wild/tests/sources/ifunc.c
@@ -20,10 +20,10 @@
 //#DiffEnabled:false
 //#ExpectSym:compute_value10$got section=".got"
 //#ExpectSym:compute_value32$got section=".got"
-//#ExpectSym:compute_unused$got section=".got"
+//#NoSym:compute_unused$got
 //#ExpectSym:compute_value10$plt section=".plt.got"
 //#ExpectSym:compute_value32$plt section=".plt.got"
-//#ExpectSym:compute_unused$plt section=".plt.got"
+//#NoSym:compute_unused$plt
 
 #include "ifunc_init.h"
 #include "init.h"


### PR DESCRIPTION
Logic for deciding when to create PLT and GOT entries for ifuncs has been moved to when we request the symbol rather than after the GC phase. This means that it isn't applied to ifuncs that aren't referenced and are only loaded because they weren't GCed.