### PR TITLE
chore: Bump MSRV to 1.93

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         container:
           - 'ubuntu:24.04'
           - 'opensuse/tumbleweed:latest'
-          - 'rust:1.92-alpine'
+          - 'rust:1.93-alpine'
         test-qemu:
           - false
         test-plugins:
@@ -46,7 +46,7 @@ jobs:
             test-qemu: false
         exclude: # TODO: https://github.com/actions/runner/issues/1637
           - runs-on: ubuntu-24.04-arm
-            container: 'rust:1.92-alpine'
+            container: 'rust:1.93-alpine'
       fail-fast: false
 
     runs-on: ${{ matrix.runs-on }}
@@ -112,7 +112,7 @@ jobs:
         persist-credentials: false
     # This is where we check that we're not using features from a more recent rust version. When
     # updating this, please also update workspace.package.rust-version in `Cargo.toml`.
-    - uses: dtolnay/rust-toolchain@1.92.0
+    - uses: dtolnay/rust-toolchain@1.93.0
       id: rust-toolchain
       with:
         components: clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/davidlattimore/wild"
 license = "MIT OR Apache-2.0"
 version = "0.8.0"
 readme = "README.md"
-rust-version = "1.92"
+rust-version = "1.93"
 edition = "2024"
 
 # Note, the versions listed here are minimum supported versions and should only be increased when

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -3,7 +3,7 @@
 # docker build --progress=plain -t wild-dev-alpine . -f docker/alpine.Dockerfile
 # docker run -it wild-dev-alpine
 
-FROM rust:1.92-alpine AS chef
+FROM rust:1.93-alpine AS chef
 RUN wget -qO- https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.1.70/cargo-chef-x86_64-unknown-linux-musl.tar.gz | tar -xzf- && \
     mv cargo-chef /usr/local/bin
 RUN rustup toolchain install nightly && \

--- a/docker/arch.Dockerfile
+++ b/docker/arch.Dockerfile
@@ -46,7 +46,7 @@ RUN wget -qO- https://github.com/LukeMathWalker/cargo-chef/releases/download/v0.
 
 RUN wget https://sh.rustup.rs -O rustup-installer && \
     chmod +x rustup-installer && \
-    ./rustup-installer -y --default-toolchain 1.92.0
+    ./rustup-installer -y --default-toolchain 1.93.0
 
 ENV PATH="/root/.cargo/bin:$PATH"
 

--- a/docker/debian.Dockerfile
+++ b/docker/debian.Dockerfile
@@ -3,7 +3,7 @@
 # docker build --progress=plain -t wild-dev-debian . -f docker/debian.Dockerfile
 # docker run -it wild-dev-debian
 
-FROM rust:1.92 AS chef
+FROM rust:1.93 AS chef
 RUN apt-get update && \
     apt-get install -y \
         clang \

--- a/docker/ubuntu-24.04.Dockerfile
+++ b/docker/ubuntu-24.04.Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && \
 
 RUN wget https://sh.rustup.rs -O rustup-installer && \
     chmod +x rustup-installer && \
-    ./rustup-installer -y --default-toolchain 1.92.0
+    ./rustup-installer -y --default-toolchain 1.93.0
 
 ENV PATH="/root/.cargo/bin:$PATH"
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1769287525,
-        "narHash": "sha256-gABuYA6BzoRMLuPaeO5p7SLrpd4qExgkwEmYaYQY4bM=",
+        "lastModified": 1771796463,
+        "narHash": "sha256-9bCDuUzpwJXcHMQYMS1yNuzYMmKO/CCwCexpjWOl62I=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "0314e365877a85c9e5758f9ea77a9972afbb4c21",
+        "rev": "3d3de3313e263e04894f284ac18177bd26169bad",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769170682,
-        "narHash": "sha256-nlVMTH3lSEtF+jygHr2bRqCxEcceCz3UzA9wsyO+RB4=",
-        "rev": "c5296fdd05cfa2c187990dd909864da9658df755",
+        "lastModified": 1771848320,
+        "narHash": "sha256-2j5NAPU1sTVgnrj1FLxkBABP63q2DiRU2eIfEG56kPk=",
+        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre933481.c5296fdd05cf/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre953160.2fc6539b481e/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",

--- a/libwild/src/grouping.rs
+++ b/libwild/src/grouping.rs
@@ -176,7 +176,15 @@ pub(crate) fn create_groups<'data, O: ObjectFile<'data>>(
         symbol_db.add_group(Group::LinkerScripts(linker_scripts));
     }
 
-    tracing::trace!("GROUPS:\n{}", GroupsDisplay(&symbol_db.groups));
+    tracing::trace!(
+        "GROUPS:\n{}",
+        std::fmt::from_fn(|f| {
+            for (i, group) in symbol_db.groups.iter().enumerate() {
+                writeln!(f, "{i}: {group}")?;
+            }
+            Ok(())
+        })
+    );
 }
 
 /// Decides after how many symbols, we should start a new group.
@@ -222,8 +230,6 @@ fn count_symbols<'data, O: ObjectFile<'data>>(
 
     objects.iter().map(|o| o.num_symbols()).sum::<usize>()
 }
-
-struct GroupsDisplay<'a, 'data, O: ObjectFile<'data>>(&'a [Group<'data, O>]);
 
 impl<'data, O: ObjectFile<'data>> SequencedInputObject<'data, O> {
     pub(crate) fn symbol_name(
@@ -286,15 +292,6 @@ impl<'db, 'data, O: ObjectFile<'data>> SequencedInput<'db, 'data, O> {
         } else {
             false
         }
-    }
-}
-
-impl<'data, O: ObjectFile<'data>> Display for GroupsDisplay<'_, 'data, O> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for (i, group) in self.0.iter().enumerate() {
-            writeln!(f, "{i}: {group}")?;
-        }
-        Ok(())
     }
 }
 

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -6182,7 +6182,10 @@ impl std::fmt::Debug for FileLayoutState<'_> {
     }
 }
 
-fn section_debug(object: &crate::elf::File, section_index: object::SectionIndex) -> SectionDebug {
+fn section_debug(
+    object: &crate::elf::File,
+    section_index: object::SectionIndex,
+) -> impl std::fmt::Display {
     let name = object
         .section(section_index)
         .and_then(|section| object.section_name(section))
@@ -6190,17 +6193,7 @@ fn section_debug(object: &crate::elf::File, section_index: object::SectionIndex)
             |_| "??".to_owned(),
             |name| String::from_utf8_lossy(name).into_owned(),
         );
-    SectionDebug { name }
-}
-
-struct SectionDebug {
-    name: String,
-}
-
-impl Display for SectionDebug {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "`{}`", self.name)
-    }
+    std::fmt::from_fn(move |f| write!(f, "`{name}`"))
 }
 
 impl<'data> DynamicSymbolDefinition<'data> {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -12,8 +12,8 @@
   glibc,
   stdenv,
 }:
-assert lib.assertMsg (lib.versionAtLeast rustc.version "1.92.0")
-  "Wild requires at least Rust 1.92.0, this instance of nixpkgs has Rust ${rustc.version}";
+assert lib.assertMsg (lib.versionAtLeast rustc.version "1.93.0")
+  "Wild requires at least Rust 1.93.0, this instance of nixpkgs has Rust ${rustc.version}";
 
 let
   cargoToml = builtins.fromTOML (builtins.readFile ../Cargo.toml);


### PR DESCRIPTION
Also, clean up the parts that became more readable thanks to the newly stabilized `std::fmt::from_fn`.