### PR TITLE
Allow parsing tokens enclosed in double quotes in linker scripts

### DIFF
--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -106,7 +106,7 @@ tests = [
 
 [skipped_groups.linker_script]
 reason = "Linker script support"
-tests  = ["linker-script-defsym.sh", "linker-script.sh"]
+tests  = ["linker-script-defsym.sh"]
 
 [skipped_groups.z_options]
 reason = "Related to -z"


### PR DESCRIPTION
It seems that in linker scripts, file names and other elements may sometimes be enclosed in double quotes.

https://www.sourceware.org/binutils/docs-2.15/ld/Script-Format.html

> If the file name contains a character such as a comma which would otherwise serve to separate file names, you may put the file name in double quotes. There is no way to use a double quote character in a file name.