### PR TITLE
feat: Reject conflicting RISC-V ISA extensions

### DIFF
--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -3523,7 +3523,8 @@ fn integration_test(
         "stack-size.c",
         "undefined-weak-sym.c",
         "auxiliary.c",
-        "new-dtags.c"
+        "new-dtags.c",
+        "riscv-attr-conflict.s"
     )]
     program_name: &'static str,
     #[allow(unused_variables)] setup_symlink: (),

--- a/wild/tests/sources/riscv-attr-conflict-1.s
+++ b/wild/tests/sources/riscv-attr-conflict-1.s
@@ -1,0 +1,7 @@
+.section .text, "ax", @progbits
+.globl conflict_func
+.type conflict_func, @function
+conflict_func:
+    li a0, 1
+    ret
+.size conflict_func, .-conflict_func

--- a/wild/tests/sources/riscv-attr-conflict.s
+++ b/wild/tests/sources/riscv-attr-conflict.s
@@ -1,0 +1,16 @@
+/*
+//#Arch: riscv64
+//#SkipLinker:ld
+//#CompArgs:-march=rv64imafc -mabi=lp64
+//#Object:riscv-attr-conflict-1.s:-march=rv64imac_zfinx -mabi=lp64
+//#ExpectError:'f'.*incompatible.*'zfinx'
+*/
+
+.section .text, "ax", @progbits
+.globl _start
+.type _start, @function
+_start:
+    li a0, 42
+    li a7, 93
+    ecall
+.size _start, .-_start


### PR DESCRIPTION
part of #916 

While base ISA conflicts are already caught by `merge_eflags`, there were no checks to detect conflicting combinations of ISA extensions.