### PR TITLE
feat: Add base to track byte reduction due to relaxation

### DIFF
--- a/libwild/src/arch.rs
+++ b/libwild/src/arch.rs
@@ -10,6 +10,7 @@ use linker_utils::elf::DynamicRelocationKind;
 use linker_utils::elf::RelocationKindInfo;
 use linker_utils::elf::SectionFlags;
 use linker_utils::relaxation::RelocationModifier;
+use object::SectionIndex;
 use object::elf::EM_AARCH64;
 use object::elf::EM_LOONGARCH;
 use object::elf::EM_RISCV;
@@ -120,4 +121,14 @@ pub(crate) trait Relaxation {
     fn next_modifier(&self) -> RelocationModifier;
 
     fn is_mandatory(&self) -> bool;
+}
+
+#[expect(unused)]
+pub(crate) struct RelaxSymbolInfo {
+    /// The section in which the symbol is defined.
+    pub section_index: SectionIndex,
+    /// The symbol's offset within its section.
+    pub offset: u64,
+    /// Whether the symbol may be interposed at runtime.
+    pub is_interposable: bool,
 }

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -11,6 +11,7 @@ use crate::OutputKind;
 use crate::alignment;
 use crate::alignment::Alignment;
 use crate::arch::Arch;
+use crate::arch::Architecture;
 use crate::arch::Relaxation as _;
 use crate::args::Args;
 use crate::args::BuildIdOption;
@@ -106,7 +107,9 @@ use linker_utils::elf::shf;
 use linker_utils::elf::sht;
 use linker_utils::elf::sht::NOTE;
 use linker_utils::elf::sht::RISCV_ATTRIBUTES;
+use linker_utils::relaxation::RelaxDeltaMap;
 use linker_utils::relaxation::RelocationModifier;
+use linker_utils::relaxation::opt_input_to_output;
 use object::LittleEndian;
 use object::SectionIndex;
 use object::elf::GNU_PROPERTY_X86_ISA_1_NEEDED;
@@ -1059,6 +1062,8 @@ pub(crate) struct ObjectLayout<'data> {
     pub(crate) symbol_id_range: SymbolIdRange,
     /// SFrame section ranges for this object, relative to the start of the .sframe output section.
     pub(crate) sframe_ranges: Vec<std::ops::Range<usize>>,
+    /// Sparse map from section index to relaxation delta details.
+    pub(crate) section_relax_deltas: RelaxDeltaMap,
 }
 
 #[derive(Debug)]
@@ -1640,6 +1645,10 @@ struct ObjectLayoutState<'data> {
 
     /// Indexed by `FrameIndex`.
     exception_frames: ExceptionFrames<'data>,
+
+    /// Sparse map from section index to relaxation delta details, built during `finalise_sizes`
+    /// and later transferred to `ObjectLayout`.
+    section_relax_deltas: RelaxDeltaMap,
 }
 
 enum ExceptionFrames<'data> {
@@ -1765,7 +1774,8 @@ pub(crate) struct DynamicSymbolDefinition<'data> {
 pub(crate) struct Section {
     pub(crate) index: object::SectionIndex,
     pub(crate) part_id: PartId,
-    /// Size in memory.
+    /// Size in the output. This starts as the input section size, then may be reduced by
+    /// relaxation-induced byte deletions during `scan_relaxations`.
     pub(crate) size: u64,
     pub(crate) flags: ValueFlags,
     pub(crate) is_writable: bool,
@@ -2034,9 +2044,12 @@ impl<'data> Layout<'data> {
                                     && obj.object.section_size(section).is_ok_and(|s| s > 0))
                                 .then(|| {
                                     let address = res.address;
+                                    let size = match section_slot {
+                                        SectionSlot::Loaded(sec) => sec.size,
+                                        _ => obj.object.section_size(section).unwrap(),
+                                    };
                                     linker_layout::Section {
-                                        mem_range: address
-                                            ..(address + obj.object.section_size(section).unwrap()),
+                                        mem_range: address..(address + size),
                                     }
                                 })
                             })
@@ -3271,8 +3284,8 @@ impl Section {
         Ok(section)
     }
 
-    // How much space we take up. This is our size rounded up to the next multiple of our alignment,
-    // unless we're in a packed section, in which case it's just our size.
+    // How much space we take up. This is our size rounded up to the next multiple of our
+    // alignment, unless we're in a packed section, in which case it's just our size.
     pub(crate) fn capacity(&self) -> u64 {
         if self.part_id.should_pack() {
             self.size
@@ -4653,6 +4666,7 @@ fn new_object_layout_state(input_state: resolution::ResolvedObject) -> FileLayou
         gnu_property_notes: Default::default(),
         riscv_attributes: Default::default(),
         exception_frames: Default::default(),
+        section_relax_deltas: RelaxDeltaMap::new(),
     })
 }
 
@@ -5080,12 +5094,38 @@ impl<'data> ObjectLayoutState<'data> {
                 allocate_resolution(section.flags, &mut common.mem_sizes, output_kind);
             }
         }
