### PR TITLE
chore: Add a test for `-Bsymbolic-non-weak`

### DIFF
--- a/wild/tests/sources/shared.c
+++ b/wild/tests/sources/shared.c
@@ -29,8 +29,12 @@
 //#Config:nosymbolic:default
 //#LinkArgs:-shared -z now -Bno-symbolic
 
-// TODO: Add a test for `-Bsymbolic-non-weak`. The lld included in Ubuntu 22.04
-// is old and doesn't implement the `-Bsymbolic-non-weak` option.
+//#Config:symbolic-non-weak:default
+//#LinkArgs:-shared -z now -Bsymbolic-non-weak
+//#SkipLinker:ld
+//#EnableLinker:lld
+//#DiffIgnore:section.got.plt.entsize
+//#DiffIgnore:section.relro_padding
 
 //#Config:symbolic-non-weak-functions:default
 //#LinkArgs:-shared -z now -Bsymbolic-non-weak-functions


### PR DESCRIPTION
Since we no longer run tests on Ubuntu 22.04, we can now execute the `-Bsymbolic-non-weak` tests in CI.