### PR TITLE
fix: relax debug info comparison against bfd

### DIFF
--- a/linker-diff/src/debug_info_diff.rs
+++ b/linker-diff/src/debug_info_diff.rs
@@ -130,7 +130,8 @@ fn diff_debug_info(
             let unit = info.get(ref_unit_ident);
             match unit {
                 Some(unit_size) => {
-                    if ref_unit_size != unit_size {
+                    // Sometimes ld can GC some of the Compilation Units and so the size is smaller.
+                    if ref_unit_size != unit_size && &objects[object_id].name != "ld" {
                         mismatches.push(Diff {
                             key: format!("{DEBUG_INFO_ERROR_KEY}.size_mismatch"),
                             values: DiffValues::PreFormatted(format!(


### PR DESCRIPTION
Bfd can sometimes ignore completely a Compilation Unit and so it ends up with a smaller Dwarf for a source file. Seems other linkers (mold, lld) end up with the same result as Wild.

Fixes: #1341