+
+        // Scan for size-changing relaxation opportunities (e.g. RISC-V call relaxation)
+        // when --relax is enabled.
+        if resources.symbol_db.args.relax {
+            self.scan_relaxations(common, per_symbol_flags, resources);
+        }
+
         // TODO: Deduplicate CIEs from different objects, then only allocate space for those CIEs
         // that we "won".
         for cie in &self.cies {
             self.eh_frame_size += cie.cie.bytes.len() as u64;
         }
         common.allocate(part_id::EH_FRAME, self.eh_frame_size);
+    }
+
+    /// Scan loaded executable sections for size-changing relaxation opportunities.
+    // These warnings are intentional since they are expected to be removed when actual collection
+    // of relaxation deltas is implemented.
+    #[expect(clippy::unused_self, clippy::needless_pass_by_ref_mut)]
+    fn scan_relaxations(
+        &mut self,
+        _common: &mut CommonGroupState,
+        _per_symbol_flags: &AtomicPerSymbolFlags,
+        resources: &FinaliseSizesResources<'data, '_>,
+    ) {
+        let symbol_db = resources.symbol_db;
+        let arch = symbol_db.args.arch;
+
+        // Relaxations that reduce bytes are currently only implemented for RISC-V
+        if !matches!(arch, Architecture::RISCV64) {}
+
+        // TODO: For each loaded executable section, collect relaxation deltas.
     }
 
     fn allocate_symtab_space(
@@ -5210,6 +5250,7 @@ impl<'data> ObjectLayoutState<'data> {
             section_resolutions,
             symbol_id_range,
             sframe_ranges,
+            section_relax_deltas: self.section_relax_deltas,
         })
     }
 
