### PR TITLE
Macro to generate ELF newtypes and new SymbolType

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,6 +842,7 @@ dependencies = [
  "derive_more",
  "leb128",
  "object",
+ "paste",
 ]
 
 [[package]]
@@ -1000,6 +1001,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "perf-event"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ object = { version = "0.37.3", default-features = false, features = [
     "archive",
 ] }
 os_info = "3.0.0"
+paste = "1.0.15"
 perf-event = "0.4.8"
 postcard = { version = "1.1.1", features = ["use-std"] }
 rayon = "1.5.1"

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -96,6 +96,7 @@ use linker_utils::elf::secnames::DEBUG_RANGES_SECTION_NAME;
 use linker_utils::elf::secnames::DYNSYM_SECTION_NAME_STR;
 use linker_utils::elf::shf;
 use linker_utils::elf::sht;
+use linker_utils::elf::stt;
 use linker_utils::relaxation::RelocationModifier;
 use object::LittleEndian;
 use object::SymbolIndex;
@@ -3111,7 +3112,7 @@ fn write_internal_symbols(
 
         let mut address = resolution.value();
 
-        if def_info.elf_symbol_type == object::elf::STT_TLS {
+        if def_info.elf_symbol_type == stt::TLS {
             address -= layout.tls_start_address();
         }
 
@@ -3125,7 +3126,7 @@ fn write_internal_symbols(
             .define_symbol(false, shndx, address, 0, symbol_name.bytes())
             .with_context(|| format!("Failed to write {}", layout.symbol_debug(symbol_id)))?;
 
-        entry.set_st_info(object::elf::STB_GLOBAL, def_info.elf_symbol_type);
+        entry.set_st_info(object::elf::STB_GLOBAL, def_info.elf_symbol_type.raw());
     }
     Ok(())
 }

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -18,6 +18,8 @@ use crate::output_section_id;
 use crate::output_section_id::OutputSectionId;
 use crate::symbol::UnversionedSymbolName;
 use crate::symbol_db::SymbolId;
+use linker_utils::elf::SymbolType;
+use linker_utils::elf::stt;
 use rayon::iter::IntoParallelRefIterator;
 use rayon::iter::ParallelIterator;
 
@@ -104,7 +106,7 @@ pub(crate) struct InternalSymDefInfo<'data> {
     pub(crate) placement: SymbolPlacement,
     #[debug("{:?}", String::from_utf8_lossy(name))]
     pub(crate) name: &'data [u8],
-    pub(crate) elf_symbol_type: u8,
+    pub(crate) elf_symbol_type: SymbolType,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -128,7 +130,7 @@ impl<'data> InternalSymDefInfo<'data> {
         Self {
             placement,
             name,
-            elf_symbol_type: object::elf::STT_NOTYPE,
+            elf_symbol_type: stt::NOTYPE,
         }
     }
 }
@@ -213,7 +215,7 @@ impl<'data> Prelude<'data> {
                 SymbolPlacement::SectionEnd(output_section_id::TBSS)
             },
             name: b"_TLS_MODULE_BASE_",
