### PR TITLE
ci: Set `timeout-minutes` for CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       fail-fast: false
 
     runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 10
 
     container:
       image: ${{ matrix.container }}
@@ -93,8 +94,8 @@ jobs:
       - run: WILD_TEST_CROSS=$WILD_TEST_CROSS cargo test --profile ci --workspace
 
   minimal-versions:
-    runs-on:
-      - ubuntu-24.04
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - run: sudo apt-get update && sudo apt-get -y install gcc g++ clang clang-format lld curl
       - uses: actions/checkout@v5
@@ -118,6 +119,7 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@v5
       with:
@@ -143,6 +145,7 @@ jobs:
   rustfmt:
     name: Check formatting
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@v5
       with:
@@ -155,6 +158,7 @@ jobs:
   riscv-build:
     name: RISC-V build
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@v5
       with:
@@ -169,6 +173,7 @@ jobs:
   spelling:
     name: Spell Check with Typos
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
         with:
@@ -179,6 +184,7 @@ jobs:
   calc-matrix:
     name: Find Nix checks
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     outputs:
       matrix: ${{ steps.calc-matrix.outputs.matrix }}
 
@@ -210,6 +216,7 @@ jobs:
       matrix:
         check: ${{ fromJson(needs.calc-matrix.outputs.matrix) }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     name: Nix/${{ matrix.check }}
 
     steps:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -11,6 +11,7 @@ jobs:
   markdown-link-check:
     if: github.repository_owner == 'davidlattimore'
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/external_tests.yml
+++ b/.github/workflows/external_tests.yml
@@ -18,6 +18,7 @@ jobs:
   external-tests:
     name: Run mold tests
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     container:
       image: 'ubuntu:25.04'
     steps:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -14,6 +14,7 @@ jobs:
   nix-cache:
     name: Refresh Nix Cache
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
 
     steps:
       - name: Checkout

--- a/.github/workflows/update-nix-lockfile.yaml
+++ b/.github/workflows/update-nix-lockfile.yaml
@@ -10,6 +10,7 @@ jobs:
     name: Update Nix lockfile
     if: github.repository_owner == 'davidlattimore'
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: write
 


### PR DESCRIPTION
The exact cause remains unclear, but checks for `minimal-versions` sometimes appear to hang (e.g. https://github.com/davidlattimore/wild/actions/runs/19277294367/job/55120115423). GitHub Actions' default timeout is 6 hours - while retries can eventually pass these checks, catching such issues early is clearly beneficial. Therefore, we'll set `timeout-minutes` for each CI job. For now, we've configured all jobs with a 10-minute timeout, but based on actual execution times, a slightly shorter duration might be appropriate (though we've included some buffer to account for potential future CI time increases).