### PR TITLE
test: Don't skip running dynamically linked executables

### DIFF
--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -848,7 +848,6 @@ fn parse_configs(src_filename: &Path, default_config: &Config) -> Result<Vec<Con
                         .parse()
                         .with_context(|| format!("Invalid Mode `{arg}`"))?;
                     if mode == Mode::Dynamic {
-                        config.should_run = false;
                         config.assertions.expect_dynamic = true;
                     }
                     config.linker_driver.direct_mut()?.mode = mode;

--- a/wild/tests/sources/basic-comdat.s
+++ b/wild/tests/sources/basic-comdat.s
@@ -1,6 +1,7 @@
 /* For some reason, GAS on riscv64 does not support '//' comments.
 //#Object:basic-comdat-1.s
 //#Mode:dynamic
+//#RunEnabled:false
 //#LinkArgs:-shared -z now
 //#DiffIgnore:section.got
 //#DiffIgnore:segment.GNU_STACK.alignment

--- a/wild/tests/sources/entry-in-shared.c
+++ b/wild/tests/sources/entry-in-shared.c
@@ -1,6 +1,7 @@
 // https://github.com/davidlattimore/wild/issues/1137
 //#Config:entry-in-shared
 //#LinkArgs:-shared -z now
+//#RunEnabled:false
 //#Object:runtime.c
 //#DiffIgnore:.dynamic.DT_RELA*
 //#Mode:dynamic

--- a/wild/tests/sources/exclude-libs.c
+++ b/wild/tests/sources/exclude-libs.c
@@ -1,5 +1,6 @@
 //#LinkArgs:-z now -Bshareable --exclude-libs ALL
 //#Mode:dynamic
+//#RunEnabled:false
 //#Archive:exclude-libs-archive.c
 // We optimise away the GOT, but GNU ld doesn't.
 //#DiffIgnore:section.got

--- a/wild/tests/sources/exclude-section.s
+++ b/wild/tests/sources/exclude-section.s
@@ -1,5 +1,6 @@
 /* For some reason, GAS on riscv64 does not support '//' comments.
 //#Mode:dynamic
+//#RunEnabled:false
 //#LinkArgs:-shared --no-gc-sections -z now
 //#DiffIgnore:section.got
 //#DiffIgnore:segment.LOAD.RX.alignment

--- a/wild/tests/sources/export-dynamic.c
+++ b/wild/tests/sources/export-dynamic.c
@@ -5,6 +5,7 @@
 //#ExpectDynSym:foo
 //#Shared:empty.c
 //#Mode:unspecified
+//#RunEnabled:false
 // We're linking different .so files, so this is expected.
 //#DiffIgnore:.dynamic.DT_NEEDED
 // TODO: Wild probably should set dynamic linker here
@@ -24,6 +25,7 @@
 //#ExpectDynSym:baz
 //#Shared:empty.c
 //#Mode:dynamic
+//#RunEnabled:false
 // We're linking different .so files, so this is expected.
 //#DiffIgnore:.dynamic.DT_NEEDED
 //#EnableLinker:lld
@@ -34,6 +36,7 @@
 //#ExpectDynSym:baz
 //#Shared:empty.c
 //#Mode:dynamic
+//#RunEnabled:false
 // We're linking different .so files, so this is expected.
 //#DiffIgnore:.dynamic.DT_NEEDED
 //#EnableLinker:lld
@@ -44,6 +47,7 @@
 //#ExpectDynSym:baz
 //#Shared:empty.c
 //#Mode:dynamic
+//#RunEnabled:false
 // We're linking different .so files, so this is expected.
 //#DiffIgnore:.dynamic.DT_NEEDED
 //#DiffIgnore:.dynamic.DT_RELA*

--- a/wild/tests/sources/linker-script.c
+++ b/wild/tests/sources/linker-script.c
@@ -1,4 +1,5 @@
 //#Mode:dynamic
+//#RunEnabled:false
 //#LinkArgs:-shared -z now -T ./linker-script.ld
 //#DiffIgnore:section.got
 //#ExpectDynSym:start_bar section="bar",offset-in-section=0

--- a/wild/tests/sources/shared.c
+++ b/wild/tests/sources/shared.c
@@ -8,6 +8,7 @@
 //#Config:default
 //#LinkArgs:-shared -z now
 //#Mode:dynamic
+//#RunEnabled:false
 //#Shared:shared-s1.c
 //#Archive:shared-a1.c,shared-a2.c
 //#DiffIgnore:.dynamic.DT_RELA

--- a/wild/tests/sources/shlib-undefined.c
+++ b/wild/tests/sources/shlib-undefined.c
@@ -6,6 +6,7 @@
 //#SkipLinker:ld
 //#Object:runtime.c
 //#Mode:dynamic
+//#RunEnabled:false
 //#DiffIgnore:.dynamic.DT_RELA
 //#DiffIgnore:.dynamic.DT_RELAENT
 //#DiffIgnore:.dynamic.DT_NEEDED

--- a/wild/tests/sources/unresolved-symbols-object.c
+++ b/wild/tests/sources/unresolved-symbols-object.c
@@ -5,6 +5,7 @@
 
 //#Config:ignore-all-dynamic:default
 //#Mode:dynamic
+//#RunEnabled:false
 //#Shared:force-dynamic-linking.c
 //#LinkArgs:--unresolved-symbols=ignore-all -z now
 //#DiffIgnore:.dynamic.DT_NEEDED

--- a/wild/tests/sources/unresolved-symbols-shared.c
+++ b/wild/tests/sources/unresolved-symbols-shared.c
@@ -2,6 +2,7 @@
 //#SkipLinker:ld
 //#DiffEnabled:false
 //#Mode:dynamic
+//#RunEnabled:false
 //#LinkArgs:-shared -z now
 
 //#Config:ignore-in-object-files:default

--- a/wild/tests/sources/visibility-merging.c
+++ b/wild/tests/sources/visibility-merging.c
@@ -1,4 +1,5 @@
 //#Mode:dynamic
+//#RunEnabled:false
 //#LinkArgs:-shared -z now
 //#Object:visibility-merging-1.c
 //#DiffIgnore:section.got

--- a/wild/tests/sources/z-defs.c
+++ b/wild/tests/sources/z-defs.c
@@ -1,11 +1,13 @@
 //#Config:z-defs
 //#LinkArgs:-Bshareable -z now -z defs
 //#Mode:dynamic
+//#RunEnabled:false
 //#ExpectError:foo
 
 //#Config:z-undefs
 //#LinkArgs:-Bshareable -z now -z undefs
 //#Mode:dynamic
+//#RunEnabled:false
 //#DiffIgnore:.dynamic.DT_RELA
 //#DiffIgnore:.dynamic.DT_RELAENT
 


### PR DESCRIPTION
I previously made Mode:dynamic skip running. But this meant that we weren't running some executables that we could be running, like the copy-relocations test.