### PR TITLE
refactor: Move move queries from SectionFlags/Type to SectionHeader

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -1588,6 +1588,18 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
             })
             .collect()
     }
+
+    fn section_flags(header: &Self::SectionHeader) -> Self::SectionFlags {
+        SectionFlags::from_header(header)
+    }
+
+    fn section_attributes(header: &Self::SectionHeader) -> Self::SectionAttributes {
+        SectionAttributes {
+            flags: SectionFlags::from_header(header),
+            ty: SectionType::from_header(header),
+            entsize: header.sh_entsize.get(LittleEndian),
+        }
+    }
 }
 
 fn process_eh_frame_relocations<
@@ -1820,21 +1832,53 @@ fn compute_version_mapping(
     out
 }
 
-impl<'data> platform::SectionHeader<'data, File<'data>> for SectionHeader {
-    fn flags(&self) -> SectionFlags {
-        SectionFlags::from_header(self)
+impl platform::SectionHeader for SectionHeader {
+    fn is_alloc(&self) -> bool {
+        SectionFlags::from_header(self).is_alloc()
     }
 
-    fn attributes(&self) -> SectionAttributes {
-        SectionAttributes {
-            flags: SectionFlags::from_header(self),
-            ty: SectionType::from_header(self),
-            entsize: self.sh_entsize.get(LittleEndian),
-        }
+    fn is_writable(&self) -> bool {
+        SectionFlags::from_header(self).contains(shf::WRITE)
     }
 
-    fn section_type(&self) -> SectionType {
-        SectionType::from_header(self)
+    fn is_executable(&self) -> bool {
+        SectionFlags::from_header(self).contains(shf::EXECINSTR)
+    }
+
+    fn is_tls(&self) -> bool {
+        SectionFlags::from_header(self).contains(shf::TLS)
+    }
+
+    fn is_merge_section(&self) -> bool {
+        SectionFlags::from_header(self).contains(shf::MERGE)
+    }
+
+    fn is_strings(&self) -> bool {
+        SectionFlags::from_header(self).contains(shf::STRINGS)
+    }
+
+    fn should_retain(&self) -> bool {
+        SectionFlags::from_header(self).contains(shf::GNU_RETAIN)
+    }
+
+    fn should_exclude(&self) -> bool {
+        SectionFlags::from_header(self).should_exclude()
+    }
+
+    fn is_group(&self) -> bool {
+        SectionFlags::from_header(self).contains(shf::GROUP)
+    }
+
+    fn is_note(&self) -> bool {
+        SectionType::from_header(self) == sht::NOTE
+    }
+
+    fn is_prog_bits(&self) -> bool {
+        SectionType::from_header(self) == sht::PROGBITS
+    }
+
+    fn is_no_bits(&self) -> bool {
+        SectionType::from_header(self) == sht::NOBITS
     }
 }
 
@@ -1842,55 +1886,11 @@ impl platform::SectionType for SectionType {
     fn is_null(self) -> bool {
         self == sht::NULL
     }
-
-    fn is_note(self) -> bool {
-        self == sht::NOTE
-    }
-
-    fn is_prog_bits(self) -> bool {
-        self == sht::PROGBITS
-    }
-
-    fn is_no_bits(self) -> bool {
-        self == sht::NOBITS
-    }
 }
 
 impl platform::SectionFlags for SectionFlags {
     fn is_alloc(self) -> bool {
         self.contains(shf::ALLOC)
-    }
-
-    fn is_writable(self) -> bool {
-        self.contains(shf::WRITE)
-    }
-
-    fn is_executable(self) -> bool {
-        self.contains(shf::EXECINSTR)
-    }
-
-    fn is_merge_section(self) -> bool {
-        self.contains(shf::MERGE)
-    }
-
-    fn is_strings(self) -> bool {
-        self.contains(shf::STRINGS)
-    }
-
-    fn should_retain(self) -> bool {
-        self.contains(shf::GNU_RETAIN)
-    }
-
-    fn should_exclude(&self) -> bool {
-        self.contains(shf::EXCLUDE)
-    }
-
-    fn is_group(self) -> bool {
-        self.contains(shf::GROUP)
-    }
-
-    fn is_tls(self) -> bool {
-        self.contains(shf::TLS)
     }
 }
 

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -1165,7 +1165,7 @@ impl<'data, O: ObjectFile<'data>> CommonGroupState<'data, O> {
     fn store_section_attributes(&mut self, part_id: PartId, header: &O::SectionHeader) {
         let existing_attributes = self.section_attributes.get_mut(part_id.output_section_id());
 
-        let new_attributes = header.attributes();
+        let new_attributes = O::section_attributes(header);
 
         if let Some(existing) = existing_attributes {
             existing.merge(new_attributes);
@@ -1507,7 +1507,7 @@ impl<'data, O: ObjectFile<'data>> Layout<'data, O> {
                             .zip(&obj.sections)
                             .map(|((res, section), section_slot)| {
                                 (matches!(section_slot, SectionSlot::Loaded(..))
-                                    && section.flags().is_alloc()
+                                    && section.is_alloc()
                                     && obj.object.section_size(section).is_ok_and(|s| s > 0))
                                 .then(|| {
                                     let address = res.address;
@@ -2641,7 +2641,7 @@ impl Section {
             part_id,
             size,
             flags: ValueFlags::empty(),
-            is_writable: header.flags().is_writable(),
+            is_writable: header.is_writable(),
         };
         Ok(section)
     }
@@ -2691,7 +2691,7 @@ pub(crate) fn process_relocation<'data, 'scope, P: Platform<'data>, R: Relocatio
         flags.merge(resources.local_flags_for_symbol(local_symbol_id));
         let rel_offset = rel.offset();
         let r_type = rel.raw_type();
-        let section_flags = section.flags();
+        let section_flags = <P::File as ObjectFile<'data>>::section_flags(section);
 
         let rel_info = if let Some(relaxation) = P::new_relaxation(
             r_type,
@@ -2711,7 +2711,7 @@ pub(crate) fn process_relocation<'data, 'scope, P: Platform<'data>, R: Relocatio
             P::relocation_from_raw(r_type)?
         };
 
-        let section_is_writable = section_flags.is_writable();
+        let section_is_writable = section.is_writable();
         let mut flags_to_add = resolution_flags(rel_info.kind);
 
         if !section_flags.is_alloc() {
@@ -4835,7 +4835,7 @@ fn relaxation_scan_pass<'data, P: Platform<'data>>(
                             .filter_map(|(i, slot)| {
                                 if let SectionSlot::Loaded(_) = slot
                                     && let Ok(header) = obj.object.section(SectionIndex(i))
-                                    && header.flags().is_executable()
+                                    && header.is_executable()
                                 {
                                     Some(i)
                                 } else {

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -16,8 +16,7 @@ use crate::output_section_id::SectionName;
 use crate::parsing::InternalSymDefInfo;
 use crate::parsing::ProcessedLinkerScript;
 use crate::parsing::SymbolPlacement;
-use crate::platform::SectionFlags;
-use crate::platform::SectionType;
+use crate::platform::SectionHeader;
 use glob::Pattern;
 use hashbrown::HashTable;
 use linker_utils::elf::secnames;
@@ -463,10 +462,9 @@ impl<'data> SectionRules<'data> {
         &self,
         section_name: &[u8],
         file_name: Option<&[u8]>,
-        section_flags: impl SectionFlags,
-        sh_type: impl SectionType,
+        section_header: &impl SectionHeader,
     ) -> SectionRuleOutcome {
-        if section_flags.should_exclude() {
+        if section_header.should_exclude() {
             return SectionRuleOutcome::Discard;
         }
 
@@ -479,7 +477,7 @@ impl<'data> SectionRules<'data> {
         }
 
         if section_name.is_empty() {
-            return unnamed_section_output(section_flags, sh_type);
+            return unnamed_section_output(section_header);
         }
 
         SectionRuleOutcome::Custom
@@ -494,24 +492,21 @@ fn section_name_prefix_hash(name: &[u8]) -> Option<u64> {
 }
 
 /// Determines, where if anywhere, we should place an input section with no name.
-fn unnamed_section_output(
-    section_flags: impl SectionFlags,
-    sh_type: impl SectionType,
-) -> SectionRuleOutcome {
-    if !section_flags.is_alloc() {
+fn unnamed_section_output(section_header: &impl SectionHeader) -> SectionRuleOutcome {
+    if !section_header.is_alloc() {
         SectionRuleOutcome::Discard
-    } else if sh_type.is_prog_bits() {
-        if section_flags.is_executable() {
+    } else if section_header.is_prog_bits() {
+        if section_header.is_executable() {
             SectionRuleOutcome::Section(SectionOutputInfo::regular(output_section_id::TEXT))
-        } else if section_flags.is_tls() {
+        } else if section_header.is_tls() {
             SectionRuleOutcome::Section(SectionOutputInfo::regular(output_section_id::TDATA))
-        } else if section_flags.is_writable() {
+        } else if section_header.is_writable() {
             SectionRuleOutcome::Section(SectionOutputInfo::regular(output_section_id::DATA))
         } else {
             SectionRuleOutcome::Section(SectionOutputInfo::regular(output_section_id::RODATA))
         }
-    } else if sh_type.is_no_bits() {
-        if section_flags.is_tls() {
+    } else if section_header.is_no_bits() {
+        if section_header.is_tls() {
             SectionRuleOutcome::Section(SectionOutputInfo::regular(output_section_id::TBSS))
         } else {
             SectionRuleOutcome::Section(SectionOutputInfo::regular(output_section_id::BSS))
@@ -524,14 +519,19 @@ fn unnamed_section_output(
 #[test]
 fn test_section_mapping() {
     let rules = SectionRules::from_rules(BUILT_IN_RULES);
-    let lookup_name = |name: &str| {
-        rules.lookup(
-            name.as_bytes(),
-            None,
-            linker_utils::elf::SectionFlags::empty(),
-            linker_utils::elf::SectionType::from_u32(0),
-        )
+    let header = crate::elf::SectionHeader {
+        sh_name: Default::default(),
+        sh_type: Default::default(),
+        sh_flags: Default::default(),
+        sh_addr: Default::default(),
+        sh_offset: Default::default(),
+        sh_size: Default::default(),
+        sh_link: Default::default(),
+        sh_info: Default::default(),
+        sh_addralign: Default::default(),
+        sh_entsize: Default::default(),
     };
+    let lookup_name = |name: &str| rules.lookup(name.as_bytes(), None, &header);
 
     assert_eq!(
         lookup_name(".comment"),

--- a/libwild/src/part_id.rs
+++ b/libwild/src/part_id.rs
@@ -57,15 +57,15 @@ pub(crate) const CUSTOM_PLACEHOLDER: PartId = PartId(u32::MAX);
 /// Returns whether the supplied section meets our criteria for section merging. Section merging is
 /// optional, so there are cases where we might be able to merge, but don't currently. For example
 /// if alignment is > 1.
-pub(crate) fn should_merge_sections<S: platform::SectionFlags>(
-    section_flags: S,
+pub(crate) fn should_merge_sections(
+    section_header: &impl platform::SectionHeader,
     section_alignment: u64,
     args: &Args,
 ) -> bool {
     if !args.merge_sections {
         return false;
     }
-    section_flags.is_merge_section() && section_alignment <= 1
+    section_header.is_merge_section() && section_alignment <= 1
 }
 
 impl PartId {

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -150,7 +150,7 @@ pub(crate) struct RelaxSymbolInfo {
 /// Abstracts over the different object file formats that we support (or may support). e.g. ELF.
 pub(crate) trait ObjectFile<'data>: Send + Sync + Sized + std::fmt::Debug + 'data {
     type Symbol: Symbol;
-    type SectionHeader: SectionHeader<'data, Self>;
+    type SectionHeader: SectionHeader;
     type SectionFlags: SectionFlags;
     type SectionType: SectionType;
     type SegmentType: SegmentType;
@@ -217,6 +217,10 @@ pub(crate) trait ObjectFile<'data>: Send + Sync + Sized + std::fmt::Debug + 'dat
     fn symbol(&self, index: object::SymbolIndex) -> Result<&'data Self::Symbol>;
 
     fn section_size(&self, header: &Self::SectionHeader) -> Result<u64>;
+
+    fn section_flags(header: &Self::SectionHeader) -> Self::SectionFlags;
+
+    fn section_attributes(header: &Self::SectionHeader) -> Self::SectionAttributes;
 
     fn symbol_name(&self, symbol: &Self::Symbol) -> Result<&'data [u8]>;
 
@@ -519,27 +523,37 @@ pub(crate) trait ObjectFile<'data>: Send + Sync + Sized + std::fmt::Debug + 'dat
     fn built_in_section_infos() -> Vec<crate::output_section_id::SectionOutputInfo<'data>>;
 }
 
-pub(crate) trait SectionHeader<'data, O: ObjectFile<'data>>:
-    std::fmt::Debug + Send + Sync + 'data
-{
-    fn flags(&self) -> O::SectionFlags;
+pub(crate) trait SectionHeader: std::fmt::Debug + Send + Sync + 'static {
+    fn is_alloc(&self) -> bool;
 
-    fn attributes(&self) -> O::SectionAttributes;
+    fn is_writable(&self) -> bool;
 
-    fn section_type(&self) -> O::SectionType;
+    fn is_executable(&self) -> bool;
+
+    fn is_tls(&self) -> bool;
+
+    fn is_merge_section(&self) -> bool;
+
+    fn is_strings(&self) -> bool;
+
+    fn should_retain(&self) -> bool;
+
+    fn should_exclude(&self) -> bool;
+
+    fn is_group(&self) -> bool;
+
+    fn is_note(&self) -> bool;
+
+    fn is_prog_bits(&self) -> bool;
+
+    /// Returns whether the section has no contents in the file (zero initialised).
+    fn is_no_bits(&self) -> bool;
 }
 
 pub(crate) trait SectionType:
     Default + Copy + Send + Sync + std::fmt::Debug + 'static
 {
     fn is_null(self) -> bool;
-
-    fn is_note(self) -> bool;
-
-    fn is_prog_bits(self) -> bool;
-
-    /// Returns whether the section has no contents in the file (zero initialised).
-    fn is_no_bits(self) -> bool;
 }
 
 pub(crate) trait SegmentType:
@@ -551,22 +565,6 @@ pub(crate) trait SectionFlags:
     Default + Copy + std::fmt::Debug + Send + Sync + 'static
 {
     fn is_alloc(self) -> bool;
-
-    fn is_writable(self) -> bool;
-
-    fn is_executable(self) -> bool;
-
-    fn is_tls(self) -> bool;
-
-    fn is_merge_section(self) -> bool;
-
-    fn is_strings(self) -> bool;
-
-    fn should_retain(self) -> bool;
-
-    fn should_exclude(&self) -> bool;
-
-    fn is_group(self) -> bool;
 }
 
 pub(crate) trait Symbol: std::fmt::Debug + Send + Sync + 'static {

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -32,9 +32,7 @@ use crate::platform::DynamicTagValues as _;
 use crate::platform::FrameIndex;
 use crate::platform::ObjectFile;
 use crate::platform::RawSymbolName as _;
-use crate::platform::SectionFlags as _;
 use crate::platform::SectionHeader as _;
-use crate::platform::SectionType as _;
 use crate::platform::Symbol as _;
 use crate::platform::VerneedTable as _;
 use crate::string_merging::StringMergeSectionExtra;
@@ -649,7 +647,7 @@ pub(crate) struct ResolvedObject<'data, O: ObjectFile<'data>> {
     pub(crate) sections: Vec<SectionSlot>,
     pub(crate) relocations: O::RelocationSections,
 
-    pub(crate) string_merge_extras: Vec<StringMergeSectionExtra<'data, O::SectionFlags>>,
+    pub(crate) string_merge_extras: Vec<StringMergeSectionExtra<'data>>,
 
     /// Details about each custom section that is defined in this object.
     custom_sections: Vec<CustomSectionDetails<'data>>,
@@ -1169,15 +1167,13 @@ fn resolve_section<'data, O: ObjectFile<'data>>(
         return Err(symbol_db::linker_plugin_disabled_error());
     }
 
-    let section_flags = input_section.flags();
     let raw_alignment = obj.common.object.section_alignment(input_section)?;
     let alignment = Alignment::new(raw_alignment.max(1))?;
-    let should_merge_sections = part_id::should_merge_sections(section_flags, raw_alignment, args);
+    let should_merge_sections = part_id::should_merge_sections(input_section, raw_alignment, args);
 
     let mut unloaded_section;
     let mut is_debug_info = false;
-    let section_type = input_section.section_type();
-    let mut must_load = section_flags.should_retain() || section_type.is_note();
+    let mut must_load = input_section.should_retain() || input_section.is_note();
 
     let file_name = if let Some(entry) = &obj.common.input.entry {
         // For archive members, match against the member name (e.g., "app.o"),
@@ -1192,7 +1188,7 @@ fn resolve_section<'data, O: ObjectFile<'data>>(
             .map(|n| n.as_encoded_bytes())
     };
 
-    match rules.lookup(section_name, file_name, section_flags, section_type) {
+    match rules.lookup(section_name, file_name, input_section) {
         SectionRuleOutcome::Section(output_info) => {
             let part_id = if output_info.section_id.is_regular() {
                 output_info.section_id.part_id_with_alignment(alignment)
@@ -1231,11 +1227,11 @@ fn resolve_section<'data, O: ObjectFile<'data>>(
             return Ok(SectionSlot::NoteGnuProperty(input_section_index));
         }
         SectionRuleOutcome::Debug => {
-            if args.strip_debug() && !section_flags.is_alloc() {
+            if args.strip_debug() && !input_section.is_alloc() {
                 return Ok(SectionSlot::Discard);
             }
 
-            is_debug_info = !section_flags.is_alloc();
+            is_debug_info = !input_section.is_alloc();
 
             unloaded_section = UnloadedSection::new(part_id::CUSTOM_PLACEHOLDER);
         }
@@ -1263,7 +1259,6 @@ fn resolve_section<'data, O: ObjectFile<'data>>(
             obj.common
                 .object
                 .section_data(input_section, allocator, loaded_metrics)?;
-        let section_flags = input_section.flags();
 
         if section_data.is_empty() {
             SectionSlot::Discard
@@ -1271,7 +1266,7 @@ fn resolve_section<'data, O: ObjectFile<'data>>(
             obj.string_merge_extras.push(StringMergeSectionExtra {
                 index: input_section_index,
                 section_data,
-                section_flags,
+                is_strings: input_section.is_strings(),
             });
 
             SectionSlot::MergeStrings(StringMergeSectionSlot::new(unloaded_section.part_id))

--- a/libwild/src/string_merging.rs
+++ b/libwild/src/string_merging.rs
@@ -38,7 +38,6 @@ use crate::output_section_map::OutputSectionMap;
 use crate::output_section_part_map::OutputSectionPartMap;
 use crate::part_id::PartId;
 use crate::platform::ObjectFile;
-use crate::platform::SectionFlags;
 use crate::platform::Symbol as _;
 use crate::resolution::ResolvedFile;
 use crate::resolution::ResolvedGroup;
@@ -106,10 +105,10 @@ impl StringMergeSectionSlot {
 /// Extra stuff that we don't want to put in `StringMergeSectionSlot` because like all section
 /// slots, we want to keep it as small as possible.
 #[derive(Debug)]
-pub(crate) struct StringMergeSectionExtra<'data, S: SectionFlags> {
+pub(crate) struct StringMergeSectionExtra<'data> {
     pub(crate) index: object::SectionIndex,
     pub(crate) section_data: &'data [u8],
-    pub(crate) section_flags: S,
+    pub(crate) is_strings: bool,
 }
 
 /// An input offset. We pretend that we've placed all input sections for a given output section one
@@ -321,7 +320,7 @@ fn group_merge_string_sections_by_output<'data, O: ObjectFile<'data>>(
                     .push(StringMergeInputSection {
                         section_data: extra.section_data,
                         start_input_offset: *starting_offset,
-                        is_string: extra.section_flags.is_strings(),
+                        is_string: extra.is_strings,
                     });
 
                 *starting_offset = *starting_offset

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -36,7 +36,6 @@ use crate::parsing::SyntheticSymbols;
 use crate::platform;
 use crate::platform::ObjectFile;
 use crate::platform::RawSymbolName as _;
-use crate::platform::SectionFlags as _;
 use crate::platform::SectionHeader;
 use crate::platform::Symbol;
 use crate::resolution::ResolvedFile;
@@ -893,9 +892,7 @@ impl<'data, O: ObjectFile<'data>> SymbolDb<'data, O> {
             return false;
         };
 
-        let flags = header.flags();
-
-        flags.is_group()
+        header.is_group()
     }
 
     pub(crate) fn entry_symbol_name(&self) -> &[u8] {


### PR DESCRIPTION
Platforms may differ as to whether these attributes come from the flags or the section type.

Also removed the lifetime from SectionHeader.

Issue #1538