### PR TITLE
feat: Define `_etext`, `__etext` and `_edata` special symbols

### DIFF
--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -756,6 +756,7 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = [
         kind: SectionKind::Primary(SectionName(TEXT_SECTION_NAME)),
         ty: sht::PROGBITS,
         section_flags: shf::ALLOC.with(shf::EXECINSTR),
+        end_symbol_name: Some("_etext"),
         ..DEFAULT_DEFS
     },
     BuiltInSectionDetails {
@@ -776,6 +777,7 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = [
         section_flags: shf::ALLOC.with(shf::WRITE),
         // TODO: define the symbol only on RISC-V target
         start_symbol_name: Some(GLOBAL_POINTER_SYMBOL_NAME),
+        end_symbol_name: Some("_edata"),
         ..DEFAULT_DEFS
     },
     BuiltInSectionDetails {

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -292,6 +292,11 @@ impl<'data> Prelude<'data> {
         }));
 
         symbol_definitions.push(InternalSymDefInfo::notype(
+            SymbolPlacement::SectionEnd(output_section_id::TEXT),
+            b"__etext",
+        ));
+
+        symbol_definitions.push(InternalSymDefInfo::notype(
             SymbolPlacement::LoadBaseAddress,
             b"__executable_start",
         ));

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -3578,7 +3578,8 @@ fn integration_test(
         "new-dtags.c",
         "riscv-attr-conflict.s",
         "riscv-call-relaxation.s",
-        "riscv-cross-object-call-relaxation.s"
+        "riscv-cross-object-call-relaxation.s",
+        "segment-end-syms.c"
     )]
     program_name: &'static str,
     #[allow(unused_variables)] setup_symlink: (),

--- a/wild/tests/sources/segment-end-syms.c
+++ b/wild/tests/sources/segment-end-syms.c
@@ -1,0 +1,58 @@
+//#AbstractConfig:default
+//#Object:runtime.c
+//#Object:ptr_black_box.c
+
+//#Config:no-pie:default
+//#LinkArgs:-no-pie -znow
+
+//#Config:pie:default
+
+#include "ptr_black_box.h"
+#include "runtime.h"
+
+extern char _etext;
+extern char __etext;
+extern char _edata;
+extern char _end;
+
+int data_var = 123;
+
+void _start(void) {
+  runtime_init();
+
+  if (ptr_to_int(&_etext) == 0) {
+    exit_syscall(10);
+  }
+
+  if (ptr_to_int(&_etext) <= ptr_to_int(&_start)) {
+    exit_syscall(11);
+  }
+
+  if (ptr_to_int(&__etext) != ptr_to_int(&_etext)) {
+    exit_syscall(12);
+  }
+
+  if (ptr_to_int(&_edata) == 0) {
+    exit_syscall(13);
+  }
+
+  if (ptr_to_int(&_edata) <= ptr_to_int(&data_var)) {
+    exit_syscall(14);
+  }
+
+  if (ptr_to_int(&_edata) <= ptr_to_int(&_etext)) {
+    exit_syscall(15);
+  }
+
+  if (ptr_to_int(&_end) == 0) {
+    exit_syscall(16);
+  }
+
+  // _end (end of .bss) should be >= _edata (end of .data). They can be equal
+  // when there is no .bss content, as is the case in this test.
+  if (ptr_to_int(&_end) < ptr_to_int(&_edata)) {
+    exit_syscall(17);
+  }
+
+  exit_syscall(42);
+}


### PR DESCRIPTION
`_etext` points to the end of the `.text` section, while `__etext` is an alias for `_etext` that is conventionally used in some contexts. `_edata`, meanwhile, points to the end of the `.data` section.

also close #1562