### PR TITLE
Add readable Debug implementations for internal data structures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "dhat"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +745,7 @@ dependencies = [
  "crossbeam-channel",
  "crossbeam-queue",
  "crossbeam-utils",
+ "derive_more",
  "flate2",
  "foldhash",
  "gimli",
@@ -817,6 +839,7 @@ name = "linker-utils"
 version = "0.6.0"
 dependencies = [
  "anyhow",
+ "derive_more",
  "leb128",
  "object",
 ]
@@ -1647,6 +1670,12 @@ name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ colosseum = "0.2.2"
 crossbeam-queue = "0.3.10"
 crossbeam-utils = "0.8.18"
 crossbeam-channel = "0.5.15"
+derive_more = { version = "2.0.1", features = ["debug"] }
 dhat = { version = "0.3.3" }
 fallible-iterator = "0.3.0"
 fd-lock = "4.0.0"

--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -14,6 +14,7 @@ bitflags = { workspace = true }
 blake3 = { workspace = true }
 bumpalo-herd = { workspace = true }
 bytesize = { workspace = true }
+derive_more = { workspace = true }
 colored = { workspace = true }
 colosseum = { workspace = true }
 crossbeam-channel = { workspace = true }

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -36,6 +36,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicI64;
 use std::sync::atomic::Ordering;
 
+#[derive(Debug)]
 pub struct Args {
     pub(crate) unrecognized_options: Vec<String>,
 
@@ -117,7 +118,7 @@ pub struct Args {
     jobserver_client: Option<Client>,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum CounterKind {
     Cycles,
     Instructions,
@@ -130,7 +131,7 @@ pub enum CounterKind {
     L1dMiss,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) enum CopyRelocations {
     Allowed,
     Disallowed(CopyRelocationsDisabledReason),
@@ -2280,7 +2281,7 @@ impl FromStr for CounterKind {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) enum CopyRelocationsDisabledReason {
     Flag,
     SharedObject,

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -55,12 +55,17 @@ pub(crate) type NoteHeader = object::elf::NoteHeader64<LittleEndian>;
 type SectionTable<'data> = object::read::elf::SectionTable<'data, FileHeader>;
 type SymbolTable<'data> = object::read::elf::SymbolTable<'data, FileHeader>;
 
+#[derive(derive_more::Debug)]
 pub(crate) struct File<'data> {
     pub(crate) arch: Architecture,
+    #[debug(skip)]
     pub(crate) data: &'data [u8],
+    #[debug(skip)]
     pub(crate) sections: SectionTable<'data>,
     /// This may be symtab or dynsym depending on the file type.
+    #[debug(skip)]
     pub(crate) symbols: SymbolTable<'data>,
+    #[debug(skip)]
     pub(crate) versym: &'data [Versym],
 
     /// An iterator over the version definitions and the corresponding linked string table index.

--- a/libwild/src/export_list.rs
+++ b/libwild/src/export_list.rs
@@ -10,7 +10,7 @@ use crate::version_script::parse_matcher;
 use winnow::BStr;
 use winnow::Parser;
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub(crate) struct ExportList<'data>(MatchRules<'data>);
 
 impl<'data> ExportList<'data> {

--- a/libwild/src/grouping.rs
+++ b/libwild/src/grouping.rs
@@ -13,6 +13,7 @@ use crate::symbol_db::SymbolId;
 use crate::symbol_db::SymbolIdRange;
 use std::fmt::Display;
 
+#[derive(Debug)]
 pub(crate) enum Group<'data> {
     Prelude(Prelude<'data>),
     Objects(&'data [SequencedInputObject<'data>]),
@@ -20,18 +21,21 @@ pub(crate) enum Group<'data> {
     Epilogue(Epilogue),
 }
 
+#[derive(Debug)]
 pub(crate) struct SequencedInputObject<'data> {
     pub(crate) parsed: ParsedInputObject<'data>,
     pub(crate) symbol_id_range: SymbolIdRange,
     pub(crate) file_id: FileId,
 }
 
+#[derive(Debug)]
 pub(crate) struct SequencedLinkerScript<'data> {
     pub(crate) parsed: ProcessedLinkerScript<'data>,
     pub(crate) symbol_id_range: SymbolIdRange,
     pub(crate) file_id: FileId,
 }
 
+#[derive(Debug)]
 pub(crate) enum SequencedInput<'data> {
     Prelude(&'data Prelude<'data>),
     Object(&'data SequencedInputObject<'data>),

--- a/libwild/src/input_data.rs
+++ b/libwild/src/input_data.rs
@@ -59,11 +59,13 @@ pub(crate) struct ScriptData<'data> {
 }
 
 /// Identifies an input file. IDs start from 0 which is reserved for our prelude file.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(derive_more::Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[debug("file-{_0}")]
 pub(crate) struct FileId(u32);
 
 pub(crate) const PRELUDE_FILE_ID: FileId = FileId::new(0, 0);
 
+#[derive(Debug)]
 pub(crate) struct InputFile {
     pub(crate) filename: PathBuf,
 
@@ -76,6 +78,7 @@ pub(crate) struct InputFile {
     data: Option<FileData>,
 }
 
+#[derive(Debug)]
 pub(crate) struct FileData {
     bytes: Mmap,
 
@@ -108,6 +111,7 @@ struct InputPath {
     original: PathBuf,
 }
 
+#[derive(Debug)]
 pub(crate) struct InputLinkerScript<'data> {
     pub(crate) script: LinkerScript<'data>,
     pub(crate) input_file: &'data InputFile,

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -605,6 +605,7 @@ fn compute_total_file_size(section_layouts: &OutputSectionMap<OutputRecordLayout
 
 /// Information about what goes where. Also includes relocation data, since that's computed at the
 /// same time.
+#[derive(Debug)]
 pub struct Layout<'data> {
     pub(crate) symbol_db: SymbolDb<'data>,
     pub(crate) symbol_resolutions: SymbolResolutions,
@@ -623,6 +624,7 @@ pub struct Layout<'data> {
     pub(crate) per_symbol_flags: PerSymbolFlags,
 }
 
+#[derive(Debug)]
 pub(crate) struct SegmentLayouts {
     /// The layout of each of our segments. Segments containing no active output sections will have
     /// been filtered, so don't try to index this by our internal segment IDs.
@@ -630,12 +632,13 @@ pub(crate) struct SegmentLayouts {
     pub(crate) tls_layout: Option<OutputRecordLayout>,
 }
 
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone)]
 pub(crate) struct SegmentLayout {
     pub(crate) id: ProgramSegmentId,
     pub(crate) sizes: OutputRecordLayout,
 }
 
+#[derive(Debug)]
 pub(crate) struct SymbolResolutions {
     resolutions: Vec<Option<Resolution>>,
 }
@@ -668,8 +671,9 @@ pub(crate) struct Resolution {
 }
 
 /// Address information for a section.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(derive_more::Debug, Clone, Copy, Eq, PartialEq)]
 pub(crate) struct SectionResolution {
+    #[debug("0x{address:x}")]
     address: u64,
 }
 
@@ -753,6 +757,7 @@ pub(crate) struct GnuHashLayout {
     pub(crate) symbol_base: u32,
 }
 
+#[derive(Debug)]
 pub(crate) struct EpilogueLayout<'data> {
     pub(crate) internal_symbols: InternalSymbols<'data>,
     pub(crate) gnu_hash_layout: Option<GnuHashLayout>,
@@ -764,6 +769,7 @@ pub(crate) struct EpilogueLayout<'data> {
     pub(crate) riscv_attributes_length: u32,
 }
 
+#[derive(Debug)]
 pub(crate) struct ObjectLayout<'data> {
     pub(crate) input: InputRef<'data>,
     pub(crate) file_id: FileId,
@@ -774,6 +780,7 @@ pub(crate) struct ObjectLayout<'data> {
     pub(crate) symbol_id_range: SymbolIdRange,
 }
 
+#[derive(Debug)]
 pub(crate) struct PreludeLayout<'data> {
     pub(crate) entry_symbol_id: Option<SymbolId>,
     pub(crate) tlsld_got_entry: Option<NonZeroU64>,
@@ -783,6 +790,7 @@ pub(crate) struct PreludeLayout<'data> {
     pub(crate) dynamic_linker: Option<CString>,
 }
 
