### PR TITLE
refactor: Split ResolvedObject into dynamic and non-dynamic variants

### DIFF
--- a/libwild/src/diagnostics.rs
+++ b/libwild/src/diagnostics.rs
@@ -39,7 +39,8 @@ impl<'data> SymbolInfoPrinter<'data> {
                 group.files.iter().filter_map(|file| match file {
                     ResolvedFile::NotLoaded(_) => None,
                     ResolvedFile::Prelude(_) => Some(PRELUDE_FILE_ID),
-                    ResolvedFile::Object(obj) => Some(obj.file_id),
+                    ResolvedFile::Object(obj) => Some(obj.common.file_id),
+                    ResolvedFile::Dynamic(obj) => Some(obj.common.file_id),
                     ResolvedFile::LinkerScript(obj) => Some(obj.file_id),
                     ResolvedFile::SyntheticSymbols(obj) => Some(obj.file_id),
                 })

--- a/libwild/src/string_merging.rs
+++ b/libwild/src/string_merging.rs
@@ -308,12 +308,8 @@ fn group_merge_string_sections_by_output<'data>(
             let ResolvedFile::Object(obj) = file else {
                 continue;
             };
-            let Some(non_dynamic) = obj.non_dynamic.as_mut() else {
-                continue;
-            };
-            for extra in &non_dynamic.string_merge_extras {
-                let SectionSlot::MergeStrings(sec) = &mut non_dynamic.sections[extra.index.0]
-                else {
+            for extra in &obj.string_merge_extras {
+                let SectionSlot::MergeStrings(sec) = &mut obj.sections[extra.index.0] else {
                     bail!("Internal error: expected SectionSlot::MergeStrings");
                 };
 

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -771,9 +771,9 @@ impl<'data> SymbolDb<'data> {
         resolved: &[ResolvedGroup],
     ) -> SymbolStrength {
         let file_id = self.file_id_for_symbol(symbol_id);
-        if let ResolvedFile::Object(obj) = &resolved[file_id.group()].files[file_id.file()] {
-            let local_index = symbol_id.to_input(obj.symbol_id_range);
-            let Ok(obj_symbol) = obj.object.symbol(local_index) else {
+        if let Some(common) = resolved[file_id.group()].files[file_id.file()].common() {
+            let local_index = symbol_id.to_input(common.symbol_id_range);
+            let Ok(obj_symbol) = common.object.symbol(local_index) else {
                 // Errors from this function should have been reported elsewhere.
                 return SymbolStrength::Undefined;
             };
@@ -799,13 +799,13 @@ impl<'data> SymbolDb<'data> {
             return false;
         };
 
-        let local_index = symbol_id.to_input(obj.symbol_id_range);
-        let Ok(obj_symbol) = obj.object.symbol(local_index) else {
+        let local_index = symbol_id.to_input(obj.common.symbol_id_range);
+        let Ok(obj_symbol) = obj.common.object.symbol(local_index) else {
             return false;
         };
 
         let section_index = object::SectionIndex(usize::from(obj_symbol.st_shndx(LittleEndian)));
-        let Ok(header) = obj.object.section(section_index) else {
+        let Ok(header) = obj.common.object.section(section_index) else {
             return false;
         };
 


### PR DESCRIPTION
The main motivation for doing this is so that we can store state that is specific to dynamic objects.

Issue #1325