### PR TITLE
refactor: Move eflags out of the prelude

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -323,7 +323,7 @@ fn populate_file_header<A: Arch>(
         e,
         u64::from(elf::FILE_HEADER_SIZE) + header_info.program_headers_size(),
     );
-    header.e_flags.set(e, header_info.eflags);
+    header.e_flags.set(e, header_info.eflags.0);
     header.e_ehsize.set(e, elf::FILE_HEADER_SIZE);
     header.e_phentsize.set(e, elf::PROGRAM_HEADER_SIZE);
     header


### PR DESCRIPTION
This gets rid of get_prelude_mut and changes merge_eflags to only take shared state.