### PR TITLE
refactor: Get rid of Format and make Platform have a 'data lifetime

### DIFF
--- a/libwild/src/dwarf_address_info.rs
+++ b/libwild/src/dwarf_address_info.rs
@@ -33,7 +33,7 @@ pub(crate) struct SourceInfoDetails {
 const SECTION_LOAD_ADDRESS: u64 = 0x1_000_000_000;
 
 /// Attempts to locate source info for `offset_in_section` within `section`.
-pub(crate) fn get_source_info<P: Platform>(
+pub(crate) fn get_source_info<'data, P: Platform<'data>>(
     object: &File,
     relocations: &RelocationSections,
     section: &object::elf::SectionHeader64<LittleEndian>,
@@ -99,7 +99,7 @@ pub(crate) fn get_source_info<P: Platform>(
 }
 
 /// Gets the data for section `id` from `object` and applies relocations to it.
-fn section_data_with_relocations<P: Platform>(
+fn section_data_with_relocations<'data, P: Platform<'data>>(
     object: &File,
     relocations: &RelocationSections,
     id: gimli::SectionId,
@@ -137,7 +137,7 @@ fn section_data_with_relocations<P: Platform>(
     Ok(data)
 }
 
-fn apply_section_relocations<P: Platform, R: Relocation>(
+fn apply_section_relocations<'data, P: Platform<'data>, R: Relocation>(
     object: &File<'_>,
     section_of_interest: &object::elf::SectionHeader64<LittleEndian>,
     section_data: &mut [u8],

--- a/libwild/src/elf_aarch64.rs
+++ b/libwild/src/elf_aarch64.rs
@@ -31,9 +31,9 @@ const _ASSERTS: () = {
     assert!(PLT_ENTRY_TEMPLATE.len() as u64 == PLT_ENTRY_SIZE);
 };
 
-impl crate::platform::Platform for ElfAArch64 {
+impl<'data> crate::platform::Platform<'data> for ElfAArch64 {
     type Relaxation = Relaxation;
-    type Format = crate::elf::Elf;
+    type File = crate::elf::File<'data>;
 
     const KIND: crate::arch::Architecture = crate::arch::Architecture::AArch64;
 

--- a/libwild/src/elf_loongarch64.rs
+++ b/libwild/src/elf_loongarch64.rs
@@ -28,9 +28,9 @@ const _ASSERTS: () = {
     assert!(PLT_ENTRY_TEMPLATE.len() as u64 == PLT_ENTRY_SIZE);
 };
 
-impl crate::platform::Platform for ElfLoongArch64 {
+impl<'data> crate::platform::Platform<'data> for ElfLoongArch64 {
     type Relaxation = Relaxation;
-    type Format = crate::elf::Elf;
+    type File = crate::elf::File<'data>;
 
     const KIND: crate::arch::Architecture = crate::arch::Architecture::LoongArch64;
 

--- a/libwild/src/elf_riscv64.rs
+++ b/libwild/src/elf_riscv64.rs
@@ -35,9 +35,9 @@ const _ASSERTS: () = {
     assert!(PLT_ENTRY_TEMPLATE.len() as u64 == PLT_ENTRY_SIZE);
 };
 
-impl crate::platform::Platform for ElfRiscV64 {
+impl<'data> crate::platform::Platform<'data> for ElfRiscV64 {
     type Relaxation = Relaxation;
-    type Format = crate::elf::Elf;
+    type File = crate::elf::File<'data>;
 
     const KIND: crate::arch::Architecture = crate::arch::Architecture::RISCV64;
 

--- a/libwild/src/elf_x86_64.rs
+++ b/libwild/src/elf_x86_64.rs
@@ -40,9 +40,9 @@ const _ASSERTS: () = {
     assert!(PLT_ENTRY_TEMPLATE.len() as u64 == PLT_ENTRY_SIZE);
 };
 
-impl crate::platform::Platform for ElfX86_64 {
+impl<'data> crate::platform::Platform<'data> for ElfX86_64 {
     type Relaxation = Relaxation;
-    type Format = crate::elf::Elf;
+    type File = crate::elf::File<'data>;
 
     const KIND: crate::arch::Architecture = crate::arch::Architecture::X86_64;
 

--- a/libwild/src/file_writer.rs
+++ b/libwild/src/file_writer.rs
@@ -186,10 +186,10 @@ impl Output {
         }
     }
 
-    pub fn write<'data>(
+    pub fn write<'data, 'layout>(
         &self,
-        layout: &Layout<'data>,
-        write_fn: impl Fn(&mut SizedOutput, &Layout) -> Result,
+        layout: &'layout Layout<'data>,
+        write_fn: impl FnOnce(&mut SizedOutput, &'layout Layout<'data>) -> Result,
     ) -> Result {
         timing_phase!("Write output file");
         if layout.args().write_layout {

--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -205,10 +205,10 @@ impl Linker {
         }
     }
 
-    fn link_for_arch<'layout_inputs, P: Platform>(
-        &'layout_inputs self,
-        args: &'layout_inputs Args,
-    ) -> error::Result<LinkerOutput<'layout_inputs>> {
+    fn link_for_arch<'data, P: Platform<'data>>(
+        &'data self,
+        args: &'data Args,
+    ) -> error::Result<LinkerOutput<'data>> {
         let mut file_loader = input_data::FileLoader::new(&self.inputs_arena);
 
         // Note, we propagate errors from `link_with_input_data` after we've checked if any files
@@ -233,7 +233,7 @@ impl Linker {
         result
     }
 
-    fn load_inputs_and_link<'data, P: Platform>(
+    fn load_inputs_and_link<'data, P: Platform<'data>>(
         &'data self,
         file_loader: &mut FileLoader<'data>,
         args: &'data Args,


### PR DESCRIPTION
Turns out that GATs cause lifetimes to be invariant, which causes us problems, so we need to avoid them. That means that we need our 'data lifetime to be on the trait(s) not on the associated types. Given that, the Format trait is redundant as with a lifetime it wouldn't be different to ObjectFile.