### PR TITLE
Linker script: support `VERSION` command

### DIFF
--- a/libwild/src/input_data.rs
+++ b/libwild/src/input_data.rs
@@ -322,6 +322,17 @@ impl<'data> InputData<'data> {
                 self.files.append(&mut input_files);
             }
             Some(LoadedFileState::LinkerScript(loaded_linker_script_state)) => {
+                // Check if the linker script contains a VERSION command
+                if let Some(version_content) = loaded_linker_script_state
+                    .script
+                    .script
+                    .get_version_script_content()
+                {
+                    self.version_script_data = Some(ScriptData {
+                        raw: version_content,
+                    });
+                }
+
                 self.linker_scripts.push(loaded_linker_script_state.script);
 
                 for i in loaded_linker_script_state.file_indexes {

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -106,7 +106,7 @@ tests = [
 
 [skipped_groups.linker_script]
 reason = "Linker script support"
-tests  = ["linker-script-defsym.sh", "linker-script.sh", "linker-script4.sh"]
+tests  = ["linker-script-defsym.sh", "linker-script.sh"]
 
 [skipped_groups.z_options]
 reason = "Related to -z"


### PR DESCRIPTION
As noted in [this discussion](https://wild.zulipchat.com/#narrow/channel/508469-general/topic/Gentoo.20testing.20with.20Wild/with/543727426), `emerge mariadb-connector-c` currently fails on Gentoo, producing the following error message:
```
wild: error: Failed to parse linker script `/var/tmp/portage/dev-db/mariadb-connector-c-3.4.5-r1/work/mariadb-connector-c-3.4.5-src_build-abi_x86_64.amd64/libmariadb/mariadbclient.def`:
parse error at line 1, column 9
  |
1 | VERSION {
  |         ^
```

This occurs because Wild currently lacks the capability to set symbol visibility in linker scripts in the same way as version scripts.

The PR addresses this issue by using the parser for version scripts to also handle `VERSION` commands in linker scripts, allowing them to be parsed and applied. While this is presumably a rare case, builds that involve both `VERSION` commands and version scripts now prioritize the later-defined definitions.