### PR TITLE
chore: Configure typos so that you can just run it

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -3,3 +3,10 @@ flate = "flate"
 rela = "rela"
 ot = "ot"
 FRE = "FRE"
+
+[files]
+extend-exclude = [
+  "external_test_suites",
+  "wild/tests/bins",
+]
+


### PR DESCRIPTION
Ignore a few paths that have typos in them that are either external or over which we have limited control.