### PR TITLE
Version script: Replace glob with custom matcher to support negation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
@@ -527,14 +527,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasip2",
 ]
 
 [[package]]
@@ -728,7 +728,6 @@ dependencies = [
  "foldhash",
  "gimli",
  "git-version",
- "glob",
  "hashbrown",
  "hex",
  "indexmap",
@@ -1672,15 +1671,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "wasi"
-version = "0.14.7+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
-dependencies = [
- "wasip2",
 ]
 
 [[package]]

--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -23,7 +23,6 @@ flate2 = { workspace = true }
 foldhash = { workspace = true }
 gimli = { workspace = true }
 git-version = { workspace = true }
-glob = { workspace = true }
 hashbrown = { workspace = true }
 hex = { workspace = true }
 indexmap = { workspace = true }

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -100,7 +100,6 @@ tests = [
 reason = "Version script support"
 tests = [
   "version-script-search-paths.sh",
-  "version-script15.sh",
   "version-script17.sh",
 ]
 


### PR DESCRIPTION
part of #990 

Let me start by noting that this change introduces a certain level of complexity, so I think there’s room for discussion about whether it should be merged.

As I mentioned in the issue above, using the negation character `^` in version scripts is not part of the GNU standard, but since both lld and mold support it, it would be ideal for Wild to support it as well.
The main reason this hasn’t been possible so far is that the `glob` crate hardcodes `!` as the negation character. Because of this, there are two possible solutions:

- Preprocess the version script, parsing it once to replace `^` with `!` before using the `glob` crate.
- Implement custom matching logic without relying on the `glob` crate.

The first approach would effectively require parsing twice, which is inefficient (simply replacing characters wouldn’t handle cases like [`version-script15.sh`](https://github.com/rui314/mold/blob/main/test/version-script15.sh)). Therefore, I implemented the second approach.

In practice, benchmarking with `bevy_dylib` showed no noticeable performance degradation (however the results may vary in other environments):

```
（▰╹◡╹）❯  hyperfine --warmup 2 '/tmp/wild/bevy/60/run-with ./wild.before' '/tmp/wild/bevy/60/run-with ./wild.after'
Benchmark 1: /tmp/wild/bevy/60/run-with ./wild.before
  Time (mean ± σ):      2.528 s ±  0.799 s    [User: 1.004 s, System: 0.346 s]
  Range (min … max):    2.008 s …  4.706 s    10 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Benchmark 2: /tmp/wild/bevy/60/run-with ./wild.after
  Time (mean ± σ):      2.388 s ±  0.290 s    [User: 1.010 s, System: 0.341 s]
  Range (min … max):    1.957 s …  2.955 s    10 runs

Summary
  /tmp/wild/bevy/60/run-with ./wild.after ran
    1.06 ± 0.36 times faster than /tmp/wild/bevy/60/run-with ./wild.before

```