### PR TITLE
refactoring: Make timing annotations use tracing indirectly

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -73,6 +73,7 @@ use crate::string_merging::get_merged_string_output_address;
 use crate::symbol_db::RawSymbolName;
 use crate::symbol_db::SymbolDb;
 use crate::symbol_db::SymbolId;
+use crate::timing_phase;
 use crate::value_flags::PerSymbolFlags;
 use crate::value_flags::ValueFlags;
 use hashbrown::HashMap;
@@ -184,8 +185,8 @@ fn compute_hash(sized_output: &SizedOutput) -> blake3::Hash {
         .finalize()
 }
 
-#[tracing::instrument(skip_all, name = "Write data to file")]
 fn write_file_contents<A: Arch>(sized_output: &mut SizedOutput, layout: &Layout) -> Result {
+    timing_phase!("Write data to file");
     let mut section_buffers = split_output_into_sections(layout, &mut sized_output.out);
 
     let mut writable_buckets = split_buffers_by_alignment(&mut section_buffers, layout);
@@ -242,8 +243,8 @@ fn fill_padding(mut section_buffers: OutputSectionMap<&mut [u8]>) {
     });
 }
 
-#[tracing::instrument(skip_all, name = "Sort .eh_frame_hdr")]
 fn sort_eh_frame_hdr_entries(eh_frame_hdr: &mut [u8]) {
+    timing_phase!("Sort .eh_frame_hdr");
     let entry_bytes = &mut eh_frame_hdr[size_of::<elf::EhFrameHdr>()..];
     let entries = <[elf::EhFrameHdrEntry]>::mut_from_bytes(entry_bytes).unwrap();
     entries.par_sort_by_key(|e| e.frame_ptr);

--- a/libwild/src/grouping.rs
+++ b/libwild/src/grouping.rs
@@ -11,6 +11,7 @@ use crate::sharding::ShardKey as _;
 use crate::symbol::UnversionedSymbolName;
 use crate::symbol_db::SymbolId;
 use crate::symbol_db::SymbolIdRange;
+use crate::timing_phase;
 use std::fmt::Display;
 
 #[derive(Debug)]
@@ -74,12 +75,13 @@ impl Group<'_> {
     }
 }
 
-#[tracing::instrument(skip_all, name = "Group files")]
 pub(crate) fn group_files<'data>(
     parsed_inputs: ParsedInputs<'data>,
     args: &Args,
     herd: &'data bumpalo_herd::Herd,
 ) -> Vec<Group<'data>> {
+    timing_phase!("Group files");
+
     let max_files_per_group = determine_max_files_per_group(args);
     let symbols_per_group = determine_symbols_per_group(&parsed_inputs, args);
 

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -37,6 +37,7 @@ use crate::program_segments::ProgramSegmentId;
 use crate::program_segments::ProgramSegments;
 use crate::program_segments::STACK_SEGMENT_DEF;
 use crate::resolution::SectionSlot;
+use crate::timing_phase;
 use core::slice;
 use hashbrown::HashMap;
 use linker_utils::elf::SectionFlags;
@@ -974,8 +975,9 @@ impl<'data> OutputSections<'data> {
         }
     }
 
