### PR TITLE
Replace all uses of bytemuck with zerocopy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,26 +190,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytemuck"
-version = "1.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
-dependencies = [
- "bytemuck_derive",
-]
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,7 +718,6 @@ dependencies = [
  "bitflags",
  "blake3",
  "bumpalo-herd",
- "bytemuck",
  "bytesize",
  "colored",
  "colosseum",
@@ -794,7 +773,6 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "ascii_table",
- "bytemuck",
  "clap",
  "colored",
  "fallible-iterator",
@@ -813,6 +791,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "which",
+ "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ atomic-take = "1.0.0"
 bitflags = "2.4.0"
 blake3 = { version = "1.0.0", features = ["rayon"] }
 bumpalo-herd = "0.1.0"
-bytemuck = { version = "1.10.0", features = ["derive"] }
 bytesize = "2.0.0"
 clap = { version = "4.0.0", features = ["derive"] }
 colored = "3.0.0"

--- a/cackle.toml
+++ b/cackle.toml
@@ -9,10 +9,6 @@ import_std = [
 [sandbox]
 kind = "Bubblewrap"
 
-[pkg.bytemuck_derive]
-allow_proc_macro = true
-allow_unsafe = true
-
 [pkg.unicode-ident]
 allow_unsafe = true
 
@@ -79,9 +75,6 @@ from.test.allow_apis = [
 allow_unsafe = true
 
 [pkg.rayon-core]
-allow_unsafe = true
-
-[pkg.bytemuck]
 allow_unsafe = true
 
 [pkg.object]

--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -13,7 +13,6 @@ atomic-take = { workspace = true }
 bitflags = { workspace = true }
 blake3 = { workspace = true }
 bumpalo-herd = { workspace = true }
-bytemuck = { workspace = true }
 bytesize = { workspace = true }
 colored = { workspace = true }
 colosseum = { workspace = true }

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -130,6 +130,7 @@ use std::sync::Mutex;
 use std::sync::atomic;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
+use zerocopy::FromBytes;
 
 #[tracing::instrument(skip_all, name = "Layout")]
 pub fn compute<'data, A: Arch>(
@@ -4724,8 +4725,8 @@ fn process_eh_frame_relocations<'data, 'rel: 'data, A: Arch>(
         // no guarantee that the object is aligned within the archive to any more
         // than 2 bytes, so we can't rely on alignment here. Archives are annoying!
         // See https://www.airs.com/blog/archives/170
-        let prefix: elf::EhFrameEntryPrefix =
-            bytemuck::pod_read_unaligned(&data[offset..offset + PREFIX_LEN]);
+        let prefix =
+            elf::EhFrameEntryPrefix::read_from_bytes(&data[offset..offset + PREFIX_LEN]).unwrap();
         let size = size_of_val(&prefix.length) + prefix.length as usize;
         let next_offset = offset + size;
 

--- a/libwild/src/validation.rs
+++ b/libwild/src/validation.rs
@@ -7,6 +7,7 @@ use crate::layout::Layout;
 use linker_utils::elf::secnames::GOT_SECTION_NAME_STR;
 use object::LittleEndian;
 use object::read::elf::SectionHeader as _;
+use zerocopy::FromBytes;
 
 pub(crate) fn validate_bytes(layout: &Layout, file_bytes: &[u8]) -> Result {
     let object =
@@ -88,7 +89,7 @@ fn validate_resolution(
             return Ok(());
         }
         let expected = resolution.raw_value;
-        let address = bytemuck::pod_read_unaligned(&got_data[start_offset..end_offset]);
+        let address = u64::read_from_bytes(&got_data[start_offset..end_offset]).unwrap();
         if expected != address {
             let name = String::from_utf8_lossy(name);
             bail!(

--- a/linker-diff/Cargo.toml
+++ b/linker-diff/Cargo.toml
@@ -16,7 +16,6 @@ iced-x86 = { workspace = true }
 symbolic-demangle = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
-bytemuck = { workspace = true }
 itertools = { workspace = true }
 gimli = { workspace = true }
 fallible-iterator = { workspace = true }
@@ -29,6 +28,7 @@ tempfile = { workspace = true }
 which = { workspace = true }
 ascii_table = { workspace = true }
 hashbrown = { workspace = true }
+zerocopy = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Closes #1200. Unwraps have been used where bytemuck would panic on a size mismatch, or where the size is explicitly checked before performing the conversion.