### PR TITLE
perf: Rewrite scheduling of string merging tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,6 +772,7 @@ dependencies = [
  "symbolic-common",
  "symbolic-demangle",
  "tempfile",
+ "thread_local",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ strum = { version = "0.27.0", features = ["derive"] }
 symbolic-common = "12.0.0"
 symbolic-demangle = {version = "12.0.0", default-features = false, features = ["cpp", "rust"]}
 tempfile = "3.0.2"
+thread_local = "1.1.9"
 toml = "0.9.0"
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3.16", default-features = false, features = [

--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -44,6 +44,7 @@ sharded-vec-writer = { workspace = true }
 smallvec = { workspace = true }
 symbolic-common = { workspace = true }
 symbolic-demangle = { workspace = true }
+thread_local = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }


### PR DESCRIPTION
The old do_splitting_work, if there were lots of threads and insufficient work to do, could end up effectively busy-waiting, which was terrible for performance.

We now spawn a separate task for each bit of work. We also now constrain the number of split input section Vecs that we'll keep in memory.

Issue #1085