### PR TITLE
chore: Add a missing ID to minimal-versions check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
+        id: rust-toolchain
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-hack,cargo-minimal-versions


### PR DESCRIPTION
This ID is referenced by the cache key.