### PR TITLE
chore: Ignore `section.ARM.attributes` in linker-diff

### DIFF
--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -271,6 +271,7 @@ impl Config {
         match arch {
             ArchKind::Aarch64 => self.ignore.extend(
                 [
+                    "section.ARM.attributes",
                     // Other linkers have a bigger initial PLT entry, thus the entsize is set to
                     // zero: https://sourceware.org/bugzilla/show_bug.cgi?id=26312
                     "section.plt.entsize",


### PR DESCRIPTION
Recent toolchain changes seem to have caused the `ARM.attributes` section to be output. See this run: https://github.com/davidlattimore/wild/actions/runs/21901730592/job/63231472110

```
---- integration_test::program_name_096___section_start_c__ stdout ----
wild: /__w/wild/wild/wild/tests/build/section-start.c/section-start-aarch64/section-start.c.wild
ld: /__w/wild/wild/wild/tests/build/section-start.c/section-start-aarch64/section-start.c.ld
section.ARM.attributes
  wild Section missing
  ld OK
```