### PR TITLE
fix: Don't try to emit copy relocations for non-canonical symbol aliases

### DIFF
--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -5812,6 +5812,10 @@ impl<'data> DynamicLayoutState<'data> {
 
             let symbol_id = self.symbol_id_range.offset_to_id(i);
 
+            if !symbol_db.is_canonical(symbol_id) {
+                continue;
+            }
+
             export_dynamic(common, symbol_id, symbol_db)?;
 
             per_symbol_flags

--- a/wild/tests/sources/copy-relocations-2.c
+++ b/wild/tests/sources/copy-relocations-2.c
@@ -30,3 +30,10 @@ int get_w3(void) { return w3; }
 // alignment. This is to verify that we correctly handle the alignment when
 // performing a copy relocation.
 __attribute__((aligned(0x100))) int aligned_int = 700;
+
+int s4 = 4;
+
+__attribute__((weak, alias("s4"))) extern int w4;
+
+int get_s4(void) { return s4; }
+int get_w4(void) { return w4; }

--- a/wild/tests/sources/copy-relocations.c
+++ b/wild/tests/sources/copy-relocations.c
@@ -24,10 +24,17 @@ extern int s2;
 int get_s2(void);
 int get_w2(void);
 
-// Lastly, we reference the weak symbol and not the strong one.
+// Here, we reference the weak symbol and not the strong one.
 extern int w3;
 int get_s3(void);
 int get_w3(void);
+
+// This time we strongly define w4, which overrides the weak alias w4 in the
+// shared object.
+extern int s4;
+int w4 = 24;
+int get_s4(void);
+int get_w4(void);
 
 // This is defined in a separate object file that is compiled with -fPIC.
 int get_s1_pic(void);
@@ -88,7 +95,18 @@ void _start(void) {
     exit_syscall(54);
   }
   if (ptr_to_int(&aligned_int2) & 0xff) {
-    exit_syscall(54);
+    exit_syscall(55);
+  }
+
+  if (get_s4() != 4) {
+    exit_syscall(56);
+  }
+  s4 = 14;
+  if (get_s4() != 14) {
+    exit_syscall(57);
+  }
+  if (get_w4() != 24) {
+    exit_syscall(58);
   }
 
   exit_syscall(42);


### PR DESCRIPTION
Issue #1302