### PR TITLE
perf: Tweak how we determine the target number of groups

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -217,7 +217,11 @@ pub(crate) enum Experiment {
     MergeStringSplitParallelism = 0,
 
     /// Number of bytes of string-merge sections before we'll break to a new group.
-    MergeStringMinGroupBytes = 2,
+    MergeStringMinGroupBytes = 1,
+
+    GroupsPerThread = 2,
+
+    MinGroups = 3,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
This mostly helps to reduce overheads observed when we have lots of threads.