### PR TITLE
fix: delete the file instead of truncating it when updating busy executable

### DIFF
--- a/libwild/src/file_writer.rs
+++ b/libwild/src/file_writer.rs
@@ -277,7 +277,9 @@ impl SizedOutput {
                         FileWriteMode::UpdateInPlaceWithFallback
                     )
                 {
-                    open_options.truncate(true).open(&path)?
+                    // If the file is being executed, we can't modify it, but we can delete it.
+                    std::fs::remove_file(&path)?;
+                    open_options.create(true).open(&path)?
                 } else {
                     return Err(error)
                         .with_context(|| format!("Failed to open `{}`", path.display()));


### PR DESCRIPTION
When we try to update a running executable, and we fail because the file is busy, we retried with truncate which fails too. Instead, we have to remove the file, and create it again.

I encountered this bug sporadically when building stuff in the LLVM repo.