### PR TITLE
ci: Use appropriate test config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
 
     steps:
       - run: echo "WILD_TEST_CONFIG=test-config-ci.toml" >> $GITHUB_ENV
-        if: ${{ env.CI == 'true' }}
       - run: echo "WILD_TEST_CROSS=aarch64,riscv64" >> $GITHUB_ENV
         if: ${{ matrix.test-qemu }}
       - run: apt-get update && apt-get -y install gcc g++ clang clang-format lld curl bubblewrap binutils-aarch64-linux-gnu binutils-riscv64-linux-gnu


### PR DESCRIPTION
It seems that `${{ env.CI }}` isn't set. From what I can read, perhaps `$CI` is set. In any case, I'm not sure why we'd ever want to skip using `test-config-ci.toml` when running our CI action.