### PR TITLE
Fix a test that was expecting dynamic linking, but wasn't

### DIFF
--- a/wild/tests/sources/force-dynamic-linking.c
+++ b/wild/tests/sources/force-dynamic-linking.c
@@ -1,0 +1,5 @@
+// The contents of this file isn't really important. We link against it as a
+// shared object as a way to force the linker to produce a dynamically linked
+// executable.
+
+int x(void) {}

--- a/wild/tests/sources/string_merging.c
+++ b/wild/tests/sources/string_merging.c
@@ -12,8 +12,10 @@
 
 //#Config:export_merged_str_dyn:default
 //#Mode:dynamic
-//#LinkArgs:--export-dynamic-symbol s1w
+//#Shared:force-dynamic-linking.c
+//#LinkArgs:--export-dynamic-symbol s1w -z now
 //#DiffIgnore:.gnu.hash
+//#DiffIgnore:.dynamic.DT_NEEDED
 //#DiffIgnore:.dynamic
 //#DiffIgnore:dynsym.s1w.section
 //#DiffIgnore:segment.PT_DYNAMIC.*


### PR DESCRIPTION
Mode:dynamic adds the --dynamic-linker flag, which used to cause wild to dynamically link. Since this is no longer the case, this test wasn't actually dynamically linking. We add a check to the integration test framework that when we specify `Mode:dynamic` that we end up with .dynsym.