### PR TITLE
chore: drop fd-lock dev dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,17 +470,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "fd-lock"
-version = "4.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
-dependencies = [
- "cfg-if",
- "rustix",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,7 +1771,6 @@ version = "0.7.0"
 dependencies = [
  "ar",
  "dhat",
- "fd-lock",
  "itertools",
  "libwild",
  "linker-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ crossbeam-channel = "0.5.15"
 derive_more = { version = "2.0.1", features = ["debug"] }
 dhat = { version = "0.3.3" }
 fallible-iterator = "0.3.0"
-fd-lock = "4.0.0"
 flate2 = { version = "1.1.0", features = ["zlib-rs"] }
 foldhash = "0.2.0"
 gimli = "0.32.0"

--- a/wild/Cargo.toml
+++ b/wild/Cargo.toml
@@ -23,7 +23,6 @@ dhat = { workspace = true, optional = true }
 
 [dev-dependencies]
 ar = { workspace = true }
-fd-lock = { workspace = true }
 itertools = { workspace = true }
 linker-diff = { path = "../linker-diff" }
 object = { workspace = true }

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -1420,8 +1420,8 @@ fn build_linker_input(
         InputType::SharedObject => {
             let so_path = first_obj_path.with_extension(format!("{linker}.so"));
             let so_lockfile = first_obj_path.with_extension(format!("{linker}.so.lock"));
-            let mut so_lock = fd_lock::RwLock::new(File::create(&so_lockfile)?);
-            let _write_lock = so_lock.write().unwrap();
+            let so_lock = File::create(&so_lockfile)?;
+            let _write_lock = so_lock.lock();
 
             let out = linker.link_shared(&objects, &so_path, &config, cross_arch)?;
             let assertions = Assertions::default();
@@ -1644,8 +1644,8 @@ fn build_obj(
             .and_then(|ext| ext.to_str())
             .unwrap_or_default()
     ));
-    let mut output_file_lock = fd_lock::RwLock::new(File::create(&lock_path)?);
-    let _write_lock = output_file_lock.write().unwrap();
+    let output_file_lock = File::create(&lock_path)?;
+    let _write_lock = output_file_lock.lock();
 
     if is_newer(&output_path, std::iter::once(&src_path)) {
         return Ok(BuiltObject {


### PR DESCRIPTION
Use std lock API stabilized in 1.89: https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#stabilized-apis