### PR TITLE
CI: Limit the conditions for executing `update-nix-lockfile`

### DIFF
--- a/.github/workflows/update-nix-lockfile.yaml
+++ b/.github/workflows/update-nix-lockfile.yaml
@@ -8,6 +8,7 @@ name: Update Nix lockfile
 jobs:
   bump-nix:
     name: Update Nix lockfile
+    if: github.repository_owner == 'davidlattimore'
     runs-on: ubuntu-24.04
     permissions:
       contents: write


### PR DESCRIPTION
Some forks seem to periodically run the `update-nix-lockfile` action via cron. (My own fork doesn’t do this, since its `main` branch is outdated, but I noticed it while looking through other forks.)
We can prevent this by limiting the workflow’s trigger conditions to the repository owner.