### PR TITLE
test: Hash input files rather than using timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,9 +539,9 @@ checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
 
 [[package]]
 name = "flate2"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2142,6 +2142,7 @@ version = "0.8.0"
 dependencies = [
  "ar",
  "dhat",
+ "foldhash",
  "itertools",
  "libwild",
  "linker-diff",
@@ -2238,9 +2239,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+checksum = "a7948af682ccbc3342b6e9420e8c51c1fe5d7bf7756002b4a3c6cabfe96a7e3c"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,3 +222,7 @@ case_sensitive_file_extension_comparisons = "warn"
 cloned_instead_of_copied = "warn"
 cast_lossless = "warn"
 needless_pass_by_ref_mut = "warn"
+
+# We do a bit of hashing, especially in the integration tests. Optimising this speeds up tests.
+[profile.dev.package."foldhash"]
+opt-level = 2

--- a/wild/Cargo.toml
+++ b/wild/Cargo.toml
@@ -24,6 +24,7 @@ dhat = { workspace = true, optional = true }
 [dev-dependencies]
 ar = { workspace = true }
 itertools = { workspace = true }
+foldhash = { workspace = true }
 linker-diff = { path = "../linker-diff" }
 object = { workspace = true }
 os_info = { workspace = true }


### PR DESCRIPTION
This will hopefully result in less stale test build directory issues. If not, at least we'll now have a file listing the input hashes with which to debug such issues.