### PR TITLE
fix: Differentiate between local and global version symbols in linker-diff

### DIFF
--- a/linker-diff/src/version_diff.rs
+++ b/linker-diff/src/version_diff.rs
@@ -120,10 +120,11 @@ fn read_gnu_version(bin: &crate::Binary) -> Result<FieldValues> {
         let version_index = version_index_raw & VERSYM_VERSION;
         let hidden = version_index_raw & VERSYM_HIDDEN == VERSYM_HIDDEN;
 
-        let version_name = if version_index == 0 {
-            b"local" as &[u8]
-        } else if version_index == 1 {
-            b"global" as &[u8]
+        let version_name = if version_index <= 1 {
+            // GNU ld recently switched which version index it uses for undefined symbols,
+            // so the choice of 0 (local) vs 1 (global) varies between GNU ld versions.
+            // Treat them as equivalent for comparison purposes.
+            b"local or global" as &[u8]
         } else {
             versions
                 .version(VersionIndex(version_index))?


### PR DESCRIPTION
This pull request refines how symbol versions are reported in the `read_gnu_version` function. Previously, local and global symbols were not differentiated and were both labeled as "local or global". Now, the function distinctly labels version 0 as "local" and version 1 as "global", providing more accurate information.