### PR TITLE
chore: Make CI fail when a new external test passes

### DIFF
--- a/.github/workflows/external_tests.yml
+++ b/.github/workflows/external_tests.yml
@@ -39,5 +39,4 @@ jobs:
       - name: Check regressions
         run: WILD_TEST_CROSS=all cargo test --features mold_tests external_tests::mold_tests::check_mold_tests_regression
       - name: Check tests that should fail still fail
-        continue-on-error: true
         run: WILD_TEST_CROSS=all cargo test --features mold_tests external_tests::mold_tests::verify_skipped_mold_tests_still_fail


### PR DESCRIPTION
Previously, we didn't configure CI to fail when new external tests passed, but since I think few false positives recently, we can now make CI fail when new tests pass. This helps keep the skip list up-to-date.