### PR TITLE
refactor: Move SectionHeader associated types to ObjectFile

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -225,6 +225,9 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
     type Symbol = Symbol;
     type SectionHeader = SectionHeader;
     type SectionIterator = core::slice::Iter<'data, Self::SectionHeader>;
+    type SectionFlags = SectionFlags;
+    type SectionAttributes = SectionAttributes;
+    type SectionType = SectionType;
     type DynamicTagValues = crate::elf::DynamicTagValues<'data>;
     type DynamicEntry = DynamicEntry;
     type RelocationList = RelocationList<'data>;
@@ -1381,24 +1384,20 @@ fn compute_version_mapping(
     out
 }
 
-impl platform::SectionHeader for SectionHeader {
-    type SectionFlags = SectionFlags;
-    type Attributes = SectionAttributes;
-    type SectionType = SectionType;
-
-    fn flags(&self) -> Self::SectionFlags {
+impl<'data> platform::SectionHeader<'data, File<'data>> for SectionHeader {
+    fn flags(&self) -> SectionFlags {
         SectionFlags::from_header(self)
     }
 
-    fn attributes(&self) -> Self::Attributes {
-        Self::Attributes {
+    fn attributes(&self) -> SectionAttributes {
+        SectionAttributes {
             flags: SectionFlags::from_header(self),
             ty: SectionType::from_header(self),
             entsize: self.sh_entsize.get(LittleEndian),
         }
     }
 
-    fn section_type(&self) -> Self::SectionType {
+    fn section_type(&self) -> SectionType {
         SectionType::from_header(self)
     }
 }

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -649,12 +649,7 @@ pub(crate) struct ResolvedObject<'data, O: ObjectFile<'data>> {
     pub(crate) sections: Vec<SectionSlot>,
     pub(crate) relocations: O::RelocationSections,
 
-    pub(crate) string_merge_extras: Vec<
-        StringMergeSectionExtra<
-            'data,
-            <O::SectionHeader as crate::platform::SectionHeader>::SectionFlags,
-        >,
-    >,
+    pub(crate) string_merge_extras: Vec<StringMergeSectionExtra<'data, O::SectionFlags>>,
 
     /// Details about each custom section that is defined in this object.
     custom_sections: Vec<CustomSectionDetails<'data>>,


### PR DESCRIPTION
Referencing associated types of associated types is too verbose.

Issue #1538