### PR TITLE
fix: Use actual segment alignment in `layout_section_parts`

### DIFF
--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -5979,6 +5979,9 @@ fn layout_section_parts(
     output_order: &OutputOrder,
     args: &Args,
 ) -> OutputSectionPartMap<OutputRecordLayout> {
+    let segment_alignments =
+        compute_segment_alignments(sizes, program_segments, output_order, args);
+
     let mut file_offset = 0;
     let mut mem_offset = output_sections.base_address;
     let mut nonalloc_mem_offsets: OutputSectionMap<u64> =
@@ -5995,7 +5998,10 @@ fn layout_section_parts(
             }
             OrderEvent::SegmentStart(segment_id) => {
                 if program_segments.is_load_segment(segment_id) {
-                    let segment_alignment = program_segments.segment_alignment(segment_id, args);
+                    let segment_alignment = segment_alignments
+                        .get(&segment_id)
+                        .copied()
+                        .unwrap_or_else(|| args.loadable_segment_alignment());
                     if let Some(location) = pending_location.take() {
                         mem_offset = location.address;
                         file_offset =
@@ -6080,6 +6086,51 @@ fn layout_section_parts(
     }
 
     records_out
+}
+
+/// Computes the maximum alignment for each LOAD segment by examining the alignments of all sections
+/// that will be placed in that segment.
+fn compute_segment_alignments(
+    sizes: &OutputSectionPartMap<u64>,
+    program_segments: &ProgramSegments,
+    output_order: &OutputOrder,
+    args: &Args,
+) -> HashMap<ProgramSegmentId, Alignment> {
+    timing_phase!("Computing segment alignments");
+
+    let mut segment_alignments: HashMap<ProgramSegmentId, Alignment> = HashMap::new();
+    let mut active_load_segments: Vec<ProgramSegmentId> = Vec::new();
+
+    for event in output_order {
+        match event {
+            OrderEvent::SegmentStart(segment_id) => {
+                if program_segments.is_load_segment(segment_id) {
+                    // Initialize with the base loadable segment alignment
+                    segment_alignments
+                        .entry(segment_id)
+                        .or_insert_with(|| args.loadable_segment_alignment());
+                    active_load_segments.push(segment_id);
+                }
+            }
+            OrderEvent::SegmentEnd(segment_id) => {
+                active_load_segments.retain(|&id| id != segment_id);
+            }
+            OrderEvent::Section(section_id) => {
+                let part_id_range = section_id.part_id_range();
+                let max_alignment = sizes.max_alignment(part_id_range);
+
+                // Update the alignment for all active LOAD segments
+                for &segment_id in &active_load_segments {
+                    segment_alignments
+                        .entry(segment_id)
+                        .and_modify(|a| *a = (*a).max(max_alignment));
+                }
+            }
+            OrderEvent::SetLocation(_) => {}
+        }
+    }
+
+    segment_alignments
 }
 
 impl<'data> DynamicLayoutState<'data> {

--- a/libwild/src/program_segments.rs
+++ b/libwild/src/program_segments.rs
@@ -1,4 +1,3 @@
-use crate::alignment::Alignment;
 use linker_utils::elf::SegmentFlags;
 use linker_utils::elf::SegmentType;
 use linker_utils::elf::pf;
@@ -105,18 +104,6 @@ impl ProgramSegments {
 
     pub(crate) fn len(&self) -> usize {
         self.program_segment_details.len()
-    }
-
-    pub(crate) fn segment_alignment(
-        &self,
-        segment_id: ProgramSegmentId,
-        args: &crate::Args,
-    ) -> Alignment {
-        if self.segment_def(segment_id).segment_type == pt::LOAD {
-            args.loadable_segment_alignment()
-        } else {
-            crate::alignment::MIN
-        }
     }
 
     pub(crate) fn segment_def(&self, segment_id: ProgramSegmentId) -> &ProgramSegmentDef {

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -233,8 +233,6 @@ tests = [
   "glibc-2.22-bug.sh",
   "hidden-undef.sh",
   "initfirst.sh",
-  "large-alignment-dso.sh",
-  "large-alignment.sh",
   "mergeable-strings.sh",
   "missing-error.sh",
   "no-allow-shlib-undefined-circular.sh",


### PR DESCRIPTION
When computing section layouts, `align_modulo` was using only the page alignment instead of the actual maximum alignment of sections within each segment. This caused incorrect `file_offset`/`mem_offset` relationships when segments contained sections with large alignments, resulting in `file_size` > `mem_size` which Linux kernel rejects.