### PR TITLE
feat: Support `--enable-new-dtags` and `--disable-new-dtags`

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -97,6 +97,7 @@ pub struct Args {
     pub(crate) export_list: Vec<String>,
     pub(crate) export_list_path: Option<PathBuf>,
     pub(crate) auxiliary: Vec<String>,
+    pub(crate) enable_new_dtags: bool,
 
     /// Symbol definitions from `--defsym` options. Each entry is (symbol_name, value_or_symbol).
     pub(crate) defsym: Vec<(String, DefsymValue)>,
@@ -369,7 +370,6 @@ const SILENTLY_IGNORED_SHORT_FLAGS: &[&str] = &[
 
 const IGNORED_FLAGS: &[&str] = &[
     "gdb-index",
-    "disable-new-dtags",
     "fix-cortex-a53-835769",
     "fix-cortex-a53-843419",
     "discard-all",
@@ -382,7 +382,6 @@ const DEFAULT_FLAGS: &[&str] = &[
     "no-copy-dt-needed-entries",
     "no-add-needed",
     "discard-locals",
-    "enable-new-dtags",
     "no-fatal-warnings",
 ];
 const DEFAULT_SHORT_FLAGS: &[&str] = &[
@@ -435,6 +434,7 @@ impl Default for Args {
             verbose_gc_stats: false,
             rpath: None,
             soname: None,
+            enable_new_dtags: true,
             execstack: false,
             should_fork: true,
             mmap_output_file: true,
@@ -2265,6 +2265,24 @@ fn setup_argument_parser() -> ArgumentParser {
                 "both" => HashStyle::Both,
                 _ => bail!("Unknown hash-style `{value}`"),
             };
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("enable-new-dtags")
+        .help("Use DT_RUNPATH and DT_FLAGS/DT_FLAGS_1 (default)")
+        .execute(|args, _modifier_stack| {
+            args.enable_new_dtags = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("disable-new-dtags")
+        .help("Use DT_RPATH and individual dynamic entries instead of DT_FLAGS")
+        .execute(|args, _modifier_stack| {
+            args.enable_new_dtags = false;
             Ok(())
         });
 

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -226,7 +226,6 @@ tests = [
   "common-symbols.sh",
   "defsym-missing-symbol.sh",
   "demangle-cpp.sh",
-  "disable-new-dtags.sh",
   "discard-section.sh",
   "discard.sh",
   "dynamic-linker.sh",

--- a/wild/tests/sources/new-dtags.c
+++ b/wild/tests/sources/new-dtags.c
@@ -1,0 +1,28 @@
+//#AbstractConfig:default
+//#Object:runtime.c
+//#Mode:dynamic
+//#RunEnabled:false
+//#DiffIgnore:.dynamic.DT_RELA
+//#DiffIgnore:.dynamic.DT_RELAENT
+
+//#Config:new-dtags:default
+//#LinkArgs:-shared -rpath /test/path --enable-new-dtags -z now
+//#ExpectDynamic:DT_RUNPATH
+//#ExpectDynamic:DT_FLAGS
+//#ExpectDynamic:DT_FLAGS_1
+//#NoDynamic:DT_RPATH
+//#NoDynamic:DT_BIND_NOW
+
+//#Config:old-dtags:default
+//#LinkArgs:-shared -rpath /test/path --disable-new-dtags -z now
+//#ExpectDynamic:DT_RPATH
+//#ExpectDynamic:DT_BIND_NOW
+//#ExpectDynamic:DT_FLAGS_1
+//#NoDynamic:DT_RUNPATH
+//#NoDynamic:DT_FLAGS
+//#DiffIgnore:.dynamic.DT_FLAGS_1.NOW
+//#DiffIgnore:.dynamic.DT_RPATH
+
+int foo(void);
+
+int call_foo(void) { return foo() + 2; }


### PR DESCRIPTION
The `--disable-new-dtags` option is used when building Chromium for Android.  
This patch implements conditional switching between `RPATH` and `RUNPATH`, conditional emission of `DT_FLAGS`, and the addition of separate dynamic entries when `--disable-new-dtags` is specified.

Note that GNU ld always emits `DT_FLAGS_1`, so the implementation was adjusted to match this behavior.

```
$ cat dtag_test.c
int foo(void) { return 42; }

$ gcc -c -fPIC dtag_test.c -o dtag_test.o

$ ld -shared -rpath /test/path --enable-new-dtags -z now -o enabled.so dtag_test.o && readelf -d enabled.so | grep FLAGS
 0x000000000000001e (FLAGS)              BIND_NOW
 0x000000006ffffffb (FLAGS_1)            Flags: NOW

$ ld -shared -rpath /test/path --disable-new-dtags -z now -o disabled.so dtag_test.o && readelf -d disabled.so | grep FLAGS
 0x000000000000001e (FLAGS)              BIND_NOW
 0x000000006ffffffb (FLAGS_1)            Flags: NOW
```

close #1464 