+#[derive(Debug)]
 pub(crate) struct InternalSymbols<'data> {
     pub(crate) symbol_definitions: Vec<InternalSymDefInfo<'data>>,
     pub(crate) start_symbol_id: SymbolId,
@@ -1161,7 +1169,7 @@ impl<'data> SymbolRequestHandler<'data> for EpilogueLayoutState<'data> {
 
 /// Attributes that we'll take from an input section and apply to the output section into which it's
 /// placed.
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 struct SectionAttributes {
     flags: SectionFlags,
     ty: SectionType,
@@ -1192,6 +1200,7 @@ impl SectionAttributes {
     }
 }
 
+#[derive(Debug)]
 struct CommonGroupState<'data> {
     mem_sizes: OutputSectionPartMap<u64>,
 
@@ -1360,7 +1369,7 @@ pub(crate) enum RiscVAttribute {
     PrivilegedSpecRevision(u64),
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct LocalWorkQueue {
     /// The index of the worker that owns this queue.
     index: usize,
@@ -1409,9 +1418,10 @@ pub(crate) struct VerneedInfo<'data> {
     pub(crate) version_count: u16,
 }
 
-#[derive(Clone, Copy)]
+#[derive(derive_more::Debug, Clone, Copy)]
 pub(crate) struct DynamicSymbolDefinition<'data> {
     pub(crate) symbol_id: SymbolId,
+    #[debug("{:?}", String::from_utf8_lossy(name))]
     pub(crate) name: &'data [u8],
     pub(crate) hash: u32,
     pub(crate) version: u16,
@@ -1427,6 +1437,7 @@ pub(crate) struct Section {
     pub(crate) is_writable: bool,
 }
 
+#[derive(Debug)]
 pub(crate) struct GroupLayout<'data> {
     pub(crate) files: Vec<FileLayout<'data>>,
 
@@ -1442,6 +1453,7 @@ pub(crate) struct GroupLayout<'data> {
     pub(crate) file_sizes: OutputSectionPartMap<usize>,
 }
 
