### PR TITLE
RISC-V: Support `.variant_cc`

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -459,8 +459,14 @@ pub(crate) const GNU_NOTE_NAME: &[u8] = b"GNU\0";
 pub(crate) const GNU_NOTE_PROPERTY_ENTRY_SIZE: usize = 16;
 
 // AArch64-specific constants
+// TODO: Use values from object crate when they become available.
 pub(crate) const STO_AARCH64_VARIANT_PCS: u8 = 0x80;
 pub(crate) const DT_AARCH64_VARIANT_PCS: u32 = 0x70000005;
+
+// RISC-V-specific constants
+// TODO: Use values from object crate when they become available.
+pub(crate) const STO_RISCV_VARIANT_CC: u8 = 0x80;
+pub(crate) const DT_RISCV_VARIANT_CC: u32 = 0x70000001;
 
 /// For additional information on Elf_Prop, see
 /// Linux Extensions to gABI at https://gitlab.com/x86-psABIs/Linux-ABI.

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -3395,7 +3395,12 @@ const EPILOGUE_DYNAMIC_ENTRY_WRITERS: &[DynamicEntryWriter] = &[
     ),
     DynamicEntryWriter::optional(
         crate::elf::DT_AARCH64_VARIANT_PCS,
-        |inputs| inputs.has_variant_pcs,
+        |inputs| inputs.has_variant_pcs && inputs.args.arch == crate::arch::Architecture::AArch64,
+        |_inputs| 0,
+    ),
+    DynamicEntryWriter::optional(
+        crate::elf::DT_RISCV_VARIANT_CC,
+        |inputs| inputs.has_variant_pcs && inputs.args.arch == crate::arch::Architecture::RISCV64,
         |_inputs| 0,
     ),
     DynamicEntryWriter::new(object::elf::DT_NULL, |_inputs| 0),

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -1101,6 +1101,16 @@ impl<'data> SymbolRequestHandler<'data> for DynamicLayoutState<'data> {
                 .store(true, atomic::Ordering::Relaxed);
         }
 
+        // Check for VARIANT_CC flag in RISC-V symbols
+        if A::KIND == crate::arch::Architecture::RISCV64
+            && let Ok(sym) = self.object.symbols.symbol(object::SymbolIndex(local_index))
+            && (sym.st_other & crate::elf::STO_RISCV_VARIANT_CC) != 0
+        {
+            resources
+                .has_variant_pcs
+                .store(true, atomic::Ordering::Relaxed);
+        }
+
         Ok(())
     }
 }

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -173,7 +173,6 @@ tests = [
   "arch-riscv64-relax-hi20.sh",
   "arch-riscv64-reloc-overflow.sh",
   "arch-riscv64-symbol-size.sh",
-  "arch-riscv64-variant-cc.sh",
 ]
 
 [skipped_groups.tls]


### PR DESCRIPTION
Similar to #1272, RISC-V also has a directive indicating that the calling convention differs from the standard one.