-    #[tracing::instrument(skip_all, name = "Compute output order")]
     pub(crate) fn output_order(&self) -> (OutputOrder, ProgramSegments) {
+        timing_phase!("Compute output order");
+
         let mut custom = CustomSectionIds::default();
 
         self.section_infos.for_each(|id, info| {

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -18,17 +18,19 @@ use crate::output_section_id;
 use crate::output_section_id::OutputSectionId;
 use crate::symbol::UnversionedSymbolName;
 use crate::symbol_db::SymbolId;
+use crate::timing_phase;
 use linker_utils::elf::SymbolType;
 use linker_utils::elf::stt;
 use rayon::iter::IntoParallelRefIterator;
 use rayon::iter::ParallelIterator;
 
-#[tracing::instrument(skip_all, name = "Parse input files")]
 pub(crate) fn parse_input_files<'data>(
     inputs: &[InputBytes<'data>],
     linker_scripts: Vec<ProcessedLinkerScript<'data>>,
     args: &'data Args,
 ) -> Result<ParsedInputs<'data>> {
+    timing_phase!("Parse input files");
+
     let (objects, prelude) = rayon::join(
         || {
             inputs
@@ -51,11 +53,12 @@ pub(crate) fn parse_input_files<'data>(
     })
 }
 
-#[tracing::instrument(skip_all, name = "Process linker scripts")]
 pub(crate) fn process_linker_scripts<'data>(
     linker_scripts_in: &[InputLinkerScript<'data>],
     output_sections: &mut OutputSections<'data>,
 ) -> Result<(Vec<ProcessedLinkerScript<'data>>, LayoutRules<'data>)> {
+    timing_phase!("Process linker scripts");
+
     let mut builder = LayoutRulesBuilder::default();
 
     let linker_scripts = linker_scripts_in

--- a/libwild/src/string_merging.rs
+++ b/libwild/src/string_merging.rs
@@ -37,6 +37,7 @@ use crate::part_id::PartId;
 use crate::resolution::ResolvedFile;
 use crate::resolution::ResolvedGroup;
 use crate::resolution::SectionSlot;
+use crate::timing_phase;
 use crossbeam_channel::Sender;
 use crossbeam_queue::ArrayQueue;
 use crossbeam_utils::atomic::AtomicCell;
@@ -192,12 +193,13 @@ pub(crate) struct MergeStringsSectionBucket<'data> {
 
 /// Merges identical strings from all loaded objects where those strings are from input sections
 /// that are marked with both the SHF_MERGE and SHF_STRINGS flags.
-#[tracing::instrument(skip_all, name = "Merge strings")]
 pub(crate) fn merge_strings<'data>(
     resolved: &mut [ResolvedGroup<'data>],
     output_sections: &OutputSections,
     args: &Args,
 ) -> Result<OutputSectionMap<MergedStringsSection<'data>>> {
+    timing_phase!("Merge strings");
+
     let input_sections_by_output =
         group_merge_string_sections_by_output(resolved, output_sections)?;
 
@@ -966,12 +968,13 @@ fn find_string(
 }
 
 impl MergedStringStartAddresses {
-    #[tracing::instrument(skip_all, name = "Compute merged string section start addresses")]
     pub(crate) fn compute(
         output_sections: &OutputSections<'_>,
         starting_mem_offsets_by_group: &[OutputSectionPartMap<u64>],
         merge_string_sections: &OutputSectionMap<MergedStringsSection>,
     ) -> Self {
+        timing_phase!("Compute merged string section start addresses");
+
         let mut addresses = output_sections.new_section_map_with(|| [0; MERGE_STRING_BUCKETS]);
         let internal_start_offsets = starting_mem_offsets_by_group.first().unwrap();
         merge_string_sections.for_each(|section_id, sec| {

--- a/libwild/src/timing.rs
+++ b/libwild/src/timing.rs
@@ -9,6 +9,14 @@ use std::time::Duration;
 use std::time::Instant;
 use tracing::field::Visit;
 
+#[macro_export]
+macro_rules! timing_phase {
+    ($phase:expr) => {
+        let span = tracing::span!(tracing::Level::INFO, $phase);
+        let _guard = span.enter();
+    };
+}
+
 struct TimingLayer {
     counter_pool: Option<ArrayQueue<CounterList>>,
 }

--- a/libwild/src/version_script.rs
+++ b/libwild/src/version_script.rs
@@ -12,6 +12,7 @@ use crate::hash::PreHashed;
 use crate::input_data::ScriptData;
 use crate::linker_script::skip_comments_and_whitespace;
 use crate::symbol::UnversionedSymbolName;
+use crate::timing_phase;
 use glob::Pattern;
 use hashbrown::HashMap;
 use hashbrown::HashSet;
@@ -377,8 +378,9 @@ fn parse_version_script<'input>(input: &mut &'input BStr) -> winnow::Result<Vers
 }
 
 impl<'data> VersionScript<'data> {
-    #[tracing::instrument(skip_all, name = "Parse version script")]
     pub(crate) fn parse(data: ScriptData<'data>) -> Result<VersionScript<'data>> {
+        timing_phase!("Parse version script");
+
         parse_version_script
             .parse(BStr::new(data.raw))
             .map_err(|err| error!("Failed to parse version script:\n{err}"))


### PR DESCRIPTION
Also fix a few unnecessary Result return type warnings that were being masked by tracing::instrument.