### PR TITLE
test: Make a test failure message less confusing

### DIFF
--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -2781,13 +2781,8 @@ fn run_with_config(
             let result = program_inputs
                 .build(linker, config, cross_arch)
                 .with_context(|| {
-                    let message = if config.expect_errors.is_empty() {
-                        "Failed"
-                    } else {
-                        "Unexpectedly succeeded"
-                    };
                     format!(
-                        "{message} to build program `{program_inputs}` \
+                        "Test failed: `{program_inputs}` \
                         with linker `{linker}` config `{}`",
                         config.name
                     )


### PR DESCRIPTION
This code was assuming that if a test with ExpectError set failed, that it was because the build succeeded, but there are other causes of errors. e.g. it failed, but produced the wrong error message.