### PR TITLE
fix: Handle non-absolute paths with `--no-allow-shlib-undefined`

### DIFF
--- a/libwild/src/input_data.rs
+++ b/libwild/src/input_data.rs
@@ -362,7 +362,8 @@ impl<'data> InputData<'data> {
 
     pub(crate) fn has_file(&self, name: &'data [u8]) -> bool {
         self.path_to_load_index
-            .contains_key(Path::new(OsStr::from_bytes(name)))
+            .keys()
+            .any(|path| path.ends_with(Path::new(OsStr::from_bytes(name))))
     }
 }
 

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -190,6 +190,9 @@ tests = [
   "linker-script-error.sh",         # Different message formats
   "mold-wrapper.sh",
   "mold-wrapper2.sh",
+  "no-allow-shlib-undefined.sh",    # Different message formats
+  "no-allow-shlib-undefined3.sh",   # Different message formats
+  "no-allow-shlib-undefined4.sh",   # GNU ld and LLD also fail
   "plt-symbols.sh",                 # Wild currently doesn't create entries in the symbol table with the `$plt` suffix unless `--got-plt-syms` is specified
   "run-clang.sh",                   # This test checks the comment section to verify if it's linked with mold.
   "start-lib.sh",                   # Passes when `--no-gc-sections` is passed.
@@ -238,10 +241,6 @@ tests = [
   "mergeable-strings.sh",
   "missing-error.sh",
   "no-allow-shlib-undefined-circular.sh",
-  "no-allow-shlib-undefined.sh",
-  "no-allow-shlib-undefined2.sh",
-  "no-allow-shlib-undefined3.sh",
-  "no-allow-shlib-undefined4.sh",
   "no-undefined-version.sh",
   "nocopyreloc.sh",
   "noinhibit-exec.sh",


### PR DESCRIPTION
Previously, it worked only for absolute paths. That was because we read `DT_NEEDED` from libs and compare it directly with list of paths that we load.
For example, with DSO that needs only glibc, `has_file()` falsely gave negative result because `libc.so.6` didn't match `/usr/lib/libc.so.6`:
```
❯ readelf -Wd home/mateusz/Projects/wild/fakes-debug/out/test/x86_64/no-allow-shlib-undefined/libbar.so | rg NEEDED
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]

❯ ./run-with ~/Projects/wild/target/debug/wild                                                                                                                                              WARNING: wild: --plugin /usr/lib/gcc/x86_64-pc-linux-gnu/15.2.1/liblto_plugin.so is not yet supported
[libwild/src/input_data.rs:364:9] OsStr::from_bytes(name) = "libc.so.6"
[libwild/src/input_data.rs:364:9] self.path_to_load_index.keys() = [
    "/home/mateusz/tmp/mold-undef/usr/lib/gcc/x86_64-pc-linux-gnu/15.2.1/libgcc.a",
    "./usr/lib/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../lib/crtn.o",
    "/usr/lib/libc_nonshared.a",
    "./usr/lib/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../lib/crti.o",
    "./usr/lib/gcc/x86_64-pc-linux-gnu/15.2.1/crtbeginS.o",
    "./usr/lib/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../lib/Scrt1.o",
    "/home/mateusz/tmp/mold-undef/home/mateusz/Projects/wild/fakes-debug/out/test/x86_64/no-allow-shlib-undefined/libbar.so",
    "./home/mateusz/Projects/wild/fakes-debug/out/test/x86_64/no-allow-shlib-undefined/a.o",
    "/home/mateusz/tmp/mold-undef/usr/lib/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../lib/libc.so",
    "/usr/lib/ld-linux-x86-64.so.2",
    "./usr/lib/gcc/x86_64-pc-linux-gnu/15.2.1/crtendS.o",
    "/usr/lib/libc.so.6",
    "/home/mateusz/tmp/mold-undef/usr/lib/libgcc_s.so.1",
    "/home/mateusz/tmp/mold-undef/usr/lib/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../lib/libgcc_s.so",
]
```

This won't be found by Wild's tests because they use absolute path, so there is an exact match:
```
❯ sh wild/tests/build/shlib-undefined.c-disallow-complete-host.wild.cmd
[..]
[libwild/src/input_data.rs:364:9] OsStr::from_bytes(name) = "/home/mateusz/Projects/wild/wild/tests/build/shlib-undefined-3.disallow-complete-host-e03ad4e215723beb.wild.so"
[libwild/src/input_data.rs:364:9] self.path_to_load_index.keys() = [
    "/home/mateusz/Projects/wild/wild/tests/build/shlib-undefined.disallow-complete-host-b6d62e2a7d1268ef.o",
    "/home/mateusz/Projects/wild/wild/tests/build/shlib-undefined-3.disallow-complete-host-e03ad4e215723beb.wild.so",
    "/home/mateusz/Projects/wild/wild/tests/build/runtime.disallow-complete-host-699440acab20af0b.o",
    "/home/mateusz/Projects/wild/wild/tests/build/shlib-undefined-2.disallow-complete-host-4de10f7f1a323260.wild.so",
]
wild: error: Failed to activate /home/mateusz/Projects/wild/wild/tests/build/shlib-undefined-2.disallow-complete-host-4de10f7f1a323260.wild.so (768 (3/0))
  Caused by:
    undefined reference to `def2` from /home/mateusz/Projects/wild/wild/tests/build/shlib-undefined-2.disallow-complete-host-4de10f7f1a323260.wild.so (768 (3/0))

❯ readelf -Wd wild/tests/build/shlib-undefined-2.disallow-complete-host-4de10f7f1a323260.wild.so | rg NEEDED
 0x0000000000000001 (NEEDED)             Shared library: [/home/mateusz/Projects/wild/wild/tests/build/shlib-undefined-3.disallow-complete-host-e03ad4e215723beb.wild.so]
```
This test expects the error to occur, so it works fine with absolute path. If DSO didn't use absolute path, the test would have caught the issue.