### PR TITLE
refactor: Move relaxation creation to Platform trait

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2261,7 +2261,7 @@ fn apply_relocation<
     let rel_info;
     let output_kind = layout.symbol_db.output_kind;
 
-    let relaxation = P::Relaxation::new(
+    let relaxation = P::new_relaxation(
         r_type,
         out,
         offset_in_section,

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -2923,7 +2923,7 @@ fn process_relocation<'data, 'scope, P: ElfPlatform<'data>, R: Relocation>(
         let r_type = rel.raw_type();
         let section_flags = SectionFlags::from_header(section);
 
-        let rel_info = if let Some(relaxation) = P::Relaxation::new(
+        let rel_info = if let Some(relaxation) = P::new_relaxation(
             r_type,
             object.object.raw_section_data(section)?,
             rel_offset,

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -63,12 +63,10 @@ pub(crate) trait Platform<'data> {
 
     // A list of high-part relocations that need to be tracked in a relocation cache
     fn high_part_relocations() -> &'static [u32];
-}
 
-pub(crate) trait Relaxation {
     /// Tries to create a relaxation for the relocation of the specified kind, to be applied at the
     /// specified offset in the supplied section.
-    fn new(
+    fn new_relaxation(
         relocation_kind: u32,
         section_bytes: &[u8],
         offset_in_section: u64,
@@ -77,10 +75,10 @@ pub(crate) trait Relaxation {
         section_flags: linker_utils::elf::SectionFlags,
         non_zero_address: bool,
         relax_deltas: Option<&SectionRelaxDeltas>,
-    ) -> Option<Self>
-    where
-        Self: std::marker::Sized;
+    ) -> Option<Self::Relaxation>;
+}
 
+pub(crate) trait Relaxation {
     fn apply(&self, section_bytes: &mut [u8], offset_in_section: &mut u64, addend: &mut i64);
 
     fn rel_info(&self) -> RelocationKindInfo;


### PR DESCRIPTION
This makes it easier for relaxation creation to access associated types on Platform and File.

Issue #1538