### PR TITLE
increase maximal supported alignment to 2^16

### DIFF
--- a/libwild/src/alignment.rs
+++ b/libwild/src/alignment.rs
@@ -9,13 +9,18 @@ pub(crate) struct Alignment {
     pub(crate) exponent: u8,
 }
 
-pub(crate) const NUM_ALIGNMENTS: usize = 16;
+/// The maximum supported alignment exponent.
+const MAX_ALIGNMENT_EXPONENT: u8 = 16;
+
+pub(crate) const NUM_ALIGNMENTS: usize = MAX_ALIGNMENT_EXPONENT as usize + 1;
 
 /// The minimum alignment that we support.
 pub(crate) const MIN: Alignment = Alignment { exponent: 0 };
 
 /// The maximum alignment that we support.
-pub(crate) const MAX: Alignment = Alignment { exponent: 15 };
+pub(crate) const MAX: Alignment = Alignment {
+    exponent: MAX_ALIGNMENT_EXPONENT,
+};
 
 /// Alignment for entries in the symbol table.
 pub(crate) const SYMTAB_ENTRY: Alignment = Alignment { exponent: 3 };

--- a/libwild/src/output_section_part_map.rs
+++ b/libwild/src/output_section_part_map.rs
@@ -212,17 +212,17 @@ fn test_merge_parts() {
             1
         });
     let num_regular_sections = output_sections.num_regular_sections();
-    let mut num_sections_with_16 = 0;
+    let mut num_sections_with_17 = 0;
     let sum_of_1s: OutputSectionMap<u32> = all_1.merge_parts(|_, values| values.iter().sum());
     let mut sum_of_sums = 0;
     sum_of_1s.for_each(|section_id, sum| {
         sum_of_sums += *sum;
-        if *sum == 16 {
-            num_sections_with_16 += 1;
+        if *sum == 17 {
+            num_sections_with_17 += 1;
         }
         assert!(*sum > 0, "Expected non-zero sum for section {section_id:?}");
     });
-    assert_eq!(num_regular_sections, num_sections_with_16);
+    assert_eq!(num_regular_sections, num_sections_with_17);
     assert_eq!(sum_of_sums, expected_sum_of_sums);
 
     let mut headers_only = output_sections.new_part_map::<u32>();

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -2710,7 +2710,8 @@ fn integration_test(
         "symbol-version-symver.c",
         "symbol-version-symver-error.c",
         "args-precedence.c",
-        "entry-in-shared.c"
+        "entry-in-shared.c",
+        "alignment.c"
     )]
     program_name: &'static str,
     #[allow(unused_variables)] setup_symlink: (),

--- a/wild/tests/sources/alignment.c
+++ b/wild/tests/sources/alignment.c
@@ -1,0 +1,17 @@
+//#LinkerDriver:gcc
+
+#define ALIGNMENT 65536
+
+struct __attribute__((aligned(ALIGNMENT))) S {
+  short f[3];
+};
+struct S object;
+
+int main() {
+  void* ptr = &object;
+  if ((unsigned long long)ptr & (ALIGNMENT - 1)) {
+    __builtin_abort();
+  }
+
+  return 42;
+}


### PR DESCRIPTION
Noticed that while building Gentoo packages, the following one uses 2^16: https://github.com/NVIDIA/libglvnd/blob/606f6627cf481ee6dcb32387edc010c502cdf38b/src/GLdispatch/vnd-glapi/entry_aarch64_tsd.c#L47-L58

The package basically needs to align to page size that could be equal to 64KiB on aarch64.