### PR TITLE
chore: Rename extract_bits to extract_bit_range

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -549,7 +549,7 @@ pub(crate) fn write_relocation_to_buffer(
                 range,
                 instruction: insn,
             }) => {
-                let extracted_value = value.extract_bits(range.start..range.end);
+                let extracted_value = value.extract_bit_range(range.start..range.end);
                 let negative = (value as i64).is_negative();
                 let output_len = output.len();
                 insn.write_to_value(extracted_value, negative, &mut output[..output_len]);

--- a/linker-utils/src/aarch64.rs
+++ b/linker-utils/src/aarch64.rs
@@ -62,15 +62,15 @@ impl RelaxationKind {
             }
             RelaxationKind::MovzXnLsl16 => {
                 let reg = u64::from(u32_from_slice(&section_bytes[offset..offset + 4]))
-                    .extract_bits(0..5) as u8;
+                    .extract_bit_range(0..5) as u8;
                 section_bytes[offset..offset + 4].copy_from_slice(&[
                     reg, 0x0, 0xa0, 0xd2, // movz x{reg}, ${offset}, lsl #16
                 ]);
             }
             RelaxationKind::MovkXn => {
                 let raw = u64::from(u32_from_slice(&section_bytes[offset..offset + 4]));
-                let dst_reg = raw.extract_bits(0..5) as u8;
-                let src_reg = raw.extract_bits(5..10) as u8;
+                let dst_reg = raw.extract_bit_range(0..5) as u8;
+                let src_reg = raw.extract_bit_range(5..10) as u8;
                 debug_assert_eq!(
                     src_reg, dst_reg,
                     "Source and destination registers must be equal"
@@ -952,8 +952,8 @@ impl AArch64Instruction {
         match self {
             // C6.2.13
             AArch64Instruction::Adr => {
-                mask = ((extracted_value.extract_bits(0..2) as u32) << 29)
-                    | ((extracted_value.extract_bits(2..32) as u32) << 5);
+                mask = ((extracted_value.extract_bit_range(0..2) as u32) << 29)
+                    | ((extracted_value.extract_bit_range(2..32) as u32) << 5);
             }
             // C6.2.252, C6.2.254
             AArch64Instruction::Movkz => {
@@ -969,7 +969,7 @@ impl AArch64Instruction {
                     // Set opcode for MOVZ instruction
                     mask |= 1 << 30;
                 }
-                mask |= ((value as u64).extract_bits(0..16) as u32) << 5;
+                mask |= ((value as u64).extract_bit_range(0..16) as u32) << 5;
             }
             // C6.2.192
             AArch64Instruction::Ldr => {

--- a/linker-utils/src/bit_misc.rs
+++ b/linker-utils/src/bit_misc.rs
@@ -14,7 +14,7 @@ pub trait BitExtraction {
 
     /// Extract range bits from the provided `value`.
     #[must_use]
-    fn extract_bits(self, range: Range<u32>) -> u64;
+    fn extract_bit_range(self, range: Range<u32>) -> u64;
 
     /// Extract the low `num_bits` bits from `self`.
     #[must_use]
@@ -33,10 +33,10 @@ impl BitExtraction for u64 {
     // TODO: seems like a clippy issue as `position..=position` would lead to InclusiveRange type.
     #[allow(clippy::range_plus_one)]
     fn extract_bit(self, position: u32) -> u64 {
-        self.extract_bits(position..position + 1)
+        self.extract_bit_range(position..position + 1)
     }
 
-    fn extract_bits(self, range: Range<u32>) -> u64 {
+    fn extract_bit_range(self, range: Range<u32>) -> u64 {
         if range.start == 0 && range.end == u64::BITS {
             return self;
         }
@@ -67,9 +67,12 @@ mod tests {
 
     #[test]
     fn test_bit_operations() {
-        assert_eq!(0b11000, 0b1100_0000u64.extract_bits(3..8));
-        assert_eq!(0b1010_1010_0000, 0b10101010_00001111u64.extract_bits(4..16));
-        assert_eq!(u32::MAX, u64::MAX.extract_bits(0..32) as u32);
+        assert_eq!(0b11000, 0b1100_0000u64.extract_bit_range(3..8));
+        assert_eq!(
+            0b1010_1010_0000,
+            0b10101010_00001111u64.extract_bit_range(4..16)
+        );
+        assert_eq!(u32::MAX, u64::MAX.extract_bit_range(0..32) as u32);
     }
 
     #[test]
@@ -77,14 +80,14 @@ mod tests {
     #[should_panic]
     #[allow(clippy::reversed_empty_ranges)]
     fn test_extract_bits_wrong_range() {
-        let _ = 0u64.extract_bits(2..1);
+        let _ = 0u64.extract_bit_range(2..1);
     }
 
     #[test]
     #[cfg(debug_assertions)]
     #[should_panic]
     fn test_extract_bits_too_large() {
-        let _ = 0u64.extract_bits(0..100);
+        let _ = 0u64.extract_bit_range(0..100);
     }
 
     #[test]

--- a/linker-utils/src/riscv64.rs
+++ b/linker-utils/src/riscv64.rs
@@ -378,7 +378,10 @@ impl RiscVInstruction {
                 // we must prevent add 0x800 in order to not make HI20 a huge negative if the final
                 // value is a small negative value.
                 // For instance, -10i32 (0xfffffff6) should become 0x0 (HI20) and 0xff6 (LO12).
-                let mask = (extracted_value.wrapping_add(0x800).extract_bits(12..32) as u32) << 12;
+                let mask = (extracted_value
+                    .wrapping_add(0x800)
+                    .extract_bit_range(12..32) as u32)
+                    << 12;
                 and_from_slice(dest, UTYPE_IMMEDIATE_MASK.to_le_bytes().as_slice());
                 or_from_slice(dest, &mask.to_le_bytes());
             }
@@ -388,33 +391,33 @@ impl RiscVInstruction {
                 or_from_slice(dest, &(mask as u32).to_le_bytes());
             }
             RiscVInstruction::SType => {
-                let mut mask = extracted_value.extract_bits(0..5) << 7;
-                mask |= extracted_value.extract_bits(5..12) << 25;
+                let mut mask = extracted_value.extract_bit_range(0..5) << 7;
+                mask |= extracted_value.extract_bit_range(5..12) << 25;
                 and_from_slice(dest, STYPE_IMMEDIATE_MASK.to_le_bytes().as_slice());
                 or_from_slice(dest, &(mask as u32).to_le_bytes());
             }
             RiscVInstruction::BType => {
                 let mut mask = extracted_value.extract_bit(11) << 7;
-                mask |= extracted_value.extract_bits(1..5) << 8;
-                mask |= extracted_value.extract_bits(5..11) << 25;
+                mask |= extracted_value.extract_bit_range(1..5) << 8;
+                mask |= extracted_value.extract_bit_range(5..11) << 25;
                 mask |= extracted_value.extract_bit(12) << 31;
                 and_from_slice(dest, BTYPE_IMMEDIATE_MASK.to_le_bytes().as_slice());
                 or_from_slice(dest, &(mask as u32).to_le_bytes());
             }
             RiscVInstruction::JType => {
-                let mut mask = extracted_value.extract_bits(12..20) << 12;
+                let mut mask = extracted_value.extract_bit_range(12..20) << 12;
                 mask |= extracted_value.extract_bit(11) << 20;
-                mask |= extracted_value.extract_bits(1..11) << 21;
+                mask |= extracted_value.extract_bit_range(1..11) << 21;
                 mask |= extracted_value.extract_bit(20) << 31;
                 and_from_slice(dest, JTYPE_IMMEDIATE_MASK.to_le_bytes().as_slice());
                 or_from_slice(dest, &(mask as u32).to_le_bytes());
             }
             RiscVInstruction::CbType => {
                 let mut mask = extracted_value.extract_bit(5) << 2;
-                mask |= extracted_value.extract_bits(1..3) << 3;
-                mask |= extracted_value.extract_bits(6..8) << 5;
+                mask |= extracted_value.extract_bit_range(1..3) << 3;
+                mask |= extracted_value.extract_bit_range(6..8) << 5;
                 // rs1' register takes 3 bits here
-                mask |= extracted_value.extract_bits(3..5) << 10;
+                mask |= extracted_value.extract_bit_range(3..5) << 10;
                 mask |= extracted_value.extract_bit(8) << 12;
                 // The compressed instruction only takes 2 bytes.
                 and_from_slice(dest, CBTYPE_IMMEDIATE_MASK.to_le_bytes().as_slice());
@@ -422,11 +425,11 @@ impl RiscVInstruction {
             }
             RiscVInstruction::CjType => {
                 let mut mask = extracted_value.extract_bit(5) << 2;
-                mask |= extracted_value.extract_bits(1..4) << 3;
+                mask |= extracted_value.extract_bit_range(1..4) << 3;
                 mask |= extracted_value.extract_bit(7) << 6;
                 mask |= extracted_value.extract_bit(6) << 7;
                 mask |= extracted_value.extract_bit(10) << 8;
-                mask |= extracted_value.extract_bits(8..10) << 9;
+                mask |= extracted_value.extract_bit_range(8..10) << 9;
                 mask |= extracted_value.extract_bit(4) << 11;
                 mask |= extracted_value.extract_bit(11) << 12;
                 // The compressed instruction only takes 2 bytes.


### PR DESCRIPTION
This avoids a potential future conflict with a standard library method of the same name.