### PR TITLE
perf: Merge some of the GC phases into a single phase

### DIFF
--- a/wild/tests/sources/symbol-version-symver-error.c
+++ b/wild/tests/sources/symbol-version-symver-error.c
@@ -1,5 +1,6 @@
 //#Config:default
 //#SkipLinker:ld
+//#CompArgs:-fPIC
 //#RunEnabled:false
 //#ExpectError: Symbol foo has undefined version VERSION_XYZ
 //#LinkArgs:--shared --version-script=./symbol-versions-script.map -z now


### PR DESCRIPTION
The change to `symbol-version-symver-error.c` is because on opensuse the object wasn't being compiled as position-independent. This wasn't causing the test to fail previously because we were hitting the expected error before the other error (`Cannot apply relocation R_X86_64_32 to read-only section`). This change however caused the order of the errors to change.