### PR TITLE
chore: Discard `.note.GNU-stack`

### DIFF
--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -361,6 +361,7 @@ const BUILT_IN_RULES: &[SectionRule<'static>] = &[
     ),
     SectionRule::prefix(b".rela", SectionRuleOutcome::Discard),
     SectionRule::prefix(b".crel", SectionRuleOutcome::Discard),
+    SectionRule::exact(b".note.GNU-stack", SectionRuleOutcome::Discard),
     SectionRule::exact(secnames::STRTAB_SECTION_NAME, SectionRuleOutcome::Discard),
     SectionRule::exact(secnames::SYMTAB_SECTION_NAME, SectionRuleOutcome::Discard),
     SectionRule::exact(secnames::SHSTRTAB_SECTION_NAME, SectionRuleOutcome::Discard),


### PR DESCRIPTION
After recently updating glibc (is probably the cause) on my machine (Ubuntu 26.04), one mold test began failing:
```
failures:

---- external_tests::mold_tests::check_mold_tests_regression::mold_test_063__UP_external_test_suites_mold_test_arch_x86_64_isa_level_sh stdout ----
Error: Mold test `/home/lapla/repos/wild/external_test_suites/mold/test/arch-x86_64-isa-level.sh` failed with status: exit status: 1
Output:
Testing arch-x86_64-isa-level ... + cat
+ cc -o out/test/x86_64/arch-x86_64-isa-level/a.o -c -xc -
+ cc -B. -o out/test/x86_64/arch-x86_64-isa-level/exe2 out/test/x86_64/arch-x86_64-isa-level/a.o -Wl,-z,x86-64-v2
WARNING: wild: --plugin /usr/libexec/gcc/x86_64-linux-gnu/15/liblto_plugin.so is not yet supported
+ readelf -n out/test/x86_64/arch-x86_64-isa-level/exe2
+ grep -F 'Unknown note type: (0x00000005)'
+ readelf -n out/test/x86_64/arch-x86_64-isa-level/exe2
+ grep -F 'procesor-specific type 0xc0008002'
+ readelf -n out/test/x86_64/arch-x86_64-isa-level/exe2
+ grep 'x86 ISA needed: .*x86-64-v2'
	x86 ISA needed: x86-64-baseline, x86-64-v2
++ on_error 11
++ code=1
++ echo 'command failed: 11: grep '\''x86 ISA needed: .*x86-64-v2'\'''
command failed: 11: grep 'x86 ISA needed: .*x86-64-v2'
++ trap - EXIT
++ exit 1
```

While we can dump the `exe2` note section, its exit code is 1:
```
（▰╹^╹）❯  readelf -n fakes-debug/out/test/x86_64/arch-x86_64-isa-level/exe2

Displaying notes found in: .note.gnu.property
  Owner                Data size 	Description
  GNU                  0x00000020	NT_GNU_PROPERTY_TYPE_0
      Properties: x86 feature: IBT, SHSTK
	x86 ISA needed: x86-64-baseline, x86-64-v2

Displaying notes found in: .note.gnu.build-id
  Owner                Data size 	Description
  GNU                  0x00000020	NT_GNU_BUILD_ID (unique build ID bitstring)
    Build ID: 81b9735b0aa998158c1c3431d5996b01536071b14fb1c80eb5b511a9b2a81685

Displaying notes found in: .note.ABI-tag
  Owner                Data size 	Description
  GNU                  0x00000010	NT_GNU_ABI_TAG (ABI version tag)
    OS: Linux, ABI: 3.2.0

（▰╹^╹）❯  echo $?
1
```

This is because the `.note.GNU-stack` section is being treated as a NOTE section, and `readelf` is failing when attempting to read an empty section. Other linkers don't seem to include this section in the output file since it's merely a marker section, so it's reasonable to follow that behavior.