### PR TITLE
Fix #1457: Make --version exit immediately, -v continue linking

### DIFF
--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -174,10 +174,17 @@ impl Linker {
         args: &'layout_inputs ActivatedArgs,
     ) -> error::Result<LinkerOutput<'layout_inputs>> {
         let args = &args.args;
-        if args.should_print_version {
-            println!("{}", linker_identity());
-            if args.inputs.is_empty() {
+        match args.version_mode {
+            args::VersionMode::ExitAfterPrint => {
+                println!("{}", linker_identity());
                 return Ok(LinkerOutput { layout: None });
+            }
+            args::VersionMode::Verbose => {
+                println!("{}", linker_identity());
+                // Continue linking
+            }
+            args::VersionMode::None => {
+                // Don't print version
             }
         }
 


### PR DESCRIPTION
Fixes #1457

## Problem
When running `clang -Wl,--version`, Wild was printing the version but continuing to link, which caused failures when undefined symbols were present. Other linkers (GNU ld, LLD) print their version and exit immediately with code 0, even if there are linking errors.

## Solution
This PR separates the behavior of `-v` and `--version` flags to match GNU ld and LLD:

### Changes Made
- **Added `VersionMode` enum** with three states:
  - `None`: Don't print version
  - `Verbose`: Print version and continue linking (for `-v` flag)
  - `ExitAfterPrint`: Print version and exit immediately (for `--version` flag)

- **Separated flag handlers** in `args.rs`:
  - `--version` → Sets `VersionMode::ExitAfterPrint`
  - `-v` → Sets `VersionMode::Verbose`

- **Updated linker logic** in `lib.rs`:
  - `ExitAfterPrint` → Returns immediately after printing version
  - `Verbose` → Prints version and continues with normal linking
  - `None` → No version output

- **Updated tests** to verify the new behavior

### Behavior
**Before:**
```bash
$ clang -Wl,--version --ld-path=./wild
Wild version 0.8.0 ...
wild: error: Undefined symbol main
Exit code: 255 ❌
```
After:
```bash
$ clang -Wl,--version --ld-path=./wild
Wild version 0.8.0 ...
Exit code: 0 ✅
```
Testing
Manually tested:
wild --version - Prints version and exits with code 0 (no linking)
wild --version file.o - Ignores input files, exits immediately
wild -v file.o - Prints version and continues linking
clang -Wl,--version - Works correctly now

Compatibility
This implementation now matches the behavior of:
GNU ld (GNU Binutils)
LLD (LLVM linker)
Gold linker
This ensures Wild can be used as a drop-in replacement in build systems that query linker versions.