### PR TITLE
feat: Add flag to turn off version in .comment

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -127,6 +127,7 @@ pub struct Args {
     pub(crate) got_plt_syms: bool,
     pub(crate) b_symbolic: BSymbolicKind,
     pub(crate) relax: bool,
+    pub(crate) should_write_linker_identity: bool,
     pub(crate) hash_style: HashStyle,
     pub(crate) unresolved_symbols: UnresolvedSymbols,
     pub(crate) error_unresolved_symbols: bool,
@@ -440,6 +441,7 @@ impl Default for Args {
             mmap_output_file: true,
             needs_origin_handling: false,
             needs_nodelete_handling: false,
+            should_write_linker_identity: true,
             file_write_mode: None,
             build_id: BuildIdOption::None,
             files_per_group: None,
@@ -2160,6 +2162,15 @@ fn setup_argument_parser() -> ArgumentParser {
         .help("Ignore files in GC stats")
         .execute(|args, _modifier_stack, value| {
             args.gc_stats_ignore.push(value.to_owned());
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("no-identity-comment")
+        .help("Don't write the linker name and version in .comment")
+        .execute(|args, _modifier_stack| {
+            args.should_write_linker_identity = false;
             Ok(())
         });
 

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2770,13 +2770,15 @@ fn write_merged_strings(
         }
     });
 
-    // Write linker identity into .comment section.
-    let comment_buffer =
-        buffers.get_mut(output_section_id::COMMENT.part_id_with_alignment(alignment::MIN));
-    comment_buffer
-        .split_off_mut(..prelude.identity.len())
-        .unwrap()
-        .copy_from_slice(prelude.identity.as_bytes());
+    if layout.args().should_write_linker_identity {
+        // Write linker identity into .comment section.
+        let comment_buffer =
+            buffers.get_mut(output_section_id::COMMENT.part_id_with_alignment(alignment::MIN));
+        comment_buffer
+            .split_off_mut(..prelude.identity.len())
+            .unwrap()
+            .copy_from_slice(prelude.identity.as_bytes());
+    }
 }
 
 fn write_plt_got_entries<A: Arch>(

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3548,11 +3548,13 @@ impl<'data> PreludeLayoutState<'data> {
         queue: &mut LocalWorkQueue,
         scope: &Scope<'scope>,
     ) -> Result {
-        // Allocate space to store the identity of the linker in the .comment section.
-        common.allocate(
-            output_section_id::COMMENT.part_id_with_alignment(alignment::MIN),
-            self.identity.len() as u64,
-        );
+        if resources.symbol_db.args.should_write_linker_identity {
+            // Allocate space to store the identity of the linker in the .comment section.
+            common.allocate(
+                output_section_id::COMMENT.part_id_with_alignment(alignment::MIN),
+                self.identity.len() as u64,
+            );
+        }
 
         // The first entry in the symbol table must be null. Similarly, the first string in the
         // strings table must be empty.
@@ -3993,10 +3995,13 @@ impl<'data> PreludeLayoutState<'data> {
         self.internal_symbols
             .finalise_layout(memory_offsets, resolutions_out, resources)?;
 
-        memory_offsets.increment(
-            output_section_id::COMMENT.part_id_with_alignment(alignment::MIN),
-            self.identity.len() as u64,
-        );
+        if resources.symbol_db.args.should_write_linker_identity {
+            memory_offsets.increment(
+                output_section_id::COMMENT.part_id_with_alignment(alignment::MIN),
+                self.identity.len() as u64,
+            );
+        }
+
         resources.merged_strings.for_each(|section_id, merged| {
             if merged.len() > 0 {
                 memory_offsets.increment(


### PR DESCRIPTION
This is mostly intended to make it easier to verify that a change that is supposed to be a refactoring doesn't change the output. The version string contains the git hash, which would otherwise show as a change.