-            elf_symbol_type: object::elf::STT_TLS,
+            elf_symbol_type: stt::TLS,
         });
 
         symbol_definitions.extend(args.undefined.iter().map(|name| {

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -61,6 +61,7 @@ use std::num::NonZeroU32;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
+#[derive(Debug)]
 pub(crate) struct ResolutionOutputs<'data> {
     pub(crate) groups: Vec<ResolvedGroup<'data>>,
     pub(crate) merged_strings: OutputSectionMap<MergedStringsSection<'data>>,
@@ -366,10 +367,12 @@ impl<'scope> ResolutionResources<'_, '_, 'scope> {
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct ResolvedGroup<'data> {
     pub(crate) files: Vec<ResolvedFile<'data>>,
 }
 
+#[derive(Debug)]
 pub(crate) enum ResolvedFile<'data> {
     NotLoaded(NotLoaded),
     Prelude(ResolvedPrelude<'data>),
@@ -378,6 +381,7 @@ pub(crate) enum ResolvedFile<'data> {
     Epilogue(ResolvedEpilogue<'data>),
 }
 
+#[derive(Debug)]
 pub(crate) struct NotLoaded {
     pub(crate) symbol_id_range: SymbolIdRange,
 }
@@ -442,11 +446,12 @@ impl UnloadedSection {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct FrameIndex(NonZeroU32);
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct ResolvedPrelude<'data> {
     pub(crate) symbol_definitions: Vec<InternalSymDefInfo<'data>>,
 }
 
+#[derive(Debug)]
 pub(crate) struct ResolvedObject<'data> {
     pub(crate) input: InputRef<'data>,
     pub(crate) object: &'data File<'data>,
@@ -457,6 +462,7 @@ pub(crate) struct ResolvedObject<'data> {
 }
 
 /// Parts of a resolved object that are only applicable to non-dynamic objects.
+#[derive(Debug)]
 pub(crate) struct NonDynamicResolved<'data> {
     pub(crate) sections: Vec<SectionSlot>,
     pub(crate) relocations: object::read::elf::RelocationSections,
@@ -467,6 +473,7 @@ pub(crate) struct NonDynamicResolved<'data> {
     custom_sections: Vec<CustomSectionDetails<'data>>,
 }
 
+#[derive(Debug)]
 pub(crate) struct ResolvedLinkerScript<'data> {
     pub(crate) input: InputRef<'data>,
     pub(crate) file_id: FileId,
@@ -474,7 +481,7 @@ pub(crate) struct ResolvedLinkerScript<'data> {
     pub(crate) symbol_definitions: Vec<InternalSymDefInfo<'data>>,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct ResolvedEpilogue<'data> {
     pub(crate) file_id: FileId,
     pub(crate) start_symbol_id: SymbolId,

--- a/libwild/src/string_merging.rs
+++ b/libwild/src/string_merging.rs
@@ -85,6 +85,7 @@ impl StringMergeSectionSlot {
 
 /// Extra stuff that we don't want to put in `StringMergeSectionSlot` because like all section
 /// slots, we want to keep it as small as possible.
+#[derive(Debug)]
 pub(crate) struct StringMergeSectionExtra<'data> {
     pub(crate) index: object::SectionIndex,
     pub(crate) section_data: &'data [u8],

--- a/linker-diff/src/segment.rs
+++ b/linker-diff/src/segment.rs
@@ -3,7 +3,7 @@ use crate::header_diff::DiffMode;
 use crate::header_diff::FieldValues;
 use anyhow::Ok;
 use anyhow::Result;
-use linker_utils::elf::segment_type_to_string;
+use linker_utils::elf::SegmentType;
 use object::LittleEndian;
 use object::elf::PT_LOAD;
 use object::read::elf::ProgramHeader as _;
@@ -46,16 +46,16 @@ fn read_program_segment_fields(object: &crate::Binary) -> Result<FieldValues> {
                 object,
             );
         } else {
-            let type_str = segment_type_to_string(p_type);
+            let segment_type = SegmentType::from_u32(p_type);
 
             values.insert(
-                format!("{type_str}.alignment"),
+                format!("{segment_type}.alignment"),
                 p_align,
                 Converter::None,
                 object,
             );
             values.insert(
-                format!("{type_str}.flags"),
+                format!("{segment_type}.flags"),
                 p_flags,
                 Converter::None,
                 object,

--- a/linker-utils/Cargo.toml
+++ b/linker-utils/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = { workspace = true }
 derive_more = { workspace = true }
 object = { workspace = true }
 leb128 = { workspace = true }
+paste = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
The code in `linker-utils/src/elf.rs` wraps enum constants from `object` in newtypes. It's got hand-written and sometimes missing implementations of `Debug` and `Display` for each. I introduced a macro to generate the newtype as well as a sub-module that contains the constants of this form:

```rust
pub const GNU_LIBLIST: SectionType = SectionType(object::elf::SHT_GNU_LIBLIST);
```

This has a few benefits. There is less hand-written code to maintain. Human error in naming the constants is no longer possible. The macro also generates common inherent methods and trait implementations for all the newtypes. The other nice thing is that there are now far fewer results when searching for values of these enums. Also, it's possible to define constants _not_ present in `object`, such as `RISCV_ATTRIBUTES`.

I used this new macro to introduce another newtype - `SymbolType`. I've shoehorned in a couple of `Debug` derivations which originally catalyzed this work. There are fewer opaque integers in debug output. Example:

```
InternalSymDefInfo {
    placement: SectionEnd(
        osid-34,
    ),
    name: "_TLS_MODULE_BASE_",
    elf_symbol_type: TLS,
},
```

One new dependency is required - `paste` - but it is lightweight, compile-time only dtolnayware that was already in the dependency closure.