### PR TITLE
fix: prevent panic when writing to stdout fails in --version and --help

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -1717,12 +1717,14 @@ fn setup_argument_parser() -> ArgumentParser {
         .long("help")
         .help("Show this help message")
         .execute(|_args, _modifier_stack| {
+            use std::io::Write as _;
             let parser = setup_argument_parser();
-            println!("{}", parser.generate_help());
+            let mut stdout = std::io::stdout().lock();
+            writeln!(stdout, "{}", parser.generate_help())?;
 
             // The following listing is something autoconf detection relies on.
-            println!("wild: supported targets:elf64 -x86-64 elf64-littleaarch64 elf64-littleriscv elf64-loongarch");
-            println!("wild: supported emulations: elf_x86_64 aarch64elf elf64lriscv elf64loongarch");
+            writeln!(stdout, "wild: supported targets:elf64 -x86-64 elf64-littleaarch64 elf64-littleriscv elf64-loongarch")?;
+            writeln!(stdout, "wild: supported emulations: elf_x86_64 aarch64elf elf64lriscv elf64loongarch")?;
 
             std::process::exit(0);
         });

--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -183,11 +183,13 @@ impl Linker {
         let args = &args.args;
         match args.version_mode {
             args::VersionMode::ExitAfterPrint => {
-                println!("{}", linker_identity());
+                let mut stdout = std::io::stdout().lock();
+                writeln!(stdout, "{}", linker_identity())?;
                 return Ok(LinkerOutput { layout: None });
             }
             args::VersionMode::Verbose => {
-                println!("{}", linker_identity());
+                let mut stdout = std::io::stdout().lock();
+                writeln!(stdout, "{}", linker_identity())?;
                 // Continue linking
             }
             args::VersionMode::None => {


### PR DESCRIPTION
This PR replaces println! calls with explicit writeln! to a locked stdout in the --version and --help command handlers.
This ensures that if writing to stdout fails (e.g., when redirected to /dev/full), the linker returns a proper error instead of panicking.

Changes made:
- Updated libwild/src/lib.rs (in --version mode) to use std::io::stdout().lock() + writeln!.
- Updated libwild/src/args.rs (in --help execution closure) similarly.

fixed: issue #1405 

Preserved existing output formatting and behavior.

<img width="1346" height="77" alt="Screenshot 2026-03-03 at 10 28 20 PM" src="https://github.com/user-attachments/assets/99a1c9d8-3544-403c-8685-4cc937a6812f" />
