### PR TITLE
style: Wrap comments at 100 characters

### DIFF
--- a/libwild/src/archive.rs
+++ b/libwild/src/archive.rs
@@ -306,7 +306,8 @@ impl<'data> ThinEntry<'data> {
 
 impl<'data> Identifier<'data> {
     pub(crate) fn as_slice(&self) -> &'data [u8] {
-        // For BSD format placeholder, return as-is (this shouldn't normally be called for BSD format)
+        // For BSD format placeholder, return as-is (this shouldn't normally be called for BSD
+        // format)
         if self.data.is_empty() {
             return self.data;
         }

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -215,8 +215,8 @@ pub struct Modifiers {
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) struct Input {
     pub(crate) spec: InputSpec,
-    /// A directory to search first. Only present when the input came from a linker script, in which
-    /// case this is the directory containing the linker script.
+    /// A directory to search first. Only present when the input came from a linker script, in
+    /// which case this is the directory containing the linker script.
     pub(crate) search_first: Option<PathBuf>,
     pub(crate) modifiers: Modifiers,
 }
@@ -291,7 +291,8 @@ const SILENTLY_IGNORED_FLAGS: &[&str] = &[
 const SILENTLY_IGNORED_SHORT_FLAGS: &[&str] = &[
     "(",
     ")",
-    // On Illumos, the Clang driver inserts a meaningless -C flag before calling any non-GNU ld linker.
+    // On Illumos, the Clang driver inserts a meaningless -C flag before calling any non-GNU ld
+    // linker.
     #[cfg(target_os = "illumos")]
     "C",
 ];
@@ -332,10 +333,11 @@ impl Default for Args {
             time_phase_options: None,
             num_threads: None,
             strip: Strip::Nothing,
-            // For now, we default to --gc-sections. This is different to other linkers, but other than
-            // being different, there doesn't seem to be any downside to doing this. We don't currently do
-            // any less work if we're not GCing sections, but do end up writing more, so --no-gc-sections
-            // will almost always be as slow or slower than --gc-sections. For that reason, the latter is
+            // For now, we default to --gc-sections. This is different to other linkers, but other
+            // than being different, there doesn't seem to be any downside to doing
+            // this. We don't currently do any less work if we're not GCing sections,
+            // but do end up writing more, so --no-gc-sections will almost always be as
+            // slow or slower than --gc-sections. For that reason, the latter is
             // probably a good default.
             gc_sections: true,
             prepopulate_maps: false,

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -353,10 +353,10 @@ fn decompress_into(
                 flate2::FlushDecompress::Finish,
             )?;
         }
-        // We might use pure Rust implementation for the decompression (ruzstd), however the decompression
-        // speed is not on par with the official C library.
-        // With the official library, the linking time of Clang binary (contains 1GB of debug info sections)
-        // shrinks by 30%!
+        // We might use pure Rust implementation for the decompression (ruzstd), however the
+        // decompression speed is not on par with the official C library.
+        // With the official library, the linking time of Clang binary (contains 1GB of debug info
+        // sections) shrinks by 30%!
         object::elf::ELFCOMPRESS_ZSTD => {
             zstd::stream::Decoder::new(input)?.read_exact(out)?;
         }
@@ -552,8 +552,9 @@ pub(crate) fn write_relocation_to_buffer(
             insn.write_to_value(
                 extracted_value,
                 negative,
-                // We can write a non-text section, so we might need to limit the output buffer slice
-                // e.g. .gcc_except_table is written on riscv64 using the ULEB128 encoding
+                // We can write a non-text section, so we might need to limit the output buffer
+                // slice e.g. .gcc_except_table is written on riscv64 using the
+                // ULEB128 encoding
                 &mut output[..insn.write_windows_size().min(output_len)],
             );
         }

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -463,8 +463,8 @@ struct TableWriter<'layout, 'out> {
     eh_frame_start_address: u64,
     eh_frame: &'out mut [u8],
 
-    /// Note, this is stored as raw bytes because it starts with an EhFrameHdr, but is then followed
-    /// by multiple EhFrameHdrEntry.
+    /// Note, this is stored as raw bytes because it starts with an EhFrameHdr, but is then
+    /// followed by multiple EhFrameHdrEntry.
     eh_frame_hdr: &'out mut [u8],
 
     dynamic: DynamicEntriesWriter<'out>,
@@ -538,7 +538,8 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
         let mut got_address = got_address.get();
         let flags = res.flags;
 
-        // For TLS variables, we'll generally only have one of these, but we might have all 3 combinations.
+        // For TLS variables, we'll generally only have one of these, but we might have all 3
+        // combinations.
         if flags.needs_got_tls_offset()
             || flags.needs_got_tls_module()
             || flags.needs_got_tls_descriptor()
@@ -610,7 +611,8 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
             *got_entry = 0;
             return Ok(());
         }
-        // TLS_MODULE_BASE points at the end of the .tbss in some cases, thus relax the verification.
+        // TLS_MODULE_BASE points at the end of the .tbss in some cases, thus relax the
+        // verification.
         if !(self.tls.start..=self.tls.end).contains(&address) {
             bail!(
                 "GotTlsOffset resolves to address not in TLS segment 0x{:x}",
@@ -1986,8 +1988,9 @@ fn apply_relocation<'data, A: Arch>(
             .bitand(mask.symbol_plus_addend)
             .wrapping_sub(place.bitand(mask.place)),
         RelocationKind::RelativeRiscVLow12 => {
-            // The iterator is used for e.g. R_RISCV_PCREL_HI20 & R_RISCV_PCREL_LO12_I pair of relocations where the later
-            // one actually points to a label of the HI20 relocations and thus we need to find it. The relocation is typically
+            // The iterator is used for e.g. R_RISCV_PCREL_HI20 & R_RISCV_PCREL_LO12_I pair of
+            // relocations where the later one actually points to a label of the HI20
+            // relocations and thus we need to find it. The relocation is typically
             // right before the LO12_* relocation.
             ensure!(
                 addend == 0,
@@ -3122,7 +3125,8 @@ fn write_internal_symbols(
         }
 
         // Mandatory RISC-V symbol defined by the default linker script as:
-        // __global_pointer$ = MIN(__SDATA_BEGIN__ + 0x800, MAX(__DATA_BEGIN__ + 0x800, __BSS_END__ - 0x800));
+        // __global_pointer$ = MIN(__SDATA_BEGIN__ + 0x800, MAX(__DATA_BEGIN__ + 0x800, __BSS_END__
+        // - 0x800));
         if symbol_name.bytes() == GLOBAL_POINTER_SYMBOL_NAME.as_bytes() {
             address += RISCV_TLS_DTV_OFFSET;
         }

--- a/libwild/src/file_writer.rs
+++ b/libwild/src/file_writer.rs
@@ -170,7 +170,8 @@ impl Output {
                     // Create the output file.
                     let sized_output = SizedOutput::new(path, output_config, size);
 
-                    // Pass it to the main thread, so that it can start writing it once layout finishes.
+                    // Pass it to the main thread, so that it can start writing it once layout
+                    // finishes.
                     let _ = sender.send(sized_output);
                 });
             }
@@ -264,7 +265,8 @@ impl SizedOutput {
         // subprocess to inherit our file descriptor. This unfortunately doesn't prevent that, since
         // unless and until the subprocess calls exec, it will inherit the file descriptor. However,
         // assuming it eventually calls exec, this at least means that it inherits the file
-        // descriptor for less time. i.e. this doesn't really fix anything, but makes problems less bad.
+        // descriptor for less time. i.e. this doesn't really fix anything, but makes problems less
+        // bad.
         std::os::unix::fs::OpenOptionsExt::custom_flags(&mut open_options, libc::O_CLOEXEC);
 
         match output_config.file_write_mode {

--- a/libwild/src/input_data.rs
+++ b/libwild/src/input_data.rs
@@ -30,8 +30,8 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 pub(crate) struct InputData<'data> {
-    /// These are actual files on disk. We mostly only need to keep these so that we can verify that
-    /// they didn't change while we were running.
+    /// These are actual files on disk. We mostly only need to keep these so that we can verify
+    /// that they didn't change while we were running.
     pub(crate) files: Vec<&'data InputFile>,
 
     /// This is like `files`, but archives have been split into their separate parts.
@@ -130,11 +130,11 @@ struct TemporaryState<'data, 'ch> {
     /// Indexed by FileLoadIndex. As we finish each file, we'll put them into their appropriate
     /// slot. The order in which we finish isn't deterministic, but the indexes at which we place
     /// them are deterministic. Note, the order here is not quite the output order, since files
-    /// requested by linker scripts will appear at the end of this Vec, even though those files need
-    /// to be put into the final ordering at the place where the linker script was listed. We do it
-    /// this way because we don't know how many files a linker script will request until we parse
-    /// it. In fact, we don't even know that it will be a linker script until we've actually opened
-    /// it.
+    /// requested by linker scripts will appear at the end of this Vec, even though those files
+    /// need to be put into the final ordering at the place where the linker script was listed.
+    /// We do it this way because we don't know how many files a linker script will request
+    /// until we parse it. In fact, we don't even know that it will be a linker script until
+    /// we've actually opened it.
     files: Vec<Option<LoadedFileState<'data>>>,
 
     work_recv: &'ch Receiver<OpenFileRequest>,

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -384,15 +384,17 @@ fn merge_dynamic_symbol_definitions(group_states: &mut [GroupState]) -> Result {
 
 pub(crate) enum PropertyClass {
     // A bit in the output pr_data is set if it is set in any relocatable input.
-    // If all bits in the output pr_data field are zero, this property should be removed from output.
+    // If all bits in the output pr_data field are zero, this property should be removed from
+    // output.
     Or,
-    // A bit in the output pr_data field is set only if it is set in all relocatable input pr_data fields.
-    // If all bits in the output pr_data field are zero, this property should be removed from output.
+    // A bit in the output pr_data field is set only if it is set in all relocatable input pr_data
+    // fields. If all bits in the output pr_data field are zero, this property should be
+    // removed from output.
     And,
-    // A bit in the output pr_data field is set if it is set in any relocatable input pr_data fields
-    // and this property is present in all relocatable input files. When all bits in the output pr_data
-    // field are zero, this property should not be removed from output to indicate it has
-    // zero in all bits.
+    // A bit in the output pr_data field is set if it is set in any relocatable input pr_data
+    // fields and this property is present in all relocatable input files. When all bits in
+    // the output pr_data field are zero, this property should not be removed from output to
+    // indicate it has zero in all bits.
     AndOr,
 }
 
@@ -663,8 +665,8 @@ pub(crate) struct Resolution {
 
     pub(crate) dynamic_symbol_index: Option<NonZeroU32>,
 
-    /// The base GOT address for this resolution. For pointers to symbols the GOT entry will contain
-    /// a single pointer. For TLS variables there can be up to 3 pointers. If
+    /// The base GOT address for this resolution. For pointers to symbols the GOT entry will
+    /// contain a single pointer. For TLS variables there can be up to 3 pointers. If
     /// ValueFlags::GOT_TLS_OFFSET is set, then that will be the first value. If
     /// ValueFlags::GOT_TLS_MODULE is set, then there will be a pair of values (module and
     /// offset within module).
@@ -1415,9 +1417,10 @@ struct DynamicLayoutState<'data> {
 }
 
 struct CopyRelocationInfo {
-    /// The symbol ID for which we'll actually generate the copy relocation. Initially, this is just
-    /// the first symbol at a particular address for which we requested a copy relocation, then
-    /// later we may update it to point to a different symbol if that first symbol was weak.
+    /// The symbol ID for which we'll actually generate the copy relocation. Initially, this is
+    /// just the first symbol at a particular address for which we requested a copy relocation,
+    /// then later we may update it to point to a different symbol if that first symbol was
+    /// weak.
     symbol_id: SymbolId,
 
     is_weak: bool,
@@ -1501,8 +1504,8 @@ struct GraphResources<'data, 'scope> {
     /// A queue in which we store threads when they're idle so that other threads can wake them up
     /// when more work comes in. We always have one less slot in this array than the number of
     /// threads, since we never want all threads to be idle because that means we're finished. None
-    /// if we're running with a single thread - mostly because ArrayQueue panics if we try to create
-    /// an instance with zero size.
+    /// if we're running with a single thread - mostly because ArrayQueue panics if we try to
+    /// create an instance with zero size.
     idle_threads: Option<ArrayQueue<std::thread::Thread>>,
 
     done: AtomicBool,
@@ -1564,8 +1567,8 @@ enum WorkItem {
 struct SectionLoadRequest {
     file_id: FileId,
 
-    /// The offset of the section within the file's sections. i.e. the same as object::SectionIndex,
-    /// but stored as a u32 for compactness.
+    /// The offset of the section within the file's sections. i.e. the same as
+    /// object::SectionIndex, but stored as a u32 for compactness.
     section_index: u32,
 }
 
@@ -1938,7 +1941,8 @@ fn compute_segment_layout(
                     // RISCV_ATTRIBUTES segment.
                     if [NOTE, RISCV_ATTRIBUTES].contains(&section_info.ty) {
                     } else {
-                        // All segments should only cover sections that are allocated and have a non-zero address.
+                        // All segments should only cover sections that are allocated and have a
+                        // non-zero address.
                         ensure!(
                             section_layout.mem_offset != 0 || merge_target == FILE_HEADER,
                             "Missing memory offset for section {} present in a program segment.",
@@ -4070,7 +4074,8 @@ impl<'data> ObjectLayoutState<'data> {
                 self.load_section::<A>(common, queue, *unloaded, section_index, resources)?;
             }
             SectionSlot::UnloadedDebugInfo(part_id) => {
-                // On RISC-V, the debug info sections contain relocations to local symbols (e.g. labels).
+                // On RISC-V, the debug info sections contain relocations to local symbols (e.g.
+                // labels).
                 self.load_debug_section::<A>(common, queue, *part_id, section_index, resources)?;
             }
             SectionSlot::Discard => {
@@ -4403,8 +4408,8 @@ impl<'data> ObjectLayoutState<'data> {
                 SectionSlot::Loaded(sec) => {
                     let part_id = sec.part_id;
                     let address = *memory_offsets.get(part_id);
-                    // TODO: We probably need to be able to handle sections that are ifuncs and sections
-                    // that need a TLS GOT struct.
+                    // TODO: We probably need to be able to handle sections that are ifuncs and
+                    // sections that need a TLS GOT struct.
                     *memory_offsets.get_mut(part_id) += sec.capacity();
                     SectionResolution { address }
                 }
@@ -5299,8 +5304,8 @@ fn layout_section_parts(
                         let section_flags = output_sections.section_flags(merge_target);
                         let mem_size = part_size;
 
-                        // Note, we align up even if our size is zero, otherwise our section will start at an
-                        // unaligned address.
+                        // Note, we align up even if our size is zero, otherwise our section will
+                        // start at an unaligned address.
                         file_offset = alignment.align_up_usize(file_offset);
 
                         if section_flags.contains(shf::ALLOC) {

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -7,9 +7,9 @@
 //!   the multi-part sections.
 //! * Add the section to `test_constant_ids` to make sure the ID is consistent with its position in
 //!   `SECTION_DEFINITIONS`.
-//! * Insert the new section into the output order in `sections_and_segments_events`. The position needs
-//!   to be consistent with the access flags on the section. e.g. if the section is read-only data,
-//!   it should go between the start and end of the read-only segment.
+//! * Insert the new section into the output order in `sections_and_segments_events`. The position
+//!   needs to be consistent with the access flags on the section. e.g. if the section is read-only
+//!   data, it should go between the start and end of the read-only segment.
 //!
 //! Adding a new alignment-base (regular) section is similar to the above, but skip the steps
 //! related to `part_id.rs` and insert later in `SECTION_DEFINITIONS` (probably at the end). Also,

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -71,8 +71,9 @@ pub(crate) struct ParsedInputs<'data> {
     pub(crate) objects: Vec<ParsedInputObject<'data>>,
     pub(crate) linker_scripts: Vec<ProcessedLinkerScript<'data>>,
 
-    /// Total number of symbols in the prelude, input objects and defined by linker scripts. Doesn't
-    /// include symbols defined by the epilogue, since we don't know what they will be until later.
+    /// Total number of symbols in the prelude, input objects and defined by linker scripts.
+    /// Doesn't include symbols defined by the epilogue, since we don't know what they will be
+    /// until later.
     pub(crate) num_symbols: usize,
 }
 

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -696,8 +696,9 @@ fn canonicalise_undefined_symbols<'data>(
                             }
                         }
 
-                        // If the symbol isn't a start/stop symbol, then assign responsibility for the
-                        // symbol to the first object that referenced it. This lets us have PLT/GOT entries
+                        // If the symbol isn't a start/stop symbol, then assign responsibility for
+                        // the symbol to the first object that referenced
+                        // it. This lets us have PLT/GOT entries
                         // for the symbol if they're needed.
                         let symbol_id = symbol_id.unwrap_or(undefined.symbol_id);
                         entry.insert(symbol_id);

--- a/libwild/src/save_dir.rs
+++ b/libwild/src/save_dir.rs
@@ -256,7 +256,8 @@ impl SaveDirState {
                 }
             }
 
-            // To save disk space, we first attempt to hard link the file. If that fails, then just copy it.
+            // To save disk space, we first attempt to hard link the file. If that fails, then just
+            // copy it.
             if std::fs::hard_link(source_path, &dest_path).is_err() {
                 std::fs::copy(source_path, &dest_path).with_context(|| {
                     format!(

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -74,8 +74,8 @@ pub struct SymbolDb<'data> {
 
     epilogue_file_id: FileId,
 
-    /// The names of symbols that mark the start / stop of sections. These are indexed by the offset
-    /// into the epilogue's symbol IDs.
+    /// The names of symbols that mark the start / stop of sections. These are indexed by the
+    /// offset into the epilogue's symbol IDs.
     start_stop_symbol_names: Vec<UnversionedSymbolName<'data>>,
 
     pub(crate) version_script: VersionScript<'data>,
@@ -107,9 +107,9 @@ struct SymbolBucket<'data> {
     /// Global symbols that have multiple definitions keyed by the first symbol with that name.
     alternative_definitions: HashMap<SymbolId, Vec<SymbolId>>,
 
-    /// Alternative definitions, but only for versioned symbols. This might be more efficient with a
-    /// proper multi-map that doesn't need a separate Vec for each value, however we don't expect
-    /// many entries here.
+    /// Alternative definitions, but only for versioned symbols. This might be more efficient with
+    /// a proper multi-map that doesn't need a separate Vec for each value, however we don't
+    /// expect many entries here.
     alternative_versioned_definitions: HashMap<SymbolId, Vec<SymbolId>>,
 }
 
@@ -801,8 +801,9 @@ impl<'data> SymbolBucket<'data> {
             .get(&symbol_id)?
             .iter()
             .find(|alt| {
-                // For now, we just get the first definition that isn't from a shared object. We should
-                // actually take symbol binding into account, but don't yet. TODO: Fix this.
+                // For now, we just get the first definition that isn't from a shared object. We
+                // should actually take symbol binding into account, but don't yet.
+                // TODO: Fix this.
                 let file_id = symbol_db.file_id_for_symbol(**alt);
                 !symbol_db.file(file_id).is_dynamic()
             })

--- a/libwild/src/version_script.rs
+++ b/libwild/src/version_script.rs
@@ -260,8 +260,8 @@ impl<'data> VersionScript<'data> {
             }
         }
 
-        // 2) Otherwise, the last version tag with a non-* wildcard pattern wins ('global' should be checked first).
-        //    Otherwise, the last version tag with a * pattern wins.
+        // 2) Otherwise, the last version tag with a non-* wildcard pattern wins ('global' should be
+        //    checked first). Otherwise, the last version tag with a * pattern wins.
         for &non_star in &[true, false] {
             for (i, version) in self.versions.iter().enumerate().rev() {
                 let body = &version.version_body;

--- a/libwild/src/x86_64.rs
+++ b/libwild/src/x86_64.rs
@@ -365,7 +365,8 @@ impl crate::arch::Relaxation for Relaxation {
             object::elf::R_X86_64_GOTPC32_TLSDESC
                 if !interposable && output_kind.is_executable() =>
             {
-                // We require that the instruction that this relocation applies to is a LEA instruction.
+                // We require that the instruction that this relocation applies to is a LEA
+                // instruction.
                 let bytes = section_bytes.get(offset - 3..offset - 1);
                 if bytes == Some(&[0x48, 0x8d]) || bytes == Some(&[0x4c, 0x8d]) {
                     return Some(Relaxation {
@@ -378,7 +379,8 @@ impl crate::arch::Relaxation for Relaxation {
             // Note, the conditions on this relaxation (is_executable) must match those on
             // TLSDESC_CALL below.
             object::elf::R_X86_64_GOTPC32_TLSDESC if output_kind.is_executable() => {
-                // We require that the instruction that this relocation applies to is a LEA instruction.
+                // We require that the instruction that this relocation applies to is a LEA
+                // instruction.
                 let bytes = section_bytes.get(offset - 3..offset - 1);
                 if bytes == Some(&[0x48, 0x8d]) || bytes == Some(&[0x4c, 0x8d]) {
                     return Some(Relaxation {

--- a/linker-diff/src/arch.rs
+++ b/linker-diff/src/arch.rs
@@ -37,8 +37,8 @@ pub(crate) trait Arch: Clone + Copy + Eq + PartialEq + Debug {
     /// The maximum number of bytes after a relocation offset that a relaxation might modify.
     const MAX_RELAX_MODIFY_AFTER: u64;
 
-    /// Calls `cb` with each relaxation that we think is possible for the supplied relocation type and
-    /// section kind.
+    /// Calls `cb` with each relaxation that we think is possible for the supplied relocation type
+    /// and section kind.
     fn possible_relaxations_do(
         r_type: Self::RType,
         section_kind: object::SectionKind,
@@ -169,9 +169,9 @@ pub(crate) struct Relaxation<A: Arch> {
     pub(crate) relaxation_kind: A::RelaxationKind,
     pub(crate) new_r_type: A::RType,
 
-    /// A second relocation type that is also consistent with the same relaxation. The main use-case
-    /// for this is calling a function directly, or calling a function via the PLT. When just
-    /// looking at the instructions, we cannot tell these two apart.
+    /// A second relocation type that is also consistent with the same relaxation. The main
+    /// use-case for this is calling a function directly, or calling a function via the PLT.
+    /// When just looking at the instructions, we cannot tell these two apart.
     pub(crate) alt_r_type: Option<A::RType>,
 }
 
@@ -204,11 +204,11 @@ pub(crate) struct RelaxationMask {
 
     /// Which bits should be considered part of the instructions modified by a particular
     /// relaxation. e.g. a byte of 0xff would indicate that all bits of the corresponding byte
-    /// should be treated as part of the instruction. A 0 byte would indicate that the corresponding
-    /// byte should not be compared - i.e. if it's part of the offset written by the new relocation.
-    /// Note that bytes that are part of the instruction should still be compared even if they're
-    /// not written by the relocation, since the fact that the byte wasn't changed is important in
-    /// identifying a particular relaxation.
+    /// should be treated as part of the instruction. A 0 byte would indicate that the
+    /// corresponding byte should not be compared - i.e. if it's part of the offset written by
+    /// the new relocation. Note that bytes that are part of the instruction should still be
+    /// compared even if they're not written by the relocation, since the fact that the byte
+    /// wasn't changed is important in identifying a particular relaxation.
     ///
     /// Example: 48 8d 3d 00 00 00 00    lea    0x0(%rip),%rdi
     ///                   ^ The relocation points here

--- a/linker-diff/src/asm_diff.rs
+++ b/linker-diff/src/asm_diff.rs
@@ -124,8 +124,8 @@ pub(crate) fn report_section_diffs<A: Arch>(report: &mut Report, binaries: &[Bin
     let mut section_ids_to_process = matched_sections
         .keys()
         .copied()
-        // Sort sections so that we process sections in a deterministic order, since that affects our
-        // output order.
+        // Sort sections so that we process sections in a deterministic order, since that affects
+        // our output order.
         .sorted()
         .collect_vec();
 
@@ -388,9 +388,10 @@ impl<'data, A: Arch> RelaxationGroup<'data, A> {
             if let RelaxationMatchResult::Matched(m) = result
                 && let Some(alt_r_type) = m.relaxation.alt_r_type
             {
-                // Some relaxations cannot be identified purely by the instruction bytes. For example
-                // relaxing a PLT32 to a PC32, the instruction bytes are left the same. All that differs is
-                // whether we now point to the PLT or not.
+                // Some relaxations cannot be identified purely by the instruction bytes. For
+                // example relaxing a PLT32 to a PC32, the instruction bytes are
+                // left the same. All that differs is whether we now point to the
+                // PLT or not.
 
                 match (
                     reference.verify_consistent_with_r_type(m.relaxation.new_r_type),
@@ -1388,8 +1389,8 @@ struct ResolvedGroup<'data, A: Arch> {
     start: u64,
 
     /// The exclusive end of the bytes associated with this resolution. This should the the offset
-    /// of the first byte after the later of (a) any instructions modified by the relaxation and (b)
-    /// the bytes of the relocation offset.
+    /// of the first byte after the later of (a) any instructions modified by the relaxation and
+    /// (b) the bytes of the relocation offset.
     end: u64,
 
     trace: TraceOutput,
@@ -1726,14 +1727,14 @@ struct RelaxationTester<'data> {
 
     section_size: u64,
 
-    /// The exclusive offset of the end of the previous resolution. Bytes from this offset should be
-    /// checked when considering the next resolution.
+    /// The exclusive offset of the end of the previous resolution. Bytes from this offset should
+    /// be checked when considering the next resolution.
     previous_end: u64,
 
     /// Indicates whether the next relocation should be skipped. This is used when a relaxation
     /// replaces not only the current relocation, but the next one too. For example when relaxing
-    /// TLSGD to initial exec, the second relocation is a call to `__tls_get_addr` that is no longer
-    /// needed.
+    /// TLSGD to initial exec, the second relocation is a call to `__tls_get_addr` that is no
+    /// longer needed.
     next_modifier: RelocationModifier,
 
     bin: &'data Binary<'data>,
@@ -3352,9 +3353,9 @@ impl<'data> GotIndex<'data> {
                         }
                         (BasicValueKind::TlsGd, Some(symbol)) => Ok(Referent::TlsGd(*symbol)),
                         (BasicValueKind::TlsGd, None) => {
-                            // There's no symbol associated with the DTPMOD relocation, so it's a TLS
-                            // variable within the current DSO. Read the next word of data to get the
-                            // offset.
+                            // There's no symbol associated with the DTPMOD relocation, so it's a
+                            // TLS variable within the current DSO. Read
+                            // the next word of data to get the offset.
                             let tls_offset =
                                 read_word_at(bin.elf_file, got_address + size_of::<u64>() as u64)?
                                     .context("Short read after DTPMOD")?

--- a/linker-diff/src/gnu_hash.rs
+++ b/linker-diff/src/gnu_hash.rs
@@ -59,8 +59,8 @@ pub(crate) fn check_object(obj: &Binary) -> Result {
             )
         })?;
 
-    // For a simple binary, both LLD and BFD create .gnu.hash section that does not contain any chain:
-    // Contents of section .gnu.hash:
+    // For a simple binary, both LLD and BFD create .gnu.hash section that does not contain any
+    // chain: Contents of section .gnu.hash:
     // objdump -s -j .gnu.hash
     // 4003e8 01000000 01000000 01000000 00000000
     // 4003f8 00000000 00000000 00000000

--- a/linker-diff/src/header_diff.rs
+++ b/linker-diff/src/header_diff.rs
@@ -76,8 +76,8 @@ impl Converter {
         match self {
             Converter::None => Ok(ConvertedValue::Single(format!("0x{value:x}"))),
             Converter::SectionAddress => {
-                // Find the first non-empty, section at that address. Only return an empty section if
-                // there is no non-empty sections at that address.
+                // Find the first non-empty, section at that address. Only return an empty section
+                // if there is no non-empty sections at that address.
                 let mut empty_section_name = None;
                 for section in obj.elf_file.sections() {
                     let object::SectionFlags::Elf { sh_flags } = section.flags() else {

--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -143,9 +143,9 @@ impl Config {
     fn apply_wild_defaults(&mut self, arch: ArchKind) {
         self.ignore.extend(
             [
-                // We don't currently support allocating space except in sections, so we have sections
-                // to hold the section and program headers. We then need to ignore them because GNU ld
-                // doesn't define such sections.
+                // We don't currently support allocating space except in sections, so we have
+                // sections to hold the section and program headers. We then need
+                // to ignore them because GNU ld doesn't define such sections.
                 "section.shdr",
                 "section.phdr",
                 // We don't yet support these sections.
@@ -164,9 +164,9 @@ impl Config {
                 "section.annobin.notes.entsize",
                 // We don't yet group .lrodata sections separately.
                 "section.lrodata",
-                // We sometimes eliminate __tls_get_addr where GNU ld doesn't. This can mean that we
-                // have no versioned symbols for ld-linux-x86-64.so.2 or equivalent, which means we
-                // end up with one less version record.
+                // We sometimes eliminate __tls_get_addr where GNU ld doesn't. This can mean that
+                // we have no versioned symbols for ld-linux-x86-64.so.2 or
+                // equivalent, which means we end up with one less version record.
                 ".dynamic.DT_VERNEEDNUM",
                 // We currently handle these dynamic tags differently
                 ".dynamic.DT_JMPREL",
@@ -179,7 +179,8 @@ impl Config {
                 "section.plt.sec",
                 // We don't yet write this.
                 ".dynamic.DT_HASH",
-                // aarch64-linux-gnu-ld on arch linux emits DT_BIND_NOW instead of DT_FLAGS.BIND_NOW
+                // aarch64-linux-gnu-ld on arch linux emits DT_BIND_NOW instead of
+                // DT_FLAGS.BIND_NOW
                 ".dynamic.DT_BIND_NOW",
                 ".dynamic.DT_FLAGS.BIND_NOW",
                 // TODO: Implement proper ordering of .init .ctors etc
@@ -189,10 +190,11 @@ impl Config {
                 // canonical PLT entry and points the GOT at that. This means that it ends up with
                 // GOT->PLT->GOT. We don't as yet support doing this.
                 "rel.missing-got-plt-got",
-                // We do support this. TODO: Should definitely look into why we're seeing this missing
-                // in our output.
+                // We do support this. TODO: Should definitely look into why we're seeing this
+                // missing in our output.
                 "section.rela.plt",
-                // We currently write 10 byte PLT entries in some cases where GNU ld writes 8 byte ones.
+                // We currently write 10 byte PLT entries in some cases where GNU ld writes 8 byte
+                // ones.
                 "section.plt.got.alignment",
                 // GNU ld sometimes makes this writable sometimes not. Presumably this depends on
                 // whether there are relocations or some flags.
@@ -227,8 +229,8 @@ impl Config {
                 // `-zdynamic-undefined-weak`.
                 "rel.undefined-weak.dynamic.R_X86_64_64",
                 "rel.undefined-weak.dynamic.R_AARCH64_ABS64",
-                // On aarch64, GNU ld, at least sometimes, converts R_AARCH64_ABS64 to a PLT-forming
-                // relocation. We at present, don't.
+                // On aarch64, GNU ld, at least sometimes, converts R_AARCH64_ABS64 to a
+                // PLT-forming relocation. We at present, don't.
                 "rel.dynamic-plt-bypass",
                 // If we don't optimise a TLS access, then we'll have references to __tls_get_addr,
                 // when GNU ld doesn't.
@@ -254,8 +256,8 @@ impl Config {
         match arch {
             ArchKind::Aarch64 => self.ignore.extend(
                 [
-                    // Other linkers have a bigger initial PLT entry, thus the entsize is set to zero:
-                    // https://sourceware.org/bugzilla/show_bug.cgi?id=26312
+                    // Other linkers have a bigger initial PLT entry, thus the entsize is set to
+                    // zero: https://sourceware.org/bugzilla/show_bug.cgi?id=26312
                     "section.plt.entsize",
                     // On Alpine Linux, aarch64, GNU ld seems to emit the _DYNAMIC symbol without a
                     // section index instead of pointing it at the .dynamic section.

--- a/linker-diff/src/x86_64.rs
+++ b/linker-diff/src/x86_64.rs
@@ -284,9 +284,9 @@ impl Arch for X86_64 {
                     0xf2, 0xe9, 0, 0, 0, 0,    // bnd jmp {plt[0]}(%rip)
                     0x90, // nop
                 ];
-                // Note: Some variants use jmp instead of bnd jmp, then a different padding instruction.
-                // Because we use the index that gets pushed, we ignore the bytes of the later
-                // instructions, so that we support these variants.
+                // Note: Some variants use jmp instead of bnd jmp, then a different padding
+                // instruction. Because we use the index that gets pushed, we ignore the bytes of
+                // the later instructions, so that we support these variants.
                 if plt_entry[..5] == PLT_ENTRY_TEMPLATE[..5] {
                     let index = u32_from_slice(&plt_entry[5..]);
                     return Some(PltEntry::JumpSlot(index));

--- a/linker-layout/src/lib.rs
+++ b/linker-layout/src/lib.rs
@@ -17,7 +17,8 @@ pub struct Layout {
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
 pub struct InputFile {
-    /// Path to the input file on disk. In case of archives, multiple inputs may have the same path.
+    /// Path to the input file on disk. In case of archives, multiple inputs may have the same
+    /// path.
     pub path: PathBuf,
 
     /// If the input is an archive, then contains information about where in the archive the file

--- a/linker-utils/src/aarch64.rs
+++ b/linker-utils/src/aarch64.rs
@@ -167,7 +167,8 @@ pub const fn relocation_type_from_raw(r_type: u32) -> Option<RelocationKindInfo>
         // object::elf::R_AARCH64_PLT32
 
         // 5.7.6   Static AArch64 relocations
-        // Group relocations to create a 16-, 32-, 48-, or 64-bit unsigned data value or address inline
+        // Group relocations to create a 16-, 32-, 48-, or 64-bit unsigned data value or address
+        // inline
         object::elf::R_AARCH64_MOVW_UABS_G0 => (
             RelocationKind::Absolute,
             RelocationSize::bit_mask_aarch64(0, 16, AArch64Instruction::Movkz),
@@ -947,8 +948,8 @@ pub const fn relocation_type_from_raw(r_type: u32) -> Option<RelocationKindInfo>
 
 impl AArch64Instruction {
     // Encode computed relocation value and store it based on the encoding of an instruction.
-    // Each instruction links to a chapter in the Arm Architecture Reference Manual for A-profile architecture
-    // manual: https://developer.arm.com/documentation/ddi0487/latest/
+    // Each instruction links to a chapter in the Arm Architecture Reference Manual for A-profile
+    // architecture manual: https://developer.arm.com/documentation/ddi0487/latest/
     pub fn write_to_value(self, extracted_value: u64, negative: bool, dest: &mut [u8]) {
         let mut mask;
         match self {

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -814,9 +814,9 @@ pub enum RelocationKind {
     /// The address of the symbol, relative to the place of the relocation.
     Relative,
 
-    /// The address of the symbol, relative to the place of the relocation. The address of the relocation
-    /// points to an instruction for which the R_RISCV_PCREL_HI20 relocation is used and that is the place
-    /// we make this relocation relative to.
+    /// The address of the symbol, relative to the place of the relocation. The address of the
+    /// relocation points to an instruction for which the R_RISCV_PCREL_HI20 relocation is used
+    /// and that is the place we make this relocation relative to.
     RelativeRiscVLow12,
 
     /// The address of the symbol, relative to the base address of the GOT.
@@ -887,7 +887,8 @@ pub enum RelocationKind {
     /// The address of a TLS descriptor structure, relative to the start of the GOT.
     TlsDescGotBase,
 
-    /// Call to the TLS descriptor trampoline. Used only as a placeholder for a linker relaxation opportunity.
+    /// Call to the TLS descriptor trampoline. Used only as a placeholder for a linker relaxation
+    /// opportunity.
     TlsDescCall,
 
     /// No relocation needs to be applied. Produced when we eliminate a relocation due to an
@@ -1089,7 +1090,8 @@ pub enum RiscVInstruction {
     // Specifies a field as the immediate field in a CJ-type (compressed jump) instruction
     CjType,
 
-    // Encode the value using ULEB128 encoding (the size of the output is variable based on the value)
+    // Encode the value using ULEB128 encoding (the size of the output is variable based on the
+    // value)
     Uleb128,
 }
 

--- a/linker-utils/src/riscv64.rs
+++ b/linker-utils/src/riscv64.rs
@@ -366,7 +366,8 @@ impl RiscVInstruction {
     // https://msyksphinz-self.github.io/riscv-isadoc/html/index.html.
 
     // During the build of the static libc.a, there are various places where the immediate operand
-    // of an instruction is already filled up. Thus, we zero the bits before a relocation value is applied.
+    // of an instruction is already filled up. Thus, we zero the bits before a relocation value is
+    // applied.
     pub fn write_to_value(self, extracted_value: u64, _negative: bool, dest: &mut [u8]) {
         match self {
             RiscVInstruction::UiType => {

--- a/linker-utils/src/x86_64.rs
+++ b/linker-utils/src/x86_64.rs
@@ -265,7 +265,8 @@ const RELOC_1_BYTE_SIGNED: RelocSizeAndRange = (
 );
 const RELOC_NONE: RelocSizeAndRange = (RelocationSize::ByteSize(0), AllowedRange::no_check());
 
-/// Returns the supplied x86-64 relocation as RelocationKindType. Returns `None` if the r_type isn't recognised.
+/// Returns the supplied x86-64 relocation as RelocationKindType. Returns `None` if the r_type isn't
+/// recognised.
 #[must_use]
 #[inline(always)]
 pub const fn relocation_from_raw(r_type: u32) -> Option<RelocationKindInfo> {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,3 +2,5 @@ edition = "2024"
 use_field_init_shorthand = true
 imports_granularity = "Item"
 group_imports = "One"
+wrap_comments = true
+comment_width = 100

--- a/wild/tests/external_tests/mold_tests.rs
+++ b/wild/tests/external_tests/mold_tests.rs
@@ -140,7 +140,8 @@ fn should_skip_mold_test_by_toml(path: &Path) -> bool {
     false
 }
 
-// Some mold tests have names starting with `arch-`, indicating the target architecture they run on. Therefore, we have to implement a similar filter for the wild tests as well.
+// Some mold tests have names starting with `arch-`, indicating the target architecture they run on.
+// Therefore, we have to implement a similar filter for the wild tests as well.
 fn should_skip_mold_test_by_arch(path: &Path) -> bool {
     let file_name = path
         .file_name()

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -2009,12 +2009,12 @@ impl LinkCommand {
                         Compiler::Gcc(_) => {
                             match linker {
                                 Linker::Wild => {
-                                    // GCC unfortunately doesn't provide any way to use a custom linker.
-                                    // Their flag for switching linkers only accepts a hard-coded list
-                                    // of alternatives and the developers don't seem to want any
-                                    // equivalent to clang's --ld-path. The closest we can get is to put
-                                    // a file called "ld" in a directory, then pass "-B" and that
-                                    // directory.
+                                    // GCC unfortunately doesn't provide any way to use a custom
+                                    // linker. Their flag for switching linkers only accepts a
+                                    // hard-coded list of alternatives and the developers don't seem
+                                    // to want any equivalent to clang's --ld-path. The closest we
+                                    // can get is to put a file called "ld" in a directory, then
+                                    // pass "-B" and that directory.
                                     let bin_dir = wild_path().parent().unwrap();
                                     command.arg("-B").arg(bin_dir);
                                 }
@@ -2027,8 +2027,8 @@ impl LinkCommand {
                     }
 
                     if arch == Architecture::AArch64 {
-                        // Provide a workaround for ld.lld: error: unknown argument '--fix-cortex-a53-835769'
-                        // Bug link: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105941
+                        // Provide a workaround for ld.lld: error: unknown argument
+                        // '--fix-cortex-a53-835769' Bug link: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105941
                         command.arg("-mno-fix-cortex-a53-835769");
                     }
 


### PR DESCRIPTION
This is a small stylistic change. I normally rely on Rustfmt's comment wrapping feature. Even though it's not a stable feature, it has worked well and stably for the last few years. Also, I added a second commit so that the changes affecting these 28 files can be excluded from `git blame`. See also: https://www.stefanjudis.com/today-i-learned/how-to-exclude-commits-from-git-blame/

GitHub respects this file by default:
<img width="960" height="540" alt="image" src="https://github.com/user-attachments/assets/5fa60dd0-2a06-4888-b98c-1d178ddefd5d" />
