### PR TITLE
fix: Use local symbol interposability when processing relocations

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -1912,7 +1912,7 @@ fn apply_relocation<'data, A: Arch>(
     }
 
     let (resolution, symbol_index, local_symbol_id) = get_resolution(rel, object_layout, layout)?;
-    let flags = resolution.flags;
+    let flags = layout.flags_for_symbol(local_symbol_id);
     let mut next_modifier = RelocationModifier::Normal;
     let rel_info;
     let output_kind = layout.args().output_kind();

--- a/wild/tests/sources/visibility-merging-1.c
+++ b/wild/tests/sources/visibility-merging-1.c
@@ -7,3 +7,6 @@ int data1 __attribute__((weak, visibility(("hidden")))) = 0x100;
 int data3 __attribute__((weak, visibility(("protected")))) = 0x55;
 
 int data4 __attribute__((weak, visibility(("hidden")))) = 0x99;
+
+// This has default visibility here, but is hidden in the main file.
+int data5 = 0x101;

--- a/wild/tests/sources/visibility-merging.c
+++ b/wild/tests/sources/visibility-merging.c
@@ -6,6 +6,7 @@
 // TODO: Prevent dynsym export of symbols like these.
 //#DiffIgnore:dynsym.data1.*
 //#DiffIgnore:dynsym.data4.*
+//#DiffIgnore:dynsym.data5.*
 
 // This symbol is included, but isn't exported as a dynamic symbol because of a
 // second definition in our other file that's marked as hidden.
@@ -31,3 +32,7 @@ int get_data1(void) { return data1; }
 // references should be permitted, however GNU ld < 2.40 would error in the case
 // of direct references to protected symbols, so in order to allow our tests to
 // pass with such versions, we don't.
+
+extern int data5 __attribute__((visibility(("hidden"))));
+
+int get_data5(void) { return data5; }


### PR DESCRIPTION
When an object file references a symbol that it doesn't define and that reference has hidden or protected visibility, the symbol needs to be treated as non-interposable even if the object that defines the symbol doesn't mark the symbol as hidden or protected.

Issue #1254