### PR TITLE
fix: Make --strip-debug suppress earlier --strip-all

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -1176,7 +1176,7 @@ fn write_object<A: Arch>(
         }
     }
 
-    if !layout.args().strip_all {
+    if !layout.args().strip_all() {
         write_symbols(object, &mut table_writer.debug_symbol_writer, layout)?;
     }
     Ok(())
@@ -2424,7 +2424,7 @@ fn write_prelude<A: Arch>(
 
     write_plt_got_entries::<A>(prelude, layout, table_writer)?;
 
-    if !layout.args().strip_all {
+    if !layout.args().strip_all() {
         write_symbol_table_entries(prelude, &mut table_writer.debug_symbol_writer, layout)?;
     }
 
@@ -2710,7 +2710,7 @@ fn write_epilogue<A: Arch>(
 
     write_internal_symbols_plt_got_entries::<A>(&epilogue.internal_symbols, table_writer, layout)?;
 
-    if !layout.args().strip_all {
+    if !layout.args().strip_all() {
         write_internal_symbols(
             &epilogue.internal_symbols,
             layout,

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3104,7 +3104,7 @@ impl<'data> PreludeLayoutState<'data> {
 
         // The first entry in the symbol table must be null. Similarly, the first string in the
         // strings table must be empty.
-        if !resources.symbol_db.args.strip_all {
+        if !resources.symbol_db.args.strip_all() {
             common.allocate(part_id::SYMTAB_LOCAL, size_of::<elf::SymtabEntry>() as u64);
             common.allocate(part_id::STRTAB, 1);
         }
@@ -3242,7 +3242,7 @@ impl<'data> PreludeLayoutState<'data> {
         symbol_db: &SymbolDb<'_>,
         extra_sizes: &mut OutputSectionPartMap<u64>,
     ) -> Result<(), Error> {
-        if symbol_db.args.strip_all {
+        if symbol_db.args.strip_all() {
             return Ok(());
         }
 
@@ -3689,7 +3689,7 @@ impl<'data> EpilogueLayoutState<'data> {
         symbol_db: &SymbolDb<'data>,
         per_symbol_flags: &AtomicPerSymbolFlags,
     ) -> Result {
-        if !symbol_db.args.strip_all {
+        if !symbol_db.args.strip_all() {
             self.internal_symbols.allocate_symbol_table_sizes(
                 &mut common.mem_sizes,
                 symbol_db,
@@ -4307,7 +4307,7 @@ impl<'data> ObjectLayoutState<'data> {
         per_symbol_flags: &AtomicPerSymbolFlags,
     ) {
         common.mem_sizes.resize(output_sections.num_parts());
-        if !symbol_db.args.strip_all {
+        if !symbol_db.args.strip_all() {
             self.allocate_symtab_space(common, symbol_db, per_symbol_flags);
         }
         let output_kind = symbol_db.args.output_kind();

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -851,7 +851,7 @@ fn resolve_sections_for_object<'data>(
                     return Ok(SectionSlot::NoteGnuProperty(input_section_index));
                 }
                 SectionRuleOutcome::Debug => {
-                    if args.strip_debug && !section_flags.contains(shf::ALLOC) {
+                    if args.strip_debug() && !section_flags.contains(shf::ALLOC) {
                         return Ok(SectionSlot::Discard);
                     }
 

--- a/wild/tests/sources/link_args.c
+++ b/wild/tests/sources/link_args.c
@@ -34,6 +34,19 @@
 //#EnableLinker:lld
 //#LinkArgs:--no-mmap-output-file
 
+// The later --strip-all flag should override --strip-debug.
+//#Config:strip-debug-strip-all
+//#Object:runtime.c
+//#LinkArgs:--strip-debug --strip-all
+//#DiffIgnore:file-header.entry
+//#NoSym:_start
+
+// The later --strip-debug flag should override --strip-all.
+//#Config:strip-all-strip-debug
+//#Object:runtime.c
+//#LinkArgs:--strip-all --strip-debug
+//#ExpectSym:_start
+
 #include "runtime.h"
 
 void _start(void) {


### PR DESCRIPTION
This matches the behaviour observed of GNU ld and lld.