### PR TITLE
Direct git blame to ignore previous commit that reflowed comments.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+4c08fad6dd8ef5f9f4698bd22fe25dfc6e110c04


### PR DESCRIPTION
Follow up to #1268 