### PR TITLE
Swap rayon for orx-parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,7 +1294,7 @@ dependencies = [
 [[package]]
 name = "orx-parallel"
 version = "3.4.0"
-source = "git+https://github.com/TechnoPorg/orx-parallel.git?branch=relax-lifetimes#41079baffc2feb1eb002e52111fc9a1a042e4c00"
+source = "git+https://github.com/orxfun/orx-parallel.git#d884a6ea0524244766f54c62232849d6319fe332"
 dependencies = [
  "orx-concurrent-bag",
  "orx-concurrent-iter",
@@ -1307,6 +1307,7 @@ dependencies = [
  "orx-priority-queue",
  "orx-pseudo-default",
  "orx-split-vec",
+ "rayon-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,7 +1294,7 @@ dependencies = [
 [[package]]
 name = "orx-parallel"
 version = "3.4.0"
-source = "git+https://github.com/orxfun/orx-parallel.git#d884a6ea0524244766f54c62232849d6319fe332"
+source = "git+https://github.com/TechnoPorg/orx-parallel.git?branch=push-lmpnoynmpxpy#9f384d86562c5eaef13cc9e8324422f670e9d74d"
 dependencies = [
  "orx-concurrent-bag",
  "orx-concurrent-iter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,6 +840,7 @@ dependencies = [
  "memchr",
  "memmap2",
  "object 0.38.1",
+ "orx-parallel",
  "perf-event",
  "perfetto-recorder",
  "rayon",
@@ -1209,6 +1210,156 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "orx-concurrent-bag"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eecf494b42a5a4c8ba3c6f053f32984b7ef2b8092c4693fb16100356e4e2da7a"
+dependencies = [
+ "orx-fixed-vec",
+ "orx-pinned-concurrent-col",
+ "orx-pinned-vec",
+ "orx-pseudo-default",
+ "orx-split-vec",
+]
+
+[[package]]
+name = "orx-concurrent-iter"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78e4381d6f1393a99e5a2bebe63e7a4c58c2526cdf25e01830baa11410c7ece1"
+dependencies = [
+ "orx-iterable",
+ "orx-pseudo-default",
+]
+
+[[package]]
+name = "orx-concurrent-ordered-bag"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cc7d7d463f49b7fc9bc8052ab17f5d8eb908eddd28425d1aff53bc431508e4"
+dependencies = [
+ "orx-fixed-vec",
+ "orx-pinned-concurrent-col",
+ "orx-pinned-vec",
+ "orx-split-vec",
+]
+
+[[package]]
+name = "orx-concurrent-queue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b096e39c0ac22afd0168c91a14b22657ce3d8c0a21fc9cf45461265699bff35"
+dependencies = [
+ "orx-fixed-vec",
+ "orx-pinned-vec",
+ "orx-split-vec",
+]
+
+[[package]]
+name = "orx-concurrent-recursive-iter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce3720a094ed6471a1bfd2e8e1a2591ad41306f208bfaa7882ab0acc16149bc2"
+dependencies = [
+ "orx-concurrent-iter",
+ "orx-concurrent-queue",
+ "orx-fixed-vec",
+ "orx-pinned-vec",
+ "orx-split-vec",
+]
+
+[[package]]
+name = "orx-fixed-vec"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96586d7477170175263986dfdfd36cc9a4b08bcc1743084f06115d6610181bb4"
+dependencies = [
+ "orx-concurrent-iter",
+ "orx-iterable",
+ "orx-pinned-vec",
+ "orx-pseudo-default",
+]
+
+[[package]]
+name = "orx-iterable"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa2cb3f82a187c68835faac9cf03faaee70b93f4da3b85515ac1b4c6f8a432d"
+dependencies = [
+ "orx-self-or",
+]
+
+[[package]]
+name = "orx-parallel"
+version = "3.4.0"
+source = "git+https://github.com/TechnoPorg/orx-parallel.git?branch=relax-lifetimes#41079baffc2feb1eb002e52111fc9a1a042e4c00"
+dependencies = [
+ "orx-concurrent-bag",
+ "orx-concurrent-iter",
+ "orx-concurrent-ordered-bag",
+ "orx-concurrent-recursive-iter",
+ "orx-fixed-vec",
+ "orx-iterable",
+ "orx-pinned-concurrent-col",
+ "orx-pinned-vec",
+ "orx-priority-queue",
+ "orx-pseudo-default",
+ "orx-split-vec",
+]
+
+[[package]]
+name = "orx-pinned-concurrent-col"
+version = "2.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56b22c9e39d97d1c1d63dcbd9be68ac414cc61c9c6b8e799a125d383a18f3f10"
+dependencies = [
+ "orx-fixed-vec",
+ "orx-pinned-vec",
+ "orx-pseudo-default",
+ "orx-split-vec",
+]
+
+[[package]]
+name = "orx-pinned-vec"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38ff024d902a587fefdc502598107bbbf3d2a5350d63247bef34bd6a5518de9"
+dependencies = [
+ "orx-iterable",
+ "orx-pseudo-default",
+]
+
+[[package]]
+name = "orx-priority-queue"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89722d987db848624cf8fca21245d59cf6382b01b4ca79ae70261cea5747495"
+
+[[package]]
+name = "orx-pseudo-default"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34eaace9ae01f7025804fbca40ec45b87c19ba0328d97195e01c6135897762a8"
+
+[[package]]
+name = "orx-self-or"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8e35dfe18921e475b9861266fd58a5ecfd681161f242d24a9e2d1e07fbc28"
+
+[[package]]
+name = "orx-split-vec"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794100ff181e3903c90398e91147bbba7734ab0a1c6e13c4c569f4a15bccd6f7"
+dependencies = [
+ "orx-concurrent-iter",
+ "orx-iterable",
+ "orx-pinned-vec",
+ "orx-pseudo-default",
+]
 
 [[package]]
 name = "os_info"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,4 +226,4 @@ cast_lossless = "warn"
 needless_pass_by_ref_mut = "warn"
 
 [patch.crates-io]
-orx-parallel = { git = "https://github.com/orxfun/orx-parallel.git" }
+orx-parallel = { git = "https://github.com/TechnoPorg/orx-parallel.git", branch = "push-lmpnoynmpxpy" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ object = { version = "0.38.1", default-features = false, features = [
     "unaligned",
     "archive",
 ] }
+orx-parallel = "3.4.0"
 os_info = "3.0.0"
 paste = "1.0.15"
 perf-event = "0.4.8"
@@ -223,3 +224,6 @@ case_sensitive_file_extension_comparisons = "warn"
 cloned_instead_of_copied = "warn"
 cast_lossless = "warn"
 needless_pass_by_ref_mut = "warn"
+
+[patch.crates-io]
+orx-parallel = { git = "https://github.com/TechnoPorg/orx-parallel.git", branch = "relax-lifetimes" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ object = { version = "0.38.1", default-features = false, features = [
     "unaligned",
     "archive",
 ] }
-orx-parallel = "3.4.0"
+orx-parallel = { version = "3.4.0", features = ["rayon-core"] }
 os_info = "3.0.0"
 paste = "1.0.15"
 perf-event = "0.4.8"
@@ -226,4 +226,4 @@ cast_lossless = "warn"
 needless_pass_by_ref_mut = "warn"
 
 [patch.crates-io]
-orx-parallel = { git = "https://github.com/TechnoPorg/orx-parallel.git", branch = "relax-lifetimes" }
+orx-parallel = { git = "https://github.com/orxfun/orx-parallel.git" }

--- a/cackle.toml
+++ b/cackle.toml
@@ -77,6 +77,9 @@ allow_unsafe = true
 [pkg.rayon-core]
 allow_unsafe = true
 
+[pkg.orx-parallel]
+allow_unsafe = true
+
 [pkg.object]
 allow_unsafe = true
 

--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -30,7 +30,7 @@ hex = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 jobserver = { workspace = true }
-leb128 = {workspace = true}
+leb128 = { workspace = true }
 libc = { workspace = true }
 linker-layout = { path = "../linker-layout", version = "0.7.0" }
 linker-trace = { path = "../linker-trace", version = "0.7.0" }
@@ -38,6 +38,7 @@ linker-utils = { path = "../linker-utils", version = "0.7.0" }
 memchr = { workspace = true }
 memmap2 = { workspace = true }
 object = { workspace = true }
+orx-parallel = { workspace = true }
 perfetto-recorder = { workspace = true }
 rayon = { workspace = true }
 sharded-offset-map = { workspace = true }

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -12,6 +12,7 @@
 //! Basically, we need to be able to parse arguments in the same way as the other linkers on the
 //! platform that we're targeting.
 
+use crate::RAYON_POOL;
 use crate::alignment::Alignment;
 use crate::arch::Architecture;
 use crate::bail;
@@ -629,10 +630,11 @@ impl Args {
             }
         });
 
-        // The pool might be already initialized, suppress the error intentionally.
-        let _ = ThreadPoolBuilder::new()
+        let thread_pool = ThreadPoolBuilder::new()
             .num_threads(self.available_threads.get())
-            .build_global();
+            .build()
+            .unwrap();
+        let _ = RAYON_POOL.set(thread_pool);
 
         Ok(ActivatedArgs {
             args: self,

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -230,23 +230,25 @@ impl<'data> File<'data> {
     /// Copies the data for the specified section into `out`, which must be the correct size.
     /// Decompresses the data if necessary.
     pub(crate) fn copy_section_data(&self, section: &SectionHeader, out: &mut [u8]) -> Result {
-        let data = section.data(LittleEndian, self.data)?;
+        crate::RAYON_POOL.get().unwrap().install(|| {
+            let data = section.data(LittleEndian, self.data)?;
 
-        if let Some((compression, _, _)) = section.compression(LittleEndian, self.data)? {
-            decompress_into(compression, &data[COMPRESSION_HEADER_SIZE..], out)?;
-        } else if section.sh_type(LittleEndian) == object::elf::SHT_NOBITS {
-            out.fill(0);
-        } else if data.len() >= Self::SECTION_PAR_COPY_SIZE_THRESHOLD {
-            let threads = rayon::current_num_threads();
-            let chunk_size = (data.len() / threads).max(1);
+            if let Some((compression, _, _)) = section.compression(LittleEndian, self.data)? {
+                decompress_into(compression, &data[COMPRESSION_HEADER_SIZE..], out)?;
+            } else if section.sh_type(LittleEndian) == object::elf::SHT_NOBITS {
+                out.fill(0);
+            } else if data.len() >= Self::SECTION_PAR_COPY_SIZE_THRESHOLD {
+                let threads = crate::RAYON_POOL.get().unwrap().current_num_threads();
+                let chunk_size = (data.len() / threads).max(1);
 
-            data.par_chunks(chunk_size)
-                .zip(out.par_chunks_mut(chunk_size))
-                .for_each(|(src, dst)| dst.copy_from_slice(src));
-        } else {
-            out.copy_from_slice(data);
-        }
-        Ok(())
+                data.par_chunks(chunk_size)
+                    .zip(out.par_chunks_mut(chunk_size))
+                    .for_each(|(src, dst)| dst.copy_from_slice(src));
+            } else {
+                out.copy_from_slice(data);
+            }
+            Ok(())
+        })
     }
 
     /// Returns the contents of a section as a Cow. Will heap-allocate if the section is compressed.

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -211,6 +211,7 @@ fn write_file_contents<A: Arch>(sized_output: &mut SizedOutput, layout: &Layout)
     groups_and_buffers
         .into_par()
         .with_pool(crate::RAYON_POOL.get().unwrap())
+        .chunk_size(1)
         .map(|(group, mut buffers)| -> Result {
             verbose_timing_phase!("Write group");
 

--- a/libwild/src/file_writer.rs
+++ b/libwild/src/file_writer.rs
@@ -149,7 +149,7 @@ impl Output {
 
                 let output_config = self.config;
 
-                rayon::spawn(move || {
+                crate::RAYON_POOL.get().unwrap().spawn(move || {
                     verbose_timing_phase!("Create output file");
 
                     if output_config.file_write_mode == FileWriteMode::UnlinkAndReplace {

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -2147,8 +2147,9 @@ fn compute_symbols_and_layouts<'data>(
                         &state.common.mem_sizes,
                     );
 
-                    // Make sure that ignored offsets really aren't used by `finalise_layout` by setting
-                    // them to an arbitrary value. If they are used, we'll quickly notice.
+                    // Make sure that ignored offsets really aren't used by `finalise_layout` by
+                    // setting them to an arbitrary value. If they are used,
+                    // we'll quickly notice.
                     crate::verification::clear_ignored(&mut memory_offsets);
 
                     let layout =

--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -65,6 +65,8 @@ pub(crate) mod verification;
 pub(crate) mod version_script;
 pub(crate) mod x86_64;
 
+use std::sync::OnceLock;
+
 use crate::args::ActivatedArgs;
 use crate::error::Result;
 use crate::identity::linker_identity;
@@ -80,6 +82,7 @@ use input_data::InputFile;
 use input_data::InputLinkerScript;
 use layout_rules::LayoutRules;
 use output_section_id::OutputSections;
+use rayon::ThreadPool;
 pub use subprocess::run_in_subprocess;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt;
@@ -117,6 +120,8 @@ pub fn setup_tracing(args: &Args) -> Result<(), AlreadyInitialised> {
             .map_err(|_| AlreadyInitialised)
     }
 }
+
+pub(crate) static RAYON_POOL: OnceLock<ThreadPool> = OnceLock::new();
 
 /// This is effectively a data store for use while linking. It takes ownership of all the input data
 /// that we read, which allows the linking stages to borrow that data. Dropping this struct might be

--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -65,8 +65,6 @@ pub(crate) mod verification;
 pub(crate) mod version_script;
 pub(crate) mod x86_64;
 
-use std::sync::OnceLock;
-
 use crate::args::ActivatedArgs;
 use crate::error::Result;
 use crate::identity::linker_identity;
@@ -83,6 +81,7 @@ use input_data::InputLinkerScript;
 use layout_rules::LayoutRules;
 use output_section_id::OutputSections;
 use rayon::ThreadPool;
+use std::sync::OnceLock;
 pub use subprocess::run_in_subprocess;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt;

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -54,6 +54,7 @@ use linker_utils::elf::SectionFlags;
 use linker_utils::elf::shf;
 use object::LittleEndian;
 use object::read::elf::Sym as _;
+use orx_parallel::ExactSizeParIter;
 use orx_parallel::IntoParIter;
 use orx_parallel::ParIter;
 use orx_parallel::ParIterResult;
@@ -1326,8 +1327,8 @@ fn populate_symbol_db<'data>(
         timing_phase!("Populate symbol map");
         buckets
             .into_par()
-            .with_pool(crate::RAYON_POOL.get().unwrap())
             .enumerate()
+            .with_pool(crate::RAYON_POOL.get().unwrap())
             .for_each(|(b, bucket)| {
                 verbose_timing_phase!("Process symbol bucket");
 
@@ -1352,7 +1353,7 @@ fn populate_symbol_db<'data>(
                     }
                 }
             });
-    })
+    });
 }
 
 fn load_linker_script_symbols<'data>(

--- a/libwild/src/timing.rs
+++ b/libwild/src/timing.rs
@@ -290,7 +290,7 @@ pub(crate) fn finalise_perfetto_trace() -> Result {
     trace.process_thread_data(&perfetto_recorder::ThreadTraceData::take_current_thread());
     let trace = Mutex::new(trace);
 
-    rayon::in_place_scope(|scope| {
+    crate::RAYON_POOL.get().unwrap().in_place_scope(|scope| {
         scope.spawn_broadcast(|_scope, _ctx| {
             trace
                 .lock()


### PR DESCRIPTION
As discussed in #1072, exploring Rayon alternatives has the potential to help performance. Of the options proposed in that discussion, orx-parallel seemed to me like the best fit (although there may be other considerations that I've neglected).

I haven't finished porting everything, in particular the graph algorithms and some specific parallel iterator cases that orx-parallel doesn't support right now, like enumeration; however, I'm getting some pretty good numbers already:

```
poop "/tmp/wild/ripgrep/6/run-with wild" "/tmp/wild/ripgrep/6/run-with /home/maya/Documents/Programming/wild/target/release/wild"
Benchmark 1 (124 runs): /tmp/wild/ripgrep/6/run-with wild
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          36.1ms ± 3.49ms    15.2ms … 41.9ms          6 ( 5%)        0%
  peak_rss           5.09MB ±  153KB    4.60MB … 5.61MB         30 (24%)        0%
  cpu_cycles          125M  ± 8.43M      107M  …  144M           0 ( 0%)        0%
  instructions        105M  ± 9.17M     80.0M  …  122M           4 ( 3%)        0%
  cache_references   1.58M  ± 68.7K     1.38M  … 1.73M           2 ( 2%)        0%
  cache_misses        142K  ± 24.3K     86.4K  …  208K           1 ( 1%)        0%
  branch_misses       258K  ± 18.7K      212K  …  303K           0 ( 0%)        0%
Benchmark 2 (130 runs): /tmp/wild/ripgrep/6/run-with /home/maya/Documents/Programming/wild/target/release/wild
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          34.9ms ± 4.18ms    18.2ms … 40.8ms         15 (12%)          -  3.3% ±  2.6%
  peak_rss           5.22MB ±  234KB    4.58MB … 5.68MB          1 ( 1%)        💩+  2.4% ±  1.0%
  cpu_cycles         78.0M  ± 4.81M     65.6M  … 90.2M           0 ( 0%)        ⚡- 37.6% ±  1.3%
  instructions       77.2M  ± 8.75M     48.8M  … 95.6M           5 ( 4%)        ⚡- 26.2% ±  2.1%
  cache_references   1.17M  ± 64.5K      966K  … 1.32M           9 ( 7%)        ⚡- 26.0% ±  1.0%
  cache_misses        112K  ± 22.6K     45.8K  …  177K           4 ( 3%)        ⚡- 21.1% ±  4.1%
  branch_misses       200K  ± 20.1K      135K  …  246K           6 ( 5%)        ⚡- 22.4% ±  1.9%
```

This PR also depends on some changes to orx-parallel:

- orxfun/orx-parallel#121
- orxfun/orx-parallel#122
- orxfun/orx-parallel#127

Let me know whether this is a direction you'd like me to continue working in.