### PR TITLE
Set the `TRIPLE` environment variable if needed when running mold tests

### DIFF
--- a/wild/tests/external_tests/mod.rs
+++ b/wild/tests/external_tests/mod.rs
@@ -24,16 +24,21 @@ fn should_not_ignore_tests(external_test: &str) -> bool {
 }
 
 #[allow(unused)]
-fn run_external_test(external_test: &Path) -> Result<Output> {
+fn run_external_test(external_test: &Path, extra_env: &[(&str, &str)]) -> Result<Output> {
     let path = env::var("PATH")?;
     let current_dir = env::current_dir()?;
     let wild_dir = current_dir.parent().unwrap().join("fakes-debug");
 
-    Command::new("bash")
+    let mut command = Command::new("bash");
+    command
         .current_dir("../fakes-debug")
         .arg("-c")
         .arg(format!("{} 2>&1", external_test.display()))
-        .env("PATH", format!("{wild_dir:?}:{path}"))
-        .output()
-        .map_err(Into::into)
+        .env("PATH", format!("{wild_dir:?}:{path}"));
+
+    for (key, value) in extra_env {
+        command.env(key, value);
+    }
+
+    command.output().map_err(Into::into)
 }

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -161,21 +161,21 @@ reason = "Aarch64 specific tests"
 tests = [
   "arch-aarch64-long-thunk.sh",
   "arch-aarch64-range-extension-thunk-disassembly.sh",
+  "arch-aarch64-variant-pcs.sh",
 ]
 
 [skipped_groups.arch_riscv64]
 reason = "RISC-V specific tests"
 tests = [
-  "arch-riscv64-attributes.sh",
-  "arch-riscv64-global-pointer-dso.sh",
   "arch-riscv64-global-pointer.sh",
   "arch-riscv64-obj-compatible.sh",
+  "arch-riscv64-relax-align.sh",
   "arch-riscv64-relax-got.sh",
   "arch-riscv64-relax-hi20.sh",
   "arch-riscv64-relax-j.sh",
   "arch-riscv64-reloc-overflow.sh",
   "arch-riscv64-symbol-size.sh",
-  "arch-riscv64-weak-undef.sh",
+  "arch-riscv64-variant-cc.sh",
 ]
 
 [skipped_groups.tls]

--- a/wild/tests/external_tests/mold_tests.rs
+++ b/wild/tests/external_tests/mold_tests.rs
@@ -11,6 +11,7 @@ use std::env;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
+use std::process::Output;
 use std::str::FromStr;
 use std::sync::OnceLock;
 
@@ -26,6 +27,30 @@ struct SkippedGroup {
 
 static SKIP_TESTS_NAME: OnceLock<Option<Vec<String>>> = OnceLock::new();
 
+/// Run a mold test with mold-specific environment setup.
+fn run_mold_test(mold_test: &Path) -> Result<Output> {
+    // Mold tests use the `arch-` prefix to indicate architecture-specific tests.
+    // If the test is architecture-specific (e.g., arch-riscv64-*.sh),
+    // set the TRIPLE environment variable for cross-compilation
+    let triple = if let Some(file_name) = mold_test.file_name().and_then(|n| n.to_str())
+        && let Some(arch_str) = file_name.strip_prefix("arch-")
+        && let Some(arch_name) = arch_str.split('-').next()
+        && let Ok(arch) = Architecture::from_str(arch_name)
+    {
+        Some(format!("{}-linux-gnu", arch))
+    } else {
+        None
+    };
+
+    let env_vars: Vec<(&str, &str)> = if let Some(ref triple_value) = triple {
+        vec![("TRIPLE", triple_value.as_str())]
+    } else {
+        vec![]
+    };
+
+    run_external_test(mold_test, &env_vars)
+}
+
 #[rstest]
 fn check_mold_tests_regression(
     #[files("../external_test_suites/mold/test/*.sh")] mold_test: PathBuf,
@@ -34,7 +59,7 @@ fn check_mold_tests_regression(
         return Ok(());
     }
 
-    let output = run_external_test(&mold_test)?;
+    let output = run_mold_test(&mold_test)?;
     if !output.status.success() {
         let error_message = format!(
             "Mold test `{}` failed with status: {}\nOutput:\n{}",
@@ -56,7 +81,7 @@ fn verify_skipped_mold_tests_still_fail(
         return Ok(());
     }
 
-    let output = run_external_test(&mold_test)?;
+    let output = run_mold_test(&mold_test)?;
     if output.status.success() {
         return Err(format!(
             "Test `{}` is in skip list but now passes. Should be removed from skip list.",


### PR DESCRIPTION
In the mold test suite, architecture-specific tests reference the `TRIPLE` environment variable, which is set by CTest, to determine the appropriate cross-compiler. However, Wild’s current mold test execution process omitted this step, so when running tests such as `arch-riscv64-relax-got.sh`, the following output was produced because the native cc compiler was used instead:

```
---- external_tests::mold_tests::check_mold_tests_regression::mold_test_032__UP_external_test_suites_mold_test_arch_riscv64_relax_got_sh stdout ----
Error: Mold test `/home/lapla/repos/wild/external_test_suites/mold/test/arch-riscv64-relax-got.sh` failed with exit status: 1
Output:
Testing arch-riscv64-relax-got ... + cat
+ cc -o out/test/x86_64/arch-riscv64-relax-got/a.o -c -xassembler -
{standard input}: Assembler messages:
{standard input}:2: Error: unknown pseudo-op: `.option'
{standard input}:4: Error: unrecognized reloc type
{standard input}:5: Error: unrecognized reloc type
{standard input}:6: Error: no such instruction: `auipc a0,0'
{standard input}:7: Error: unrecognized reloc type
{standard input}:8: Error: unrecognized reloc type
{standard input}:9: Error: no such instruction: `ld a0,0(a0)'
{standard input}:12: Error: unrecognized reloc type
{standard input}:13: Error: unrecognized reloc type
{standard input}:14: Error: no such instruction: `auipc a0,0'
...
```
