### PR TITLE
refactor: Parse files as we open them

### DIFF
--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -220,7 +220,7 @@ impl Linker {
             &mut per_symbol_flags,
             &mut output_sections,
             &mut layout_rules_builder,
-            &loaded,
+            loaded,
         )?;
 
         symbol_db.apply_wrapped_symbol_overrides();

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -366,11 +366,11 @@ impl<'data> SymbolDb<'data> {
         per_symbol_flags: &mut PerSymbolFlags,
         output_sections: &mut OutputSections<'data>,
         layout_rules_builder: &mut LayoutRulesBuilder<'data>,
-        loaded: &LoadedInputs<'data>,
+        loaded: LoadedInputs<'data>,
     ) -> Result {
         timing_phase!("Load inputs into symbol DB");
 
-        let parsed_objects = parsing::parse_input_files(&loaded.inputs, self.args)?;
+        let parsed_objects = loaded.objects.into_iter().try_collect()?;
 
         let processed_linker_scripts = parsing::process_linker_scripts(
             &loaded.linker_scripts,


### PR DESCRIPTION
This should make supporting linker-plugins easier, since the plugin API needs access to the file descriptor which we now close after we've parsed the file.