### PR TITLE
test: only set `TRIPLE` when cross-compiling

### DIFF
--- a/wild/tests/external_tests/mold_tests.rs
+++ b/wild/tests/external_tests/mold_tests.rs
@@ -36,6 +36,7 @@ fn run_mold_test(mold_test: &Path) -> Result<Output> {
         && let Some(arch_str) = file_name.strip_prefix("arch-")
         && let Some(arch_name) = arch_str.split('-').next()
         && let Ok(arch) = Architecture::from_str(arch_name)
+        && arch != get_host_architecture()
     {
         Some(format!("{}-linux-gnu", arch))
     } else {


### PR DESCRIPTION
Noticed the tests crashing like this:
```
        FAIL [   2.713s] wild-linker::integration_tests external_tests::mold_tests::check_mold_tests_regression::mold_test_062__UP_external_test_suites_mold_test_arch_x86_64_large_bss_sh
  stdout ───

    running 1 test
    test external_tests::mold_tests::check_mold_tests_regression::mold_test_062__UP_external_test_suites_mold_test_arch_x86_64_large_bss_sh ... FAILED

    failures:

    failures:
        external_tests::mold_tests::check_mold_tests_regression::mold_test_062__UP_external_test_suites_mold_test_arch_x86_64_large_bss_sh

    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 997 filtered out; finished in 2.71s

  stderr ───
    Error: Mold test `/home/mateusz/Projects/wild/external_test_suites/mold/test/arch-x86_64-large-bss.sh` failed with status: exit status: 1
    Output:
    Testing arch-x86_64-large-bss ... + cat
    + x86_64-linux-gnu-gcc -o out/test/x86_64/arch-x86_64-large-bss/a.o -c -xc - -mcmodel=large
    + cat
    + x86_64-linux-gnu-gcc -o out/test/x86_64/arch-x86_64-large-bss/b.o -c -xc - -mcmodel=large
    + x86_64-linux-gnu-gcc -B. -o out/test/x86_64/arch-x86_64-large-bss/exe out/test/x86_64/arch-x86_64-large-bss/a.o out/test/x86_64/arch-x86_64-large-bss/b.o
    WARNING: wild: --plugin /usr/lib/gcc/x86_64-pc-linux-gnu/15.2.1/liblto_plugin.so is not yet supported
    + qemu-x86_64 -L /usr/x86_64-linux-gnu out/test/x86_64/arch-x86_64-large-bss/exe
    + grep -E '^1 c0000000$'
    qemu: uncaught target signal 4 (Illegal instruction) - core dumped
    ++ on_error 18
    ++ code=1
    ++ echo 'command failed: 18: grep -E '\''^1 c0000000$'\'''
    command failed: 18: grep -E '^1 c0000000$'
    ++ trap - EXIT
    ++ exit 1
```
and it got me wondering why it used `qemu-x86_64` on `x86_64` host. Turns out it was set not only when cross-compiling.