@@ -5258,7 +5299,12 @@ impl<'data> ObjectLayoutState<'data> {
             .symbol_section(local_symbol, local_symbol_index)?
         {
             if let Some(section_address) = section_resolutions[section_index.0].address() {
-                local_symbol.st_value(e) + section_address
+                let input_offset = local_symbol.st_value(e);
+                let output_offset = opt_input_to_output(
+                    self.section_relax_deltas.get(section_index.0),
+                    input_offset,
+                );
+                output_offset + section_address
             } else {
                 match get_merged_string_output_address(
                     local_symbol_index,

--- a/libwild/src/output_section_part_map.rs
+++ b/libwild/src/output_section_part_map.rs
@@ -71,6 +71,16 @@ impl OutputSectionPartMap<u64> {
     pub(crate) fn increment(&mut self, part_id: PartId, size: u64) {
         *self.get_mut(part_id) += size;
     }
+
+    #[expect(unused)]
+    pub(crate) fn decrement(&mut self, part_id: PartId, size: u64) {
+        let v = self.get_mut(part_id);
+        debug_assert!(
+            *v >= size,
+            "decrement underflow for {part_id:?}: {v} < {size}"
+        );
+        *v -= size;
+    }
 }
 
 impl<T: Default + PartialEq> OutputSectionPartMap<T> {

--- a/linker-utils/src/relaxation.rs
+++ b/linker-utils/src/relaxation.rs
@@ -3,3 +3,186 @@ pub enum RelocationModifier {
     Normal,
     SkipNextRelocation,
 }
+
+/// Records the number of bytes deleted at a specific offset within an input section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RelaxDelta {
+    /// Offset within the input section where the deletion occurs.
+    pub input_offset: u64,
+    /// Cumulative bytes deleted up to and including this entry.
+    pub cumulative_deleted: u64,
+    /// Number of bytes deleted at this position.
+    pub bytes_deleted: u32,
+}
+
+/// Tracks all relaxation-induced byte deletions for a single section.
+#[derive(Debug, Clone, Default)]
+pub struct SectionRelaxDeltas {
+    /// Sorted (by `input_offset`) list of individual deletions.
+    /// Each entry carries a precomputed `cumulative_deleted` field.
+    deltas: Vec<RelaxDelta>,
+}
+
+impl SectionRelaxDeltas {
+    #[must_use]
+    pub fn new(raw: Vec<(u64, u32)>) -> Self {
+        debug_assert!(
+            raw.windows(2).all(|w| w[0].0 < w[1].0),
+            "entries must be sorted by input_offset in strictly ascending order"
+        );
+
+        let mut deltas = Vec::with_capacity(raw.len());
+        let mut running = 0u64;
+        for (input_offset, bytes_deleted) in raw {
+            running += u64::from(bytes_deleted);
+            deltas.push(RelaxDelta {
+                input_offset,
+                cumulative_deleted: running,
+                bytes_deleted,
+            });
+        }
+
+        SectionRelaxDeltas { deltas }
+    }
+
+    #[must_use]
+    pub fn deltas(&self) -> &[RelaxDelta] {
+        &self.deltas
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.deltas.is_empty()
+    }
+
+    #[must_use]
+    pub fn total_deleted(&self) -> u64 {
+        self.deltas.last().map_or(0, |d| d.cumulative_deleted)
+    }
+
+    #[must_use]
+    pub fn has_delta_at(&self, offset: u64) -> bool {
+        self.deltas
+            .binary_search_by_key(&offset, |d| d.input_offset)
+            .is_ok()
+    }
+
+    // Converts an input section offset to the corresponding output section offset by subtracting
+    // the cumulative bytes deleted strictly before `input_offset`.
+    #[must_use]
+    pub fn input_to_output_offset(&self, input_offset: u64) -> u64 {
+        if self.deltas.is_empty() {
+            return input_offset;
+        }
+
+        // Find the number of deltas whose input_offset is strictly before the
+        // queried input_offset.
+        let idx = self
+            .deltas
+            .partition_point(|d| d.input_offset < input_offset);
+
+        if idx == 0 {
+            input_offset
+        } else {
+            input_offset - self.deltas[idx - 1].cumulative_deleted
+        }
+    }
+
+    // Converts an output section offset back to the corresponding input section offset.
+    #[must_use]
+    pub fn output_to_input_offset(&self, output_offset: u64) -> u64 {
+        if self.deltas.is_empty() {
+            return output_offset;
+        }
+
+        let lo = self.deltas.partition_point(|d| {
+            d.input_offset + u64::from(d.bytes_deleted) - d.cumulative_deleted <= output_offset
+        });
+
+        if lo == 0 {
+            output_offset
+        } else {
+            output_offset + self.deltas[lo - 1].cumulative_deleted
+        }
+    }
+
+    #[must_use]
+    pub fn cursor(&self) -> RelaxCursor<'_> {
+        RelaxCursor {
+            deltas: &self.deltas,
+            index: 0,
+            current_cumulative: 0,
+        }
+    }
+}
+
+pub struct RelaxCursor<'a> {
+    deltas: &'a [RelaxDelta],
+    /// Index of the next delta that has not yet been "consumed".
+    index: usize,
+    /// Cumulative bytes deleted up to (but not including) `deltas[index]`.
+    current_cumulative: u64,
+}
+
+impl RelaxCursor<'_> {
+    // Translates an input section offset to the corresponding output section offset.
+    #[inline]
+    pub fn translate(&mut self, input_offset: u64) -> u64 {
+        // Advance past all deltas that are strictly before the queried offset.
+        while self.index < self.deltas.len() && self.deltas[self.index].input_offset < input_offset
+        {
+            self.current_cumulative = self.deltas[self.index].cumulative_deleted;
+            self.index += 1;
+        }
+        input_offset - self.current_cumulative
+    }
+}
+
+// Translates an input offset through optional relaxation deltas.
+#[inline]
+#[must_use]
+pub fn opt_input_to_output(deltas: Option<&SectionRelaxDeltas>, input_offset: u64) -> u64 {
+    match deltas {
+        Some(d) => d.input_to_output_offset(input_offset),
+        None => input_offset,
+    }
+}
+
+/// Sparse map from section index to [`SectionRelaxDeltas`].
+#[derive(Debug, Clone, Default)]
+pub struct RelaxDeltaMap {
+    /// Sorted by section index
+    entries: Vec<(usize, SectionRelaxDeltas)>,
+}
+
+impl RelaxDeltaMap {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+
+    pub fn insert(&mut self, section_index: usize, deltas: SectionRelaxDeltas) {
+        debug_assert!(
+            self.entries
+                .last()
+                .is_none_or(|(idx, _)| *idx < section_index),
+            "entries must be inserted in ascending section index order"
+        );
+        self.entries.push((section_index, deltas));
+    }
+
+    #[must_use]
+    pub fn get(&self, section_index: usize) -> Option<&SectionRelaxDeltas> {
+        self.entries
+            .binary_search_by_key(&section_index, |(idx, _)| *idx)
+            .ok()
+            .map(|i| &self.entries[i].1)
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}


### PR DESCRIPTION
part of #874 

Some relaxations in architectures such as RISC-V and LoongArch actually reduce the generated code size. Although similar relaxations exist in x86_64 and AArch64, those implementations pad the shortened instructions with NOPs, so the overall symbol sizes remain unchanged. In contrast, the relaxations mentioned above truly shrink the symbols themselves, which means we must track how much each symbol’s size is reduced during the layout phase. A naive implementation would require running the layout process twice (the second pass accounting for size reductions in other symbols) which would clearly hurt performance.

Therefore, while this PR does not introduce any specific relaxation, it lays the groundwork for tracking size reductions caused by relaxations without requiring a second layout pass.

`SectionRelaxDeltas` maintains a list of offsets from which each section should remove a specific number of bytes. This information is used during the write phase to calculate offsets individually. The `relaxation_deleted` field within `Section` records the amount of byte reduction achieved for each section. From this data, we can calculate the actual size of each section, which can be used for the layout phase.
