### PR TITLE
refactor: Separate Epilogue into two separate entities

### DIFF
--- a/libwild/src/diagnostics.rs
+++ b/libwild/src/diagnostics.rs
@@ -41,7 +41,7 @@ impl<'data> SymbolInfoPrinter<'data> {
                     ResolvedFile::Prelude(_) => Some(PRELUDE_FILE_ID),
                     ResolvedFile::Object(obj) => Some(obj.file_id),
                     ResolvedFile::LinkerScript(obj) => Some(obj.file_id),
-                    ResolvedFile::Epilogue(obj) => Some(obj.file_id),
+                    ResolvedFile::SyntheticSymbols(obj) => Some(obj.file_id),
                 })
             })
             .collect();
@@ -118,9 +118,9 @@ impl<'data> SymbolInfoPrinter<'data> {
                         sym_debug = "Linker script symbol".to_owned();
                         input = s.parsed.input.to_string();
                     }
-                    SequencedInput::Epilogue(_) => {
-                        input = "  <epilogue>".to_owned();
-                        sym_debug = "Epilogue symbol".to_owned();
+                    SequencedInput::SyntheticSymbols(_) => {
+                        input = "  <synthetic>".to_owned();
+                        sym_debug = "Synthetic symbol".to_owned();
                     }
                 }
 

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -18,6 +18,7 @@ use crate::output_section_id;
 use crate::output_section_id::OutputSectionId;
 use crate::symbol::UnversionedSymbolName;
 use crate::symbol_db::SymbolId;
+use crate::symbol_db::SymbolIdRange;
 use crate::timing_phase;
 use crate::verbose_timing_phase;
 use linker_utils::elf::SymbolType;
@@ -70,9 +71,9 @@ pub(crate) struct ProcessedLinkerScript<'data> {
 }
 
 #[derive(Debug)]
-pub(crate) struct Epilogue {
+pub(crate) struct SyntheticSymbols {
     pub(crate) file_id: FileId,
-    pub(crate) start_symbol_id: SymbolId,
+    pub(crate) symbol_id_range: SymbolIdRange,
 }
 
 #[derive(Clone, Copy, derive_more::Debug)]

--- a/libwild/src/validation.rs
+++ b/libwild/src/validation.rs
@@ -40,7 +40,6 @@ fn validate_object(object: &crate::elf::File, layout: &Layout) -> Result {
     for group in &layout.group_layouts {
         for file in &group.files {
             match file {
-                crate::layout::FileLayout::Prelude(_) => {}
                 crate::layout::FileLayout::Object(obj) => {
                     for (sec_index, sec) in obj.object.sections.enumerate() {
                         if let Some(resolution) =
@@ -55,10 +54,7 @@ fn validate_object(object: &crate::elf::File, layout: &Layout) -> Result {
                         }
                     }
                 }
-                crate::layout::FileLayout::LinkerScript(_) => {}
-                crate::layout::FileLayout::Dynamic(_) => {}
-                crate::layout::FileLayout::Epilogue(_) => {}
-                crate::layout::FileLayout::NotLoaded => {}
+                _ => {}
             }
         }
     }


### PR DESCRIPTION
__start/__stop symbols are now handled by a new SyntheticSymbols entity. Epilogue is stuff that has to come last and is now only created in the layout stage. This means that it should be possible to add additional objects after SyntheticSymbols and before the epilogue, provided it's done before layout.