### PR TITLE
feat: Support RISC-V HI20 relaxation

### DIFF
--- a/libwild/src/elf_aarch64.rs
+++ b/libwild/src/elf_aarch64.rs
@@ -144,6 +144,7 @@ impl crate::platform::Relaxation for Relaxation {
         output_kind: crate::output_kind::OutputKind,
         section_flags: linker_utils::elf::SectionFlags,
         non_zero_address: bool,
+        _relax_deltas: Option<&linker_utils::relaxation::SectionRelaxDeltas>,
     ) -> Option<Self>
     where
         Self: std::marker::Sized,

--- a/libwild/src/elf_loongarch64.rs
+++ b/libwild/src/elf_loongarch64.rs
@@ -126,6 +126,7 @@ impl crate::platform::Relaxation for Relaxation {
         output_kind: crate::output_kind::OutputKind,
         section_flags: linker_utils::elf::SectionFlags,
         non_zero_address: bool,
+        _relax_deltas: Option<&linker_utils::relaxation::SectionRelaxDeltas>,
     ) -> Option<Self>
     where
         Self: std::marker::Sized,

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2269,6 +2269,7 @@ fn apply_relocation<
         output_kind,
         section_info.section_flags,
         resolution.raw_value != 0,
+        relax_deltas,
     )
     .filter(|relaxation| layout.args().relax || relaxation.is_mandatory());
 

--- a/libwild/src/elf_x86_64.rs
+++ b/libwild/src/elf_x86_64.rs
@@ -138,6 +138,7 @@ impl crate::platform::Relaxation for Relaxation {
         output_kind: OutputKind,
         section_flags: SectionFlags,
         _non_zero_address: bool,
+        _relax_deltas: Option<&linker_utils::relaxation::SectionRelaxDeltas>,
     ) -> Option<Self> {
         let is_known_address = flags.is_address();
         let is_absolute = flags.is_absolute() && !flags.is_dynamic();
@@ -477,6 +478,7 @@ fn test_relaxation() {
             OutputKind::StaticExecutable(RelocationModel::Relocatable),
             shf::EXECINSTR,
             true,
+            None,
         ) {
             r.apply(&mut out, &mut offset, &mut 0);
 
@@ -493,6 +495,7 @@ fn test_relaxation() {
             OutputKind::StaticExecutable(RelocationModel::Relocatable),
             shf::EXECINSTR,
             true,
+            None,
         ) {
             out.copy_from_slice(bytes_in);
             r.apply(&mut out, &mut offset, &mut 0);

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -11,6 +11,7 @@ use crate::value_flags::ValueFlags;
 use linker_utils::elf::DynamicRelocationKind;
 use linker_utils::elf::RelocationKindInfo;
 use linker_utils::relaxation::RelocationModifier;
+use linker_utils::relaxation::SectionRelaxDeltas;
 use std::borrow::Cow;
 use std::ops::Range;
 
@@ -72,6 +73,7 @@ pub(crate) trait Relaxation {
         output_kind: OutputKind,
         section_flags: linker_utils::elf::SectionFlags,
         non_zero_address: bool,
+        relax_deltas: Option<&SectionRelaxDeltas>,
     ) -> Option<Self>
     where
         Self: std::marker::Sized;

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -1280,6 +1280,9 @@ pub enum RiscVInstruction {
 
     // Specifies a field as the immediate field in a CJ-type (compressed jump) instruction
     CjType,
+
+    // Encodes the immediate field of a C.LUI instruction (CI-type, 2 bytes).
+    CluiType,
 }
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -139,7 +139,6 @@ tests = [
   "arch-riscv64-relax-got.sh",
   "arch-riscv64-relax-hi20.sh",
   "arch-riscv64-reloc-overflow.sh",
-  "arch-riscv64-symbol-size.sh",
 ]
 
 [skipped_groups.arch_loongarch64]

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -3579,6 +3579,7 @@ fn integration_test(
         "riscv-attr-conflict.s",
         "riscv-call-relaxation.s",
         "riscv-cross-object-call-relaxation.s",
+        "riscv-hi20-relaxation.s",
         "segment-end-syms.c"
     )]
     program_name: &'static str,

--- a/wild/tests/sources/riscv-hi20-relaxation-1.s
+++ b/wild/tests/sources/riscv-hi20-relaxation-1.s
@@ -1,0 +1,2 @@
+.globl abs_sym
+abs_sym = 0xf00

--- a/wild/tests/sources/riscv-hi20-relaxation.s
+++ b/wild/tests/sources/riscv-hi20-relaxation.s
@@ -1,0 +1,33 @@
+/*
+//#Arch: riscv64
+//#CompArgs: -march=rv64gc
+//#LinkArgs: -nostdlib -static --relax
+//#Object:riscv-hi20-relaxation-1.s
+//#ExpectSym:load_value size=8
+*/
+
+.section .text, "ax", @progbits
+
+.globl _start
+.type _start, @function
+_start:
+    call load_value
+    # Verify that load_value returned the expected value (0xf00).
+    li t0, 0xf00
+    bne a0, t0, .Lfail
+    li a0, 42
+    li a7, 93
+    ecall
+.Lfail:
+    li a0, 1
+    li a7, 93
+    ecall
+.size _start, .-_start
+
+.globl load_value
+.type load_value, @function
+load_value:
+    lui a0, %hi(abs_sym)
+    add a0, a0, %lo(abs_sym)
+    ret
+.size load_value, .-load_value


### PR DESCRIPTION
Compress 4-byte lui to 2-byte c.lui when the HI20 immediate fits in a 6-bit signed non-zero range.

part of #874 