### PR TITLE
docker: Add Dockerfile for Gentoo

### DIFF
--- a/docker/gentoo.Dockerfile
+++ b/docker/gentoo.Dockerfile
@@ -1,0 +1,37 @@
+# Run on Gentoo
+#
+# docker build --progress=plain -t wild-dev-gentoo . -f docker/gentoo.Dockerfile
+# docker run -it wild-dev-gentoo
+
+FROM gentoo/stage3:20251208 AS chef
+
+RUN echo "dev-util/rustup" >> /etc/portage/package.accept_keywords/wild
+RUN emerge-webrsync
+# Required for installing binary packages.
+RUN getuto
+RUN emerge -g dev-util/rustup llvm-core/clang llvm-core/lld
+# Ensures the PATH is correct upon running the image.
+RUN echo 'export PATH="/root/.cargo/bin:${PATH}"' >> /etc/profile
+
+RUN rustup-init --default-toolchain stable -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup toolchain install nightly \
+        --allow-downgrade \
+        --target x86_64-unknown-linux-musl,aarch64-unknown-linux-gnu,aarch64-unknown-linux-musl,riscv64gc-unknown-linux-gnu,riscv64gc-unknown-linux-musl \
+        --component rustc-codegen-cranelift-preview
+RUN cargo install --locked cargo-chef
+WORKDIR /wild
+
+# This ensures LLVM's PATH update from the emerge is recognized, while also ensuring
+# rustup's environment in /root is added to PATH, as Docker does not source
+# /etc/profile by default.
+CMD ["/bin/bash", "-l"]
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /wild/recipe.json recipe.json
+RUN cargo chef cook --all-targets --recipe-path recipe.json
+COPY . .


### PR DESCRIPTION
Tests passed for me within the image.

Binary packages get installed to reduce friction, as Clang can have a long build time depending on the hardware in use.

One thing I'm not 100% sure on is the method for ensuring `PATH` is correct by updating `CMD`. It was the simplest solution I could think of though, open to better ideas!