### PR TITLE
feat: Support `--no-eh-frame-hdr`

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -1819,6 +1819,15 @@ fn setup_argument_parser() -> ArgumentParser {
 
     parser
         .declare()
+        .long("no-eh-frame-hdr")
+        .help("Don't create .eh_frame_hdr section")
+        .execute(|args, _modifier_stack| {
+            args.should_write_eh_frame_hdr = false;
+            Ok(())
+        });
+
+    parser
+        .declare()
         .long("export-dynamic")
         .short("E")
         .help("Export all dynamic symbols")

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -32,7 +32,6 @@ tests = [
   "linker-script-relocatable.sh",      # `--relocatable`
   "many-input-sections2.sh",           # `--relocatable`
   "nmagic.sh",
-  "no-eh-frame-header.sh",
   "no-quick-exit.sh",
   "oformat-binary.sh",
   "omagic.sh",


### PR DESCRIPTION
Found this option might be used in the .NET Android SDK: https://github.com/dotnet/android/blob/31cc7b16b0191c8210ad7954e8924ec2f8ae9987/src/native/CMakeLists.txt#L498