+#[derive(Debug)]
 struct GroupState<'data> {
     queue: LocalWorkQueue,
     files: Vec<FileLayoutState<'data>>,
@@ -2101,7 +2113,7 @@ struct NonAddressableIndexes {
     gnu_version_r_index: u16,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub(crate) struct NonAddressableCounts {
     /// The number of shared objects that want to emit a verneed record.
     pub(crate) verneed_count: u64,
@@ -2123,6 +2135,7 @@ struct WorkerSlot<'data> {
     worker: Option<GroupState<'data>>,
 }
 
+#[derive(Debug)]
 struct GcOutputs<'data> {
     group_states: Vec<GroupState<'data>>,
     sections_with_content: OutputSectionMap<bool>,
@@ -3872,6 +3885,7 @@ impl<'data> EpilogueLayoutState<'data> {
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct HeaderInfo {
     pub(crate) num_output_sections_with_content: u16,
     pub(crate) active_segment_ids: Vec<ProgramSegmentId>,
@@ -6122,7 +6136,9 @@ fn verify_consistent_allocation_handling(flags: ValueFlags, output_kind: OutputK
     Ok(())
 }
 
+#[derive(derive_more::Debug)]
 pub(crate) struct VersionDef {
+    #[debug("{}", String::from_utf8_lossy(name))]
     pub(crate) name: Vec<u8>,
     pub(crate) parent_index: Option<u16>,
 }

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -52,14 +52,17 @@ pub(crate) struct LinkerScript<'a> {
     pub(crate) commands: Vec<Command<'a>>,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(derive_more::Debug, PartialEq, Eq)]
 pub(crate) enum Command<'a> {
+    #[debug("{}", String::from_utf8_lossy(_0))]
     Arg(&'a [u8]),
     Group(Vec<Command<'a>>),
     AsNeeded(Vec<Command<'a>>),
     Ignored,
     Sections(Sections<'a>),
+    #[debug("{}", String::from_utf8_lossy(_0))]
     Entry(&'a [u8]),
+    #[debug("{}", String::from_utf8_lossy(_0))]
     Version(&'a [u8]),
 }
 

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -58,7 +58,8 @@ pub(crate) const NUM_BUILT_IN_SECTIONS: usize =
 
 /// An ID for an output section. This is used for looking up section info. It's independent of
 /// section ordering.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, derive_more::Debug)]
+#[debug("osid-{_0}")]
 pub(crate) struct OutputSectionId(u32);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -117,6 +118,7 @@ pub(crate) const DATA_REL_RO: OutputSectionId = OutputSectionId::regular(14);
 
 pub(crate) const NUM_BUILT_IN_REGULAR_SECTIONS: usize = 15;
 
+#[derive(Debug)]
 pub(crate) struct OutputSections<'data> {
     /// The base address for our output binary.
     pub(crate) base_address: u64,
@@ -133,6 +135,7 @@ pub(crate) struct OutputSections<'data> {
 
 /// Encodes the order of output sections and the start and end of each program segment. This struct
 /// is intended to be used by iterating over it.
+#[derive(Debug)]
 pub(crate) struct OutputOrder {
     events: Vec<OrderEvent>,
 }

--- a/libwild/src/output_section_map.rs
+++ b/libwild/src/output_section_map.rs
@@ -2,6 +2,7 @@ use crate::error::Result;
 use crate::output_section_id::OutputSectionId;
 
 /// A map from output section IDs to something.
+#[derive(Debug)]
 pub(crate) struct OutputSectionMap<T> {
     // TODO: Consider only storing frequently used segment IDs in an array and storing less
     // frequently used IDs in an on-demand sorted Vec or smallvec.

--- a/libwild/src/output_section_part_map.rs
+++ b/libwild/src/output_section_part_map.rs
@@ -15,12 +15,13 @@ use std::ops::Range;
 /// parts in different ways. Sections that come from input files are split by alignment. Some
 /// sections have no splitting and some have splitting that is specific to that particular section.
 /// For example the symbol table is split into local then global symbols.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, derive_more::Debug)]
 pub(crate) struct OutputSectionPartMap<T> {
     // TODO: We used to store all the generated parts in separate instance variables. When we
     // switched to instead storing them in this Vec, we saw a small drop in performance (about 2%).
     // This may be due to an extra pointer indirection and/or bounds checking. Experiment with
     // storing all our built-in parts in an array.
+    #[debug(skip)]
     pub(crate) parts: Vec<T>,
 }
 

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -74,10 +74,12 @@ pub(crate) struct ParsedInputs<'data> {
     pub(crate) num_symbols: usize,
 }
 
+#[derive(Debug)]
 pub(crate) struct Prelude<'data> {
     pub(crate) symbol_definitions: Vec<InternalSymDefInfo<'data>>,
 }
 
+#[derive(Debug)]
 pub(crate) struct ParsedInputObject<'data> {
     pub(crate) input: InputRef<'data>,
     pub(crate) object: File<'data>,
@@ -85,24 +87,27 @@ pub(crate) struct ParsedInputObject<'data> {
     pub(crate) modifiers: Modifiers,
 }
 
+#[derive(Debug)]
 pub(crate) struct ProcessedLinkerScript<'data> {
     pub(crate) input: InputRef<'data>,
     pub(crate) symbol_defs: Vec<InternalSymDefInfo<'data>>,
 }
 
+#[derive(Debug)]
 pub(crate) struct Epilogue {
     pub(crate) file_id: FileId,
     pub(crate) start_symbol_id: SymbolId,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, derive_more::Debug)]
 pub(crate) struct InternalSymDefInfo<'data> {
     pub(crate) placement: SymbolPlacement,
+    #[debug("{:?}", String::from_utf8_lossy(name))]
     pub(crate) name: &'data [u8],
     pub(crate) elf_symbol_type: u8,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum SymbolPlacement {
     /// Symbol 0 - the undefined symbol.
     Undefined,

--- a/libwild/src/program_segments.rs
+++ b/libwild/src/program_segments.rs
@@ -8,11 +8,12 @@ use std::fmt::Display;
 #[derive(Default, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, Debug)]
 pub(crate) struct ProgramSegmentId(u8);
 
+#[derive(Debug)]
 pub(crate) struct ProgramSegments {
     program_segment_details: Vec<ProgramSegmentDef>,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct ProgramSegmentDef {
     pub(crate) segment_type: SegmentType,
     pub(crate) segment_flags: SegmentFlags,

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -383,7 +383,7 @@ pub(crate) struct NotLoaded {
 }
 
 /// A section, but where we may or may not yet have decided to load it.
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) enum SectionSlot {
     /// We've decided that this section won't be loaded.
     Discard,
@@ -416,7 +416,7 @@ pub(crate) enum SectionSlot {
     RiscvVAttributes(object::SectionIndex),
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct UnloadedSection {
     pub(crate) part_id: PartId,
 
@@ -439,7 +439,7 @@ impl UnloadedSection {
 }
 
 /// An index into the exception frames for an object.
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct FrameIndex(NonZeroU32);
 
 #[derive(Clone)]

--- a/libwild/src/save_dir.rs
+++ b/libwild/src/save_dir.rs
@@ -14,7 +14,7 @@ use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub(crate) struct SaveDir(Option<SaveDirState>);
 
 const SAVE_DIR_ENV: &str = "WILD_SAVE_DIR";
@@ -23,6 +23,7 @@ const SKIP_LINKING_ENV: &str = "WILD_SAVE_SKIP_LINKING";
 
 const PRELUDE: &str = include_str!("save-dir-prelude.sh");
 
+#[derive(Debug)]
 struct SaveDirState {
     dir: PathBuf,
     args: Vec<String>,

--- a/libwild/src/string_merging.rs
+++ b/libwild/src/string_merging.rs
@@ -64,7 +64,7 @@ const MERGE_STRING_BUCKETS: usize = 1 << MERGE_STRING_BUCKET_BITS;
 /// spilled to the hashmap.
 const MAP_BLOCK_SIZE: u64 = 256;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct StringMergeSectionSlot {
     pub(crate) part_id: PartId,
 
@@ -92,7 +92,7 @@ pub(crate) struct StringMergeSectionExtra<'data> {
 
 /// An input offset. We pretend that we've placed all input sections for a given output section one
 /// after the other. This offset is then the offset into that space.
-#[derive(Copy, Clone, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
 struct LinearInputOffset(u64);
 
 impl std::ops::Add<u64> for LinearInputOffset {
@@ -118,11 +118,13 @@ pub(crate) struct MergeString<'data> {
 }
 
 /// The addresses of the start of the merged strings for each output section.
+#[derive(Debug)]
 pub(crate) struct MergedStringStartAddresses {
     addresses: OutputSectionMap<[u64; MERGE_STRING_BUCKETS]>,
 }
 
 /// A section containing null terminated strings post-merging.
+#[derive(derive_more::Debug)]
 pub(crate) struct MergedStringsSection<'data> {
     /// The buckets based on the hash value of the input string.
     pub(crate) buckets: Vec<MergeStringsSectionBucket<'data>>,
@@ -131,6 +133,7 @@ pub(crate) struct MergedStringsSection<'data> {
     bucket_offsets: [u64; MERGE_STRING_BUCKETS],
 
     /// Map from input offsets to output offsets.
+    #[debug(skip)]
     string_offsets: OffsetMap<BucketOffset, MAP_BLOCK_SIZE>,
 
     /// Offsets of strings that didn't fit in `string_offsets`.
@@ -148,7 +151,7 @@ impl Default for MergedStringsSection<'_> {
     }
 }
 
-#[derive(Default)]
+#[derive(derive_more::Debug, Default)]
 pub(crate) struct MergeStringsSectionBucket<'data> {
     index: usize,
 
@@ -157,6 +160,8 @@ pub(crate) struct MergeStringsSectionBucket<'data> {
     next_input_group_index: usize,
 
     /// The strings in this section, in order. Includes null terminators.
+    /// TODO: Debug
+    #[debug(skip)]
     pub(crate) strings: Vec<&'data [u8]>,
 
     /// The offset within the section of the next string to be added, or if we're done adding
@@ -660,7 +665,7 @@ fn work_with_bucket<'data>(
     Ok(did_work)
 }
 
-#[derive(Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default)]
 struct BucketOffset(u32);
 
 struct OverflowedOffset {

--- a/libwild/src/symbol.rs
+++ b/libwild/src/symbol.rs
@@ -17,14 +17,16 @@ pub(crate) enum PreHashedSymbolName<'data> {
     Versioned(PreHashed<VersionedSymbolName<'data>>),
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(derive_more::Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct UnversionedSymbolName<'data> {
+    #[debug("{}", String::from_utf8_lossy(bytes))]
     bytes: &'data [u8],
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(derive_more::Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct VersionedSymbolName<'data> {
     name: UnversionedSymbolName<'data>,
+    #[debug("{}", String::from_utf8_lossy(version))]
     version: &'data [u8],
 }
 
@@ -64,12 +66,6 @@ impl Display for UnversionedSymbolName<'_> {
         } else {
             write!(f, "INVALID UTF-8({:?})", self.bytes)
         }
-    }
-}
-
-impl std::fmt::Debug for UnversionedSymbolName<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Debug::fmt(&String::from_utf8_lossy(self.bytes), f)
     }
 }
 

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -53,6 +53,7 @@ use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
 use symbolic_demangle::demangle;
 
+#[derive(Debug)]
 pub struct SymbolDb<'data> {
     pub(crate) args: &'data Args,
 
@@ -94,6 +95,7 @@ struct AtomicSymbolDb<'data, 'db> {
     definitions: Vec<AtomicSymbolId>,
 }
 
+#[derive(Debug)]
 struct SymbolBucket<'data> {
     /// Mapping from global symbol names to a symbol ID with that name. If there are multiple
     /// globals with the same name, then this will point to the one we encountered first, which may
@@ -127,7 +129,8 @@ struct PendingVersionedSymbol<'data> {
 
 /// An ID for a symbol. All symbols from all input files are allocated a unique symbol ID. The
 /// symbol ID 0 is reserved for the undefined symbol.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, derive_more::Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[debug("sym-{_0}")]
 pub(crate) struct SymbolId(u32);
 
 struct AtomicSymbolId(AtomicU32);

--- a/libwild/src/value_flags.rs
+++ b/libwild/src/value_flags.rs
@@ -10,10 +10,12 @@ use zerocopy::transmute_mut;
 
 /// A raw representation of `ValueFlags`. This is separate from `ValueFlags` so that we can derive
 /// `FromBytes` and `IntoBytes`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, FromBytes, IntoBytes)]
+#[derive(derive_more::Debug, Clone, Copy, PartialEq, Eq, Hash, FromBytes, IntoBytes)]
+#[debug("{}", ValueFlags::from_bits_retain(*_0))]
 pub(crate) struct RawFlags(u16);
 
 /// Flags for each symbol.
+#[derive(Debug)]
 pub(crate) struct PerSymbolFlags {
     flags: Vec<RawFlags>,
 }

--- a/libwild/src/version_script.rs
+++ b/libwild/src/version_script.rs
@@ -44,7 +44,7 @@ pub(crate) struct Version<'data> {
 }
 
 /// A version script. See https://sourceware.org/binutils/docs/ld/VERSION.html
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub(crate) struct VersionScript<'data> {
     versions: Vec<Version<'data>>,
     version_name_mapping: HashMap<&'data [u8], usize>,

--- a/linker-utils/Cargo.toml
+++ b/linker-utils/Cargo.toml
@@ -9,6 +9,7 @@ edition.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+derive_more = { workspace = true }
 object = { workspace = true }
 leb128 = { workspace = true }
 

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -590,7 +590,8 @@ pub mod secnames {
     pub const GNU_LTO_SYMTAB_PREFIX: &str = ".gnu.lto_.symtab";
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, derive_more::Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[debug("{}", segment_type_to_string(*_0))]
 pub struct SegmentType(u32);
 
 impl SegmentType {


### PR DESCRIPTION
I'm an inveterate user of print statement debugging. Over the last few weeks I've noticed that Wild doesn't have `Debug` implementations for lots of things I'd like to print. As soon as one starts to add automatically derived `Debug` implementations it becomes clear why they are not very useful in Wild:

1. There are many, many long runs of byte arrays. Printing them clogs the screen and provides approximately zero insight.
2. New-type integer identifiers like `SymbolId` consume at least three lines.
3. Some of the most important data structures contain values from other libraries, such as `object`, whose `Debug` implementations suffer from the same problems.

I propose this change, which takes a dependency on `derive_more` to help automatically derive _useful_ `Debug` implementations for a number of internal data structures. It does three things to make itself useful:

1. New-type integer identifiers get a prefix and then their number. Example: `sym-1234`. 
2. Byte arrays that one might reasonably expect to be able convert to UTF-8, like section names, are lossily converted to UTF-8.
3. Some fields are intentionally ignored, but `derive_more` inserts ellipses so that it's clear some data has been elided.

I haven't implemented `Debug` on everything. I don't think that's worth doing. But, this change makes it possible to print a useful representation of some of the most important structures, including `SymbolDb` and `Layout`. **I already have much more insight into Wild's internals than I did earlier today.**

Example:
```
VersionedSymbolName {
    name: UnversionedSymbolName {
        bytes: localtime_r,
    },
    version: GLIBC_2.2.5,
}: sym-5249,
```

