### PR TITLE
doc: improve building and benching docs for rustc

### DIFF
--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -228,18 +228,12 @@ Before building rustc, edit or create `bootstrap.toml` in your `rust` directory 
 bootstrap-override-lld = true
 ```
 
-To build rustc, run this in the root of the rust repo:
-```sh
-./x build
-```
-
-For more information about building rustc see [building instructions on the
+Now we can build rustc using wild as the linker. In the following
+command, replace `$WILD_REPO_PATH` with the path to the directory containing the wild repo. You'll
+need to have already built wild with `cargo build --release`. For more information about building rustc see [building instructions on the
 rustc-dev-guide](https://rustc-dev-guide.rust-lang.org/building/how-to-build-and-run.html).
 
-Once you've successfully built rustc, build it again, but using wild as the linker. In the following
-command, replace `$WILD_REPO_PATH` with the path to the directory containing the wild repo. You'll
-need to have already built wild with `cargo build --release`.
-
+Cd into the rust repo root and run:
 ```sh
 touch compiler/rustc_driver/src/lib.rs
 PATH=$WILD_REPO_PATH/fakes:$PATH echo "Using $(ld.lld --version) to link rustc"


### PR DESCRIPTION
The currently recommended instructions for linking and benchmarking rustc are outdated and don't work.

There isn't any good way of opting out of using lld (so we could symlink default linker to wild) yet in `bootstrap.toml`.
Instead we can use lld from $PATH using `rust.bootstrap-override-lld = true` once
- [x] rust-lang/rust/pull/148709 is merged.

We no longer recommend to first build rustc with other linker than wild (see commit c0f337b4a26d1d0c7e322416c1d438307d774256).