### PR TITLE
RISC-V: fix lookup of the riscv-fix-hi-part

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -1989,10 +1989,12 @@ fn apply_relocation<'data, A: Arch>(
             );
             let mut relocations_to_search = relocation_sequence
                 .crel_iter()
+                // In most cases, the high-part is just before the low-part.
                 .take(relocation_index)
-                // TODO
-                //.rev()
-                .chain(relocation_sequence.crel_iter().take(relocation_index + 1));
+                // TODO: iterate the relocations in reverse order for faster lookup!
+                // .rev()
+                // If not, then it's somewhere near after the low-part.
+                .chain(relocation_sequence.crel_iter().skip(relocation_index + 1));
             let hi_offset_in_section = resolution
                 .value_with_addend(
                     addend,


### PR DESCRIPTION
In some cases, the high-part can actually follow the low part as seen when linking the `slint-viewer` binary:
```
0000000000000240  0000eb2200000018 R_RISCV_PCREL_LO12_I   00000000000002a0 .Lpcrel_hi26116 + 0
...
00000000000002a0  0000eb1100000017 R_RISCV_PCREL_HI20     0000000000002620 .LCPI3435_5 + 0
```

I've just tested it fixes the `slint-viewer` linking with the Nightly toolchain.

Fixes: #1114