### PR TITLE
CI: use rust-cache actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,16 +73,9 @@ jobs:
           targets: x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl,aarch64-unknown-linux-gnu,aarch64-unknown-linux-musl,riscv64gc-unknown-linux-gnu,riscv64gc-unknown-linux-musl,loongarch64-unknown-linux-gnu,loongarch64-unknown-linux-musl
           components: rustc-codegen-cranelift-preview
       - uses: davidlattimore/wild-action@latest
-      - uses: actions/cache@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-${{ matrix.container }}-${{ matrix.runs-on }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
-        if: ${{ !contains(matrix.container, 'alpine') }}
+          key: ${{ runner.os }}-${{ matrix.container }}-${{ matrix.runs-on }}
       - run: cargo build --profile ci --workspace --no-default-features
       - run: WILD_TEST_CROSS=$WILD_TEST_CROSS cargo test --profile ci --workspace
 
@@ -99,15 +92,7 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-hack,cargo-minimal-versions
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
       - run: cargo minimal-versions --direct test --profile ci
 
   clippy:
@@ -125,15 +110,7 @@ jobs:
       with:
         components: clippy
     - uses: davidlattimore/wild-action@latest
-    - uses: actions/cache@v5
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-clippy-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+    - uses: Swatinem/rust-cache@v2
     - run: cargo clippy --workspace --target x86_64-unknown-linux-gnu
 
   rustfmt:
@@ -161,15 +138,7 @@ jobs:
       id: rust-toolchain
       with:
         targets: riscv64gc-unknown-linux-gnu
-    - uses: actions/cache@v5
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-riscv-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+    - uses: Swatinem/rust-cache@v2
     - run: sudo apt-get update && sudo apt-get install gcc-riscv64-linux-gnu g++-riscv64-linux-gnu
     - run: cp .cargo/config.toml.cross-riscv .cargo/config.toml
     - run: cargo build --target riscv64gc-unknown-linux-gnu
@@ -189,15 +158,7 @@ jobs:
       id: rust-toolchain
       with:
         targets: loongarch64-unknown-linux-gnu
-    - uses: actions/cache@v5
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-loongarch64-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+    - uses: Swatinem/rust-cache@v2
     - run: cp .cargo/config.toml.cross-loongarch64 .cargo/config.toml
     - run: cargo build --target loongarch64-unknown-linux-gnu
 

--- a/.github/workflows/external_tests.yml
+++ b/.github/workflows/external_tests.yml
@@ -34,15 +34,7 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
         id: rust-toolchain
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-externaltests-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
       - name: Check regressions
         run: WILD_TEST_CROSS=all cargo test --features mold_tests external_tests::mold_tests::check_mold_tests_regression
       - name: Check tests that should fail still fail


### PR DESCRIPTION
By default the action uses the following parts for key:
- the github job_id (if add-job-id-key is "true"),
- the rustc release / host / hash (for all installed toolchains when available),
- the following values, if add-rust-environment-hash-key is "true":
- the value of some compiler-specific environment variables (eg. RUSTFLAGS, etc), and
- a hash of all Cargo.lock / Cargo.toml files found anywhere in the repository (if present).
- a hash of all rust-toolchain / rust-toolchain.toml files in the root of the repository (if present).
- a hash of all .cargo/config.toml files in the root of the repository (if present).

And so, we only need to append something for the matrix-based job description.