### PR TITLE
perf: Change release profile to use codegen-units=1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,14 +103,25 @@ winnow = { version = "0.7.10", features = ["simd"] }
 zerocopy = { version = "0.8.27", features = ["derive"] }
 zstd = "0.13.0"
 
-[profile.opt-debug]
+[profile.release]
+codegen-units = 1
+
+[profile.release-debug]
 inherits = "release"
 debug = true
 
-# The profile that 'dist' will build with
+# Optimised build, not quite as fast as release, but should be close.
+[profile.opt]
+inherits = "release"
+codegen-units = 16
+
+[profile.opt-debug]
+inherits = "opt"
+debug = true
+
+# The profile that we use for release builds distributed via github.
 [profile.dist]
 inherits = "release"
-lto = "thin"
 strip = true
 
 # In CI, we disable debug info. This gives us faster builds. It also reduces the size of the target

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -9,9 +9,8 @@ Linker-diff is mainly a tool to aid Wild development, so you most likely don't w
 ## Building
 
 This project uses Cargo as its build system. The official releases are built with `--profile dist`
-that enables compiler's internal ThinLTO and strips the binaries. The benefit from ThinLTO
-is very mild in Wild's case, so it's up to you whether to use it. Musl releases also enable
-`--feature mimalloc`, see below for the explanation.
+that enables stripping of the binaries. Musl releases also enable `--feature mimalloc`, see below
+for the explanation.
 
 ### Optional features
 


### PR DESCRIPTION
This gives more stable performance. i.e. it reduces the extent to which
small changes in code affect the performance of unrelated bits of code.

This also makes the release be more or less what we release, which is
useful if people `cargo install wild-linker.

Faster (to build) optimised builds are now available with the opt
profile.