### PR TITLE
chore: allow unstable_name_collisions lint for `exactly_one`

### DIFF
--- a/libwild/src/riscv64.rs
+++ b/libwild/src/riscv64.rs
@@ -92,6 +92,9 @@ impl crate::arch::Arch for RiscV64 {
         None
     }
 
+    // Allow the lint for `exactly_one`.
+    // Tracking issue available at: https://github.com/rust-lang/rust/issues/149266
+    #[allow(unstable_name_collisions)]
     fn merge_eflags(eflags: &[u32]) -> Result<u32> {
         let or_eflags = eflags.iter().fold(0, |acc, x| acc | x);
         ensure!(


### PR DESCRIPTION
This addresses the new warning that appears on nightly:
```
warning: a method with this name may be added to the standard library in the future
   --> libwild/src/riscv64.rs:102:18
    |
102 |                 .exactly_one()
    |                  ^^^^^^^^^^^
    |
    = warning: once this associated item is added to the standard library, the ambiguity may cause an error or change in behavior!
    = note: for more information, see issue #48919 <https://github.com/rust-lang/rust/issues/48919>
    = help: call with fully qualified syntax `itertools::Itertools::exactly_one(...)` to keep using the current method
    = note: `#[warn(unstable_name_collisions)]` (part of `#[warn(future_incompatible)]`) on by default
help: add `#![feature(exact_length_collection)]` to the crate attributes to enable `std::iter::Iterator::exactly_one`
   --> libwild/src/lib.rs:1:1
    |
  1 + #![feature(exact_length_collection)]
    |
```