### PR TITLE
test: Ignore some diffs in risc-v tests

### DIFF
--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -279,6 +279,8 @@ impl Config {
                     // Symbol address inconsistencies due to different optimizations
                     "error.*",
                     "section-diff-failed*",
+                    // .relro_padding is showing up on risc-v.
+                    "section.relro_padding",
                 ]
                 .into_iter()
                 .map(ToOwned::to_owned),

--- a/wild/tests/sources/rust-tls.rs
+++ b/wild/tests/sources/rust-tls.rs
@@ -1,5 +1,9 @@
 //#AbstractConfig:default
-//#RequiresNightlyRustc: true
+//#RequiresNightlyRustc:true
+// TODO: Investigate the following differences, which show up on risc-v
+//#DiffIgnore:dynsym.*
+//#DiffIgnore:.dynamic.DT_FLAGS.TEXTREL
+//#DiffIgnore:.dynamic.DT_TEXTREL
 
 //#Config:global-dynamic:default
 //#CompArgs:-Ztls-model=global-dynamic


### PR DESCRIPTION
These diffs weren't being run in CI (will fix that separately).