### PR TITLE
fix: Resolve `__real_foo` in `--wrap` even without `__wrap_foo`

### DIFF
--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -504,15 +504,14 @@ impl<'data> SymbolDb<'data> {
         let allocator = self.herd.get();
 
         for name in &self.args.wrap {
-            let wrap_name = format!("__wrap_{name}");
-            let Some(wrap_id) =
-                self.get_unversioned(&UnversionedSymbolName::prehashed(wrap_name.as_bytes()))
-            else {
-                continue;
-            };
-
             let name_bytes = allocator.alloc_slice_copy(name.as_bytes());
-            let orig_id = self.override_name(UnversionedSymbolName::prehashed(name_bytes), wrap_id);
+            let orig_id = self.get_unversioned(&UnversionedSymbolName::prehashed(name_bytes));
+            let wrap_name = format!("__wrap_{name}");
+            if let Some(wrap_id) =
+                self.get_unversioned(&UnversionedSymbolName::prehashed(wrap_name.as_bytes()))
+            {
+                self.override_name(UnversionedSymbolName::prehashed(name_bytes), wrap_id);
+            }
 
             if let Some(orig_id) = orig_id {
                 let real_name = allocator.alloc_slice_copy(format!("__real_{name}").as_bytes());

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -75,7 +75,6 @@ tests = [
   "undefined-glob.sh",
   "warn-common.sh",
   "warn-once.sh",
-  "wrap.sh",
   "zero-to-bss.sh",
 ]
 

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -3245,7 +3245,8 @@ fn integration_test(
         "tls-common.c",
         "section-start.c",
         "max-page-size.c",
-        "call-via-defsym.c"
+        "call-via-defsym.c",
+        "wrap-real-only.c"
     )]
     program_name: &'static str,
     #[allow(unused_variables)] setup_symlink: (),

--- a/wild/tests/sources/wrap-real-only.c
+++ b/wild/tests/sources/wrap-real-only.c
@@ -1,0 +1,19 @@
+//#Object:runtime.c
+//#Object:wrap-real-only2.c
+//#LinkArgs:--wrap=foo
+
+#include "runtime.h"
+
+// Note that `__wrap_foo` is not defined anywhere.
+int __real_foo(void);
+
+void _start(void) {
+  runtime_init();
+
+  // `__real_foo` should resolve to the original `foo`
+  if (__real_foo() != 123) {
+    exit_syscall(100);
+  }
+
+  exit_syscall(42);
+}

--- a/wild/tests/sources/wrap-real-only2.c
+++ b/wild/tests/sources/wrap-real-only2.c
@@ -1,0 +1,1 @@
+int foo(void) { return 123; }


### PR DESCRIPTION
The `--wrap` option should independently handle both symbol redirections:
- `foo` -> `__wrap_foo` (when `__wrap_foo` is defined)
- `__real_foo` -> `foo` (when `foo` is defined)

Previously, both mappings were skipped if `__wrap_foo` didn't exist, causing undefined symbol errors for `__real_foo` references.