### PR TITLE
feat: Allow specifying library search paths in version scripts and export lists

### DIFF
--- a/libwild/src/input_data.rs
+++ b/libwild/src/input_data.rs
@@ -192,16 +192,26 @@ pub(crate) struct AuxiliaryFiles<'data> {
 
 impl<'data> AuxiliaryFiles<'data> {
     pub(crate) fn new(args: &'data Args, inputs_arena: &'data Arena<InputFile>) -> Result<Self> {
+        let resolve_script_path = |path: &Path| -> PathBuf {
+            if path.exists() {
+                path.to_owned()
+            } else if let Some(found) = search_for_file(&args.lib_search_path, None, path) {
+                found
+            } else {
+                path.to_owned()
+            }
+        };
+
         Ok(Self {
             version_script_data: args
                 .version_script_path
                 .as_ref()
-                .map(|path| read_script_data(path, inputs_arena))
+                .map(|path| read_script_data(&resolve_script_path(path), inputs_arena))
                 .transpose()?,
             export_list_data: args
                 .export_list_path
                 .as_ref()
-                .map(|path| read_script_data(path, inputs_arena))
+                .map(|path| read_script_data(&resolve_script_path(path), inputs_arena))
                 .transpose()?,
         })
     }

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -90,11 +90,7 @@ tests = [
 
 [skipped_groups.version_script]
 reason = "Version script support"
-tests = [
-  "version-script-search-paths.sh",
-  "version-script15.sh",
-  "version-script17.sh",
-]
+tests  = ["version-script15.sh", "version-script17.sh"]
 
 [skipped_groups.z_options]
 reason = "Related to -z"


### PR DESCRIPTION
When the `-L` option specifies a library search path, Wild now also searches that path for version scripts and export lists if none are found in the current directory.