### PR TITLE
feat: support negation ('^') in version script globs

### DIFF
--- a/libwild/src/version_script.rs
+++ b/libwild/src/version_script.rs
@@ -581,7 +581,7 @@ pub(crate) fn parse_matcher<'data>(
                 //
                 // Let's optimistically assume the '^' cannot be part of the symbol's name (escaped
                 // in a pattern).
-                let pattern = pattern.replace("^", "!");
+                let pattern = pattern.replace("[^", "[!");
                 Pattern::new(pattern.as_str()).map_err(|_| {
                     ContextError::from_external_error(input, VersionScriptError::InvalidGlobPattern)
                 })


### PR DESCRIPTION
Apparently, there are various glob patterns in the `libstdc++` version script file and so we need to support it properly:

```
      std::co[^dln]*;
      std::cu[^r]*;
      std::error[^_]*;
      std::h[^a]*;
```

Fixes: #990

CC: @lapla-cogito