### PR TITLE
Support -m elf_x86_64_sol2

### DIFF
--- a/libwild/src/arch.rs
+++ b/libwild/src/arch.rs
@@ -15,7 +15,6 @@ use object::elf::EM_RISCV;
 use object::elf::EM_X86_64;
 use std::borrow::Cow;
 use std::fmt::Display;
-use std::str::FromStr;
 
 pub(crate) trait Arch {
     type Relaxation: Relaxation;
@@ -61,19 +60,6 @@ pub(crate) enum Architecture {
     X86_64,
     AArch64,
     RISCV64,
-}
-
-impl FromStr for Architecture {
-    type Err = crate::error::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "elf_x86_64" => Ok(Architecture::X86_64),
-            "aarch64elf" | "aarch64linux" => Ok(Architecture::AArch64),
-            "elf64lriscv" => Ok(Architecture::RISCV64),
-            _ => bail!("-m {s} is not yet supported"),
-        }
-    }
 }
 
 impl TryFrom<u16> for Architecture {

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -306,9 +306,6 @@ impl Default for Args {
             inputs: Vec::new(),
             output: Arc::from(Path::new("a.out")),
             is_dynamic_executable: AtomicBool::new(false),
-            #[cfg(target_os = "illumos")]
-            dynamic_linker: Some(Path::new("/lib/amd64/ld.so.1").into()),
-            #[cfg(not(target_os = "illumos"))]
             dynamic_linker: None,
             output_kind: None,
             time_phase_options: None,
@@ -1253,7 +1250,18 @@ fn setup_argument_parser() -> ArgumentParser {
             "elf_x86_64",
             "x86-64 ELF target",
             |args, _modifier_stack, _value| {
-                args.arch = Architecture::from_str("elf_x86_64")?;
+                args.arch = Architecture::X86_64;
+                Ok(())
+            },
+        )
+        .sub_option(
+            "elf_x86_64_sol2",
+            "x86-64 ELF target (Solaris)",
+            |args, _modifier_stack, _value| {
+                if args.dynamic_linker.is_none() {
+                    args.dynamic_linker = Some(Path::new("/lib/amd64/ld.so.1").into());
+                }
+                args.arch = Architecture::X86_64;
                 Ok(())
             },
         )
@@ -1261,7 +1269,15 @@ fn setup_argument_parser() -> ArgumentParser {
             "aarch64elf",
             "AArch64 ELF target",
             |args, _modifier_stack, _value| {
-                args.arch = Architecture::from_str("aarch64elf")?;
+                args.arch = Architecture::AArch64;
+                Ok(())
+            },
+        )
+        .sub_option(
+            "aarch64linux",
+            "AArch64 ELF target (Linux)",
+            |args, _modifier_stack, _value| {
+                args.arch = Architecture::AArch64;
                 Ok(())
             },
         )
@@ -1269,13 +1285,12 @@ fn setup_argument_parser() -> ArgumentParser {
             "elf64lriscv",
             "RISC-V 64-bit ELF target",
             |args, _modifier_stack, _value| {
-                args.arch = Architecture::from_str("elf64lriscv")?;
+                args.arch = Architecture::RISCV64;
                 Ok(())
             },
         )
-        .execute(|args, _modifier_stack, value| {
-            args.arch = Architecture::from_str(value)?;
-            Ok(())
+        .execute(|_args, _modifier_stack, value| {
+            bail!("-m {value} is not yet supported");
         });
 
     parser


### PR DESCRIPTION
Currently, we have a somewhat janky workaround for getting Wild to work on Illumos: https://github.com/davidlattimore/wild/pull/1173

I've opened a PR in Clang to bring the Solaris (Illumos) driver up to parity with the others: https://github.com/llvm/llvm-project/pull/163000. Once this lands, it will be possible to use the `--ld-path` argument identically to other platforms. This benefits all linkers - including lld, Gold, Mold and Wild. That is, Clang will start to supply GNU ld-compatible flags if an unknown, non-Solaris Link Editor is supplied.

Of course, we need to then support the "emulation" `elf_x86_64_sol2`. Testing Wild with this change, and Clang with my change above, I have been able to link a couple of Rust programs, including ripgrep. Excitingly, it also links LLVM itself. Finally, I confirmed with DTrace that the arguments were expected.


```
❯ readelf -p .comment $(which rg)

String dump of section '.comment':
  [     0]  GCC: (OmniOS 151054/14.2.0-il-1) 14.2.0
  [    29]  @(#)illumos  May 2025
  [    3f]  rustc version 1.90.0 (1159e78c4 2025-09-14)
  [    6b]  Linker: Wild version 0.6.0
```

```
❯ readelf -p .comment /home/omnios/llvm-project/build/bin/clang

String dump of section '.comment':
  [     0]  GCC: (OmniOS 151054/14.2.0-il-1) 14.2.0
  [    28]  OmniOS/151054 clang version 20.1.8
  [    4c]  @(#)illumos  May 2025
  [    62]  Linker: Wild version 0.6.0
```