### PR TITLE
refactor: Split ObjectFile into two traits

### DIFF
--- a/libwild/src/diagnostics.rs
+++ b/libwild/src/diagnostics.rs
@@ -4,6 +4,7 @@ use crate::grouping::SequencedInput;
 use crate::input_data::FileId;
 use crate::input_data::PRELUDE_FILE_ID;
 use crate::platform::ObjectFile;
+use crate::platform::Platform;
 use crate::platform::RawSymbolName as _;
 use crate::platform::Symbol as _;
 use crate::resolution::ResolvedFile;
@@ -39,10 +40,7 @@ impl Drop for SymbolInfoPrinter {
 }
 
 impl SymbolInfoPrinter {
-    pub(crate) fn new<'data2, O: ObjectFile<'data2>>(
-        args: &Args,
-        groups: &[ResolvedGroup<'data2, O>],
-    ) -> Self {
+    pub(crate) fn new<'data, P: Platform>(args: &Args, groups: &[ResolvedGroup<'data, P>]) -> Self {
         let Some(name) = args.sym_info.as_ref() else {
             return Self::Disabled;
         };
@@ -70,9 +68,9 @@ impl SymbolInfoPrinter {
         }))
     }
 
-    pub(crate) fn update<'data, O: ObjectFile<'data>>(
+    pub(crate) fn update<'data, P: Platform>(
         &mut self,
-        symbol_db: &SymbolDb<'data, O>,
+        symbol_db: &SymbolDb<'data, P>,
         per_symbol_flags: &AtomicPerSymbolFlags<'_>,
     ) {
         let Self::Enabled(state) = self else {
@@ -230,11 +228,11 @@ impl NameMatcher {
         }
     }
 
-    fn matches<'data, O: ObjectFile<'data>>(
+    fn matches<'data, P: Platform>(
         &self,
         name: &[u8],
         symbol_id: SymbolId,
-        symbol_db: &SymbolDb<'data, O>,
+        symbol_db: &SymbolDb<'data, P>,
     ) -> bool {
         if let Some(i) = name.iter().position(|b| *b == b'@') {
             let (name, version) = name.split_at(i);

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -37,6 +37,7 @@ use crate::platform::CommonSymbol;
 use crate::platform::DynamicTagValues as _;
 use crate::platform::FrameIndex;
 use crate::platform::ObjectFile;
+use crate::platform::Platform;
 use crate::platform::RawSymbolName as _;
 use crate::platform::Relocation;
 use crate::platform::RelocationSequence;
@@ -133,6 +134,9 @@ pub(crate) type NoteHeader = object::elf::NoteHeader64<LittleEndian>;
 
 type SectionTable<'data> = object::read::elf::SectionTable<'data, FileHeader>;
 type SymbolTable<'data> = object::read::elf::SymbolTable<'data, FileHeader>;
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct Elf;
 
 #[derive(derive_more::Debug)]
 pub(crate) struct File<'data> {
@@ -248,449 +252,463 @@ const _: () = assert!(!core::mem::needs_drop::<File>());
 /// Threshold size for using parallel copy for section data copying.
 const SECTION_PAR_COPY_SIZE_THRESHOLD: usize = 1_000_000;
 
-impl<'data> platform::ObjectFile<'data> for File<'data> {
+impl platform::Platform for Elf {
+    type File<'data> = File<'data>;
     type Symbol = Symbol;
     type SectionHeader = SectionHeader;
-    type SectionIterator = core::slice::Iter<'data, Self::SectionHeader>;
     type SectionFlags = SectionFlags;
     type SectionAttributes = SectionAttributes;
     type SectionType = SectionType;
     type SegmentType = SegmentType;
-    type DynamicTagValues = crate::elf::DynamicTagValues<'data>;
-    type DynamicEntry = DynamicEntry;
-    type RelocationList = RelocationList<'data>;
+    type ProgramSegmentDef = ProgramSegmentDef;
+    type BuiltInSectionDetails = BuiltInSectionDetails;
     type RelocationSections = RelocationSections;
-    type VersionNames = VersionNames<'data>;
-    type RawSymbolName = RawSymbolName<'data>;
-    type VerneedTable = VerneedTable<'data>;
-    type FileLayoutState = ElfObjectLayoutState<'data>;
+    type DynamicEntry = DynamicEntry;
     type LayoutProperties = ElfLayoutProperties;
     type SymbolVersionIndex = Versym;
-    type DynamicLayoutState = DynamicLayoutState<'data>;
-    type DynamicLayout = DynamicLayout<'data>;
     type NonAddressableCounts = NonAddressableCounts;
     type NonAddressableIndexes = NonAddressableIndexes;
     type EpilogueLayout = EpilogueLayout;
     type GroupLayoutExt = GroupLayoutExt;
     type CommonGroupStateExt = CommonGroupStateExt;
-    type LayoutResourcesExt = LayoutResourcesExt<'data>;
-    type ProgramSegmentDef = ProgramSegmentDef;
-    type BuiltInSectionDetails = BuiltInSectionDetails;
     type ArchIdentifier = u16;
+    type SectionIterator<'data> = core::slice::Iter<'data, SectionHeader>;
+    type DynamicTagValues<'data> = crate::elf::DynamicTagValues<'data>;
+    type RelocationList<'data> = RelocationList<'data>;
+    type VersionNames<'data> = VersionNames<'data>;
+    type RawSymbolName<'data> = RawSymbolName<'data>;
+    type VerneedTable<'data> = VerneedTable<'data>;
+    type FileLayoutState<'data> = ElfObjectLayoutState<'data>;
+    type DynamicLayoutState<'data> = DynamicLayoutState<'data>;
+    type DynamicLayout<'data> = DynamicLayout<'data>;
+    type LayoutResourcesExt<'data> = LayoutResourcesExt<'data>;
 
-    fn parse(input: &InputBytes<'data>, args: &Args) -> Result<Self> {
-        let is_dynamic = input.kind == FileKind::ElfDynamic;
+    fn apply_force_keep_sections(keep_sections: &mut OutputSectionMap<bool>, args: &Args) {
+        // Some of these sections aren't really empty, but we just haven't allocated space for them
+        // yet. e.g. we don't allocate space for section headers until we know which sections we're
+        // keeping, which by inherently needs to be after this method is called.
+        const FORCE_KEEP_SECTIONS: &[OutputSectionId] = &[
+            output_section_id::FILE_HEADER,
+            output_section_id::PROGRAM_HEADERS,
+            output_section_id::SECTION_HEADERS,
+            output_section_id::SHSTRTAB,
+            output_section_id::RELRO_PADDING,
+        ];
 
-        let file = Self::parse_bytes(input.data, is_dynamic)?;
-
-        if file.arch != args.arch {
-            bail!(
-                "`{}` has incompatible architecture: {}, expecting {}",
-                input,
-                file.arch,
-                args.arch,
-            )
+        for section_id in FORCE_KEEP_SECTIONS {
+            *keep_sections.get_mut(*section_id) = true;
         }
 
-        Ok(file)
+        // Keep .relro_padding unless relro is disabled.
+        if args.relro {
+            *keep_sections.get_mut(output_section_id::RELRO_PADDING) = true;
+        }
     }
 
-    fn parse_bytes(data: &'data [u8], is_dynamic: bool) -> Result<Self> {
-        let header = FileHeader::parse(data)?;
-        let endian = header.endian()?;
-        let architecture = header.e_machine(endian).try_into()?;
-        let sections = header.sections(endian, data)?;
-        let eflags = header.e_flags(endian);
+    fn is_zero_sized_section_content(section_id: OutputSectionId) -> bool {
+        // We always consider empty sections as content except for sframe sections.
+        section_id != output_section_id::SFRAME
+    }
 
-        let mut symbols = SymbolTable::default();
-        let mut versym: &[Versym] = &[];
-        let mut verdef = None;
-        let mut verdefnum = 0;
-        let mut verneed = None;
+    fn built_in_section_details() -> &'static [Self::BuiltInSectionDetails] {
+        &SECTION_DEFINITIONS
+    }
 
-        // Find all the sections that we're interested in a single scan of the section table so
-        // as to avoid multiple scans.
-        for (section_index, section) in sections.enumerate() {
-            match SectionType::from_header(section) {
-                sht::DYNSYM if is_dynamic => {
-                    symbols = SymbolTable::parse(endian, data, &sections, section_index, section)?;
-                }
-                sht::SYMTAB if !is_dynamic => {
-                    symbols = SymbolTable::parse(endian, data, &sections, section_index, section)?;
-                }
-                sht::GNU_VERSYM => {
-                    versym = section.data_as_array(endian, data)?;
-                }
-                sht::GNU_VERDEF => {
-                    verdef = section.gnu_verdef(endian, data)?;
-                    verdefnum = section.sh_info(endian);
-                }
-                sht::GNU_VERNEED => {
-                    verneed = section.gnu_verneed(endian, data)?;
-                }
-                _ => {}
+    fn section_flags(header: &Self::SectionHeader) -> Self::SectionFlags {
+        SectionFlags::from_header(header)
+    }
+
+    fn section_attributes(header: &Self::SectionHeader) -> Self::SectionAttributes {
+        SectionAttributes {
+            flags: SectionFlags::from_header(header),
+            ty: SectionType::from_header(header),
+            entsize: header.sh_entsize.get(LittleEndian),
+        }
+    }
+
+    fn default_section_type() -> Self::SectionType {
+        sht::PROGBITS
+    }
+
+    fn validate_sizes(mem_sizes: &OutputSectionPartMap<u64>) -> Result {
+        if *mem_sizes.get(part_id::GNU_VERSION) > 0 {
+            let num_dynamic_symbols =
+                mem_sizes.get(part_id::DYNSYM) / crate::elf::SYMTAB_ENTRY_SIZE;
+            let num_versym = mem_sizes.get(part_id::GNU_VERSION) / size_of::<Versym>() as u64;
+            if num_versym != num_dynamic_symbols {
+                bail!(
+                    "Object has {num_dynamic_symbols} dynamic symbols, but \
+                         has {num_versym} versym entries"
+                );
             }
         }
 
-        let dynamic_tag_values =
-            is_dynamic.then(|| DynamicTagValues::read(&sections, data, &symbols));
-
-        Ok(Self {
-            arch: architecture,
-            data,
-            sections,
-            symbols,
-            versym,
-            verdef,
-            verdefnum,
-            verneed,
-            eflags,
-            dynamic_tag_values,
-        })
-    }
-
-    fn section(&self, index: object::SectionIndex) -> Result<&'data Self::SectionHeader> {
-        Ok(self.sections.section(index)?)
-    }
-
-    fn section_by_name(&self, name: &str) -> Option<(object::SectionIndex, &'data SectionHeader)> {
-        self.sections.section_by_name(LittleEndian, name.as_bytes())
-    }
-
-    fn section_name(&self, section: &SectionHeader) -> Result<&'data [u8]> {
-        Ok(self.sections.section_name(LittleEndian, section)?)
-    }
-
-    fn section_display_name(&self, index: object::SectionIndex) -> Cow<'data, str> {
-        self.section(index)
-            .and_then(|section| self.section_name(section))
-            .map_or_else(
-                |_| format!("<index {}>", index.0).into(),
-                String::from_utf8_lossy,
-            )
-    }
-
-    fn raw_section_data(&self, section: &Self::SectionHeader) -> Result<&'data [u8]> {
-        Ok(section.data(LittleEndian, self.data)?)
-    }
-
-    fn section_data(
-        &self,
-        section: &Self::SectionHeader,
-        member: &bumpalo_herd::Member<'data>,
-        loaded_metrics: &LoadedMetrics,
-    ) -> Result<&'data [u8]> {
-        let data = section.data(LittleEndian, self.data)?;
-        loaded_metrics
-            .loaded_bytes
-            .fetch_add(data.len(), Ordering::Relaxed);
-
-        if let Some((compression, _, _)) = section.compression(LittleEndian, self.data)? {
-            loaded_metrics
-                .loaded_compressed_bytes
-                .fetch_add(data.len(), Ordering::Relaxed);
-            let len = self.section_size(section)?;
-            let decompressed = member.alloc_slice_fill_default(len as usize);
-            decompress_into(compression, &data[COMPRESSION_HEADER_SIZE..], decompressed)?;
-            loaded_metrics
-                .decompressed_bytes
-                .fetch_add(decompressed.len(), Ordering::Relaxed);
-            Ok(decompressed)
-        } else {
-            Ok(data)
-        }
-    }
-
-    fn copy_section_data(&self, section: &SectionHeader, out: &mut [u8]) -> Result {
-        let data = section.data(LittleEndian, self.data)?;
-
-        if let Some((compression, _, _)) = section.compression(LittleEndian, self.data)? {
-            decompress_into(compression, &data[COMPRESSION_HEADER_SIZE..], out)?;
-        } else if section.sh_type(LittleEndian) == object::elf::SHT_NOBITS {
-            out.fill(0);
-        } else if data.len() >= SECTION_PAR_COPY_SIZE_THRESHOLD {
-            let threads = rayon::current_num_threads();
-            let chunk_size = (data.len() / threads).max(1);
-
-            data.par_chunks(chunk_size)
-                .zip(out.par_chunks_mut(chunk_size))
-                .for_each(|(src, dst)| dst.copy_from_slice(src));
-        } else {
-            out.copy_from_slice(data);
-        }
         Ok(())
     }
 
-    fn section_data_cow(&self, section: &SectionHeader) -> Result<Cow<'data, [u8]>> {
-        let data = section.data(LittleEndian, self.data)?;
-
-        if let Some((compression, _, _)) = section.compression(LittleEndian, self.data)? {
-            let len = self.section_size(section)?;
-            let mut decompressed = vec![0; len as usize];
-            decompress_into(
-                compression,
-                &data[COMPRESSION_HEADER_SIZE..],
-                &mut decompressed,
-            )?;
-            Ok(Cow::Owned(decompressed))
-        } else {
-            Ok(Cow::Borrowed(data))
+    fn finalise_group_layout(memory_offsets: &OutputSectionPartMap<u64>) -> Self::GroupLayoutExt {
+        GroupLayoutExt {
+            eh_frame_start_address: *memory_offsets.get(part_id::EH_FRAME),
         }
     }
 
-    fn section_size(&self, section: &SectionHeader) -> Result<u64> {
-        Ok(section.compression(LittleEndian, self.data)?.map_or_else(
-            || section.sh_size.get(LittleEndian),
-            |compression| compression.0.ch_size(LittleEndian),
+    fn frame_data_base_address(memory_offsets: &OutputSectionPartMap<u64>) -> u64 {
+        // References to symbols defined in .eh_frame are a bit weird, since it's a section where
+        // we're GCing stuff, but crtbegin.o and crtend.o use them in order to find the start and
+        // end of the whole .eh_frame section.
+        *memory_offsets.get(part_id::EH_FRAME)
+    }
+
+    fn finalise_find_required_sections<'data>(groups: &[layout::GroupState<'data, Elf>]) {
+        tracing::debug!(target: "metrics", total = groups
+            .iter()
+            .map(|g| g.common.format_specific.exception_frame_count)
+            .sum::<usize>(), "exception frames");
+
+        tracing::debug!(target: "metrics", section = "`.eh_frame`", relocations = groups
+            .iter()
+            .map(|g| g.common.format_specific.exception_frame_relocations)
+            .sum::<usize>(), "resolved relocations");
+    }
+
+    fn pre_finalise_sizes_prelude<'data>(
+        common: &mut layout::CommonGroupState<'data, Elf>,
+        args: &Args,
+    ) {
+        if args.should_write_eh_frame_hdr {
+            common.allocate(part_id::EH_FRAME_HDR, size_of::<EhFrameHdr>() as u64);
+        }
+    }
+
+    fn finalise_object_sizes<'data>(
+        object: &mut layout::ObjectLayoutState<'data, Elf>,
+        common: &mut layout::CommonGroupState<'data, Elf>,
+    ) {
+        // TODO: Deduplicate CIEs from different objects, then only allocate space for those CIEs
+        // that we "won".
+        for cie in &object.format_specific_layout_state.cies {
+            object.format_specific_layout_state.eh_frame_size += cie.cie.bytes.len() as u64;
+        }
+        common.allocate(
+            part_id::EH_FRAME,
+            object.format_specific_layout_state.eh_frame_size,
+        );
+    }
+
+    fn finalise_object_layout<'data>(
+        object: &layout::ObjectLayoutState<'data, Elf>,
+        memory_offsets: &mut OutputSectionPartMap<u64>,
+    ) {
+        memory_offsets.increment(
+            part_id::EH_FRAME,
+            object.format_specific_layout_state.eh_frame_size,
+        );
+    }
+
+    fn compute_object_addresses<'data>(
+        object: &layout::ObjectLayoutState<'data, Elf>,
+        memory_offsets: &mut OutputSectionPartMap<u64>,
+    ) {
+        // Note, this is currently identical to finalise_object_layout above. The two functions are
+        // however called separately and they might become different at some point.
+        memory_offsets.increment(
+            part_id::EH_FRAME,
+            object.format_specific_layout_state.eh_frame_size,
+        );
+    }
+
+    fn layout_resources_ext<'data>(
+        groups: &[crate::grouping::Group<'data, Self>],
+    ) -> LayoutResourcesExt<'data> {
+        LayoutResourcesExt {
+            sonames: Sonames::new(groups),
+        }
+    }
+
+    fn load_object_section_relocations<'data, 'scope, A: Arch<Platform = Self>>(
+        state: &layout::ObjectLayoutState<'data, Self>,
+        common: &mut layout::CommonGroupState<'data, Self>,
+        queue: &mut layout::LocalWorkQueue,
+        resources: &'scope layout::GraphResources<'data, '_, Self>,
+        section: layout::Section,
+        scope: &Scope<'scope>,
+    ) -> Result {
+        match state.relocations(section.index)? {
+            RelocationList::Rela(relocations) => {
+                state.load_section_relocations::<A, Rela>(
+                    common,
+                    queue,
+                    resources,
+                    section,
+                    relocations.rel_iter(),
+                    scope,
+                )?;
+            }
+            RelocationList::Crel(relocations) => {
+                state.load_section_relocations::<A, Crel>(
+                    common,
+                    queue,
+                    resources,
+                    section,
+                    relocations.flat_map(|r| r.ok()),
+                    scope,
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn load_object_debug_relocations<'data, 'scope, A: Arch<Platform = Self>>(
+        state: &layout::ObjectLayoutState<'data, Self>,
+        common: &mut layout::CommonGroupState<'data, Self>,
+        queue: &mut layout::LocalWorkQueue,
+        resources: &'scope layout::GraphResources<'data, '_, Self>,
+        section: layout::Section,
+        scope: &Scope<'scope>,
+    ) -> Result {
+        match state.relocations(section.index)? {
+            RelocationList::Rela(relocations) => {
+                state.load_debug_relocations::<A, Rela>(
+                    common,
+                    queue,
+                    resources,
+                    section,
+                    relocations.rel_iter(),
+                    scope,
+                )?;
+            }
+            RelocationList::Crel(relocations) => {
+                state.load_debug_relocations::<A, Crel>(
+                    common,
+                    queue,
+                    resources,
+                    section,
+                    relocations.flat_map(|r| r.ok()),
+                    scope,
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn create_dynamic_symbol_definition<'data>(
+        symbol_db: &SymbolDb<'data, Self>,
+        symbol_id: SymbolId,
+    ) -> Result<layout::DynamicSymbolDefinition<'data>> {
+        let symbol_name = symbol_db.symbol_name(symbol_id)?;
+        let RawSymbolName {
+            name,
+            version_name,
+            is_default,
+        } = RawSymbolName::parse(symbol_name.bytes());
+
+        let mut version = object::elf::VER_NDX_GLOBAL;
+        if symbol_db.version_script.version_count() > 0
+            && let Some(v) = symbol_db
+                .version_script
+                .version_for_symbol(&UnversionedSymbolName::prehashed(name), version_name)?
+        {
+            version = v;
+            if !is_default {
+                version |= object::elf::VERSYM_HIDDEN;
+            }
+        }
+        Ok(layout::DynamicSymbolDefinition::new(
+            symbol_id, name, version,
         ))
     }
 
-    fn section_alignment(&self, section: &SectionHeader) -> Result<u64> {
-        Ok(section.compression(LittleEndian, self.data)?.map_or_else(
-            || section.sh_addralign(LittleEndian),
-            |compression| compression.0.ch_addralign(LittleEndian),
-        ))
+    fn validate_section<'data>(
+        section_info: &output_section_id::SectionOutputInfo,
+        section_flags: SectionFlags,
+        section_layout: &OutputRecordLayout,
+        merge_target: OutputSectionId,
+        output_sections: &OutputSections<'data>,
+        section_id: OutputSectionId,
+    ) -> Result {
+        // TODO: Remove the NOTE exception. Non-alloc sections should be placed outside of program
+        // segments. NOTE sections are sometimes alloc and sometimes not. Alloc NOTE sections should
+        // be placed within a LOAD segment and within a NOTE segment. Non-alloc NOTE sections
+        // shouldn't be in any segment.
+
+        // The .riscv.attributes section is non-alloc but is expected to be put into a
+        // RISCV_ATTRIBUTES segment.
+        if [sht::NOTE, sht::RISCV_ATTRIBUTES].contains(&section_info.ty) {
+        } else {
+            // All segments should only cover sections that are allocated and have a non-zero
+            // address.
+            ensure!(
+                section_layout.mem_offset != 0 || merge_target == output_section_id::FILE_HEADER,
+                "Missing memory offset for section {} present in a program segment.",
+                output_sections.section_debug(section_id),
+            );
+            ensure!(
+                section_flags.is_alloc(),
+                "Missing SHF_ALLOC section flag for section {} present in a program \
+                         segment.",
+                output_sections.section_debug(section_id)
+            );
+        }
+
+        Ok(())
     }
 
-    fn relocations(
-        &self,
-        index: object::SectionIndex,
-        relocations: &Self::RelocationSections,
-    ) -> Result<RelocationList<'data>> {
-        let Some(section_index) = relocations.get(index) else {
-            return Ok(RelocationList::Rela(&[]));
-        };
-        let section = self.sections.section(section_index)?;
-        Ok(
-            if let Some((rela, _)) = section.rela(LittleEndian, self.data)? {
-                RelocationList::Rela(rela)
-            } else if let Some((crel, _)) = section.crel(LittleEndian, self.data)? {
-                RelocationList::Crel(crel)
-            } else {
-                RelocationList::Rela(&[])
-            },
+    fn verify_resolution_allocation(
+        output_sections: &OutputSections,
+        output_order: &output_section_id::OutputOrder,
+        output_kind: OutputKind,
+        mem_sizes: &OutputSectionPartMap<u64>,
+        resolution: &layout::Resolution,
+    ) -> Result {
+        crate::elf_writer::verify_resolution_allocation(
+            output_sections,
+            output_order,
+            output_kind,
+            mem_sizes,
+            resolution,
         )
     }
 
-    fn symbol(&self, index: object::SymbolIndex) -> Result<&'data Symbol> {
-        Ok(self.symbols.symbol(index)?)
-    }
-
-    fn symbol_name(&self, symbol: &Self::Symbol) -> Result<&'data [u8]> {
-        Ok(self.symbols.symbol_name(LittleEndian, symbol)?)
-    }
-
-    fn symbol_section(
-        &self,
-        symbol: &Self::Symbol,
-        index: object::SymbolIndex,
-    ) -> Result<Option<object::SectionIndex>> {
-        Ok(self.symbols.symbol_section(LittleEndian, symbol, index)?)
-    }
-
-    fn dynamic_tags(&self) -> Result<&'data [Self::DynamicEntry]> {
-        dynamic_tags(&self.sections, self.data)
-    }
-
-    fn parse_relocations(&self) -> Result<Self::RelocationSections> {
-        Ok(self
-            .sections
-            .relocation_sections(LittleEndian, self.symbols.section())?)
-    }
-
-    fn num_symbols(&self) -> usize {
-        self.symbols.len()
-    }
-
-    fn is_dynamic(&self) -> bool {
-        self.dynamic_tag_values.is_some()
-    }
-
-    fn dynamic_tag_values(&self) -> Option<Self::DynamicTagValues> {
-        self.dynamic_tag_values
-    }
-
-    fn symbol_version_debug(&self, symbol_index: object::SymbolIndex) -> Option<String> {
-        let endian = LittleEndian;
-        let versym = self.versym.get(symbol_index.0)?;
-        let versym = versym.0.get(endian);
-        let is_default = versym & object::elf::VERSYM_HIDDEN == 0;
-        let symbol_version_index = versym & object::elf::VERSYM_VERSION;
-        if let Some((verdefs, string_table_index)) = self.verdef.clone() {
-            let strings = self
-                .sections
-                .strings(endian, self.data, string_table_index)
-                .ok()?;
-            for r in verdefs {
-                let (verdef, aux_iterator) = r.ok()?;
-                for aux in aux_iterator {
-                    let aux = aux.ok()?;
-                    let version_index = verdef.vd_ndx.get(endian);
-                    if version_index == symbol_version_index {
-                        return Some(format!(
-                            "{}{}",
-                            if is_default { "@@" } else { "@" },
-                            String::from_utf8_lossy(aux.name(endian, strings).ok()?)
-                        ));
-                    }
-                }
-            }
-        }
-        if let Some((verneeds, string_table_index)) = self.verneed.clone() {
-            let strings = self
-                .sections
-                .strings(endian, self.data, string_table_index)
-                .ok()?;
-            for r in verneeds {
-                let (_verneed, aux_iterator) = r.ok()?;
-                for aux in aux_iterator {
-                    let aux = aux.ok()?;
-                    let version_index = aux.vna_other.get(endian);
-                    if version_index == symbol_version_index {
-                        return Some(format!(
-                            "{}{}",
-                            if is_default { "@@" } else { "@" },
-                            String::from_utf8_lossy(aux.name(endian, strings).ok()?)
-                        ));
-                    }
-                }
-            }
-        }
-        None
-    }
-
-    fn section_iter(&self) -> Self::SectionIterator {
-        self.sections.iter()
-    }
-
-    fn enumerate_sections(
-        &self,
-    ) -> impl Iterator<Item = (object::SectionIndex, &'data Self::SectionHeader)> {
-        self.sections.enumerate()
-    }
-
-    fn get_version_names(&self) -> Result<Self::VersionNames> {
-        let endian = LittleEndian;
-
-        let mut version_names = vec![None; self.verdefnum as usize + 1];
-
-        // See https://refspecs.linuxfoundation.org/LSB_3.0.0/LSB-PDA/LSB-PDA.junk/symversion.html
-        // for information about symbol versioning.
-
-        if let Some((verdefs, string_table_index)) = &self.verdef {
-            let strings = self
-                .sections
-                .strings(endian, self.data, *string_table_index)?;
-
-            for r in verdefs.clone() {
-                let (verdef, mut aux_iterator) = r?;
-                // Every VERDEF entry should have at least one AUX entry. We currently only care
-                // about the first one.
-                let aux = aux_iterator.next()?.context("VERDEF with no AUX entry")?;
-                let version_index = verdef.vd_ndx.get(endian);
-                let name = aux.name(endian, strings)?;
-
-                *version_names
-                    .get_mut(usize::from(version_index))
-                    .with_context(|| format!("Invalid version index {version_index}"))? =
-                    Some(name);
-            }
-        }
-
-        Ok(VersionNames {
-            names: version_names,
-        })
-    }
-
-    fn get_symbol_name_and_version(
-        &self,
-        symbol: &crate::elf::Symbol,
-        local_index: usize,
-        version_names: &VersionNames<'data>,
-    ) -> Result<Self::RawSymbolName> {
-        let name_bytes = self.symbol_name(symbol)?;
-
-        let is_default;
-        let version_name;
-
-        if let Some(versym) = self.versym.get(local_index) {
-            let versym = versym.0.get(LittleEndian);
-            is_default = versym & object::elf::VERSYM_HIDDEN == 0;
-            let version_index = versym & object::elf::VERSYM_VERSION;
-            version_name = version_names
-                .names
-                .get(usize::from(version_index))
-                .copied()
-                .flatten();
-        } else {
-            is_default = true;
-            version_name = None;
-        };
-
-        Ok(RawSymbolName {
-            name: name_bytes,
-            version_name,
-            is_default,
-        })
-    }
-
-    fn symbols(&self) -> &'data [Self::Symbol] {
-        self.symbols.symbols()
-    }
-
-    fn symbols_iter(&self) -> impl Iterator<Item = &'data Self::Symbol> {
-        self.symbols.iter()
-    }
-
-    fn verneed_table(&self) -> Result<Self::VerneedTable> {
-        VerneedTable::new(self)
-    }
-
-    fn num_sections(&self) -> usize {
-        self.sections.len()
-    }
-
-    fn process_gnu_note_section(
-        &self,
-        state: &mut Self::FileLayoutState,
-        section_index: object::SectionIndex,
-    ) -> Result {
-        let section = self.section(section_index)?;
-        let e = LittleEndian;
-
-        let Some(notes) = object::read::elf::SectionHeader::notes(section, e, self.data)? else {
-            return Ok(());
-        };
-
-        for note in notes {
-            for gnu_property in note?
-                .gnu_properties(e)
-                .ok_or(error!("Invalid type of .note.gnu.property"))?
-            {
-                let gnu_property = gnu_property?;
-
-                // Right now, skip all properties other than those with size equal to 4.
-                // There are existing properties, but unused right now:
-                // GNU_PROPERTY_STACK_SIZE, GNU_PROPERTY_NO_COPY_ON_PROTECTED
-                // TODO: support in the future
-                if gnu_property.pr_data().len() != 4 {
-                    continue;
-                }
-                state.gnu_property_notes.push(crate::elf::GnuProperty {
-                    ptype: gnu_property.pr_type(),
-                    data: gnu_property.data_u32(e)?,
-                });
-            }
-        }
-
-        Ok(())
-    }
-
-    fn create_layout_properties<'states, 'files, A: Arch<File<'data> = Self>>(
+    fn update_segment_keep_list(
+        program_segments: &ProgramSegments<ProgramSegmentDef>,
+        keep_segments: &mut [bool],
         args: &Args,
-        objects: impl Iterator<Item = &'files Self>,
-        states: impl Iterator<Item = &'states Self::FileLayoutState> + Clone,
-    ) -> Result<Self::LayoutProperties>
+    ) {
+        // If relro is disabled, then discard the relro segment.
+        if !args.relro {
+            for (segment_def, keep) in program_segments.into_iter().zip(keep_segments.iter_mut()) {
+                if segment_def.segment_type == pt::GNU_RELRO {
+                    *keep = false;
+                }
+            }
+        }
+    }
+
+    fn program_segment_defs() -> &'static [ProgramSegmentDef] {
+        PROGRAM_SEGMENT_DEFS
+    }
+
+    fn unconditional_segment_defs() -> &'static [ProgramSegmentDef] {
+        &[STACK_SEGMENT_DEF]
+    }
+
+    fn create_linker_defined_symbols<'data>(
+        symbols: &mut crate::parsing::InternalSymbolsBuilder<'data>,
+        output_kind: OutputKind,
+    ) {
+        // The undefined symbol must always be symbol 0.
+        symbols
+            .add_symbol(InternalSymDefInfo::new(SymbolPlacement::Undefined, b""))
+            .hide();
+
+        symbols
+            .section_start(output_section_id::FILE_HEADER, "__ehdr_start")
+            .hide();
+
+        symbols.section_start(output_section_id::GOT, "_GLOBAL_OFFSET_TABLE_");
+
+        // .rela.plt start/stop symbols are only emitted for non-relocatable executables. Emitting
+        // them for relocatable binaries causes glibc to try to call the resolver functions without
+        // taking into account that the binary has been relocated.
+        if output_kind != OutputKind::StaticExecutable(RelocationModel::Relocatable) {
+            symbols
+                .section_start(output_section_id::RELA_PLT, "__rela_iplt_start")
+                .hide();
+            symbols
+                .section_end(output_section_id::RELA_PLT, "__rela_iplt_end")
+                .hide();
+        }
+
+        symbols
+            .section_start(output_section_id::PREINIT_ARRAY, "__preinit_array_start")
+            .hide();
+        symbols
+            .section_group_end(output_section_id::PREINIT_ARRAY, "__preinit_array_end")
+            .hide();
+
+        symbols
+            .section_start(output_section_id::INIT_ARRAY, "__init_array_start")
+            .hide();
+        symbols
+            .section_group_end(output_section_id::INIT_ARRAY, "__init_array_end")
+            .hide();
+
+        symbols
+            .section_start(output_section_id::FINI_ARRAY, "__fini_array_start")
+            .hide();
+        symbols
+            .section_group_end(output_section_id::FINI_ARRAY, "__fini_array_end")
+            .hide();
+
+        symbols.section_end(output_section_id::TEXT, "etext");
+        symbols.section_end(output_section_id::TEXT, "_etext");
+        symbols.section_end(output_section_id::TEXT, "__etext");
+
+        symbols.section_end(output_section_id::BSS, "end");
+        symbols.section_end(output_section_id::BSS, "_end");
+        symbols.section_end(output_section_id::BSS, "__end").hide();
+
+        // TODO: define the symbol only on RISC-V target
+        symbols.section_start(
+            output_section_id::DATA,
+            crate::elf::GLOBAL_POINTER_SYMBOL_NAME,
+        );
+
+        symbols.section_end(output_section_id::DATA, "edata");
+        symbols.section_end(output_section_id::DATA, "_edata");
+
+        symbols
+            .section_start(output_section_id::TDATA, "__tdata_start")
+            .hide();
+
+        if output_kind != OutputKind::StaticExecutable(RelocationModel::NonRelocatable) {
+            symbols.section_start(output_section_id::DYNAMIC, "_DYNAMIC");
+        }
+
+        symbols
+            .add_symbol(InternalSymDefInfo::new(
+                SymbolPlacement::LoadBaseAddress,
+                b"__executable_start",
+            ))
+            .hide();
+
+        // We define _TLS_MODULE_BASE_ either at the start or end of the TLS segment, depending on
+        // whether we're building a shared object or an executable. This symbol is used for TLSDESC.
+        // See https://www.fsfla.org/~lxoliva/writeups/TLS/RFC-TLSDESC-x86.txt for more details.
+        symbols.add_symbol(InternalSymDefInfo {
+            placement: if output_kind == OutputKind::SharedObject {
+                SymbolPlacement::SectionStart(output_section_id::TDATA)
+            } else {
+                SymbolPlacement::SectionEnd(output_section_id::TBSS)
+            },
+            name: b"_TLS_MODULE_BASE_",
+            elf_symbol_type: stt::TLS,
+            is_hidden: false,
+        });
+    }
+
+    fn built_in_section_infos<'data>() -> Vec<crate::output_section_id::SectionOutputInfo<'data>> {
+        SECTION_DEFINITIONS
+            .iter()
+            .map(|d| SectionOutputInfo {
+                section_flags: d.section_flags,
+                kind: d.kind,
+                ty: d.ty,
+                min_alignment: d.min_alignment,
+                entsize: d.element_size,
+                location: None,
+                secondary_order: None,
+            })
+            .collect()
+    }
+
+    fn create_layout_properties<'data, 'states, 'files, A: Arch<Platform = Self>>(
+        args: &Args,
+        objects: impl Iterator<Item = &'files Self::File<'data>>,
+        states: impl Iterator<Item = &'states Self::FileLayoutState<'data>> + Clone,
+    ) -> Result<ElfLayoutProperties>
     where
         'data: 'files,
         'data: 'states,
@@ -698,160 +716,90 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
         ElfLayoutProperties::new::<A>(objects, states, args)
     }
 
-    fn symbol_versions(&self) -> &[Self::SymbolVersionIndex] {
-        self.versym
-    }
-
-    fn dynamic_symbol_used(
-        &self,
-        symbol_index: object::SymbolIndex,
-        state: &mut Self::DynamicLayoutState,
+    fn load_exception_frame_data<'data, 'scope, A: Arch<Platform = Elf>>(
+        object: &mut crate::layout::ObjectLayoutState<'data, Elf>,
+        common: &mut crate::layout::CommonGroupState<'data, Elf>,
+        eh_frame_section_index: object::SectionIndex,
+        resources: &'scope crate::layout::GraphResources<'data, '_, Elf>,
+        queue: &mut crate::layout::LocalWorkQueue,
+        scope: &rayon::Scope<'scope>,
     ) -> Result {
-        if let Some(version_index) = self.versym.get(symbol_index.0) {
-            let version_index = version_index.0.get(LittleEndian) & object::elf::VERSYM_VERSION;
-            // Versions 0 and 1 are local and global. We care about the versions after that.
-            if version_index > object::elf::VER_NDX_GLOBAL {
-                *state
-                    .symbol_versions_needed
-                    .get_mut(version_index as usize - 1)
-                    .with_context(|| format!("Invalid symbol version index {version_index}"))? =
-                    true;
+        let file_symbol_id_range = object.symbol_id_range;
+        let eh_frame_section = object.object.section(eh_frame_section_index)?;
+        let data = object.object.raw_section_data(eh_frame_section)?;
+        let exception_frames = match object.relocations(eh_frame_section_index)? {
+            RelocationList::Rela(relocations) => {
+                ExceptionFrames::Rela(process_eh_frame_relocations::<A, Rela>(
+                    object,
+                    common,
+                    file_symbol_id_range,
+                    resources,
+                    queue,
+                    eh_frame_section,
+                    data,
+                    &relocations,
+                    scope,
+                )?)
             }
-        }
+            RelocationList::Crel(crel_iterator) => {
+                ExceptionFrames::Crel(process_eh_frame_relocations::<A, Crel>(
+                    object,
+                    common,
+                    file_symbol_id_range,
+                    resources,
+                    queue,
+                    eh_frame_section,
+                    data,
+                    &crel_iterator.collect::<Result<Vec<Crel>, _>>()?,
+                    scope,
+                )?)
+            }
+        };
+
+        object.format_specific_layout_state.exception_frames = exception_frames;
+        object.format_specific_layout_state.eh_frame_section = Some(eh_frame_section);
 
         Ok(())
     }
 
-    fn activate_dynamic(&self, state: &mut Self::DynamicLayoutState) {
-        state.symbol_versions_needed = vec![false; self.verdefnum as usize];
-    }
-
-    fn finalise_sizes_dynamic(
-        &self,
-        lib_name: &[u8],
-        state: &mut Self::DynamicLayoutState,
-        mem_sizes: &mut OutputSectionPartMap<u64>,
+    fn non_empty_section_loaded<'data, 'scope, A: Arch<Platform = Self>>(
+        object: &mut layout::ObjectLayoutState<'data, Elf>,
+        common: &mut layout::CommonGroupState<'data, Elf>,
+        queue: &mut layout::LocalWorkQueue,
+        unloaded: crate::resolution::UnloadedSection,
+        resources: &'scope layout::GraphResources<'data, 'scope, Elf>,
+        scope: &Scope<'scope>,
     ) -> Result {
-        let e = LittleEndian;
-        let mut version_count = 0;
+        let sizes = match &object.format_specific_layout_state.exception_frames {
+            ExceptionFrames::Rela(exception_frames) => process_section_exception_frames::<A, Rela>(
+                object,
+                unloaded.last_frame_index,
+                common,
+                resources,
+                queue,
+                scope,
+                exception_frames,
+            )?,
+            ExceptionFrames::Crel(exception_frames) => process_section_exception_frames::<A, Crel>(
+                object,
+                unloaded.last_frame_index,
+                common,
+                resources,
+                queue,
+                scope,
+                exception_frames,
+            )?,
+        };
 
-        if let Some((mut verdef_iterator, link)) = self.verdef.clone() {
-            let defs = verdef_iterator.clone();
+        object.format_specific_layout_state.eh_frame_size += sizes.eh_frame_size;
 
-            let strings = self.sections.strings(e, self.data, link)?;
-            let mut base_size = 0;
-            while let Some((verdef, mut aux_iterator)) = verdef_iterator.next()? {
-                let version_index = verdef.vd_ndx.get(e);
-
-                if version_index == 0 {
-                    bail!("Invalid version index");
-                }
-
-                let flags = verdef.vd_flags.get(e);
-                let is_base = (flags & object::elf::VER_FLG_BASE) != 0;
-
-                // Keep the base version and any versions that are referenced.
-                let needed = is_base
-                    || *state
-                        .symbol_versions_needed
-                        .get(usize::from(version_index - 1))
-                        .context("Invalid version index")?;
-
-                if needed {
-                    // For the base version, we use the lib_name rather than the version name from
-                    // the input file. This matches what GNU ld appears to do. Also, if we don't do
-                    // this, then the C runtime hits an assertion failure, because it expects to be
-                    // able to find a DT_NEEDED entry that matches the base name of a version.
-                    let name = if is_base {
-                        lib_name
-                    } else {
-                        // Every VERDEF entry should have at least one AUX entry.
-                        let aux = aux_iterator.next()?.context("VERDEF with no AUX entry")?;
-                        aux.name(e, strings)?
-                    };
-
-                    let name_size = name.len() as u64 + 1;
-
-                    if is_base {
-                        // The base version doesn't count as a version, so we don't increment
-                        // version_count here. We emit it as a Verneed, whereas the actual versions
-                        // are emitted as Vernaux.
-                        base_size = name_size;
-                    } else {
-                        mem_sizes.increment(part_id::DYNSTR, name_size);
-                        version_count += 1;
-                    }
-                }
-            }
-
-            if version_count > 0 {
-                mem_sizes.increment(part_id::DYNSTR, base_size);
-                mem_sizes.increment(
-                    part_id::GNU_VERSION_R,
-                    size_of::<crate::elf::Verneed>() as u64
-                        + u64::from(version_count) * size_of::<crate::elf::Vernaux>() as u64,
-                );
-
-                state.verneed_info = Some(VerneedInfo {
-                    defs,
-                    string_table_index: link,
-                    version_count,
-                });
-            }
-        }
-
-        Ok(())
-    }
-
-    fn finalise_layout_dynamic(
-        &self,
-        state: Self::DynamicLayoutState,
-        memory_offsets: &mut OutputSectionPartMap<u64>,
-        section_layouts: &OutputSectionMap<OutputRecordLayout>,
-    ) -> Self::DynamicLayout {
-        let mut is_last_verneed = false;
-
-        if let Some(v) = state.verneed_info.as_ref()
-            && v.version_count > 0
-        {
-            memory_offsets.increment(
-                part_id::GNU_VERSION_R,
-                size_of::<crate::elf::Verneed>() as u64
-                    + u64::from(v.version_count) * size_of::<crate::elf::Vernaux>() as u64,
+        if resources.symbol_db.args.should_write_eh_frame_hdr {
+            common.allocate(
+                part_id::EH_FRAME_HDR,
+                size_of::<EhFrameHdrEntry>() as u64 * sizes.num_frames,
             );
-
-            let version_r_layout = section_layouts.get(output_section_id::GNU_VERSION_R);
-
-            is_last_verneed = *memory_offsets.get(part_id::GNU_VERSION_R)
-                == version_r_layout.mem_offset + version_r_layout.mem_size;
         }
 
-        let version_mapping =
-            compute_version_mapping(&state.symbol_versions_needed, state.non_addressable_indexes);
-
-        DynamicLayout {
-            version_mapping,
-            verneed_info: state.verneed_info,
-            is_last_verneed,
-        }
-    }
-
-    fn apply_non_addressable_indexes_dynamic(
-        &self,
-        indexes: &mut Self::NonAddressableIndexes,
-        counts: &mut Self::NonAddressableCounts,
-        state: &mut DynamicLayoutState,
-    ) -> Result {
-        state.non_addressable_indexes = *indexes;
-        if let Some(info) = state.verneed_info.as_ref()
-            && info.version_count > 0
-        {
-            counts.verneed_count += 1;
-            indexes.gnu_version_r_index = indexes
-                .gnu_version_r_index
-                .checked_add(info.version_count)
-                .context("Symbol versions overflowed 2**16")?;
-        }
         Ok(())
     }
 
@@ -859,7 +807,7 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
         args: &Args,
         output_kind: OutputKind,
         dynamic_symbol_definitions: &mut [DynamicSymbolDefinition<'_>],
-    ) -> Self::EpilogueLayout {
+    ) -> EpilogueLayout {
         let gnu_hash_layout = create_gnu_hash_layout(args, output_kind, dynamic_symbol_definitions);
 
         let build_id_size = match &args.build_id {
@@ -878,8 +826,8 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
     }
 
     fn apply_non_addressable_indexes_epilogue(
-        counts: &mut Self::NonAddressableCounts,
-        state: &mut Self::EpilogueLayout,
+        counts: &mut NonAddressableCounts,
+        state: &mut EpilogueLayout,
     ) {
         counts.verdef_count += state
             .verdefs
@@ -888,9 +836,9 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
             .unwrap_or_default();
     }
 
-    fn apply_non_addressable_indexes<'groups>(
+    fn apply_non_addressable_indexes<'data, 'groups>(
         symbol_db: &SymbolDb<'data, Self>,
-        counts: &Self::NonAddressableCounts,
+        counts: &NonAddressableCounts,
         mem_sizes_iter: impl Iterator<Item = &'groups mut OutputSectionPartMap<u64>>,
     ) {
         // If we were going to output symbol versions, but we didn't actually use any, then we drop
@@ -905,11 +853,11 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
         }
     }
 
-    fn finalise_sizes_epilogue(
-        state: &mut Self::EpilogueLayout,
+    fn finalise_sizes_epilogue<'data>(
+        state: &mut EpilogueLayout,
         mem_sizes: &mut OutputSectionPartMap<u64>,
         dynamic_symbol_definitions: &[DynamicSymbolDefinition<'data>],
-        properties: &Self::LayoutProperties,
+        properties: &ElfLayoutProperties,
         symbol_db: &SymbolDb<'data, Self>,
     ) {
         if symbol_db.output_kind.needs_dynamic() {
@@ -1013,8 +961,8 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
         }
     }
 
-    fn finalise_layout_epilogue(
-        epilogue_state: &mut Self::EpilogueLayout,
+    fn finalise_layout_epilogue<'data>(
+        epilogue_state: &mut EpilogueLayout,
         memory_offsets: &mut OutputSectionPartMap<u64>,
         symbol_db: &SymbolDb<'data, Self>,
         common_state: &ElfLayoutProperties,
@@ -1072,175 +1020,583 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
         allocate_sysv_hash(state, current_sizes, extra_sizes, dynamic_symbol_defs)
     }
 
-    fn finalise_sizes_all(
+    fn finalise_sizes_all<'data>(
         mem_sizes: &mut OutputSectionPartMap<u64>,
         symbol_db: &SymbolDb<'data, Self>,
     ) {
         finalise_gnu_version_size(mem_sizes, symbol_db);
     }
+}
 
-    fn load_exception_frame_data<'scope, A: Arch<File<'data> = Self>>(
-        object: &mut crate::layout::ObjectLayoutState<'data, File<'data>>,
-        common: &mut crate::layout::CommonGroupState<'data, File<'data>>,
-        eh_frame_section_index: object::SectionIndex,
-        resources: &'scope crate::layout::GraphResources<'data, '_, File<'data>>,
-        queue: &mut crate::layout::LocalWorkQueue,
-        scope: &rayon::Scope<'scope>,
-    ) -> Result {
-        let file_symbol_id_range = object.symbol_id_range;
-        let eh_frame_section = object.object.section(eh_frame_section_index)?;
-        let data = object.object.raw_section_data(eh_frame_section)?;
-        let exception_frames = match object.relocations(eh_frame_section_index)? {
-            RelocationList::Rela(relocations) => {
-                ExceptionFrames::Rela(process_eh_frame_relocations::<A, Rela>(
-                    object,
-                    common,
-                    file_symbol_id_range,
-                    resources,
-                    queue,
-                    eh_frame_section,
-                    data,
-                    &relocations,
-                    scope,
-                )?)
+impl<'data> platform::ObjectFile<'data> for File<'data> {
+    type Platform = Elf;
+
+    fn parse(input: &InputBytes<'data>, args: &Args) -> Result<Self> {
+        let is_dynamic = input.kind == FileKind::ElfDynamic;
+
+        let file = Self::parse_bytes(input.data, is_dynamic)?;
+
+        if file.arch != args.arch {
+            bail!(
+                "`{}` has incompatible architecture: {}, expecting {}",
+                input,
+                file.arch,
+                args.arch,
+            )
+        }
+
+        Ok(file)
+    }
+
+    fn parse_bytes(data: &'data [u8], is_dynamic: bool) -> Result<Self> {
+        let header = FileHeader::parse(data)?;
+        let endian = header.endian()?;
+        let architecture = header.e_machine(endian).try_into()?;
+        let sections = header.sections(endian, data)?;
+        let eflags = header.e_flags(endian);
+
+        let mut symbols = SymbolTable::default();
+        let mut versym: &[Versym] = &[];
+        let mut verdef = None;
+        let mut verdefnum = 0;
+        let mut verneed = None;
+
+        // Find all the sections that we're interested in a single scan of the section table so
+        // as to avoid multiple scans.
+        for (section_index, section) in sections.enumerate() {
+            match SectionType::from_header(section) {
+                sht::DYNSYM if is_dynamic => {
+                    symbols = SymbolTable::parse(endian, data, &sections, section_index, section)?;
+                }
+                sht::SYMTAB if !is_dynamic => {
+                    symbols = SymbolTable::parse(endian, data, &sections, section_index, section)?;
+                }
+                sht::GNU_VERSYM => {
+                    versym = section.data_as_array(endian, data)?;
+                }
+                sht::GNU_VERDEF => {
+                    verdef = section.gnu_verdef(endian, data)?;
+                    verdefnum = section.sh_info(endian);
+                }
+                sht::GNU_VERNEED => {
+                    verneed = section.gnu_verneed(endian, data)?;
+                }
+                _ => {}
             }
-            RelocationList::Crel(crel_iterator) => {
-                ExceptionFrames::Crel(process_eh_frame_relocations::<A, Crel>(
-                    object,
-                    common,
-                    file_symbol_id_range,
-                    resources,
-                    queue,
-                    eh_frame_section,
-                    data,
-                    &crel_iterator.collect::<Result<Vec<Crel>, _>>()?,
-                    scope,
-                )?)
-            }
-        };
-
-        object.format_specific_layout_state.exception_frames = exception_frames;
-        object.format_specific_layout_state.eh_frame_section = Some(eh_frame_section);
-
-        Ok(())
-    }
-
-    fn finalise_group_layout(memory_offsets: &OutputSectionPartMap<u64>) -> Self::GroupLayoutExt {
-        GroupLayoutExt {
-            eh_frame_start_address: *memory_offsets.get(part_id::EH_FRAME),
-        }
-    }
-
-    fn non_empty_section_loaded<'scope, A: Arch<File<'data> = Self>>(
-        object: &mut layout::ObjectLayoutState<'data, File<'data>>,
-        common: &mut layout::CommonGroupState<'data, File<'data>>,
-        queue: &mut layout::LocalWorkQueue,
-        unloaded: crate::resolution::UnloadedSection,
-        resources: &'scope layout::GraphResources<'data, 'scope, File<'data>>,
-        scope: &Scope<'scope>,
-    ) -> Result {
-        let sizes = match &object.format_specific_layout_state.exception_frames {
-            ExceptionFrames::Rela(exception_frames) => process_section_exception_frames::<A, Rela>(
-                object,
-                unloaded.last_frame_index,
-                common,
-                resources,
-                queue,
-                scope,
-                exception_frames,
-            )?,
-            ExceptionFrames::Crel(exception_frames) => process_section_exception_frames::<A, Crel>(
-                object,
-                unloaded.last_frame_index,
-                common,
-                resources,
-                queue,
-                scope,
-                exception_frames,
-            )?,
-        };
-
-        object.format_specific_layout_state.eh_frame_size += sizes.eh_frame_size;
-
-        if resources.symbol_db.args.should_write_eh_frame_hdr {
-            common.allocate(
-                part_id::EH_FRAME_HDR,
-                size_of::<EhFrameHdrEntry>() as u64 * sizes.num_frames,
-            );
         }
 
-        Ok(())
+        let dynamic_tag_values =
+            is_dynamic.then(|| DynamicTagValues::read(&sections, data, &symbols));
+
+        Ok(Self {
+            arch: architecture,
+            data,
+            sections,
+            symbols,
+            versym,
+            verdef,
+            verdefnum,
+            verneed,
+            eflags,
+            dynamic_tag_values,
+        })
     }
 
-    fn finalise_find_required_sections(groups: &[layout::GroupState<'data, File<'data>>]) {
-        tracing::debug!(target: "metrics", total = groups
-            .iter()
-            .map(|g| g.common.format_specific.exception_frame_count)
-            .sum::<usize>(), "exception frames");
-
-        tracing::debug!(target: "metrics", section = "`.eh_frame`", relocations = groups
-            .iter()
-            .map(|g| g.common.format_specific.exception_frame_relocations)
-            .sum::<usize>(), "resolved relocations");
+    fn section(&self, index: object::SectionIndex) -> Result<&'data SectionHeader> {
+        Ok(self.sections.section(index)?)
     }
 
-    fn pre_finalise_sizes_prelude(
-        common: &mut layout::CommonGroupState<'data, File<'data>>,
-        args: &Args,
-    ) {
-        if args.should_write_eh_frame_hdr {
-            common.allocate(part_id::EH_FRAME_HDR, size_of::<EhFrameHdr>() as u64);
-        }
+    fn section_by_name(&self, name: &str) -> Option<(object::SectionIndex, &'data SectionHeader)> {
+        self.sections.section_by_name(LittleEndian, name.as_bytes())
     }
 
-    fn finalise_object_sizes(
-        object: &mut layout::ObjectLayoutState<'data, File<'data>>,
-        common: &mut layout::CommonGroupState<'data, File<'data>>,
-    ) {
-        // TODO: Deduplicate CIEs from different objects, then only allocate space for those CIEs
-        // that we "won".
-        for cie in &object.format_specific_layout_state.cies {
-            object.format_specific_layout_state.eh_frame_size += cie.cie.bytes.len() as u64;
-        }
-        common.allocate(
-            part_id::EH_FRAME,
-            object.format_specific_layout_state.eh_frame_size,
-        );
+    fn section_name(&self, section: &SectionHeader) -> Result<&'data [u8]> {
+        Ok(self.sections.section_name(LittleEndian, section)?)
     }
 
-    fn frame_data_base_address(memory_offsets: &OutputSectionPartMap<u64>) -> u64 {
-        // References to symbols defined in .eh_frame are a bit weird, since it's a section where
-        // we're GCing stuff, but crtbegin.o and crtend.o use them in order to find the start and
-        // end of the whole .eh_frame section.
-        *memory_offsets.get(part_id::EH_FRAME)
+    fn section_display_name(&self, index: object::SectionIndex) -> Cow<'data, str> {
+        self.section(index)
+            .and_then(|section| self.section_name(section))
+            .map_or_else(
+                |_| format!("<index {}>", index.0).into(),
+                String::from_utf8_lossy,
+            )
     }
 
-    fn finalise_object_layout(
-        object: &layout::ObjectLayoutState<'data, File<'data>>,
-        memory_offsets: &mut OutputSectionPartMap<u64>,
-    ) {
-        memory_offsets.increment(
-            part_id::EH_FRAME,
-            object.format_specific_layout_state.eh_frame_size,
-        );
+    fn raw_section_data(&self, section: &SectionHeader) -> Result<&'data [u8]> {
+        Ok(section.data(LittleEndian, self.data)?)
     }
 
-    fn compute_object_addresses(
-        object: &layout::ObjectLayoutState<'data, File<'data>>,
-        memory_offsets: &mut OutputSectionPartMap<u64>,
-    ) {
-        // Note, this is currently identical to finalise_object_layout above. The two functions are
-        // however called separately and they might become different at some point.
-        memory_offsets.increment(
-            part_id::EH_FRAME,
-            object.format_specific_layout_state.eh_frame_size,
-        );
-    }
-
-    fn should_enforce_undefined(
+    fn section_data(
         &self,
-        resources: &layout::GraphResources<'data, '_, Self>,
-    ) -> bool {
+        section: &SectionHeader,
+        member: &bumpalo_herd::Member<'data>,
+        loaded_metrics: &LoadedMetrics,
+    ) -> Result<&'data [u8]> {
+        let data = section.data(LittleEndian, self.data)?;
+        loaded_metrics
+            .loaded_bytes
+            .fetch_add(data.len(), Ordering::Relaxed);
+
+        if let Some((compression, _, _)) = section.compression(LittleEndian, self.data)? {
+            loaded_metrics
+                .loaded_compressed_bytes
+                .fetch_add(data.len(), Ordering::Relaxed);
+            let len = self.section_size(section)?;
+            let decompressed = member.alloc_slice_fill_default(len as usize);
+            decompress_into(compression, &data[COMPRESSION_HEADER_SIZE..], decompressed)?;
+            loaded_metrics
+                .decompressed_bytes
+                .fetch_add(decompressed.len(), Ordering::Relaxed);
+            Ok(decompressed)
+        } else {
+            Ok(data)
+        }
+    }
+
+    fn copy_section_data(&self, section: &SectionHeader, out: &mut [u8]) -> Result {
+        let data = section.data(LittleEndian, self.data)?;
+
+        if let Some((compression, _, _)) = section.compression(LittleEndian, self.data)? {
+            decompress_into(compression, &data[COMPRESSION_HEADER_SIZE..], out)?;
+        } else if section.sh_type(LittleEndian) == object::elf::SHT_NOBITS {
+            out.fill(0);
+        } else if data.len() >= SECTION_PAR_COPY_SIZE_THRESHOLD {
+            let threads = rayon::current_num_threads();
+            let chunk_size = (data.len() / threads).max(1);
+
+            data.par_chunks(chunk_size)
+                .zip(out.par_chunks_mut(chunk_size))
+                .for_each(|(src, dst)| dst.copy_from_slice(src));
+        } else {
+            out.copy_from_slice(data);
+        }
+        Ok(())
+    }
+
+    fn section_data_cow(&self, section: &SectionHeader) -> Result<Cow<'data, [u8]>> {
+        let data = section.data(LittleEndian, self.data)?;
+
+        if let Some((compression, _, _)) = section.compression(LittleEndian, self.data)? {
+            let len = self.section_size(section)?;
+            let mut decompressed = vec![0; len as usize];
+            decompress_into(
+                compression,
+                &data[COMPRESSION_HEADER_SIZE..],
+                &mut decompressed,
+            )?;
+            Ok(Cow::Owned(decompressed))
+        } else {
+            Ok(Cow::Borrowed(data))
+        }
+    }
+
+    fn section_size(&self, section: &SectionHeader) -> Result<u64> {
+        Ok(section.compression(LittleEndian, self.data)?.map_or_else(
+            || section.sh_size.get(LittleEndian),
+            |compression| compression.0.ch_size(LittleEndian),
+        ))
+    }
+
+    fn section_alignment(&self, section: &SectionHeader) -> Result<u64> {
+        Ok(section.compression(LittleEndian, self.data)?.map_or_else(
+            || section.sh_addralign(LittleEndian),
+            |compression| compression.0.ch_addralign(LittleEndian),
+        ))
+    }
+
+    fn relocations(
+        &self,
+        index: object::SectionIndex,
+        relocations: &RelocationSections,
+    ) -> Result<RelocationList<'data>> {
+        let Some(section_index) = relocations.get(index) else {
+            return Ok(RelocationList::Rela(&[]));
+        };
+        let section = self.sections.section(section_index)?;
+        Ok(
+            if let Some((rela, _)) = section.rela(LittleEndian, self.data)? {
+                RelocationList::Rela(rela)
+            } else if let Some((crel, _)) = section.crel(LittleEndian, self.data)? {
+                RelocationList::Crel(crel)
+            } else {
+                RelocationList::Rela(&[])
+            },
+        )
+    }
+
+    fn symbol(&self, index: object::SymbolIndex) -> Result<&'data Symbol> {
+        Ok(self.symbols.symbol(index)?)
+    }
+
+    fn symbol_name(&self, symbol: &Symbol) -> Result<&'data [u8]> {
+        Ok(self.symbols.symbol_name(LittleEndian, symbol)?)
+    }
+
+    fn symbol_section(
+        &self,
+        symbol: &Symbol,
+        index: object::SymbolIndex,
+    ) -> Result<Option<object::SectionIndex>> {
+        Ok(self.symbols.symbol_section(LittleEndian, symbol, index)?)
+    }
+
+    fn dynamic_tags(&self) -> Result<&'data [DynamicEntry]> {
+        dynamic_tags(&self.sections, self.data)
+    }
+
+    fn parse_relocations(&self) -> Result<RelocationSections> {
+        Ok(self
+            .sections
+            .relocation_sections(LittleEndian, self.symbols.section())?)
+    }
+
+    fn num_symbols(&self) -> usize {
+        self.symbols.len()
+    }
+
+    fn is_dynamic(&self) -> bool {
+        self.dynamic_tag_values.is_some()
+    }
+
+    fn dynamic_tag_values(&self) -> Option<DynamicTagValues<'data>> {
+        self.dynamic_tag_values
+    }
+
+    fn symbol_version_debug(&self, symbol_index: object::SymbolIndex) -> Option<String> {
+        let endian = LittleEndian;
+        let versym = self.versym.get(symbol_index.0)?;
+        let versym = versym.0.get(endian);
+        let is_default = versym & object::elf::VERSYM_HIDDEN == 0;
+        let symbol_version_index = versym & object::elf::VERSYM_VERSION;
+        if let Some((verdefs, string_table_index)) = self.verdef.clone() {
+            let strings = self
+                .sections
+                .strings(endian, self.data, string_table_index)
+                .ok()?;
+            for r in verdefs {
+                let (verdef, aux_iterator) = r.ok()?;
+                for aux in aux_iterator {
+                    let aux = aux.ok()?;
+                    let version_index = verdef.vd_ndx.get(endian);
+                    if version_index == symbol_version_index {
+                        return Some(format!(
+                            "{}{}",
+                            if is_default { "@@" } else { "@" },
+                            String::from_utf8_lossy(aux.name(endian, strings).ok()?)
+                        ));
+                    }
+                }
+            }
+        }
+        if let Some((verneeds, string_table_index)) = self.verneed.clone() {
+            let strings = self
+                .sections
+                .strings(endian, self.data, string_table_index)
+                .ok()?;
+            for r in verneeds {
+                let (_verneed, aux_iterator) = r.ok()?;
+                for aux in aux_iterator {
+                    let aux = aux.ok()?;
+                    let version_index = aux.vna_other.get(endian);
+                    if version_index == symbol_version_index {
+                        return Some(format!(
+                            "{}{}",
+                            if is_default { "@@" } else { "@" },
+                            String::from_utf8_lossy(aux.name(endian, strings).ok()?)
+                        ));
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    fn section_iter(&self) -> core::slice::Iter<'data, SectionHeader> {
+        self.sections.iter()
+    }
+
+    fn enumerate_sections(
+        &self,
+    ) -> impl Iterator<Item = (object::SectionIndex, &'data SectionHeader)> {
+        self.sections.enumerate()
+    }
+
+    fn get_version_names(&self) -> Result<VersionNames<'data>> {
+        let endian = LittleEndian;
+
+        let mut version_names = vec![None; self.verdefnum as usize + 1];
+
+        // See https://refspecs.linuxfoundation.org/LSB_3.0.0/LSB-PDA/LSB-PDA.junk/symversion.html
+        // for information about symbol versioning.
+
+        if let Some((verdefs, string_table_index)) = &self.verdef {
+            let strings = self
+                .sections
+                .strings(endian, self.data, *string_table_index)?;
+
+            for r in verdefs.clone() {
+                let (verdef, mut aux_iterator) = r?;
+                // Every VERDEF entry should have at least one AUX entry. We currently only care
+                // about the first one.
+                let aux = aux_iterator.next()?.context("VERDEF with no AUX entry")?;
+                let version_index = verdef.vd_ndx.get(endian);
+                let name = aux.name(endian, strings)?;
+
+                *version_names
+                    .get_mut(usize::from(version_index))
+                    .with_context(|| format!("Invalid version index {version_index}"))? =
+                    Some(name);
+            }
+        }
+
+        Ok(VersionNames {
+            names: version_names,
+        })
+    }
+
+    fn get_symbol_name_and_version(
+        &self,
+        symbol: &Symbol,
+        local_index: usize,
+        version_names: &VersionNames<'data>,
+    ) -> Result<RawSymbolName<'data>> {
+        let name_bytes = self.symbol_name(symbol)?;
+
+        let is_default;
+        let version_name;
+
+        if let Some(versym) = self.versym.get(local_index) {
+            let versym = versym.0.get(LittleEndian);
+            is_default = versym & object::elf::VERSYM_HIDDEN == 0;
+            let version_index = versym & object::elf::VERSYM_VERSION;
+            version_name = version_names
+                .names
+                .get(usize::from(version_index))
+                .copied()
+                .flatten();
+        } else {
+            is_default = true;
+            version_name = None;
+        };
+
+        Ok(RawSymbolName {
+            name: name_bytes,
+            version_name,
+            is_default,
+        })
+    }
+
+    fn symbols(&self) -> &'data [Symbol] {
+        self.symbols.symbols()
+    }
+
+    fn symbols_iter(&self) -> impl Iterator<Item = &'data Symbol> {
+        self.symbols.iter()
+    }
+
+    fn verneed_table(&self) -> Result<VerneedTable<'data>> {
+        VerneedTable::new(self)
+    }
+
+    fn num_sections(&self) -> usize {
+        self.sections.len()
+    }
+
+    fn process_gnu_note_section(
+        &self,
+        state: &mut ElfObjectLayoutState<'data>,
+        section_index: object::SectionIndex,
+    ) -> Result {
+        let section = self.section(section_index)?;
+        let e = LittleEndian;
+
+        let Some(notes) = object::read::elf::SectionHeader::notes(section, e, self.data)? else {
+            return Ok(());
+        };
+
+        for note in notes {
+            for gnu_property in note?
+                .gnu_properties(e)
+                .ok_or(error!("Invalid type of .note.gnu.property"))?
+            {
+                let gnu_property = gnu_property?;
+
+                // Right now, skip all properties other than those with size equal to 4.
+                // There are existing properties, but unused right now:
+                // GNU_PROPERTY_STACK_SIZE, GNU_PROPERTY_NO_COPY_ON_PROTECTED
+                // TODO: support in the future
+                if gnu_property.pr_data().len() != 4 {
+                    continue;
+                }
+                state.gnu_property_notes.push(crate::elf::GnuProperty {
+                    ptype: gnu_property.pr_type(),
+                    data: gnu_property.data_u32(e)?,
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    fn symbol_versions(&self) -> &[Versym] {
+        self.versym
+    }
+
+    fn dynamic_symbol_used(
+        &self,
+        symbol_index: object::SymbolIndex,
+        state: &mut DynamicLayoutState<'data>,
+    ) -> Result {
+        if let Some(version_index) = self.versym.get(symbol_index.0) {
+            let version_index = version_index.0.get(LittleEndian) & object::elf::VERSYM_VERSION;
+            // Versions 0 and 1 are local and global. We care about the versions after that.
+            if version_index > object::elf::VER_NDX_GLOBAL {
+                *state
+                    .symbol_versions_needed
+                    .get_mut(version_index as usize - 1)
+                    .with_context(|| format!("Invalid symbol version index {version_index}"))? =
+                    true;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn activate_dynamic(&self, state: &mut DynamicLayoutState<'data>) {
+        state.symbol_versions_needed = vec![false; self.verdefnum as usize];
+    }
+
+    fn finalise_sizes_dynamic(
+        &self,
+        lib_name: &[u8],
+        state: &mut DynamicLayoutState<'data>,
+        mem_sizes: &mut OutputSectionPartMap<u64>,
+    ) -> Result {
+        let e = LittleEndian;
+        let mut version_count = 0;
+
+        if let Some((mut verdef_iterator, link)) = self.verdef.clone() {
+            let defs = verdef_iterator.clone();
+
+            let strings = self.sections.strings(e, self.data, link)?;
+            let mut base_size = 0;
+            while let Some((verdef, mut aux_iterator)) = verdef_iterator.next()? {
+                let version_index = verdef.vd_ndx.get(e);
+
+                if version_index == 0 {
+                    bail!("Invalid version index");
+                }
+
+                let flags = verdef.vd_flags.get(e);
+                let is_base = (flags & object::elf::VER_FLG_BASE) != 0;
+
+                // Keep the base version and any versions that are referenced.
+                let needed = is_base
+                    || *state
+                        .symbol_versions_needed
+                        .get(usize::from(version_index - 1))
+                        .context("Invalid version index")?;
+
+                if needed {
+                    // For the base version, we use the lib_name rather than the version name from
+                    // the input file. This matches what GNU ld appears to do. Also, if we don't do
+                    // this, then the C runtime hits an assertion failure, because it expects to be
+                    // able to find a DT_NEEDED entry that matches the base name of a version.
+                    let name = if is_base {
+                        lib_name
+                    } else {
+                        // Every VERDEF entry should have at least one AUX entry.
+                        let aux = aux_iterator.next()?.context("VERDEF with no AUX entry")?;
+                        aux.name(e, strings)?
+                    };
+
+                    let name_size = name.len() as u64 + 1;
+
+                    if is_base {
+                        // The base version doesn't count as a version, so we don't increment
+                        // version_count here. We emit it as a Verneed, whereas the actual versions
+                        // are emitted as Vernaux.
+                        base_size = name_size;
+                    } else {
+                        mem_sizes.increment(part_id::DYNSTR, name_size);
+                        version_count += 1;
+                    }
+                }
+            }
+
+            if version_count > 0 {
+                mem_sizes.increment(part_id::DYNSTR, base_size);
+                mem_sizes.increment(
+                    part_id::GNU_VERSION_R,
+                    size_of::<crate::elf::Verneed>() as u64
+                        + u64::from(version_count) * size_of::<crate::elf::Vernaux>() as u64,
+                );
+
+                state.verneed_info = Some(VerneedInfo {
+                    defs,
+                    string_table_index: link,
+                    version_count,
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    fn finalise_layout_dynamic(
+        &self,
+        state: DynamicLayoutState<'data>,
+        memory_offsets: &mut OutputSectionPartMap<u64>,
+        section_layouts: &OutputSectionMap<OutputRecordLayout>,
+    ) -> DynamicLayout<'data> {
+        let mut is_last_verneed = false;
+
+        if let Some(v) = state.verneed_info.as_ref()
+            && v.version_count > 0
+        {
+            memory_offsets.increment(
+                part_id::GNU_VERSION_R,
+                size_of::<crate::elf::Verneed>() as u64
+                    + u64::from(v.version_count) * size_of::<crate::elf::Vernaux>() as u64,
+            );
+
+            let version_r_layout = section_layouts.get(output_section_id::GNU_VERSION_R);
+
+            is_last_verneed = *memory_offsets.get(part_id::GNU_VERSION_R)
+                == version_r_layout.mem_offset + version_r_layout.mem_size;
+        }
+
+        let version_mapping =
+            compute_version_mapping(&state.symbol_versions_needed, state.non_addressable_indexes);
+
+        DynamicLayout {
+            version_mapping,
+            verneed_info: state.verneed_info,
+            is_last_verneed,
+        }
+    }
+
+    fn apply_non_addressable_indexes_dynamic(
+        &self,
+        indexes: &mut NonAddressableIndexes,
+        counts: &mut NonAddressableCounts,
+        state: &mut DynamicLayoutState,
+    ) -> Result {
+        state.non_addressable_indexes = *indexes;
+        if let Some(info) = state.verneed_info.as_ref()
+            && info.version_count > 0
+        {
+            counts.verneed_count += 1;
+            indexes.gnu_version_r_index = indexes
+                .gnu_version_r_index
+                .checked_add(info.version_count)
+                .context("Symbol versions overflowed 2**16")?;
+        }
+        Ok(())
+    }
+
+    fn should_enforce_undefined(&self, resources: &layout::GraphResources<'data, '_, Elf>) -> bool {
         let is_executable = resources.symbol_db.output_kind.is_executable();
 
         !resources.symbol_db. args.allow_shlib_undefined
@@ -1251,368 +1607,13 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
             // checks our shared object against those.
             && has_complete_deps(self, resources)
     }
-
-    fn layout_resources_ext(
-        groups: &[crate::grouping::Group<'data, Self>],
-    ) -> Self::LayoutResourcesExt {
-        LayoutResourcesExt {
-            sonames: Sonames::new(groups),
-        }
-    }
-
-    fn load_object_section_relocations<'scope, A: Arch<File<'data> = Self>>(
-        state: &layout::ObjectLayoutState<'data, Self>,
-        common: &mut layout::CommonGroupState<'data, Self>,
-        queue: &mut layout::LocalWorkQueue,
-        resources: &'scope layout::GraphResources<'data, '_, Self>,
-        section: layout::Section,
-        scope: &Scope<'scope>,
-    ) -> Result {
-        match state.relocations(section.index)? {
-            RelocationList::Rela(relocations) => {
-                state.load_section_relocations::<A, Rela>(
-                    common,
-                    queue,
-                    resources,
-                    section,
-                    relocations.rel_iter(),
-                    scope,
-                )?;
-            }
-            RelocationList::Crel(relocations) => {
-                state.load_section_relocations::<A, Crel>(
-                    common,
-                    queue,
-                    resources,
-                    section,
-                    relocations.flat_map(|r| r.ok()),
-                    scope,
-                )?;
-            }
-        }
-
-        Ok(())
-    }
-
-    fn load_object_debug_relocations<'scope, A: Arch<File<'data> = Self>>(
-        state: &layout::ObjectLayoutState<'data, Self>,
-        common: &mut layout::CommonGroupState<'data, Self>,
-        queue: &mut layout::LocalWorkQueue,
-        resources: &'scope layout::GraphResources<'data, '_, Self>,
-        section: layout::Section,
-        scope: &Scope<'scope>,
-    ) -> Result {
-        match state.relocations(section.index)? {
-            RelocationList::Rela(relocations) => {
-                state.load_debug_relocations::<A, Rela>(
-                    common,
-                    queue,
-                    resources,
-                    section,
-                    relocations.rel_iter(),
-                    scope,
-                )?;
-            }
-            RelocationList::Crel(relocations) => {
-                state.load_debug_relocations::<A, Crel>(
-                    common,
-                    queue,
-                    resources,
-                    section,
-                    relocations.flat_map(|r| r.ok()),
-                    scope,
-                )?;
-            }
-        }
-
-        Ok(())
-    }
-
-    fn create_dynamic_symbol_definition(
-        symbol_db: &SymbolDb<'data, Self>,
-        symbol_id: SymbolId,
-    ) -> Result<layout::DynamicSymbolDefinition<'data>> {
-        let symbol_name = symbol_db.symbol_name(symbol_id)?;
-        let RawSymbolName {
-            name,
-            version_name,
-            is_default,
-        } = RawSymbolName::parse(symbol_name.bytes());
-
-        let mut version = object::elf::VER_NDX_GLOBAL;
-        if symbol_db.version_script.version_count() > 0
-            && let Some(v) = symbol_db
-                .version_script
-                .version_for_symbol(&UnversionedSymbolName::prehashed(name), version_name)?
-        {
-            version = v;
-            if !is_default {
-                version |= object::elf::VERSYM_HIDDEN;
-            }
-        }
-        Ok(layout::DynamicSymbolDefinition::new(
-            symbol_id, name, version,
-        ))
-    }
-
-    fn validate_section(
-        section_info: &output_section_id::SectionOutputInfo,
-        section_flags: SectionFlags,
-        section_layout: &OutputRecordLayout,
-        merge_target: OutputSectionId,
-        output_sections: &OutputSections<'data>,
-        section_id: OutputSectionId,
-    ) -> Result {
-        // TODO: Remove the NOTE exception. Non-alloc sections should be placed outside of program
-        // segments. NOTE sections are sometimes alloc and sometimes not. Alloc NOTE sections should
-        // be placed within a LOAD segment and within a NOTE segment. Non-alloc NOTE sections
-        // shouldn't be in any segment.
-
-        // The .riscv.attributes section is non-alloc but is expected to be put into a
-        // RISCV_ATTRIBUTES segment.
-        if [sht::NOTE, sht::RISCV_ATTRIBUTES].contains(&section_info.ty) {
-        } else {
-            // All segments should only cover sections that are allocated and have a non-zero
-            // address.
-            ensure!(
-                section_layout.mem_offset != 0 || merge_target == output_section_id::FILE_HEADER,
-                "Missing memory offset for section {} present in a program segment.",
-                output_sections.section_debug(section_id),
-            );
-            ensure!(
-                section_flags.is_alloc(),
-                "Missing SHF_ALLOC section flag for section {} present in a program \
-                         segment.",
-                output_sections.section_debug(section_id)
-            );
-        }
-
-        Ok(())
-    }
-
-    fn default_section_type() -> Self::SectionType {
-        sht::PROGBITS
-    }
-
-    fn validate_sizes(mem_sizes: &OutputSectionPartMap<u64>) -> Result {
-        if *mem_sizes.get(part_id::GNU_VERSION) > 0 {
-            let num_dynamic_symbols =
-                mem_sizes.get(part_id::DYNSYM) / crate::elf::SYMTAB_ENTRY_SIZE;
-            let num_versym = mem_sizes.get(part_id::GNU_VERSION) / size_of::<Versym>() as u64;
-            if num_versym != num_dynamic_symbols {
-                bail!(
-                    "Object has {num_dynamic_symbols} dynamic symbols, but \
-                         has {num_versym} versym entries"
-                );
-            }
-        }
-
-        Ok(())
-    }
-
-    fn verify_resolution_allocation(
-        output_sections: &OutputSections,
-        output_order: &output_section_id::OutputOrder,
-        output_kind: OutputKind,
-        mem_sizes: &OutputSectionPartMap<u64>,
-        resolution: &layout::Resolution,
-    ) -> Result {
-        crate::elf_writer::verify_resolution_allocation(
-            output_sections,
-            output_order,
-            output_kind,
-            mem_sizes,
-            resolution,
-        )
-    }
-
-    fn update_segment_keep_list(
-        program_segments: &ProgramSegments<Self::ProgramSegmentDef>,
-        keep_segments: &mut [bool],
-        args: &Args,
-    ) {
-        // If relro is disabled, then discard the relro segment.
-        if !args.relro {
-            for (segment_def, keep) in program_segments.into_iter().zip(keep_segments.iter_mut()) {
-                if segment_def.segment_type == pt::GNU_RELRO {
-                    *keep = false;
-                }
-            }
-        }
-    }
-
-    fn program_segment_defs() -> &'static [Self::ProgramSegmentDef] {
-        PROGRAM_SEGMENT_DEFS
-    }
-
-    fn unconditional_segment_defs() -> &'static [Self::ProgramSegmentDef] {
-        &[STACK_SEGMENT_DEF]
-    }
-
-    fn create_linker_defined_symbols(
-        symbols: &mut crate::parsing::InternalSymbolsBuilder<'data>,
-        output_kind: OutputKind,
-    ) {
-        // The undefined symbol must always be symbol 0.
-        symbols
-            .add_symbol(InternalSymDefInfo::new(SymbolPlacement::Undefined, b""))
-            .hide();
-
-        symbols
-            .section_start(output_section_id::FILE_HEADER, "__ehdr_start")
-            .hide();
-
-        symbols.section_start(output_section_id::GOT, "_GLOBAL_OFFSET_TABLE_");
-
-        // .rela.plt start/stop symbols are only emitted for non-relocatable executables. Emitting
-        // them for relocatable binaries causes glibc to try to call the resolver functions without
-        // taking into account that the binary has been relocated.
-        if output_kind != OutputKind::StaticExecutable(RelocationModel::Relocatable) {
-            symbols
-                .section_start(output_section_id::RELA_PLT, "__rela_iplt_start")
-                .hide();
-            symbols
-                .section_end(output_section_id::RELA_PLT, "__rela_iplt_end")
-                .hide();
-        }
-
-        symbols
-            .section_start(output_section_id::PREINIT_ARRAY, "__preinit_array_start")
-            .hide();
-        symbols
-            .section_group_end(output_section_id::PREINIT_ARRAY, "__preinit_array_end")
-            .hide();
-
-        symbols
-            .section_start(output_section_id::INIT_ARRAY, "__init_array_start")
-            .hide();
-        symbols
-            .section_group_end(output_section_id::INIT_ARRAY, "__init_array_end")
-            .hide();
-
-        symbols
-            .section_start(output_section_id::FINI_ARRAY, "__fini_array_start")
-            .hide();
-        symbols
-            .section_group_end(output_section_id::FINI_ARRAY, "__fini_array_end")
-            .hide();
-
-        symbols.section_end(output_section_id::TEXT, "etext");
-        symbols.section_end(output_section_id::TEXT, "_etext");
-        symbols.section_end(output_section_id::TEXT, "__etext");
-
-        symbols.section_end(output_section_id::BSS, "end");
-        symbols.section_end(output_section_id::BSS, "_end");
-        symbols.section_end(output_section_id::BSS, "__end").hide();
-
-        // TODO: define the symbol only on RISC-V target
-        symbols.section_start(
-            output_section_id::DATA,
-            crate::elf::GLOBAL_POINTER_SYMBOL_NAME,
-        );
-
-        symbols.section_end(output_section_id::DATA, "edata");
-        symbols.section_end(output_section_id::DATA, "_edata");
-
-        symbols
-            .section_start(output_section_id::TDATA, "__tdata_start")
-            .hide();
-
-        if output_kind != OutputKind::StaticExecutable(RelocationModel::NonRelocatable) {
-            symbols.section_start(output_section_id::DYNAMIC, "_DYNAMIC");
-        }
-
-        symbols
-            .add_symbol(InternalSymDefInfo::new(
-                SymbolPlacement::LoadBaseAddress,
-                b"__executable_start",
-            ))
-            .hide();
-
-        // We define _TLS_MODULE_BASE_ either at the start or end of the TLS segment, depending on
-        // whether we're building a shared object or an executable. This symbol is used for TLSDESC.
-        // See https://www.fsfla.org/~lxoliva/writeups/TLS/RFC-TLSDESC-x86.txt for more details.
-        symbols.add_symbol(InternalSymDefInfo {
-            placement: if output_kind == OutputKind::SharedObject {
-                SymbolPlacement::SectionStart(output_section_id::TDATA)
-            } else {
-                SymbolPlacement::SectionEnd(output_section_id::TBSS)
-            },
-            name: b"_TLS_MODULE_BASE_",
-            elf_symbol_type: stt::TLS,
-            is_hidden: false,
-        });
-    }
-
-    fn apply_force_keep_sections(keep_sections: &mut OutputSectionMap<bool>, args: &Args) {
-        // Some of these sections aren't really empty, but we just haven't allocated space for them
-        // yet. e.g. we don't allocate space for section headers until we know which sections we're
-        // keeping, which by inherently needs to be after this method is called.
-        const FORCE_KEEP_SECTIONS: &[OutputSectionId] = &[
-            output_section_id::FILE_HEADER,
-            output_section_id::PROGRAM_HEADERS,
-            output_section_id::SECTION_HEADERS,
-            output_section_id::SHSTRTAB,
-            output_section_id::RELRO_PADDING,
-        ];
-
-        for section_id in FORCE_KEEP_SECTIONS {
-            *keep_sections.get_mut(*section_id) = true;
-        }
-
-        // Keep .relro_padding unless relro is disabled.
-        if args.relro {
-            *keep_sections.get_mut(output_section_id::RELRO_PADDING) = true;
-        }
-    }
-
-    fn is_zero_sized_section_content(section_id: OutputSectionId) -> bool {
-        // We always consider empty sections as content except for sframe sections.
-        section_id != output_section_id::SFRAME
-    }
-
-    fn built_in_section_details() -> &'static [Self::BuiltInSectionDetails] {
-        &SECTION_DEFINITIONS
-    }
-
-    fn built_in_section_infos() -> Vec<crate::output_section_id::SectionOutputInfo<'data>> {
-        SECTION_DEFINITIONS
-            .iter()
-            .map(|d| SectionOutputInfo {
-                section_flags: d.section_flags,
-                kind: d.kind,
-                ty: d.ty,
-                min_alignment: d.min_alignment,
-                entsize: d.element_size,
-                location: None,
-                secondary_order: None,
-            })
-            .collect()
-    }
-
-    fn section_flags(header: &Self::SectionHeader) -> Self::SectionFlags {
-        SectionFlags::from_header(header)
-    }
-
-    fn section_attributes(header: &Self::SectionHeader) -> Self::SectionAttributes {
-        SectionAttributes {
-            flags: SectionFlags::from_header(header),
-            ty: SectionType::from_header(header),
-            entsize: header.sh_entsize.get(LittleEndian),
-        }
-    }
 }
 
-fn process_eh_frame_relocations<
-    'data,
-    'scope,
-    A: Arch<File<'data> = crate::elf::File<'data>>,
-    R: Relocation,
->(
-    object: &mut layout::ObjectLayoutState<'data, File<'data>>,
-    common: &mut layout::CommonGroupState<'data, File<'data>>,
+fn process_eh_frame_relocations<'data, 'scope, A: Arch<Platform = Elf>, R: Relocation>(
+    object: &mut layout::ObjectLayoutState<'data, Elf>,
+    common: &mut layout::CommonGroupState<'data, Elf>,
     file_symbol_id_range: SymbolIdRange,
-    resources: &'scope layout::GraphResources<'data, '_, File<'data>>,
+    resources: &'scope layout::GraphResources<'data, '_, Elf>,
     queue: &mut layout::LocalWorkQueue,
     eh_frame_section: &'data object::elf::SectionHeader64<LittleEndian>,
     data: &'data [u8],
@@ -1736,16 +1737,11 @@ fn process_eh_frame_relocations<
 }
 
 /// Processes the exception frames for a section that we're loading.
-fn process_section_exception_frames<
-    'data,
-    'scope,
-    A: Arch<File<'data> = crate::elf::File<'data>>,
-    R: Relocation,
->(
-    object: &layout::ObjectLayoutState<'data, File<'data>>,
+fn process_section_exception_frames<'data, 'scope, A: Arch<Platform = Elf>, R: Relocation>(
+    object: &layout::ObjectLayoutState<'data, Elf>,
     frame_index: Option<FrameIndex>,
-    common: &mut layout::CommonGroupState<'data, File<'data>>,
-    resources: &'scope layout::GraphResources<'data, '_, File<'data>>,
+    common: &mut layout::CommonGroupState<'data, Elf>,
+    resources: &'scope layout::GraphResources<'data, '_, Elf>,
     queue: &mut layout::LocalWorkQueue,
     scope: &Scope<'scope>,
     exception_frames: &[ExceptionFrame<'data, R>],
@@ -2929,9 +2925,7 @@ pub(crate) struct NonAddressableIndexes {
 }
 
 impl platform::NonAddressableIndexes for NonAddressableIndexes {
-    fn new<'data, O: platform::ObjectFile<'data>>(
-        symbol_db: &crate::symbol_db::SymbolDb<'data, O>,
-    ) -> Self {
+    fn new<'data, P: Platform>(symbol_db: &crate::symbol_db::SymbolDb<'data, P>) -> Self {
         Self {
             // Allocate version indexes starting from after the local and global indexes and any
             // versions defined by a version script.
@@ -3041,7 +3035,7 @@ impl SysvHashLayout {
 
 fn finalise_gnu_version_size<'data>(
     mem_sizes: &mut OutputSectionPartMap<u64>,
-    symbol_db: &SymbolDb<'data, crate::elf::File<'data>>,
+    symbol_db: &SymbolDb<'data, crate::elf::Elf>,
 ) {
     if symbol_db.output_kind.should_output_symbol_versions() {
         let num_dynamic_symbols = mem_sizes.get(part_id::DYNSYM) / crate::elf::SYMTAB_ENTRY_SIZE;
@@ -3123,7 +3117,7 @@ pub(crate) struct CommonGroupStateExt {
 /// we have loaded.
 fn has_complete_deps<'data>(
     file: &File<'data>,
-    resources: &layout::GraphResources<'data, '_, File<'data>>,
+    resources: &layout::GraphResources<'data, '_, Elf>,
 ) -> bool {
     let Ok(dynamic_tags) = file.dynamic_tags() else {
         return true;
@@ -3161,7 +3155,7 @@ impl<'data> Sonames<'data> {
     /// --as-needed shared objects that we're not actually linking against. This means that we can
     /// report --no-shlib-undefined errors for shared libraries that have all of their dependencies
     /// as inputs, even if we weren't going to add them as direct dependencies of our output file.
-    fn new(groups: &[Group<'data, crate::elf::File<'data>>]) -> Self {
+    fn new(groups: &[Group<'data, Elf>]) -> Self {
         timing_phase!("Build SONAME index");
 
         Sonames(
@@ -3317,11 +3311,11 @@ impl platform::ProgramSegmentDef for ProgramSegmentDef {
             pt::GNU_RELRO => {
                 info.section_flags.contains(shf::TLS)
                     || section_id
-                        .opt_built_in_details::<elf::File>()
+                        .opt_built_in_details::<Elf>()
                         .is_some_and(|details| details.is_relro)
             }
             other => section_id
-                .opt_built_in_details::<elf::File>()
+                .opt_built_in_details::<Elf>()
                 .and_then(|details| details.target_segment_type)
                 .is_some_and(|target_segment_type| target_segment_type == other),
         }

--- a/libwild/src/elf_aarch64.rs
+++ b/libwild/src/elf_aarch64.rs
@@ -1,4 +1,4 @@
-use crate::elf;
+use crate::elf::Elf;
 use crate::elf::PLT_ENTRY_SIZE;
 use crate::elf::PropertyClass;
 use crate::ensure;
@@ -6,6 +6,7 @@ use crate::error;
 use crate::error::Result;
 use crate::layout::Layout;
 use crate::platform::ObjectFile as _;
+use crate::platform::Platform;
 use linker_utils::aarch64::RelaxationKind;
 use linker_utils::aarch64::relocation_type_from_raw;
 use linker_utils::elf::AArch64Instruction;
@@ -40,10 +41,9 @@ macro_rules! rel_info_from_type {
 
 impl crate::platform::Arch for ElfAArch64 {
     type Relaxation = Relaxation;
-    type File<'data> = crate::elf::File<'data>;
+    type Platform = Elf;
 
-    fn arch_identifier<'a>() -> <Self::File<'a> as crate::platform::ObjectFile<'a>>::ArchIdentifier
-    {
+    fn arch_identifier() -> <Self::Platform as Platform>::ArchIdentifier {
         object::elf::EM_AARCH64
     }
 
@@ -99,7 +99,7 @@ impl crate::platform::Arch for ElfAArch64 {
         false
     }
 
-    fn tp_offset_start<'data>(layout: &Layout<'data, elf::File<'data>>) -> u64 {
+    fn tp_offset_start<'data>(layout: &Layout<'data, Elf>) -> u64 {
         layout.tls_start_address_aarch64()
     }
 
@@ -279,7 +279,7 @@ impl crate::platform::Arch for ElfAArch64 {
     }
 
     fn is_symbol_variant_pcs<'data>(
-        object: &Self::File<'data>,
+        object: &<Self::Platform as Platform>::File<'data>,
         symbol_index: object::SymbolIndex,
     ) -> bool {
         object
@@ -288,9 +288,9 @@ impl crate::platform::Arch for ElfAArch64 {
     }
 
     fn get_source_info<'data>(
-        object: &Self::File<'data>,
-        relocations: &<Self::File<'data> as crate::platform::ObjectFile<'data>>::RelocationSections,
-        section: &<Self::File<'data> as crate::platform::ObjectFile<'data>>::SectionHeader,
+        object: &<Self::Platform as Platform>::File<'data>,
+        relocations: &<Self::Platform as Platform>::RelocationSections,
+        section: &<Self::Platform as Platform>::SectionHeader,
         offset_in_section: u64,
     ) -> Result<crate::platform::SourceInfo> {
         crate::dwarf_address_info::get_source_info::<Self>(

--- a/libwild/src/elf_loongarch64.rs
+++ b/libwild/src/elf_loongarch64.rs
@@ -1,7 +1,8 @@
-use crate::elf;
+use crate::elf::Elf;
 use crate::elf::PLT_ENTRY_SIZE;
 use crate::error;
 use crate::error::Result;
+use crate::platform::Platform;
 use itertools::Itertools;
 use linker_utils::elf::DynamicRelocationKind;
 use linker_utils::elf::PAGE_MASK_4KB;
@@ -29,10 +30,9 @@ const _ASSERTS: () = {
 
 impl crate::platform::Arch for ElfLoongArch64 {
     type Relaxation = Relaxation;
-    type File<'data> = crate::elf::File<'data>;
+    type Platform = Elf;
 
-    fn arch_identifier<'a>() -> <Self::File<'a> as crate::platform::ObjectFile<'a>>::ArchIdentifier
-    {
+    fn arch_identifier() -> <Self::Platform as Platform>::ArchIdentifier {
         object::elf::EM_LOONGARCH
     }
 
@@ -81,7 +81,7 @@ impl crate::platform::Arch for ElfLoongArch64 {
         true
     }
 
-    fn tp_offset_start<'data>(layout: &crate::layout::Layout<'data, elf::File<'data>>) -> u64 {
+    fn tp_offset_start<'data>(layout: &crate::layout::Layout<'data, Elf>) -> u64 {
         layout.tls_start_address()
     }
 
@@ -142,9 +142,9 @@ impl crate::platform::Arch for ElfLoongArch64 {
     }
 
     fn get_source_info<'data>(
-        object: &Self::File<'data>,
-        relocations: &<Self::File<'data> as crate::platform::ObjectFile<'data>>::RelocationSections,
-        section: &<Self::File<'data> as crate::platform::ObjectFile<'data>>::SectionHeader,
+        object: &<Self::Platform as Platform>::File<'data>,
+        relocations: &<Self::Platform as Platform>::RelocationSections,
+        section: &<Self::Platform as Platform>::SectionHeader,
         offset_in_section: u64,
     ) -> Result<crate::platform::SourceInfo> {
         crate::dwarf_address_info::get_source_info::<Self>(

--- a/libwild/src/elf_riscv64.rs
+++ b/libwild/src/elf_riscv64.rs
@@ -1,4 +1,4 @@
-use crate::elf;
+use crate::elf::Elf;
 use crate::elf::PLT_ENTRY_SIZE;
 use crate::elf::RelocationList;
 use crate::ensure;
@@ -6,6 +6,7 @@ use crate::error;
 use crate::error::Context as _;
 use crate::error::Result;
 use crate::platform::ObjectFile as _;
+use crate::platform::Platform;
 use crate::platform::RelaxSymbolInfo;
 use crate::platform::Relocation;
 use crate::platform::RelocationSequence as _;
@@ -48,10 +49,9 @@ macro_rules! rel_info_from_type {
 
 impl crate::platform::Arch for ElfRiscV64 {
     type Relaxation = Relaxation;
-    type File<'data> = crate::elf::File<'data>;
+    type Platform = Elf;
 
-    fn arch_identifier<'a>() -> <Self::File<'a> as crate::platform::ObjectFile<'a>>::ArchIdentifier
-    {
+    fn arch_identifier() -> <Self::Platform as Platform>::ArchIdentifier {
         object::elf::EM_RISCV
     }
 
@@ -99,7 +99,7 @@ impl crate::platform::Arch for ElfRiscV64 {
         true
     }
 
-    fn tp_offset_start<'data>(layout: &crate::layout::Layout<'data, elf::File<'data>>) -> u64 {
+    fn tp_offset_start<'data>(layout: &crate::layout::Layout<'data, Elf>) -> u64 {
         layout.tls_start_address()
     }
 
@@ -156,7 +156,7 @@ impl crate::platform::Arch for ElfRiscV64 {
     }
 
     fn is_symbol_variant_pcs<'data>(
-        object: &Self::File<'data>,
+        object: &<Self::Platform as Platform>::File<'data>,
         symbol_index: object::SymbolIndex,
     ) -> bool {
         object
@@ -297,9 +297,9 @@ impl crate::platform::Arch for ElfRiscV64 {
     }
 
     fn get_source_info<'data>(
-        object: &Self::File<'data>,
-        relocations: &<Self::File<'data> as crate::platform::ObjectFile<'data>>::RelocationSections,
-        section: &<Self::File<'data> as crate::platform::ObjectFile<'data>>::SectionHeader,
+        object: &<Self::Platform as Platform>::File<'data>,
+        relocations: &<Self::Platform as Platform>::RelocationSections,
+        section: &<Self::Platform as Platform>::SectionHeader,
         offset_in_section: u64,
     ) -> Result<crate::platform::SourceInfo> {
         crate::dwarf_address_info::get_source_info::<Self>(
@@ -311,8 +311,8 @@ impl crate::platform::Arch for ElfRiscV64 {
     }
 
     fn process_riscv_attributes<'data>(
-        object: &Self::File<'data>,
-        format_specific: &mut <Self::File<'data> as crate::platform::ObjectFile<'data>>::FileLayoutState,
+        object: &<Self::Platform as Platform>::File<'data>,
+        format_specific: &mut <Self::Platform as Platform>::FileLayoutState<'data>,
         riscv_attributes_section_index: object::SectionIndex,
     ) -> Result {
         format_specific.riscv_attributes =

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -12,6 +12,7 @@ use crate::elf;
 use crate::elf::DynamicEntry;
 use crate::elf::EhFrameHdr;
 use crate::elf::EhFrameHdrEntry;
+use crate::elf::Elf;
 use crate::elf::FileHeader;
 use crate::elf::GLOBAL_POINTER_SYMBOL_NAME;
 use crate::elf::GNU_NOTE_NAME;
@@ -69,6 +70,7 @@ use crate::part_id;
 use crate::platform;
 use crate::platform::Arch;
 use crate::platform::ObjectFile;
+use crate::platform::Platform;
 use crate::platform::RawSymbolName as _;
 use crate::platform::Relaxation as _;
 use crate::platform::Relocation;
@@ -139,7 +141,7 @@ use uuid::Uuid;
 use zerocopy::FromBytes;
 use zerocopy::transmute_mut;
 
-type ElfLayout<'data> = Layout<'data, elf::File<'data>>;
+type ElfLayout<'data> = Layout<'data, Elf>;
 
 /// A cache for managing ELF relocations and optimization of relocation entries.
 #[derive(Debug)]
@@ -151,7 +153,7 @@ struct RelocationCache<R> {
     high_part_symbols: HashMap<u64, R>,
 }
 
-pub(crate) fn write<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
+pub(crate) fn write<'data, A: Arch<Platform = Elf>>(
     sized_output: &mut SizedOutput,
     layout: &ElfLayout<'data>,
 ) -> Result {
@@ -216,7 +218,7 @@ fn compute_hash(sized_output: &SizedOutput) -> blake3::Hash {
         .finalize()
 }
 
-fn write_file_contents<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
+fn write_file_contents<'data, A: Arch<Platform = Elf>>(
     sized_output: &mut SizedOutput,
     layout: &ElfLayout<'data>,
 ) -> Result {
@@ -355,7 +357,7 @@ fn write_program_headers(
     Ok(())
 }
 
-fn populate_file_header<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
+fn populate_file_header<A: Arch<Platform = Elf>>(
     layout: &ElfLayout,
     header_info: &HeaderInfo,
     header: &mut FileHeader,
@@ -405,8 +407,8 @@ fn populate_file_header<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
     Ok(())
 }
 
-fn write_file<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
-    file: &FileLayout<'data, crate::elf::File<'data>>,
+fn write_file<'data, A: Arch<Platform = Elf>>(
+    file: &FileLayout<'data, Elf>,
     buffers: &mut OutputSectionPartMap<&mut [u8]>,
     table_writer: &mut TableWriter,
     layout: &ElfLayout<'data>,
@@ -607,7 +609,7 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
         }
     }
 
-    fn process_resolution<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
+    fn process_resolution<'data, A: Arch<Platform = Elf>>(
         &mut self,
         layout: Option<&ElfLayout<'data>>,
         res: &Resolution,
@@ -690,7 +692,7 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
         Ok(())
     }
 
-    fn process_got_tls_offset<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
+    fn process_got_tls_offset<'data, A: Arch<Platform = Elf>>(
         &mut self,
         res: &Resolution,
         layout: &ElfLayout<'data>,
@@ -732,7 +734,7 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
         Ok(())
     }
 
-    fn process_got_tls_mod_and_offset<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
+    fn process_got_tls_mod_and_offset<A: Arch<Platform = Elf>>(
         &mut self,
         res: &Resolution,
         got_address: u64,
@@ -769,7 +771,7 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
         Ok(())
     }
 
-    fn process_got_tls_descriptor<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
+    fn process_got_tls_descriptor<A: Arch<Platform = Elf>>(
         &mut self,
         res: &Resolution,
         got_address: u64,
@@ -799,7 +801,7 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
         Ok(())
     }
 
-    fn write_plt_entry<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
+    fn write_plt_entry<A: Arch<Platform = Elf>>(
         &mut self,
         got_address: u64,
         plt_address: u64,
@@ -874,10 +876,7 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
         Ok(())
     }
 
-    fn write_ifunc_relocation<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
-        &mut self,
-        res: &Resolution,
-    ) -> Result {
+    fn write_ifunc_relocation<A: Arch<Platform = Elf>>(&mut self, res: &Resolution) -> Result {
         let out = self.rela_plt.split_off_first_mut().unwrap();
         let e = LittleEndian;
         out.r_addend.set(e, res.raw_value as i64);
@@ -895,7 +894,7 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
         Ok(())
     }
 
-    fn write_dtpmod_relocation<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
+    fn write_dtpmod_relocation<A: Arch<Platform = Elf>>(
         &mut self,
         place: u64,
         dynamic_symbol_index: u32,
@@ -908,7 +907,7 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
         )
     }
 
-    fn write_tls_descriptor_relocation<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
+    fn write_tls_descriptor_relocation<A: Arch<Platform = Elf>>(
         &mut self,
         place: u64,
         dynamic_symbol_index: u32,
@@ -922,7 +921,7 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
         )
     }
 
-    fn write_dtpoff_relocation<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
+    fn write_dtpoff_relocation<A: Arch<Platform = Elf>>(
         &mut self,
         place: u64,
         dynamic_symbol_index: u32,
@@ -935,7 +934,7 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
         )
     }
 
-    fn write_tpoff_relocation<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
+    fn write_tpoff_relocation<A: Arch<Platform = Elf>>(
         &mut self,
         place: u64,
         dynamic_symbol_index: u32,
@@ -950,7 +949,7 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
     }
 
     #[inline(always)]
-    fn write_address_relocation<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
+    fn write_address_relocation<A: Arch<Platform = Elf>>(
         &mut self,
         place: u64,
         relative_address: i64,
@@ -973,7 +972,7 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
         Ok(())
     }
 
-    fn write_ifunc_relocation_for_data<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
+    fn write_ifunc_relocation_for_data<A: Arch<Platform = Elf>>(
         &mut self,
         place: u64,
         resolver_address: i64,
@@ -988,7 +987,7 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
         )
     }
 
-    fn write_dynamic_symbol_relocation<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
+    fn write_dynamic_symbol_relocation<A: Arch<Platform = Elf>>(
         &mut self,
         place: u64,
         addend: i64,
@@ -1279,8 +1278,8 @@ impl<'layout, 'out> SymbolTableWriter<'layout, 'out> {
     }
 }
 
-fn write_object<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
-    object: &ObjectLayout<'data, crate::elf::File<'data>>,
+fn write_object<'data, A: Arch<Platform = Elf>>(
+    object: &ObjectLayout<'data, Elf>,
     buffers: &mut OutputSectionPartMap<&mut [u8]>,
     table_writer: &mut TableWriter,
     layout: &ElfLayout<'data>,
@@ -1346,8 +1345,8 @@ fn write_object<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
     Ok(())
 }
 
-fn write_object_section<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
-    object: &ObjectLayout<'data, crate::elf::File<'data>>,
+fn write_object_section<'data, A: Arch<Platform = Elf>>(
+    object: &ObjectLayout<'data, Elf>,
     layout: &ElfLayout<'data>,
     section: &Section,
     buffers: &mut OutputSectionPartMap<&mut [u8]>,
@@ -1397,8 +1396,8 @@ fn write_object_section<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
     Ok(())
 }
 
-fn write_section_reversed<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
-    object: &ObjectLayout<'data, crate::elf::File<'data>>,
+fn write_section_reversed<'data, A: Arch<Platform = Elf>>(
+    object: &ObjectLayout<'data, Elf>,
     layout: &ElfLayout<'data>,
     section: &Section,
     table_writer: &mut TableWriter<'_, '_>,
@@ -1468,8 +1467,8 @@ fn write_section_reversed<'data, A: Arch<File<'data> = crate::elf::File<'data>>>
     Ok(())
 }
 
-fn write_debug_section<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
-    object: &ObjectLayout<'data, crate::elf::File<'data>>,
+fn write_debug_section<'data, A: Arch<Platform = Elf>>(
+    object: &ObjectLayout<'data, Elf>,
     layout: &ElfLayout<'data>,
     section: &Section,
     buffers: &mut OutputSectionPartMap<&mut [u8]>,
@@ -1499,7 +1498,7 @@ fn write_debug_section<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
 }
 
 fn write_section_raw<'out, 'data>(
-    object: &ObjectLayout<'data, crate::elf::File<'data>>,
+    object: &ObjectLayout<'data, Elf>,
     layout: &ElfLayout,
     sec: &Section,
     buffers: &'out mut OutputSectionPartMap<&mut [u8]>,
@@ -1569,9 +1568,9 @@ fn write_section_raw<'out, 'data>(
 
 /// Writes debug symbols.
 fn write_symbols<'data>(
-    object: &ObjectLayout<'data, crate::elf::File<'data>>,
+    object: &ObjectLayout<'data, Elf>,
     symbol_writer: &mut SymbolTableWriter,
-    layout: &ElfLayout,
+    layout: &ElfLayout<'data>,
 ) -> Result {
     for ((sym_index, sym), flags) in object
         .object
@@ -1658,11 +1657,11 @@ fn write_symbols<'data>(
 
 fn apply_relocations<
     'data,
-    A: Arch<File<'data> = crate::elf::File<'data>>,
+    A: Arch<Platform = Elf>,
     R: Relocation,
     I: Iterator<Item = object::Result<R>> + Clone,
 >(
-    object: &ObjectLayout<'data, crate::elf::File<'data>>,
+    object: &ObjectLayout<'data, Elf>,
     out: &mut [u8],
     section: &Section,
     mut relocations: I,
@@ -1739,11 +1738,11 @@ fn apply_relocations<
 
 fn apply_debug_relocations<
     'data,
-    A: Arch<File<'data> = crate::elf::File<'data>>,
+    A: Arch<Platform = Elf>,
     R: Relocation,
     I: Iterator<Item = object::Result<R>> + Clone,
 >(
-    object: &ObjectLayout<'data, crate::elf::File<'data>>,
+    object: &ObjectLayout<'data, Elf>,
     out: &mut [u8],
     section: &Section,
     relocations: I,
@@ -1796,8 +1795,8 @@ fn apply_debug_relocations<
     Ok(())
 }
 
-fn write_eh_frame_data<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
-    object: &ObjectLayout<'data, crate::elf::File<'data>>,
+fn write_eh_frame_data<'data, A: Arch<Platform = Elf>>(
+    object: &ObjectLayout<'data, Elf>,
     eh_frame_section_index: object::SectionIndex,
     layout: &ElfLayout<'data>,
     table_writer: &mut TableWriter,
@@ -1824,12 +1823,8 @@ fn write_eh_frame_data<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
     }
 }
 
-fn write_eh_frame_relocations<
-    'data,
-    A: Arch<File<'data> = crate::elf::File<'data>>,
-    R: Relocation,
->(
-    object: &ObjectLayout<'data, crate::elf::File<'data>>,
+fn write_eh_frame_relocations<'data, A: Arch<Platform = Elf>, R: Relocation>(
+    object: &ObjectLayout<'data, Elf>,
     layout: &ElfLayout<'data>,
     table_writer: &mut TableWriter<'_, '_>,
     trace: &TraceOutput,
@@ -1998,8 +1993,8 @@ fn write_eh_frame_relocations<
     Ok(())
 }
 
-fn display_relocation<'a, 'data, A: Arch<File<'data> = crate::elf::File<'data>>, R: Relocation>(
-    object: &'a ObjectLayout<'data, crate::elf::File<'data>>,
+fn display_relocation<'a, 'data, A: Arch<Platform = Elf>, R: Relocation>(
+    object: &'a ObjectLayout<'data, Elf>,
     rel: &'a R,
     layout: &'a ElfLayout<'data>,
 ) -> DisplayRelocation<'a, 'data, A, R> {
@@ -2012,15 +2007,15 @@ fn display_relocation<'a, 'data, A: Arch<File<'data> = crate::elf::File<'data>>,
     }
 }
 
-struct DisplayRelocation<'a, 'data, A: Arch<File<'data> = crate::elf::File<'data>>, R: Relocation> {
+struct DisplayRelocation<'a, 'data, A: Arch<Platform = Elf>, R: Relocation> {
     rel: &'a R,
-    symbol_db: &'a SymbolDb<'data, crate::elf::File<'data>>,
+    symbol_db: &'a SymbolDb<'data, Elf>,
     per_symbol_flags: &'a PerSymbolFlags,
-    object: &'a ObjectLayout<'data, crate::elf::File<'data>>,
+    object: &'a ObjectLayout<'data, Elf>,
     phantom: PhantomData<A>,
 }
 
-impl<'a, 'data, A: Arch<File<'data> = crate::elf::File<'data>>, R: Relocation> Display
+impl<'a, 'data, A: Arch<Platform = Elf>, R: Relocation> Display
     for DisplayRelocation<'a, 'data, A, R>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -2054,7 +2049,7 @@ struct SectionInfo<S: platform::SectionFlags> {
 
 fn get_resolution<'data, R: Relocation>(
     rel: &R,
-    object_layout: &ObjectLayout<'data, crate::elf::File<'data>>,
+    object_layout: &ObjectLayout<'data, Elf>,
     layout: &ElfLayout,
 ) -> Result<(Resolution, SymbolIndex, SymbolId)> {
     let symbol_index = rel.symbol().context("Unsupported absolute relocation")?;
@@ -2175,12 +2170,8 @@ fn adjust_relocation_based_on_value(
 }
 
 #[inline(always)]
-fn get_pair_subtraction_relocation_value<
-    'data,
-    A: Arch<File<'data> = crate::elf::File<'data>>,
-    R: Relocation,
->(
-    object_layout: &ObjectLayout<'data, crate::elf::File<'data>>,
+fn get_pair_subtraction_relocation_value<'data, A: Arch<Platform = Elf>, R: Relocation>(
+    object_layout: &ObjectLayout<'data, Elf>,
     rel: &R,
     layout: &ElfLayout,
     resolution: Resolution,
@@ -2224,11 +2215,11 @@ fn get_pair_subtraction_relocation_value<
 #[inline(always)]
 fn apply_relocation<
     'data,
-    A: Arch<File<'data> = crate::elf::File<'data>>,
+    A: Arch<Platform = Elf>,
     R: Relocation,
     I: Iterator<Item = object::Result<R>> + Clone,
 >(
-    object_layout: &ObjectLayout<'data, crate::elf::File<'data>>,
+    object_layout: &ObjectLayout<'data, Elf>,
     mut offset_in_section: u64,
     rel: &R,
     section_info: SectionInfo<linker_utils::elf::SectionFlags>,
@@ -2681,8 +2672,8 @@ fn apply_relocation<
     Ok(next_modifier)
 }
 
-fn apply_debug_relocation<'data, A: Arch<File<'data> = crate::elf::File<'data>>, R: Relocation>(
-    object_layout: &ObjectLayout<'data, crate::elf::File<'data>>,
+fn apply_debug_relocation<'data, A: Arch<Platform = Elf>, R: Relocation>(
+    object_layout: &ObjectLayout<'data, Elf>,
     offset_in_section: u64,
     rel: &R,
     layout: &ElfLayout,
@@ -2764,7 +2755,7 @@ fn apply_debug_relocation<'data, A: Arch<File<'data> = crate::elf::File<'data>>,
         }
     } else if let Some(section_index) = section_index {
         match object_layout.sections[section_index.0] {
-            SectionSlot::MergeStrings(..) => get_merged_string_output_address(
+            SectionSlot::MergeStrings(..) => get_merged_string_output_address::<Elf>(
                 symbol_index,
                 addend,
                 object_layout.object,
@@ -2790,14 +2781,14 @@ fn apply_debug_relocation<'data, A: Arch<File<'data> = crate::elf::File<'data>>,
 }
 
 #[inline(always)]
-fn write_absolute_relocation<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
+fn write_absolute_relocation<'data, A: Arch<Platform = Elf>>(
     table_writer: &mut TableWriter,
     resolution: Resolution,
     place: u64,
     addend: i64,
-    section_info: SectionInfo<<A::File<'data> as ObjectFile<'data>>::SectionFlags>,
+    section_info: SectionInfo<<A::Platform as Platform>::SectionFlags>,
     symbol_index: object::SymbolIndex,
-    object_layout: &ObjectLayout<'data, crate::elf::File<'data>>,
+    object_layout: &ObjectLayout<'data, Elf>,
     layout: &ElfLayout,
 ) -> Result<u64> {
     if !section_info.section_flags.is_alloc() {
@@ -2853,7 +2844,7 @@ fn write_absolute_relocation<'data, A: Arch<File<'data> = crate::elf::File<'data
     }
 }
 
-fn write_prelude<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
+fn write_prelude<'data, A: Arch<Platform = Elf>>(
     prelude: &PreludeLayout,
     buffers: &mut OutputSectionPartMap<&mut [u8]>,
     table_writer: &mut TableWriter,
@@ -2951,7 +2942,7 @@ fn write_merged_strings(
     }
 }
 
-fn write_plt_got_entries<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
+fn write_plt_got_entries<'data, A: Arch<Platform = Elf>>(
     prelude: &PreludeLayout,
     layout: &ElfLayout<'data>,
     table_writer: &mut TableWriter,
@@ -3156,7 +3147,7 @@ pub(crate) struct EpilogueOffsets {
     pub(crate) soname: Option<u32>,
 }
 
-fn write_linker_script_state<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
+fn write_linker_script_state<'data, A: Arch<Platform = Elf>>(
     script: &LinkerScriptLayoutState,
     table_writer: &mut TableWriter,
     layout: &ElfLayout<'data>,
@@ -3174,7 +3165,7 @@ fn write_linker_script_state<'data, A: Arch<File<'data> = crate::elf::File<'data
     Ok(())
 }
 
-fn write_synthetic_symbols<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
+fn write_synthetic_symbols<'data, A: Arch<Platform = Elf>>(
     syn: &SyntheticSymbolsLayout,
     table_writer: &mut TableWriter,
     layout: &ElfLayout<'data>,
@@ -3194,8 +3185,8 @@ fn write_synthetic_symbols<'data, A: Arch<File<'data> = crate::elf::File<'data>>
     Ok(())
 }
 
-fn write_epilogue<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
-    epilogue: &EpilogueLayout<'data, crate::elf::File<'data>>,
+fn write_epilogue<A: Arch<Platform = Elf>>(
+    epilogue: &EpilogueLayout<Elf>,
     buffers: &mut OutputSectionPartMap<&mut [u8]>,
     table_writer: &mut TableWriter,
     layout: &ElfLayout,
@@ -3332,9 +3323,9 @@ fn write_riscv_attributes(
     Ok(())
 }
 
-fn write_sysv_hash_table<'data>(
+fn write_sysv_hash_table(
     layout: &ElfLayout,
-    epilogue: &EpilogueLayout<'data, crate::elf::File<'data>>,
+    epilogue: &EpilogueLayout<Elf>,
     buffers: &mut OutputSectionPartMap<&mut [u8]>,
 ) -> Result {
     let Some(sysv_hash_layout) = epilogue.format_specific.sysv_hash_layout.as_ref() else {
@@ -3403,9 +3394,9 @@ fn write_sysv_hash_table<'data>(
     Ok(())
 }
 
-fn write_gnu_hash_tables<'data>(
+fn write_gnu_hash_tables(
     layout: &ElfLayout,
-    epilogue: &EpilogueLayout<'data, crate::elf::File<'data>>,
+    epilogue: &EpilogueLayout<Elf>,
     buffers: &mut OutputSectionPartMap<&mut [u8]>,
 ) -> Result {
     let Some(gnu_hash_layout) = epilogue.format_specific.gnu_hash_layout.as_ref() else {
@@ -3761,7 +3752,7 @@ fn write_defsym_dynsym(
 
 fn write_copy_relocation_dynamic_symbol_definition<'data>(
     sym_def: &crate::layout::DynamicSymbolDefinition,
-    object: &DynamicLayout<'data, crate::elf::File<'data>>,
+    object: &DynamicLayout<'data, Elf>,
     layout: &ElfLayout,
     dynamic_symbol_writer: &mut SymbolTableWriter,
 ) -> Result {
@@ -3794,7 +3785,7 @@ fn write_copy_relocation_dynamic_symbol_definition<'data>(
 
 fn write_regular_object_dynamic_symbol_definition<'data>(
     sym_def: &crate::layout::DynamicSymbolDefinition,
-    object: &ObjectLayout<'data, crate::elf::File<'data>>,
+    object: &ObjectLayout<'data, Elf>,
     layout: &ElfLayout,
     dynamic_symbol_writer: &mut SymbolTableWriter,
 ) -> Result {
@@ -4398,7 +4389,7 @@ fn write_section_headers(out: &mut [u8], layout: &ElfLayout) -> Result {
 
         let entsize = output_info.entsize.max(
             section_id
-                .opt_built_in_details::<elf::File>()
+                .opt_built_in_details::<Elf>()
                 .map_or(0, |details| details.element_size),
         );
 
@@ -4536,7 +4527,7 @@ impl<'out> ProgramHeaderWriter<'out> {
     }
 }
 
-fn write_internal_symbols_plt_got_entries<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
+fn write_internal_symbols_plt_got_entries<'data, A: Arch<Platform = Elf>>(
     internal_symbols: &InternalSymbols,
     table_writer: &mut TableWriter,
     layout: &ElfLayout<'data>,
@@ -4561,8 +4552,8 @@ fn write_internal_symbols_plt_got_entries<'data, A: Arch<File<'data> = crate::el
     Ok(())
 }
 
-fn write_dynamic_file<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
-    object: &DynamicLayout<'data, crate::elf::File<'data>>,
+fn write_dynamic_file<'data, A: Arch<Platform = Elf>>(
+    object: &DynamicLayout<'data, Elf>,
     table_writer: &mut TableWriter,
     layout: &ElfLayout<'data>,
 ) -> Result {
@@ -4708,7 +4699,7 @@ fn write_dynamic_file<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
 
 /// Write dynamic entry to indicate name of shared object to load.
 fn write_so_name<'data>(
-    object: &DynamicLayout<'data, crate::elf::File<'data>>,
+    object: &DynamicLayout<'data, Elf>,
     table_writer: &mut TableWriter,
 ) -> Result {
     let needed_offset = table_writer
@@ -4721,8 +4712,8 @@ fn write_so_name<'data>(
     Ok(())
 }
 
-fn write_copy_relocations<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
-    object: &DynamicLayout<'data, crate::elf::File<'data>>,
+fn write_copy_relocations<'data, A: Arch<Platform = Elf>>(
+    object: &DynamicLayout<'data, Elf>,
     table_writer: &mut TableWriter,
     layout: &ElfLayout,
 ) -> Result {
@@ -4740,7 +4731,7 @@ fn write_copy_relocations<'data, A: Arch<File<'data> = crate::elf::File<'data>>>
     Ok(())
 }
 
-fn write_copy_relocation_for_symbol<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
+fn write_copy_relocation_for_symbol<A: Arch<Platform = Elf>>(
     symbol_id: SymbolId,
     table_writer: &mut TableWriter,
     layout: &ElfLayout,
@@ -4904,7 +4895,7 @@ fn should_reverse_contents(
 }
 
 fn link_ids(section_id: OutputSectionId) -> &'static [OutputSectionId] {
-    <elf::File as ObjectFile>::built_in_section_details()
+    Elf::built_in_section_details()
         .get(section_id.as_usize())
         .map(|def| def.link)
         .unwrap_or_default()

--- a/libwild/src/elf_x86_64.rs
+++ b/libwild/src/elf_x86_64.rs
@@ -4,10 +4,12 @@
 //! static-PIE binary because dynamic relocations haven't yet been applied to the GOT yet.
 
 use crate::OutputKind;
+use crate::elf::Elf;
 use crate::elf::PLT_ENTRY_SIZE;
 use crate::elf::PropertyClass;
 use crate::error;
 use crate::error::Result;
+use crate::platform::Platform;
 use crate::value_flags::ValueFlags;
 use linker_utils::elf::DynamicRelocationKind;
 use linker_utils::elf::RelocationKindInfo;
@@ -48,10 +50,9 @@ macro_rules! rel_info_from_type {
 
 impl crate::platform::Arch for ElfX86_64 {
     type Relaxation = Relaxation;
-    type File<'data> = crate::elf::File<'data>;
+    type Platform = Elf;
 
-    fn arch_identifier<'a>() -> <Self::File<'a> as crate::platform::ObjectFile<'a>>::ArchIdentifier
-    {
+    fn arch_identifier() -> <Self::Platform as Platform>::ArchIdentifier {
         object::elf::EM_X86_64
     }
 
@@ -90,9 +91,7 @@ impl crate::platform::Arch for ElfX86_64 {
         false
     }
 
-    fn tp_offset_start<'data>(
-        layout: &crate::layout::Layout<'data, crate::elf::File<'data>>,
-    ) -> u64 {
+    fn tp_offset_start<'data>(layout: &crate::layout::Layout<'data, Elf>) -> u64 {
         layout.tls_end_address()
     }
 
@@ -456,9 +455,9 @@ impl crate::platform::Arch for ElfX86_64 {
     }
 
     fn get_source_info<'data>(
-        object: &Self::File<'data>,
-        relocations: &<Self::File<'data> as crate::platform::ObjectFile<'data>>::RelocationSections,
-        section: &<Self::File<'data> as crate::platform::ObjectFile<'data>>::SectionHeader,
+        object: &<Self::Platform as Platform>::File<'data>,
+        relocations: &<Self::Platform as Platform>::RelocationSections,
+        section: &<Self::Platform as Platform>::SectionHeader,
         offset_in_section: u64,
     ) -> Result<crate::platform::SourceInfo> {
         crate::dwarf_address_info::get_source_info::<Self>(

--- a/libwild/src/file_writer.rs
+++ b/libwild/src/file_writer.rs
@@ -11,7 +11,7 @@ use crate::output_section_id::OutputSectionId;
 use crate::output_section_map::OutputSectionMap;
 use crate::output_section_part_map::OutputSectionPartMap;
 use crate::output_trace::TraceOutput;
-use crate::platform::ObjectFile;
+use crate::platform::Platform;
 use crate::timing_phase;
 use crate::verbose_timing_phase;
 use anyhow::anyhow;
@@ -187,10 +187,10 @@ impl Output {
         }
     }
 
-    pub fn write<'data, 'layout, O: ObjectFile<'data>>(
+    pub fn write<'data, 'layout, P: Platform>(
         &self,
-        layout: &'layout Layout<'data, O>,
-        write_fn: impl FnOnce(&mut SizedOutput, &'layout Layout<'data, O>) -> Result,
+        layout: &'layout Layout<'data, P>,
+        write_fn: impl FnOnce(&mut SizedOutput, &'layout Layout<'data, P>) -> Result,
     ) -> Result {
         timing_phase!("Write output file");
         if layout.args().write_layout {
@@ -345,11 +345,11 @@ pub(crate) fn verify_allocations_message() -> String {
     }
 }
 
-pub(crate) fn split_output_by_group<'layout, 'data, 'out, O: ObjectFile<'data>>(
-    layout: &'layout Layout<'data, O>,
+pub(crate) fn split_output_by_group<'layout, 'data, 'out, P: Platform>(
+    layout: &'layout Layout<'data, P>,
     writable_buckets: &'out mut OutputSectionPartMap<&mut [u8]>,
 ) -> Vec<(
-    &'layout GroupLayout<'data, O>,
+    &'layout GroupLayout<'data, P>,
     OutputSectionPartMap<&'out mut [u8]>,
 )> {
     timing_phase!("Split output buffers by group");
@@ -360,8 +360,8 @@ pub(crate) fn split_output_by_group<'layout, 'data, 'out, O: ObjectFile<'data>>(
         .collect()
 }
 
-pub(crate) fn split_output_into_sections<'out, 'data, O: ObjectFile<'data>>(
-    layout: &Layout<'data, O>,
+pub(crate) fn split_output_into_sections<'out, 'data, P: Platform>(
+    layout: &Layout<'data, P>,
     mut data: &'out mut [u8],
 ) -> OutputSectionMap<&'out mut [u8]> {
     let mut section_allocations = Vec::with_capacity(layout.section_layouts.len());
@@ -395,9 +395,9 @@ pub(crate) fn split_output_into_sections<'out, 'data, O: ObjectFile<'data>>(
 }
 
 /// Splits the writable buffers for each segment further into separate buffers for each alignment.
-pub(crate) fn split_buffers_by_alignment<'out, 'data, O: ObjectFile<'data>>(
+pub(crate) fn split_buffers_by_alignment<'out, 'data, P: Platform>(
     section_buffers: &'out mut OutputSectionMap<&mut [u8]>,
-    layout: &Layout<'data, O>,
+    layout: &Layout<'data, P>,
 ) -> OutputSectionPartMap<&'out mut [u8]> {
     layout.section_part_layouts.output_order_map(
         &layout.output_order,
@@ -421,13 +421,13 @@ pub(crate) fn split_buffers_by_alignment<'out, 'data, O: ObjectFile<'data>>(
     )
 }
 
-fn write_layout<'data, O: ObjectFile<'data>>(layout: &Layout<'data, O>) -> Result {
+fn write_layout<'data, P: Platform>(layout: &Layout<'data, P>) -> Result {
     let layout_path = linker_layout::layout_path(&layout.args().output);
     write_layout_to(layout, &layout_path)
         .with_context(|| format!("Failed to write layout to `{}`", layout_path.display()))
 }
 
-fn write_layout_to<'data, O: ObjectFile<'data>>(layout: &Layout<'data, O>, path: &Path) -> Result {
+fn write_layout_to<'data, P: Platform>(layout: &Layout<'data, P>, path: &Path) -> Result {
     let mut file = std::io::BufWriter::new(std::fs::File::create(path)?);
     layout.layout_data().write(&mut file)?;
     Ok(())

--- a/libwild/src/gc_stats.rs
+++ b/libwild/src/gc_stats.rs
@@ -23,13 +23,14 @@ use crate::layout::FileLayout;
 use crate::layout::GroupLayout;
 use crate::output_section_id;
 use crate::platform::ObjectFile;
+use crate::platform::Platform;
 use crate::resolution::SectionSlot;
 use hashbrown::HashMap;
 use itertools::Itertools;
 use std::path::PathBuf;
 
-pub(crate) fn maybe_write_gc_stats<'data, O: ObjectFile<'data>>(
-    group_layouts: &[GroupLayout<'data, O>],
+pub(crate) fn maybe_write_gc_stats<'data, P: Platform>(
+    group_layouts: &[GroupLayout<'data, P>],
     args: &Args,
 ) -> Result {
     let Some(stats_file) = args.write_gc_stats.as_ref() else {
@@ -46,8 +47,8 @@ struct InputFile<'data> {
     discarded_names: Vec<&'data [u8]>,
 }
 
-fn write_gc_stats<'data, O: ObjectFile<'data>>(
-    group_layouts: &[GroupLayout<'data, O>],
+fn write_gc_stats<'data, P: Platform>(
+    group_layouts: &[GroupLayout<'data, P>],
     stats_file: &std::path::Path,
     args: &Args,
 ) -> Result {

--- a/libwild/src/grouping.rs
+++ b/libwild/src/grouping.rs
@@ -7,6 +7,7 @@ use crate::parsing::Prelude;
 use crate::parsing::ProcessedLinkerScript;
 use crate::parsing::SyntheticSymbols;
 use crate::platform::ObjectFile;
+use crate::platform::Platform;
 use crate::sharding::ShardKey as _;
 use crate::symbol::UnversionedSymbolName;
 use crate::symbol_db::SymbolDb;
@@ -18,9 +19,9 @@ use crate::verbose_timing_phase;
 use std::fmt::Display;
 
 #[derive(Debug)]
-pub(crate) enum Group<'data, O: ObjectFile<'data>> {
+pub(crate) enum Group<'data, P: Platform> {
     Prelude(Prelude<'data>),
-    Objects(&'data [SequencedInputObject<'data, O>]),
+    Objects(&'data [SequencedInputObject<'data, P>]),
     LinkerScripts(Vec<SequencedLinkerScript<'data>>),
     SyntheticSymbols(SyntheticSymbols),
     #[cfg(feature = "plugins")]
@@ -28,8 +29,8 @@ pub(crate) enum Group<'data, O: ObjectFile<'data>> {
 }
 
 #[derive(Debug)]
-pub(crate) struct SequencedInputObject<'data, O: ObjectFile<'data>> {
-    pub(crate) parsed: Box<ParsedInputObject<'data, O>>,
+pub(crate) struct SequencedInputObject<'data, P: Platform> {
+    pub(crate) parsed: Box<ParsedInputObject<'data, P>>,
     pub(crate) symbol_id_range: SymbolIdRange,
     pub(crate) file_id: FileId,
 }
@@ -42,16 +43,16 @@ pub(crate) struct SequencedLinkerScript<'data> {
 }
 
 #[derive(Debug)]
-pub(crate) enum SequencedInput<'db, 'data, O: ObjectFile<'data>> {
+pub(crate) enum SequencedInput<'db, 'data, P: Platform> {
     Prelude(&'db Prelude<'data>),
-    Object(&'data SequencedInputObject<'data, O>),
+    Object(&'data SequencedInputObject<'data, P>),
     LinkerScript(&'db SequencedLinkerScript<'data>),
     SyntheticSymbols(&'db SyntheticSymbols),
     #[cfg(feature = "plugins")]
     LtoInput(&'db crate::linker_plugins::LtoInput<'data>),
 }
 
-impl<'data, O: ObjectFile<'data>> Group<'data, O> {
+impl<'data, P: Platform> Group<'data, P> {
     // This is used when the verbose-ttttiming feature is enabled.
     pub(crate) fn group_id(&self) -> usize {
         match self {
@@ -99,9 +100,9 @@ impl<'data, O: ObjectFile<'data>> Group<'data, O> {
     }
 }
 
-pub(crate) fn create_groups<'data, O: ObjectFile<'data>>(
-    symbol_db: &mut SymbolDb<'data, O>,
-    parsed_objects: Vec<Box<ParsedInputObject<'data, O>>>,
+pub(crate) fn create_groups<'data, P: Platform>(
+    symbol_db: &mut SymbolDb<'data, P>,
+    parsed_objects: Vec<Box<ParsedInputObject<'data, P>>>,
     linker_scripts: Vec<ProcessedLinkerScript<'data>>,
 ) {
     timing_phase!("Group files");
@@ -224,15 +225,13 @@ fn determine_max_files_per_group(args: &Args) -> usize {
 }
 
 /// Compute the total number of symbols in the supplied objects.
-fn count_symbols<'data, O: ObjectFile<'data>>(
-    objects: &[Box<ParsedInputObject<'data, O>>],
-) -> usize {
+fn count_symbols<'data, P: Platform>(objects: &[Box<ParsedInputObject<'data, P>>]) -> usize {
     verbose_timing_phase!("Count symbols");
 
     objects.iter().map(|o| o.num_symbols()).sum::<usize>()
 }
 
-impl<'data, O: ObjectFile<'data>> SequencedInputObject<'data, O> {
+impl<'data, P: Platform> SequencedInputObject<'data, P> {
     pub(crate) fn symbol_name(
         &self,
         symbol_id: crate::symbol_db::SymbolId,
@@ -283,7 +282,7 @@ impl<'data> SequencedLinkerScript<'data> {
     }
 }
 
-impl<'db, 'data, O: ObjectFile<'data>> SequencedInput<'db, 'data, O> {
+impl<'db, 'data, P: Platform> SequencedInput<'db, 'data, P> {
     pub(crate) fn symbol_id_range(&self) -> SymbolIdRange {
         match self {
             SequencedInput::Prelude(o) => SymbolIdRange::prelude(o.symbol_definitions.len()),
@@ -312,13 +311,13 @@ impl<'db, 'data, O: ObjectFile<'data>> SequencedInput<'db, 'data, O> {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> std::fmt::Display for SequencedInputObject<'data, O> {
+impl<'data, P: Platform> std::fmt::Display for SequencedInputObject<'data, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(&self.parsed.input, f)
     }
 }
 
-impl<'data, O: ObjectFile<'data>> Display for Group<'data, O> {
+impl<'data, P: Platform> Display for Group<'data, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Group::Prelude(_) => write!(f, "<prelude>"),
@@ -342,7 +341,7 @@ impl<'data, O: ObjectFile<'data>> Display for Group<'data, O> {
     }
 }
 
-impl<'db, 'data, O: ObjectFile<'data>> std::fmt::Display for SequencedInput<'db, 'data, O> {
+impl<'db, 'data, P: Platform> std::fmt::Display for SequencedInput<'db, 'data, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             SequencedInput::Prelude(_) => std::fmt::Display::fmt("<prelude>", f),

--- a/libwild/src/input_data.rs
+++ b/libwild/src/input_data.rs
@@ -17,7 +17,7 @@ use crate::linker_plugins::LinkerPlugin;
 use crate::linker_plugins::LtoInputInfo;
 use crate::linker_script::LinkerScript;
 use crate::parsing::ParsedInputObject;
-use crate::platform::ObjectFile;
+use crate::platform::Platform;
 use crate::timing_phase;
 use crate::verbose_timing_phase;
 use colosseum::sync::Arena;
@@ -48,11 +48,11 @@ pub(crate) struct FileLoader<'data> {
 }
 
 #[derive(Default)]
-pub(crate) struct LoadedInputs<'data, O: ObjectFile<'data>> {
+pub(crate) struct LoadedInputs<'data, P: Platform> {
     /// The results of parsing all the input files and archive entries. We defer checking for
     /// success until later, since otherwise a parse error would mean that the save-dir mechanism
     /// wouldn't capture all the input files.
-    pub(crate) objects: Vec<Result<Box<ParsedInputObject<'data, O>>>>,
+    pub(crate) objects: Vec<Result<Box<ParsedInputObject<'data, P>>>>,
 
     pub(crate) linker_scripts: Vec<InputLinkerScript<'data>>,
 
@@ -129,7 +129,7 @@ pub(crate) struct InputLinkerScript<'data> {
     pub(crate) input_file: &'data InputFile,
 }
 
-struct TemporaryState<'data, O: ObjectFile<'data>> {
+struct TemporaryState<'data, P: Platform> {
     args: &'data Args,
 
     /// Mapping from paths to the index in `files` at which we'll place the result.
@@ -137,26 +137,26 @@ struct TemporaryState<'data, O: ObjectFile<'data>> {
 
     next_file_load_index: AtomicUsize,
 
-    files: SegQueue<LoadedFile<'data, O>>,
+    files: SegQueue<LoadedFile<'data, P>>,
 
     inputs_arena: &'data Arena<InputFile>,
 }
 
-struct LoadedFile<'data, O: ObjectFile<'data>> {
+struct LoadedFile<'data, P: Platform> {
     index: FileLoadIndex,
-    state: LoadedFileState<'data, O>,
+    state: LoadedFileState<'data, P>,
 }
 
-enum LoadedFileState<'data, O: ObjectFile<'data>> {
-    Loaded(&'data InputFile, InputRecord<'data, O>),
-    Archive(&'data InputFile, Vec<InputRecord<'data, O>>),
-    ThinArchive(Vec<&'data InputFile>, Vec<InputRecord<'data, O>>),
+enum LoadedFileState<'data, P: Platform> {
+    Loaded(&'data InputFile, InputRecord<'data, P>),
+    Archive(&'data InputFile, Vec<InputRecord<'data, P>>),
+    ThinArchive(Vec<&'data InputFile>, Vec<InputRecord<'data, P>>),
     LinkerScript(LoadedLinkerScriptState<'data>),
     Error(Error),
 }
 
-enum InputRecord<'data, O: ObjectFile<'data>> {
-    Object(Result<Box<ParsedInputObject<'data, O>>>),
+enum InputRecord<'data, P: Platform> {
+    Object(Result<Box<ParsedInputObject<'data, P>>>),
     LtoInput(Box<UnclaimedLtoInput<'data>>),
 }
 
@@ -240,12 +240,12 @@ impl<'data> FileLoader<'data> {
         }
     }
 
-    pub(crate) fn load_inputs<O: ObjectFile<'data>>(
+    pub(crate) fn load_inputs<P: Platform>(
         &mut self,
         inputs: &[Input],
         args: &'data Args,
         plugin: &mut Option<LinkerPlugin<'data>>,
-    ) -> Result<LoadedInputs<'data, O>> {
+    ) -> Result<LoadedInputs<'data, P>> {
         timing_phase!("Open input files");
 
         let mut path_to_load_index = HashMap::new();
@@ -342,11 +342,11 @@ impl<'data> FileLoader<'data> {
     /// linker script is loaded, its files appear at the point at which the linker script appeared
     /// on the command-line, even though the FileLoadIndex for files loaded by linker scripts is
     /// later.
-    fn extract_all<O: ObjectFile<'data>>(
+    fn extract_all<P: Platform>(
         &mut self,
-        files: &mut [Option<LoadedFileState<'data, O>>],
+        files: &mut [Option<LoadedFileState<'data, P>>],
         plugin: &mut Option<LinkerPlugin<'data>>,
-    ) -> Result<LoadedInputs<'data, O>> {
+    ) -> Result<LoadedInputs<'data, P>> {
         let mut loaded = LoadedInputs {
             objects: Vec::with_capacity(files.len()),
             linker_scripts: Vec::new(),
@@ -360,11 +360,11 @@ impl<'data> FileLoader<'data> {
         Ok(loaded)
     }
 
-    fn extract_file<O: ObjectFile<'data>>(
+    fn extract_file<P: Platform>(
         &mut self,
         index: FileLoadIndex,
-        files: &mut [Option<LoadedFileState<'data, O>>],
-        loaded: &mut LoadedInputs<'data, O>,
+        files: &mut [Option<LoadedFileState<'data, P>>],
+        loaded: &mut LoadedInputs<'data, P>,
         plugin: &mut Option<LinkerPlugin<'data>>,
     ) -> Result {
         match core::mem::take(&mut files[index.0]) {
@@ -439,11 +439,11 @@ fn process_linker_script<'data>(
     })
 }
 
-fn process_archive<'data, O: ObjectFile<'data>>(
+fn process_archive<'data, P: Platform>(
     input_file: &'data InputFile,
     file: &Arc<std::fs::File>,
-    state: &TemporaryState<'data, O>,
-) -> Result<LoadedFileState<'data, O>> {
+    state: &TemporaryState<'data, P>,
+) -> Result<LoadedFileState<'data, P>> {
     let mut outputs = Vec::new();
 
     for entry in ArchiveIterator::from_archive_bytes(input_file.data())? {
@@ -471,10 +471,10 @@ fn process_archive<'data, O: ObjectFile<'data>>(
     Ok(LoadedFileState::Archive(input_file, outputs))
 }
 
-fn process_thin_archive<'data, O: ObjectFile<'data>>(
+fn process_thin_archive<'data, P: Platform>(
     input_file: &InputFile,
-    state: &TemporaryState<'data, O>,
-) -> Result<LoadedFileState<'data, O>> {
+    state: &TemporaryState<'data, P>,
+) -> Result<LoadedFileState<'data, P>> {
     let absolute_path = &input_file.filename;
     let parent_path = absolute_path.parent().unwrap();
     let mut files = Vec::new();
@@ -524,7 +524,7 @@ fn process_thin_archive<'data, O: ObjectFile<'data>>(
     Ok(LoadedFileState::ThinArchive(files, parsed_files))
 }
 
-impl<'data, O: ObjectFile<'data>> TemporaryState<'data, O> {
+impl<'data, P: Platform> TemporaryState<'data, P> {
     fn process_and_record_open_file_request<'scope>(
         &'scope self,
         request: OpenFileRequest,
@@ -544,7 +544,7 @@ impl<'data, O: ObjectFile<'data>> TemporaryState<'data, O> {
         &'scope self,
         request: OpenFileRequest,
         scope: &Scope<'scope>,
-    ) -> Result<LoadedFileState<'data, O>> {
+    ) -> Result<LoadedFileState<'data, P>> {
         verbose_timing_phase!("Open file");
 
         let absolute_path = &request.paths.absolute;
@@ -645,7 +645,7 @@ impl<'data, O: ObjectFile<'data>> TemporaryState<'data, O> {
         input_ref: InputRef<'data>,
         file: &Arc<std::fs::File>,
         kind: FileKind,
-    ) -> Result<InputRecord<'data, O>> {
+    ) -> Result<InputRecord<'data, P>> {
         let data = input_ref.data();
 
         // The plugin API docs say to pass files to the plugin before the linker tries to identify
@@ -914,10 +914,10 @@ impl Display for InputBytes<'_> {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> LoadedInputs<'data, O> {
+impl<'data, P: Platform> LoadedInputs<'data, P> {
     fn add_record(
         &mut self,
-        record: InputRecord<'data, O>,
+        record: InputRecord<'data, P>,
         plugin: &mut Option<LinkerPlugin<'data>>,
     ) {
         match record {
@@ -942,7 +942,7 @@ impl<'data, O: ObjectFile<'data>> LoadedInputs<'data, O> {
 
     fn add_records(
         &mut self,
-        parsed_parts: Vec<InputRecord<'data, O>>,
+        parsed_parts: Vec<InputRecord<'data, P>>,
         plugin: &mut Option<LinkerPlugin<'data>>,
     ) {
         for part in parsed_parts {
@@ -951,7 +951,7 @@ impl<'data, O: ObjectFile<'data>> LoadedInputs<'data, O> {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> InputRecord<'data, O> {
+impl<'data, P: Platform> InputRecord<'data, P> {
     fn is_dynamic_object(&self) -> bool {
         match self {
             InputRecord::Object(Ok(obj)) => obj.is_dynamic(),

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -11,6 +11,7 @@ use crate::bail;
 use crate::debug_assert_bail;
 use crate::diagnostics::SymbolInfoPrinter;
 use crate::elf;
+use crate::elf::Elf;
 use crate::ensure;
 use crate::error;
 use crate::error::Context;
@@ -38,6 +39,7 @@ use crate::part_id::PartId;
 use crate::platform::Arch;
 use crate::platform::NonAddressableIndexes as _;
 use crate::platform::ObjectFile;
+use crate::platform::Platform;
 use crate::platform::ProgramSegmentDef as _;
 use crate::platform::RawSymbolName as _;
 use crate::platform::RelaxSymbolInfo;
@@ -107,17 +109,16 @@ use std::sync::atomic::AtomicU64;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::Relaxed;
 
-pub fn compute<'data, A: Arch>(
-    symbol_db: SymbolDb<'data, A::File<'data>>,
+pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
+    symbol_db: SymbolDb<'data, A::Platform>,
     mut per_symbol_flags: PerSymbolFlags,
-    mut groups: Vec<ResolvedGroup<'data, A::File<'data>>>,
+    mut groups: Vec<ResolvedGroup<'data, A::Platform>>,
     mut output_sections: OutputSections<'data>,
     output: &mut file_writer::Output,
-) -> Result<Layout<'data, A::File<'data>>> {
+) -> Result<Layout<'data, A::Platform>> {
     timing_phase!("Layout");
 
-    let layout_resources_ext =
-        <A::File<'data> as ObjectFile<'data>>::layout_resources_ext(&symbol_db.groups);
+    let layout_resources_ext = <A::Platform as Platform>::layout_resources_ext(&symbol_db.groups);
 
     let atomic_per_symbol_flags = per_symbol_flags.borrow_atomic();
 
@@ -167,7 +168,7 @@ pub fn compute<'data, A: Arch>(
         num_symbols: 0,
     });
 
-    let properties_and_attributes = A::File::create_layout_properties::<A>(
+    let properties_and_attributes = P::create_layout_properties::<A>(
         symbol_db.args,
         objects_iter(&group_states).map(|obj| obj.object),
         objects_iter(&group_states).map(|obj| &obj.format_specific_layout_state),
@@ -196,11 +197,11 @@ pub fn compute<'data, A: Arch>(
 
     propagate_section_attributes(&group_states, &mut output_sections);
 
-    let (output_order, program_segments) = output_sections.output_order::<A::File<'data>>();
+    let (output_order, program_segments) = output_sections.output_order::<A::Platform>();
 
     tracing::trace!(
         "Output order:\n{}",
-        output_order.display::<A::File<'data>>(&output_sections, &program_segments)
+        output_order.display::<A::Platform>(&output_sections, &program_segments)
     );
 
     let mut section_part_sizes = compute_total_section_part_sizes(
@@ -213,7 +214,7 @@ pub fn compute<'data, A: Arch>(
         &finalise_sizes_resources,
     )?;
 
-    let mut section_part_layouts = layout_section_parts::<A::File<'data>>(
+    let mut section_part_layouts = layout_section_parts::<A::Platform>(
         &section_part_sizes,
         &output_sections,
         &program_segments,
@@ -246,7 +247,7 @@ pub fn compute<'data, A: Arch>(
         unreachable!();
     };
     let header_info = internal.header_info.as_ref().unwrap();
-    let segment_layouts = compute_segment_layout::<A::File<'data>>(
+    let segment_layouts = compute_segment_layout::<A::Platform>(
         &section_layouts,
         &output_sections,
         &output_order,
@@ -335,16 +336,16 @@ pub fn compute<'data, A: Arch>(
     })
 }
 
-struct FinaliseSizesResources<'data, 'scope, O: ObjectFile<'data>> {
+struct FinaliseSizesResources<'data, 'scope, P: Platform> {
     dynamic_symbol_definitions: &'scope [DynamicSymbolDefinition<'data>],
-    symbol_db: &'scope SymbolDb<'data, O>,
+    symbol_db: &'scope SymbolDb<'data, P>,
     merged_strings: &'scope OutputSectionMap<MergedStringsSection<'data>>,
-    format_specific: &'scope O::LayoutProperties,
+    format_specific: &'scope P::LayoutProperties,
 }
 
 /// Update resolutions for defsym symbols that reference other symbols.
-fn update_defsym_symbol_resolutions<'data, O: ObjectFile<'data>>(
-    symbol_db: &SymbolDb<'data, O>,
+fn update_defsym_symbol_resolutions<'data, P: Platform>(
+    symbol_db: &SymbolDb<'data, P>,
     resolutions: &mut [Option<Resolution>],
 ) -> Result {
     verbose_timing_phase!("Update symdef resolutions");
@@ -381,10 +382,10 @@ fn update_defsym_symbol_resolutions<'data, O: ObjectFile<'data>>(
     Ok(())
 }
 
-fn update_defsym_symbol_resolution<'data, O: ObjectFile<'data>>(
+fn update_defsym_symbol_resolution<'data, P: Platform>(
     symbol_id: SymbolId,
     def_info: &InternalSymDefInfo,
-    symbol_db: &SymbolDb<'data, O>,
+    symbol_db: &SymbolDb<'data, P>,
     resolutions: &mut [Option<Resolution>],
 ) -> Result {
     let SymbolPlacement::DefsymSymbol(target_name, offset) = def_info.placement else {
@@ -415,9 +416,9 @@ fn update_defsym_symbol_resolution<'data, O: ObjectFile<'data>>(
 }
 
 /// Update resolutions for all dynamic symbols that our output file defines.
-fn update_dynamic_symbol_resolutions<'data, O: ObjectFile<'data>>(
-    resources: &FinaliseLayoutResources<'_, 'data, O>,
-    layouts: &[GroupLayout<'data, O>],
+fn update_dynamic_symbol_resolutions<'data, P: Platform>(
+    resources: &FinaliseLayoutResources<'_, 'data, P>,
+    layouts: &[GroupLayout<'data, P>],
     resolutions: &mut [Option<Resolution>],
 ) {
     timing_phase!("Update dynamic symbol resolutions");
@@ -439,9 +440,9 @@ fn update_dynamic_symbol_resolutions<'data, O: ObjectFile<'data>>(
 /// symbols with copy relocations. If the other symbol is non-weak, then we do the copy relocation
 /// for that symbol instead. We also request dynamic symbol definitions for each copy relocation.
 /// For that reason, this needs to be done before we merge dynamic symbol definitions.
-fn finalise_copy_relocations<'data, O: ObjectFile<'data>>(
-    group_states: &mut [GroupState<'data, O>],
-    symbol_db: &SymbolDb<'data, O>,
+fn finalise_copy_relocations<'data, P: Platform>(
+    group_states: &mut [GroupState<'data, P>],
+    symbol_db: &SymbolDb<'data, P>,
     symbol_flags: &AtomicPerSymbolFlags,
 ) -> Result {
     timing_phase!("Finalise copy relocations");
@@ -458,11 +459,11 @@ fn finalise_copy_relocations<'data, O: ObjectFile<'data>>(
     })
 }
 
-fn finalise_all_sizes<'data, O: ObjectFile<'data>>(
-    group_states: &mut [GroupState<'data, O>],
+fn finalise_all_sizes<'data, P: Platform>(
+    group_states: &mut [GroupState<'data, P>],
     output_sections: &OutputSections,
     per_symbol_flags: &AtomicPerSymbolFlags,
-    resources: &FinaliseSizesResources<'data, '_, O>,
+    resources: &FinaliseSizesResources<'data, '_, P>,
 ) -> Result {
     timing_phase!("Finalise per-object sizes");
 
@@ -472,9 +473,9 @@ fn finalise_all_sizes<'data, O: ObjectFile<'data>>(
     })
 }
 
-fn merge_dynamic_symbol_definitions<'data, O: ObjectFile<'data>>(
-    group_states: &[GroupState<'data, O>],
-    symbol_db: &SymbolDb<'data, O>,
+fn merge_dynamic_symbol_definitions<'data, P: Platform>(
+    group_states: &[GroupState<'data, P>],
+    symbol_db: &SymbolDb<'data, P>,
 ) -> Result<Vec<DynamicSymbolDefinition<'data>>> {
     timing_phase!("Merge dynamic symbol definitions");
 
@@ -492,9 +493,9 @@ fn merge_dynamic_symbol_definitions<'data, O: ObjectFile<'data>>(
     Ok(dynamic_symbol_definitions)
 }
 
-fn append_prelude_defsym_dynamic_symbols<'data, O: ObjectFile<'data>>(
-    group_states: &[GroupState<'data, O>],
-    symbol_db: &SymbolDb<'data, O>,
+fn append_prelude_defsym_dynamic_symbols<'data, P: Platform>(
+    group_states: &[GroupState<'data, P>],
+    symbol_db: &SymbolDb<'data, P>,
     dynamic_symbol_definitions: &mut Vec<DynamicSymbolDefinition<'data>>,
 ) -> Result {
     if symbol_db.output_kind.needs_dynsym()
@@ -522,16 +523,16 @@ fn append_prelude_defsym_dynamic_symbols<'data, O: ObjectFile<'data>>(
             }
 
             dynamic_symbol_definitions
-                .push(O::create_dynamic_symbol_definition(symbol_db, symbol_id)?);
+                .push(P::create_dynamic_symbol_definition(symbol_db, symbol_id)?);
         }
     }
 
     Ok(())
 }
 
-fn objects_iter<'groups, 'data, O: ObjectFile<'data>>(
-    group_states: &'groups [GroupState<'data, O>],
-) -> impl Iterator<Item = &'groups ObjectLayoutState<'data, O>> + Clone {
+fn objects_iter<'groups, 'data, P: Platform>(
+    group_states: &'groups [GroupState<'data, P>],
+) -> impl Iterator<Item = &'groups ObjectLayoutState<'data, P>> + Clone {
     group_states.iter().flat_map(|group| {
         group.files.iter().filter_map(|file| match file {
             FileLayoutState::Object(object) => Some(object),
@@ -549,8 +550,8 @@ fn compute_total_file_size(section_layouts: &OutputSectionMap<OutputRecordLayout
 /// Information about what goes where. Also includes relocation data, since that's computed at the
 /// same time.
 #[derive(Debug)]
-pub struct Layout<'data, O: ObjectFile<'data>> {
-    pub(crate) symbol_db: SymbolDb<'data, O>,
+pub struct Layout<'data, P: Platform> {
+    pub(crate) symbol_db: SymbolDb<'data, P>,
     pub(crate) symbol_resolutions: SymbolResolutions,
     pub(crate) section_part_layouts: OutputSectionPartMap<OutputRecordLayout>,
 
@@ -560,12 +561,12 @@ pub struct Layout<'data, O: ObjectFile<'data>> {
     /// section. Values for secondary sections are reset to 0 and should not be used.
     pub(crate) merged_section_layouts: OutputSectionMap<OutputRecordLayout>,
 
-    pub(crate) group_layouts: Vec<GroupLayout<'data, O>>,
+    pub(crate) group_layouts: Vec<GroupLayout<'data, P>>,
     pub(crate) segment_layouts: SegmentLayouts,
     pub(crate) output_sections: OutputSections<'data>,
-    pub(crate) program_segments: ProgramSegments<O::ProgramSegmentDef>,
+    pub(crate) program_segments: ProgramSegments<P::ProgramSegmentDef>,
     pub(crate) output_order: OutputOrder,
-    pub(crate) non_addressable_counts: O::NonAddressableCounts,
+    pub(crate) non_addressable_counts: P::NonAddressableCounts,
     pub(crate) merged_strings: OutputSectionMap<MergedStringsSection<'data>>,
     pub(crate) merged_string_start_addresses: MergedStringStartAddresses,
     pub(crate) relocation_statistics: OutputSectionMap<AtomicU64>,
@@ -573,7 +574,7 @@ pub struct Layout<'data, O: ObjectFile<'data>> {
     pub(crate) has_variant_pcs: bool,
     pub(crate) per_symbol_flags: PerSymbolFlags,
     pub(crate) dynamic_symbol_definitions: Vec<DynamicSymbolDefinition<'data>>,
-    pub(crate) properties_and_attributes: O::LayoutProperties,
+    pub(crate) properties_and_attributes: P::LayoutProperties,
 }
 
 #[derive(Debug)]
@@ -595,12 +596,12 @@ pub(crate) struct SymbolResolutions {
     resolutions: Vec<Option<Resolution>>,
 }
 
-pub(crate) enum FileLayout<'data, O: ObjectFile<'data>> {
+pub(crate) enum FileLayout<'data, P: Platform> {
     Prelude(PreludeLayout<'data>),
-    Object(ObjectLayout<'data, O>),
-    Dynamic(DynamicLayout<'data, O>),
+    Object(ObjectLayout<'data, P>),
+    Dynamic(DynamicLayout<'data, P>),
     SyntheticSymbols(SyntheticSymbolsLayout<'data>),
-    Epilogue(EpilogueLayout<'data, O>),
+    Epilogue(EpilogueLayout<P>),
     NotLoaded,
     LinkerScript(LinkerScriptLayoutState<'data>),
 }
@@ -658,13 +659,13 @@ impl SectionResolution {
     }
 }
 
-enum FileLayoutState<'data, O: ObjectFile<'data>> {
+enum FileLayoutState<'data, P: Platform> {
     Prelude(PreludeLayoutState<'data>),
-    Object(ObjectLayoutState<'data, O>),
-    Dynamic(DynamicLayoutState<'data, O>),
+    Object(ObjectLayoutState<'data, P>),
+    Dynamic(DynamicLayoutState<'data, P>),
     NotLoaded(NotLoaded),
     SyntheticSymbols(SyntheticSymbolsLayoutState<'data>),
-    Epilogue(EpilogueLayoutState<'data, O>),
+    Epilogue(EpilogueLayoutState<P>),
     LinkerScript(LinkerScriptLayoutState<'data>),
 }
 
@@ -687,8 +688,8 @@ pub(crate) struct SyntheticSymbolsLayoutState<'data> {
     internal_symbols: InternalSymbols<'data>,
 }
 
-pub(crate) struct EpilogueLayoutState<'data, O: ObjectFile<'data>> {
-    format_specific: O::EpilogueLayout,
+pub(crate) struct EpilogueLayoutState<P: Platform> {
+    format_specific: P::EpilogueLayout,
 }
 
 #[derive(Debug)]
@@ -705,18 +706,18 @@ pub(crate) struct SyntheticSymbolsLayout<'data> {
 }
 
 #[derive(Debug)]
-pub(crate) struct EpilogueLayout<'data, O: ObjectFile<'data>> {
-    pub(crate) format_specific: O::EpilogueLayout,
+pub(crate) struct EpilogueLayout<P: Platform> {
+    pub(crate) format_specific: P::EpilogueLayout,
     pub(crate) dynsym_start_index: u32,
 }
 
 #[derive(Debug)]
-pub(crate) struct ObjectLayout<'data, O: ObjectFile<'data>> {
+pub(crate) struct ObjectLayout<'data, P: Platform> {
     pub(crate) input: InputRef<'data>,
     pub(crate) file_id: FileId,
-    pub(crate) object: &'data O,
+    pub(crate) object: &'data P::File<'data>,
     pub(crate) sections: Vec<SectionSlot>,
-    pub(crate) relocations: O::RelocationSections,
+    pub(crate) relocations: P::RelocationSections,
     pub(crate) section_resolutions: Vec<SectionResolution>,
     pub(crate) symbol_id_range: SymbolIdRange,
     /// SFrame section ranges for this object, relative to the start of the .sframe output section.
@@ -742,7 +743,7 @@ pub(crate) struct InternalSymbols<'data> {
 }
 
 #[derive(Debug)]
-pub(crate) struct DynamicLayout<'data, O: ObjectFile<'data>> {
+pub(crate) struct DynamicLayout<'data, P: Platform> {
     pub(crate) file_id: FileId,
     input: InputRef<'data>,
 
@@ -751,11 +752,11 @@ pub(crate) struct DynamicLayout<'data, O: ObjectFile<'data>> {
 
     pub(crate) symbol_id_range: SymbolIdRange,
 
-    pub(crate) object: &'data O,
+    pub(crate) object: &'data P::File<'data>,
 
     pub(crate) copy_relocation_symbols: Vec<SymbolId>,
 
-    pub(crate) format_specific_layout: O::DynamicLayout,
+    pub(crate) format_specific_layout: P::DynamicLayout<'data>,
 }
 
 trait HandlerData {
@@ -764,12 +765,12 @@ trait HandlerData {
     fn file_id(&self) -> FileId;
 }
 
-trait SymbolRequestHandler<'data, O: ObjectFile<'data>>: std::fmt::Display + HandlerData {
+trait SymbolRequestHandler<'data, P: Platform>: std::fmt::Display + HandlerData {
     fn finalise_symbol_sizes(
         &mut self,
-        common: &mut CommonGroupState<'data, O>,
+        common: &mut CommonGroupState<'data, P>,
         symbol_flags: &AtomicPerSymbolFlags,
-        resources: &FinaliseSizesResources<'data, '_, O>,
+        resources: &FinaliseSizesResources<'data, '_, P>,
     ) -> Result {
         let symbol_db = resources.symbol_db;
 
@@ -788,7 +789,7 @@ trait SymbolRequestHandler<'data, O: ObjectFile<'data>>: std::fmt::Display + Han
             // weak symbol.
             if flags.is_dynamic() && flags.has_resolution() {
                 let name = symbol_db.symbol_name(symbol_id)?;
-                let name = O::RawSymbolName::parse(name.bytes()).name();
+                let name = P::RawSymbolName::parse(name.bytes()).name();
 
                 if flags.needs_copy_relocation() {
                     // The dynamic symbol is a definition, so is handled by the epilogue. We only
@@ -803,14 +804,14 @@ trait SymbolRequestHandler<'data, O: ObjectFile<'data>>: std::fmt::Display + Han
             }
 
             if symbol_db.args.verify_allocation_consistency {
-                verify_consistent_allocation_handling::<O>(flags, symbol_db.output_kind)?;
+                verify_consistent_allocation_handling::<P>(flags, symbol_db.output_kind)?;
             }
 
             allocate_symbol_resolution(flags, &mut common.mem_sizes, symbol_db.output_kind);
 
             if symbol_db.args.got_plt_syms && flags.needs_got() {
                 let name = symbol_db.symbol_name(symbol_id)?;
-                let name = O::RawSymbolName::parse(name.bytes()).name();
+                let name = P::RawSymbolName::parse(name.bytes()).name();
                 let name_len = name.len() + 4; // "$got" or "$plt" suffix
 
                 let entry_size = size_of::<elf::SymtabEntry>() as u64;
@@ -827,24 +828,24 @@ trait SymbolRequestHandler<'data, O: ObjectFile<'data>>: std::fmt::Display + Han
         Ok(())
     }
 
-    fn load_symbol<'scope, A: Arch<File<'data> = O>>(
+    fn load_symbol<'scope, A: Arch<Platform = P>>(
         &mut self,
-        common: &mut CommonGroupState<'data, O>,
+        common: &mut CommonGroupState<'data, P>,
         symbol_id: SymbolId,
-        resources: &'scope GraphResources<'data, 'scope, O>,
+        resources: &'scope GraphResources<'data, 'scope, P>,
         queue: &mut LocalWorkQueue,
         scope: &Scope<'scope>,
     ) -> Result;
 }
 
-fn export_dynamic<'data, O: ObjectFile<'data>>(
-    common: &mut CommonGroupState<'data, O>,
+fn export_dynamic<'data, P: Platform>(
+    common: &mut CommonGroupState<'data, P>,
     symbol_id: SymbolId,
-    symbol_db: &SymbolDb<'data, O>,
+    symbol_db: &SymbolDb<'data, P>,
 ) -> Result {
     common
         .dynamic_symbol_definitions
-        .push(O::create_dynamic_symbol_definition(symbol_db, symbol_id)?);
+        .push(P::create_dynamic_symbol_definition(symbol_db, symbol_id)?);
 
     Ok(())
 }
@@ -921,7 +922,7 @@ fn allocate_resolution(
     }
 }
 
-impl<'data, O: ObjectFile<'data>> HandlerData for ObjectLayoutState<'data, O> {
+impl<'data, P: Platform> HandlerData for ObjectLayoutState<'data, P> {
     fn file_id(&self) -> FileId {
         self.file_id
     }
@@ -931,12 +932,12 @@ impl<'data, O: ObjectFile<'data>> HandlerData for ObjectLayoutState<'data, O> {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> SymbolRequestHandler<'data, O> for ObjectLayoutState<'data, O> {
-    fn load_symbol<'scope, A: Arch<File<'data> = O>>(
+impl<'data, P: Platform> SymbolRequestHandler<'data, P> for ObjectLayoutState<'data, P> {
+    fn load_symbol<'scope, A: Arch<Platform = P>>(
         &mut self,
-        common: &mut CommonGroupState<'data, O>,
+        common: &mut CommonGroupState<'data, P>,
         symbol_id: SymbolId,
-        resources: &GraphResources<'data, 'scope, O>,
+        resources: &GraphResources<'data, 'scope, P>,
         queue: &mut LocalWorkQueue,
         _scope: &Scope<'scope>,
     ) -> Result {
@@ -967,7 +968,7 @@ impl<'data, O: ObjectFile<'data>> SymbolRequestHandler<'data, O> for ObjectLayou
     }
 }
 
-impl<'data, O: ObjectFile<'data>> HandlerData for DynamicLayoutState<'data, O> {
+impl<'data, P: Platform> HandlerData for DynamicLayoutState<'data, P> {
     fn symbol_id_range(&self) -> SymbolIdRange {
         self.symbol_id_range
     }
@@ -977,12 +978,12 @@ impl<'data, O: ObjectFile<'data>> HandlerData for DynamicLayoutState<'data, O> {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> SymbolRequestHandler<'data, O> for DynamicLayoutState<'data, O> {
-    fn load_symbol<'scope, A: Arch<File<'data> = O>>(
+impl<'data, P: Platform> SymbolRequestHandler<'data, P> for DynamicLayoutState<'data, P> {
+    fn load_symbol<'scope, A: Arch<Platform = P>>(
         &mut self,
-        _common: &mut CommonGroupState<'data, O>,
+        _common: &mut CommonGroupState<'data, P>,
         symbol_id: SymbolId,
-        resources: &GraphResources<'data, 'scope, O>,
+        resources: &GraphResources<'data, 'scope, P>,
         _queue: &mut LocalWorkQueue,
         _scope: &Scope<'scope>,
     ) -> Result {
@@ -1011,12 +1012,12 @@ impl HandlerData for PreludeLayoutState<'_> {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> SymbolRequestHandler<'data, O> for PreludeLayoutState<'data> {
-    fn load_symbol<'scope, A: Arch<File<'data> = O>>(
+impl<'data, P: Platform> SymbolRequestHandler<'data, P> for PreludeLayoutState<'data> {
+    fn load_symbol<'scope, A: Arch<Platform = P>>(
         &mut self,
-        _common: &mut CommonGroupState<'data, O>,
+        _common: &mut CommonGroupState<'data, P>,
         _symbol_id: SymbolId,
-        _resources: &GraphResources<'data, 'scope, O>,
+        _resources: &GraphResources<'data, 'scope, P>,
         _queue: &mut LocalWorkQueue,
         _scope: &Scope<'scope>,
     ) -> Result {
@@ -1034,14 +1035,12 @@ impl HandlerData for LinkerScriptLayoutState<'_> {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> SymbolRequestHandler<'data, O>
-    for LinkerScriptLayoutState<'data>
-{
-    fn load_symbol<'scope, A: Arch<File<'data> = O>>(
+impl<'data, P: Platform> SymbolRequestHandler<'data, P> for LinkerScriptLayoutState<'data> {
+    fn load_symbol<'scope, A: Arch<Platform = P>>(
         &mut self,
-        _common: &mut CommonGroupState<'data, O>,
+        _common: &mut CommonGroupState<'data, P>,
         _symbol_id: SymbolId,
-        _resources: &GraphResources<'data, 'scope, O>,
+        _resources: &GraphResources<'data, 'scope, P>,
         _queue: &mut LocalWorkQueue,
         _scope: &Scope<'scope>,
     ) -> Result {
@@ -1059,14 +1058,12 @@ impl HandlerData for SyntheticSymbolsLayoutState<'_> {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> SymbolRequestHandler<'data, O>
-    for SyntheticSymbolsLayoutState<'data>
-{
-    fn load_symbol<'scope, A: Arch<File<'data> = O>>(
+impl<'data, P: Platform> SymbolRequestHandler<'data, P> for SyntheticSymbolsLayoutState<'data> {
+    fn load_symbol<'scope, A: Arch<Platform = P>>(
         &mut self,
-        _common: &mut CommonGroupState<'data, O>,
+        _common: &mut CommonGroupState<'data, P>,
         symbol_id: SymbolId,
-        resources: &'scope GraphResources<'data, 'scope, O>,
+        resources: &'scope GraphResources<'data, 'scope, P>,
         _queue: &mut LocalWorkQueue,
         scope: &Scope<'scope>,
     ) -> Result {
@@ -1092,10 +1089,10 @@ impl<'data, O: ObjectFile<'data>> SymbolRequestHandler<'data, O>
 }
 
 #[derive(Debug)]
-pub(crate) struct CommonGroupState<'data, O: ObjectFile<'data>> {
+pub(crate) struct CommonGroupState<'data, P: Platform> {
     mem_sizes: OutputSectionPartMap<u64>,
 
-    section_attributes: OutputSectionMap<Option<O::SectionAttributes>>,
+    section_attributes: OutputSectionMap<Option<P::SectionAttributes>>,
 
     /// Dynamic symbols that need to be defined. Because of the ordering requirements for symbol
     /// hashes, these get defined by the epilogue. The object on which a particular dynamic symbol
@@ -1103,10 +1100,10 @@ pub(crate) struct CommonGroupState<'data, O: ObjectFile<'data>> {
     /// symbol. That's OK though because the epilogue will sort all dynamic symbols.
     dynamic_symbol_definitions: Vec<DynamicSymbolDefinition<'data>>,
 
-    pub(crate) format_specific: <crate::elf::File<'data> as ObjectFile<'data>>::CommonGroupStateExt,
+    pub(crate) format_specific: <Elf as Platform>::CommonGroupStateExt,
 }
 
-impl<'data, O: ObjectFile<'data>> CommonGroupState<'data, O> {
+impl<'data, P: Platform> CommonGroupState<'data, P> {
     fn new(output_sections: &OutputSections) -> Self {
         Self {
             mem_sizes: output_sections.new_part_map(),
@@ -1117,7 +1114,7 @@ impl<'data, O: ObjectFile<'data>> CommonGroupState<'data, O> {
     }
 
     fn validate_sizes(&self) -> Result {
-        O::validate_sizes(&self.mem_sizes)
+        P::validate_sizes(&self.mem_sizes)
     }
 
     fn finalise_layout(
@@ -1154,7 +1151,7 @@ impl<'data, O: ObjectFile<'data>> CommonGroupState<'data, O> {
     fn section_loaded(
         &mut self,
         part_id: PartId,
-        header: &O::SectionHeader,
+        header: &P::SectionHeader,
         section: Section,
         output_sections: &OutputSections,
     ) {
@@ -1162,10 +1159,10 @@ impl<'data, O: ObjectFile<'data>> CommonGroupState<'data, O> {
         self.store_section_attributes(part_id, header);
     }
 
-    fn store_section_attributes(&mut self, part_id: PartId, header: &O::SectionHeader) {
+    fn store_section_attributes(&mut self, part_id: PartId, header: &P::SectionHeader) {
         let existing_attributes = self.section_attributes.get_mut(part_id.output_section_id());
 
-        let new_attributes = O::section_attributes(header);
+        let new_attributes = P::section_attributes(header);
 
         if let Some(existing) = existing_attributes {
             existing.merge(new_attributes);
@@ -1175,19 +1172,19 @@ impl<'data, O: ObjectFile<'data>> CommonGroupState<'data, O> {
     }
 }
 
-pub(crate) struct ObjectLayoutState<'data, O: ObjectFile<'data>> {
+pub(crate) struct ObjectLayoutState<'data, P: Platform> {
     input: InputRef<'data>,
     file_id: FileId,
     pub(crate) symbol_id_range: SymbolIdRange,
-    pub(crate) object: &'data O,
+    pub(crate) object: &'data P::File<'data>,
 
     /// Info about each of our sections. Indexed the same as the sections in the input object.
     pub(crate) sections: Vec<SectionSlot>,
 
     /// Mapping from sections to their corresponding relocation section.
-    relocations: O::RelocationSections,
+    relocations: P::RelocationSections,
 
-    pub(crate) format_specific_layout_state: O::FileLayoutState,
+    pub(crate) format_specific_layout_state: P::FileLayoutState<'data>,
 
     /// Sparse map from section index to relaxation delta details, built during `finalise_sizes`
     /// and later transferred to `ObjectLayout`.
@@ -1203,14 +1200,14 @@ pub(crate) struct LocalWorkQueue {
     local_work: Vec<WorkItem>,
 }
 
-struct DynamicLayoutState<'data, O: ObjectFile<'data>> {
-    object: &'data O,
+struct DynamicLayoutState<'data, P: Platform> {
+    object: &'data P::File<'data>,
     input: InputRef<'data>,
     file_id: FileId,
     symbol_id_range: SymbolIdRange,
     lib_name: &'data [u8],
 
-    format_specific_state: O::DynamicLayoutState,
+    format_specific_state: P::DynamicLayoutState<'data>,
 
     /// Maps from addresses within the shared object to copy relocations at that address.
     copy_relocations: HashMap<u64, CopyRelocationInfo>,
@@ -1247,8 +1244,8 @@ pub(crate) struct Section {
 }
 
 #[derive(Debug)]
-pub(crate) struct GroupLayout<'data, O: ObjectFile<'data>> {
-    pub(crate) files: Vec<FileLayout<'data, O>>,
+pub(crate) struct GroupLayout<'data, P: Platform> {
+    pub(crate) files: Vec<FileLayout<'data, P>>,
 
     /// The offset in .dynstr at which we'll start writing.
     pub(crate) dynstr_start_offset: u32,
@@ -1259,14 +1256,14 @@ pub(crate) struct GroupLayout<'data, O: ObjectFile<'data>> {
     pub(crate) mem_sizes: OutputSectionPartMap<u64>,
     pub(crate) file_sizes: OutputSectionPartMap<usize>,
 
-    pub(crate) format_specific: O::GroupLayoutExt,
+    pub(crate) format_specific: P::GroupLayoutExt,
 }
 
 #[derive(Debug)]
-pub(crate) struct GroupState<'data, O: ObjectFile<'data>> {
+pub(crate) struct GroupState<'data, P: Platform> {
     queue: LocalWorkQueue,
-    files: Vec<FileLayoutState<'data, O>>,
-    pub(crate) common: CommonGroupState<'data, O>,
+    files: Vec<FileLayoutState<'data, P>>,
+    pub(crate) common: CommonGroupState<'data, P>,
     num_symbols: usize,
 }
 
@@ -1284,12 +1281,12 @@ pub(crate) struct OutputRecordLayout {
     pub(crate) mem_offset: u64,
 }
 
-pub(crate) struct GraphResources<'data, 'scope, O: ObjectFile<'data>> {
-    pub(crate) symbol_db: &'scope SymbolDb<'data, O>,
+pub(crate) struct GraphResources<'data, 'scope, P: Platform> {
+    pub(crate) symbol_db: &'scope SymbolDb<'data, P>,
 
     output_sections: &'scope OutputSections<'data>,
 
-    worker_slots: Vec<Mutex<WorkerSlot<'data, O>>>,
+    worker_slots: Vec<Mutex<WorkerSlot<'data, P>>>,
 
     errors: Mutex<Vec<Error>>,
 
@@ -1313,13 +1310,13 @@ pub(crate) struct GraphResources<'data, 'scope, O: ObjectFile<'data>> {
     activations_remaining: AtomicUsize,
 
     /// Groups that cannot be processed until all groups have completed activation.
-    delay_processing: ArrayQueue<GroupState<'data, O>>,
+    delay_processing: ArrayQueue<GroupState<'data, P>>,
 
-    pub(crate) layout_resources_ext: O::LayoutResourcesExt,
+    pub(crate) layout_resources_ext: P::LayoutResourcesExt<'data>,
 }
 
-struct FinaliseLayoutResources<'scope, 'data, O: ObjectFile<'data>> {
-    symbol_db: &'scope SymbolDb<'data, O>,
+struct FinaliseLayoutResources<'scope, 'data, P: Platform> {
+    symbol_db: &'scope SymbolDb<'data, P>,
     per_symbol_flags: &'scope PerSymbolFlags,
     output_sections: &'scope OutputSections<'data>,
     output_order: &'scope OutputOrder,
@@ -1328,8 +1325,8 @@ struct FinaliseLayoutResources<'scope, 'data, O: ObjectFile<'data>> {
     merged_strings: &'scope OutputSectionMap<MergedStringsSection<'data>>,
     dynamic_symbol_definitions: &'scope Vec<DynamicSymbolDefinition<'data>>,
     segment_layouts: &'scope SegmentLayouts,
-    program_segments: &'scope ProgramSegments<O::ProgramSegmentDef>,
-    format_specific: &'scope O::LayoutProperties,
+    program_segments: &'scope ProgramSegments<P::ProgramSegmentDef>,
+    format_specific: &'scope P::LayoutProperties,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -1361,7 +1358,7 @@ struct SectionLoadRequest {
 }
 
 impl WorkItem {
-    fn file_id<'data, O: ObjectFile<'data>>(self, symbol_db: &SymbolDb<'data, O>) -> FileId {
+    fn file_id<'data, P: Platform>(self, symbol_db: &SymbolDb<'data, P>) -> FileId {
         match self {
             WorkItem::LoadGlobalSymbol(s) | WorkItem::CopyRelocateSymbol(s) => {
                 symbol_db.file_id_for_symbol(s)
@@ -1372,7 +1369,7 @@ impl WorkItem {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> Layout<'data, O> {
+impl<'data, P: Platform> Layout<'data, P> {
     pub(crate) fn prelude(&self) -> &PreludeLayout<'data> {
         let Some(FileLayout::Prelude(i)) = self.group_layouts.first().and_then(|g| g.files.first())
         else {
@@ -1388,7 +1385,7 @@ impl<'data, O: ObjectFile<'data>> Layout<'data, O> {
     pub(crate) fn symbol_debug<'layout>(
         &'layout self,
         symbol_id: SymbolId,
-    ) -> SymbolDebug<'layout, 'data, O> {
+    ) -> SymbolDebug<'layout, 'data, P> {
         self.symbol_db
             .symbol_debug(&self.per_symbol_flags, symbol_id)
     }
@@ -1535,7 +1532,7 @@ impl<'data, O: ObjectFile<'data>> Layout<'data, O> {
             .flags_for_symbol(&self.per_symbol_flags, symbol_id)
     }
 
-    pub(crate) fn file_layout(&self, file_id: FileId) -> &FileLayout<'data, O> {
+    pub(crate) fn file_layout(&self, file_id: FileId) -> &FileLayout<'data, P> {
         let group_layout = &self.group_layouts[file_id.group()];
         &group_layout.files[file_id.file()]
     }
@@ -1599,8 +1596,8 @@ fn merge_secondary_parts(
     }
 }
 
-fn compute_start_offsets_by_group<'data, O: ObjectFile<'data>>(
-    group_states: &[GroupState<'data, O>],
+fn compute_start_offsets_by_group<'data, P: Platform>(
+    group_states: &[GroupState<'data, P>],
     mut mem_offsets: OutputSectionPartMap<u64>,
 ) -> Vec<OutputSectionPartMap<u64>> {
     timing_phase!("Compute per-group start offsets");
@@ -1615,12 +1612,12 @@ fn compute_start_offsets_by_group<'data, O: ObjectFile<'data>>(
         .collect_vec()
 }
 
-fn compute_symbols_and_layouts<'data, O: ObjectFile<'data>>(
-    group_states: Vec<GroupState<'data, O>>,
+fn compute_symbols_and_layouts<'data, P: Platform>(
+    group_states: Vec<GroupState<'data, P>>,
     starting_mem_offsets_by_group: Vec<OutputSectionPartMap<u64>>,
     per_group_res_writers: &mut [sharded_vec_writer::Shard<Option<Resolution>>],
-    resources: &FinaliseLayoutResources<'_, 'data, O>,
-) -> Result<Vec<GroupLayout<'data, O>>> {
+    resources: &FinaliseLayoutResources<'_, 'data, P>,
+) -> Result<Vec<GroupLayout<'data, P>>> {
     timing_phase!("Assign symbol addresses");
 
     group_states
@@ -1656,11 +1653,11 @@ fn compute_symbols_and_layouts<'data, O: ObjectFile<'data>>(
         .collect()
 }
 
-fn compute_segment_layout<'data, O: ObjectFile<'data>>(
+fn compute_segment_layout<P: Platform>(
     section_layouts: &OutputSectionMap<OutputRecordLayout>,
     output_sections: &OutputSections,
     output_order: &OutputOrder,
-    program_segments: &ProgramSegments<O::ProgramSegmentDef>,
+    program_segments: &ProgramSegments<P::ProgramSegmentDef>,
     header_info: &HeaderInfo,
     args: &Args,
 ) -> Result<SegmentLayouts> {
@@ -1737,7 +1734,7 @@ fn compute_segment_layout<'data, O: ObjectFile<'data>>(
                         output_sections.section_debug(section_id)
                     );
                 } else {
-                    <crate::elf::File as ObjectFile>::validate_section(
+                    <Elf as Platform>::validate_section(
                         section_info,
                         section_flags,
                         section_layout,
@@ -1801,14 +1798,14 @@ fn compute_segment_layout<'data, O: ObjectFile<'data>>(
     })
 }
 
-fn compute_total_section_part_sizes<'data, O: ObjectFile<'data>>(
-    group_states: &mut [GroupState<'data, O>],
+fn compute_total_section_part_sizes<'data, P: Platform>(
+    group_states: &mut [GroupState<'data, P>],
     output_sections: &mut OutputSections,
     output_order: &OutputOrder,
-    program_segments: &ProgramSegments<O::ProgramSegmentDef>,
+    program_segments: &ProgramSegments<P::ProgramSegmentDef>,
     per_symbol_flags: &mut PerSymbolFlags,
     must_keep_sections: OutputSectionMap<bool>,
-    resources: &FinaliseSizesResources<'data, '_, O>,
+    resources: &FinaliseSizesResources<'data, '_, P>,
 ) -> Result<OutputSectionPartMap<u64>> {
     timing_phase!("Compute total section sizes");
 
@@ -1832,7 +1829,7 @@ fn compute_total_section_part_sizes<'data, O: ObjectFile<'data>>(
         unreachable!();
     };
 
-    prelude.apply_late_size_adjustments::<O>(
+    prelude.apply_late_size_adjustments::<P>(
         &mut first_group.common,
         &mut total_sizes,
         must_keep_sections,
@@ -1847,8 +1844,8 @@ fn compute_total_section_part_sizes<'data, O: ObjectFile<'data>>(
 }
 
 /// Propagates attributes from input sections to the output sections into which they were placed.
-fn propagate_section_attributes<'data, O: ObjectFile<'data>>(
-    group_states: &[GroupState<'data, O>],
+fn propagate_section_attributes<'data, P: Platform>(
+    group_states: &[GroupState<'data, P>],
     output_sections: &mut OutputSections,
 ) {
     timing_phase!("Propagate section attributes");
@@ -1868,15 +1865,15 @@ fn propagate_section_attributes<'data, O: ObjectFile<'data>>(
 /// This is similar to computing start addresses, but is used for things that aren't addressable,
 /// but which need to be unique. It's non parallel. It could potentially be run in parallel with
 /// some of the stages that run after it, that don't need access to the file states.
-fn apply_non_addressable_indexes<'data, O: ObjectFile<'data>>(
-    group_states: &mut [GroupState<'data, O>],
-    symbol_db: &SymbolDb<'data, O>,
-) -> Result<O::NonAddressableCounts> {
+fn apply_non_addressable_indexes<'data, P: Platform>(
+    group_states: &mut [GroupState<'data, P>],
+    symbol_db: &SymbolDb<'data, P>,
+) -> Result<P::NonAddressableCounts> {
     timing_phase!("Apply non-addressable indexes");
 
-    let mut indexes = O::NonAddressableIndexes::new(symbol_db);
+    let mut indexes = P::NonAddressableIndexes::new(symbol_db);
 
-    let mut counts = O::NonAddressableCounts::default();
+    let mut counts = P::NonAddressableCounts::default();
 
     for g in group_states.iter_mut() {
         for s in &mut g.files {
@@ -1889,14 +1886,14 @@ fn apply_non_addressable_indexes<'data, O: ObjectFile<'data>>(
                     )?;
                 }
                 FileLayoutState::Epilogue(s) => {
-                    O::apply_non_addressable_indexes_epilogue(&mut counts, &mut s.format_specific);
+                    P::apply_non_addressable_indexes_epilogue(&mut counts, &mut s.format_specific);
                 }
                 _ => {}
             }
         }
     }
 
-    O::apply_non_addressable_indexes(
+    P::apply_non_addressable_indexes(
         symbol_db,
         &counts,
         group_states.iter_mut().map(|g| &mut g.common.mem_sizes),
@@ -1915,29 +1912,29 @@ fn starting_memory_offsets(
 }
 
 #[derive(Default)]
-struct WorkerSlot<'data, O: ObjectFile<'data>> {
+struct WorkerSlot<'data, P: Platform> {
     work: Vec<WorkItem>,
-    worker: Option<GroupState<'data, O>>,
+    worker: Option<GroupState<'data, P>>,
 }
 
 #[derive(Debug)]
-struct GcOutputs<'data, O: ObjectFile<'data>> {
-    group_states: Vec<GroupState<'data, O>>,
+struct GcOutputs<'data, P: Platform> {
+    group_states: Vec<GroupState<'data, P>>,
     must_keep_sections: OutputSectionMap<bool>,
     has_static_tls: bool,
     has_variant_pcs: bool,
 }
 
-struct GroupActivationInputs<'data, O: ObjectFile<'data>> {
-    resolved: ResolvedGroup<'data, O>,
+struct GroupActivationInputs<'data, P: Platform> {
+    resolved: ResolvedGroup<'data, P>,
     num_symbols: usize,
     group_index: usize,
 }
 
-impl<'data, O: ObjectFile<'data>> GroupActivationInputs<'data, O> {
-    fn activate_group<'scope, A: Arch<File<'data> = O>>(
+impl<'data, P: Platform> GroupActivationInputs<'data, P> {
+    fn activate_group<'scope, A: Arch<Platform = P>>(
         self,
-        resources: &'scope GraphResources<'data, '_, O>,
+        resources: &'scope GraphResources<'data, '_, P>,
         scope: &Scope<'scope>,
     ) {
         let GroupActivationInputs {
@@ -1994,12 +1991,12 @@ impl<'data, O: ObjectFile<'data>> GroupActivationInputs<'data, O> {
 }
 
 fn find_required_sections<'data, A: Arch>(
-    groups_in: Vec<resolution::ResolvedGroup<'data, A::File<'data>>>,
-    symbol_db: &SymbolDb<'data, A::File<'data>>,
+    groups_in: Vec<resolution::ResolvedGroup<'data, A::Platform>>,
+    symbol_db: &SymbolDb<'data, A::Platform>,
     per_symbol_flags: &AtomicPerSymbolFlags,
     output_sections: &OutputSections<'data>,
-    layout_resources_ext: <A::File<'data> as ObjectFile<'data>>::LayoutResourcesExt,
-) -> Result<GcOutputs<'data, A::File<'data>>> {
+    layout_resources_ext: <A::Platform as Platform>::LayoutResourcesExt<'data>,
+) -> Result<GcOutputs<'data, A::Platform>> {
     timing_phase!("Find required sections");
 
     let num_groups = groups_in.len();
@@ -2042,7 +2039,7 @@ fn find_required_sections<'data, A: Arch>(
     let mut group_states = unwrap_worker_states(&resources.worker_slots);
     let must_keep_sections = resources.must_keep_sections.into_map(|v| v.into_inner());
 
-    <A::File<'data> as ObjectFile<'data>>::finalise_find_required_sections(&group_states);
+    <A::Platform as Platform>::finalise_find_required_sections(&group_states);
 
     // Give our prelude a chance to tie up a few last sizes while we still have access to
     // `resources`.
@@ -2050,7 +2047,7 @@ fn find_required_sections<'data, A: Arch>(
     let FileLayoutState::Prelude(prelude) = &mut prelude_group.files[0] else {
         unreachable!("Prelude must be first");
     };
-    prelude.pre_finalise_sizes::<A::File<'data>>(
+    prelude.pre_finalise_sizes::<A::Platform>(
         &mut prelude_group.common,
         &resources.uses_tlsld,
         resources.symbol_db.args,
@@ -2066,9 +2063,9 @@ fn find_required_sections<'data, A: Arch>(
 }
 
 fn queue_initial_group_processing<'data, 'scope, A: Arch>(
-    groups_in: Vec<resolution::ResolvedGroup<'data, A::File<'data>>>,
-    symbol_db: &'scope SymbolDb<'data, A::File<'data>>,
-    resources: &'scope GraphResources<'data, '_, A::File<'data>>,
+    groups_in: Vec<resolution::ResolvedGroup<'data, A::Platform>>,
+    symbol_db: &'scope SymbolDb<'data, A::Platform>,
+    resources: &'scope GraphResources<'data, '_, A::Platform>,
     scope: &Scope<'scope>,
 ) {
     verbose_timing_phase!("Create worker slots");
@@ -2092,21 +2089,21 @@ fn queue_initial_group_processing<'data, 'scope, A: Arch>(
         });
 }
 
-fn unwrap_worker_states<'data, O: ObjectFile<'data>>(
-    worker_slots: &[Mutex<WorkerSlot<'data, O>>],
-) -> Vec<GroupState<'data, O>> {
+fn unwrap_worker_states<'data, P: Platform>(
+    worker_slots: &[Mutex<WorkerSlot<'data, P>>],
+) -> Vec<GroupState<'data, P>> {
     worker_slots
         .iter()
         .filter_map(|w| w.lock().unwrap().worker.take())
         .collect()
 }
 
-impl<'data, O: ObjectFile<'data>> GroupState<'data, O> {
+impl<'data, P: Platform> GroupState<'data, P> {
     /// Does work until there's nothing left in the queue, then returns our worker to its slot and
     /// shuts down.
-    fn do_pending_work<'scope, A: Arch<File<'data> = O>>(
+    fn do_pending_work<'scope, A: Arch<Platform = P>>(
         mut self,
-        resources: &'scope GraphResources<'data, '_, O>,
+        resources: &'scope GraphResources<'data, '_, P>,
         scope: &Scope<'scope>,
     ) {
         loop {
@@ -2139,7 +2136,7 @@ impl<'data, O: ObjectFile<'data>> GroupState<'data, O> {
         &mut self,
         output_sections: &OutputSections,
         per_symbol_flags: &AtomicPerSymbolFlags,
-        resources: &FinaliseSizesResources<'data, '_, O>,
+        resources: &FinaliseSizesResources<'data, '_, P>,
     ) -> Result {
         for file_state in &mut self.files {
             file_state.finalise_sizes(
@@ -2158,9 +2155,9 @@ impl<'data, O: ObjectFile<'data>> GroupState<'data, O> {
         self,
         memory_offsets: &mut OutputSectionPartMap<u64>,
         resolutions_out: &mut sharded_vec_writer::Shard<Option<Resolution>>,
-        resources: &FinaliseLayoutResources<'_, 'data, O>,
-    ) -> Result<GroupLayout<'data, O>> {
-        let format_specific = O::finalise_group_layout(memory_offsets);
+        resources: &FinaliseLayoutResources<'_, 'data, P>,
+    ) -> Result<GroupLayout<'data, P>> {
+        let format_specific = P::finalise_group_layout(memory_offsets);
         let files = self
             .files
             .into_iter()
@@ -2189,10 +2186,10 @@ impl<'data, O: ObjectFile<'data>> GroupState<'data, O> {
 }
 
 fn activate<'data, 'scope, A: Arch>(
-    common: &mut CommonGroupState<'data, A::File<'data>>,
-    file: &mut FileLayoutState<'data, A::File<'data>>,
+    common: &mut CommonGroupState<'data, A::Platform>,
+    file: &mut FileLayoutState<'data, A::Platform>,
     queue: &mut LocalWorkQueue,
-    resources: &'scope GraphResources<'data, '_, A::File<'data>>,
+    resources: &'scope GraphResources<'data, '_, A::Platform>,
     scope: &Scope<'scope>,
 ) -> Result {
     match file {
@@ -2211,7 +2208,7 @@ impl LocalWorkQueue {
     #[inline(always)]
     fn send_work<'data, 'scope, A: Arch>(
         &mut self,
-        resources: &'scope GraphResources<'data, '_, A::File<'data>>,
+        resources: &'scope GraphResources<'data, '_, A::Platform>,
         file_id: FileId,
         work: WorkItem,
         scope: &Scope<'scope>,
@@ -2234,7 +2231,7 @@ impl LocalWorkQueue {
     fn send_symbol_request<'data, 'scope, A: Arch>(
         &mut self,
         symbol_id: SymbolId,
-        resources: &'scope GraphResources<'data, '_, A::File<'data>>,
+        resources: &'scope GraphResources<'data, '_, A::Platform>,
         scope: &Scope<'scope>,
     ) {
         debug_assert!(resources.symbol_db.is_canonical(symbol_id));
@@ -2250,7 +2247,7 @@ impl LocalWorkQueue {
     fn send_copy_relocation_request<'data, 'scope, A: Arch>(
         &mut self,
         symbol_id: SymbolId,
-        resources: &'scope GraphResources<'data, '_, A::File<'data>>,
+        resources: &'scope GraphResources<'data, '_, A::Platform>,
         scope: &Scope<'scope>,
     ) {
         debug_assert!(resources.symbol_db.is_canonical(symbol_id));
@@ -2264,7 +2261,7 @@ impl LocalWorkQueue {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> GraphResources<'data, '_, O> {
+impl<'data, P: Platform> GraphResources<'data, '_, P> {
     fn report_error(&self, error: Error) {
         self.errors.lock().unwrap().push(error);
     }
@@ -2272,11 +2269,11 @@ impl<'data, O: ObjectFile<'data>> GraphResources<'data, '_, O> {
     /// Sends all work in `work` to the worker for `file_id`. Leaves `work` empty so that it can be
     /// reused.
     #[inline(always)]
-    fn send_work<'scope, A: Arch<File<'data> = O>>(
+    fn send_work<'scope, A: Arch<Platform = P>>(
         &self,
         file_id: FileId,
         work: WorkItem,
-        resources: &'scope GraphResources<'data, '_, O>,
+        resources: &'scope GraphResources<'data, '_, P>,
         scope: &Scope<'scope>,
     ) {
         let worker;
@@ -2297,7 +2294,7 @@ impl<'data, O: ObjectFile<'data>> GraphResources<'data, '_, O> {
         self.per_symbol_flags.flags_for_symbol(symbol_id)
     }
 
-    fn symbol_debug<'a>(&'a self, symbol_id: SymbolId) -> SymbolDebug<'a, 'data, O> {
+    fn symbol_debug<'a>(&'a self, symbol_id: SymbolId) -> SymbolDebug<'a, 'data, P> {
         self.symbol_db
             .symbol_debug(self.per_symbol_flags, symbol_id)
     }
@@ -2315,13 +2312,13 @@ impl<'data, O: ObjectFile<'data>> GraphResources<'data, '_, O> {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> FileLayoutState<'data, O> {
+impl<'data, P: Platform> FileLayoutState<'data, P> {
     fn finalise_sizes(
         &mut self,
-        common: &mut CommonGroupState<'data, O>,
+        common: &mut CommonGroupState<'data, P>,
         output_sections: &OutputSections,
         per_symbol_flags: &AtomicPerSymbolFlags,
-        resources: &FinaliseSizesResources<'data, '_, O>,
+        resources: &FinaliseSizesResources<'data, '_, P>,
     ) -> Result {
         match self {
             FileLayoutState::Object(s) => {
@@ -2350,16 +2347,16 @@ impl<'data, O: ObjectFile<'data>> FileLayoutState<'data, O> {
             FileLayoutState::NotLoaded(_) => {}
         }
 
-        O::finalise_sizes_all(&mut common.mem_sizes, resources.symbol_db);
+        P::finalise_sizes_all(&mut common.mem_sizes, resources.symbol_db);
 
         Ok(())
     }
 
-    fn do_work<'scope, A: Arch<File<'data> = O>>(
+    fn do_work<'scope, A: Arch<Platform = P>>(
         &mut self,
-        common: &mut CommonGroupState<'data, O>,
+        common: &mut CommonGroupState<'data, P>,
         work_item: WorkItem,
-        resources: &'scope GraphResources<'data, 'scope, O>,
+        resources: &'scope GraphResources<'data, 'scope, P>,
         queue: &mut LocalWorkQueue,
         scope: &Scope<'scope>,
     ) -> Result {
@@ -2406,11 +2403,11 @@ impl<'data, O: ObjectFile<'data>> FileLayoutState<'data, O> {
         }
     }
 
-    fn handle_symbol_request<'scope, A: Arch<File<'data> = O>>(
+    fn handle_symbol_request<'scope, A: Arch<Platform = P>>(
         &mut self,
-        common: &mut CommonGroupState<'data, O>,
+        common: &mut CommonGroupState<'data, P>,
         symbol_id: SymbolId,
-        resources: &'scope GraphResources<'data, 'scope, O>,
+        resources: &'scope GraphResources<'data, 'scope, P>,
         queue: &mut LocalWorkQueue,
         scope: &Scope<'scope>,
     ) -> Result {
@@ -2450,8 +2447,8 @@ impl<'data, O: ObjectFile<'data>> FileLayoutState<'data, O> {
         self,
         memory_offsets: &mut OutputSectionPartMap<u64>,
         resolutions_out: &mut sharded_vec_writer::Shard<Option<Resolution>>,
-        resources: &FinaliseLayoutResources<'_, 'data, O>,
-    ) -> Result<FileLayout<'data, O>> {
+        resources: &FinaliseLayoutResources<'_, 'data, P>,
+    ) -> Result<FileLayout<'data, P>> {
         let resolutions_out = &mut ResolutionWriter { resolutions_out };
         let file_layout = match self {
             Self::Object(s) => {
@@ -2514,7 +2511,7 @@ impl std::fmt::Display for PreludeLayoutState<'_> {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> std::fmt::Display for EpilogueLayoutState<'data, O> {
+impl<P: Platform> std::fmt::Display for EpilogueLayoutState<P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt("<epilogue>", f)
     }
@@ -2532,7 +2529,7 @@ impl std::fmt::Display for LinkerScriptLayoutState<'_> {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> std::fmt::Display for FileLayoutState<'data, O> {
+impl<'data, P: Platform> std::fmt::Display for FileLayoutState<'data, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             FileLayoutState::Object(s) => std::fmt::Display::fmt(s, f),
@@ -2546,7 +2543,7 @@ impl<'data, O: ObjectFile<'data>> std::fmt::Display for FileLayoutState<'data, O
     }
 }
 
-impl<'data, O: ObjectFile<'data>> std::fmt::Display for FileLayout<'data, O> {
+impl<'data, P: Platform> std::fmt::Display for FileLayout<'data, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Object(s) => std::fmt::Display::fmt(s, f),
@@ -2560,7 +2557,7 @@ impl<'data, O: ObjectFile<'data>> std::fmt::Display for FileLayout<'data, O> {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> std::fmt::Display for GroupLayout<'data, O> {
+impl<'data, P: Platform> std::fmt::Display for GroupLayout<'data, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.files.len() == 1 {
             self.files[0].fmt(f)
@@ -2575,7 +2572,7 @@ impl<'data, O: ObjectFile<'data>> std::fmt::Display for GroupLayout<'data, O> {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> std::fmt::Display for GroupState<'data, O> {
+impl<'data, P: Platform> std::fmt::Display for GroupState<'data, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.files.len() == 1 {
             self.files[0].fmt(f)
@@ -2590,13 +2587,13 @@ impl<'data, O: ObjectFile<'data>> std::fmt::Display for GroupState<'data, O> {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> std::fmt::Debug for FileLayout<'data, O> {
+impl<'data, P: Platform> std::fmt::Debug for FileLayout<'data, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(&self, f)
     }
 }
 
-impl<'data, O: ObjectFile<'data>> std::fmt::Display for ObjectLayoutState<'data, O> {
+impl<'data, P: Platform> std::fmt::Display for ObjectLayoutState<'data, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(&self.input, f)?;
         // TODO: This is mostly for debugging use. Consider only showing this if some environment
@@ -2605,21 +2602,21 @@ impl<'data, O: ObjectFile<'data>> std::fmt::Display for ObjectLayoutState<'data,
     }
 }
 
-impl<'data, O: ObjectFile<'data>> std::fmt::Display for DynamicLayoutState<'data, O> {
+impl<'data, P: Platform> std::fmt::Display for DynamicLayoutState<'data, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(&self.input, f)?;
         write!(f, " ({})", self.file_id())
     }
 }
 
-impl<'data, O: ObjectFile<'data>> std::fmt::Display for DynamicLayout<'data, O> {
+impl<'data, P: Platform> std::fmt::Display for DynamicLayout<'data, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(&self.input, f)?;
         write!(f, " ({})", self.file_id)
     }
 }
 
-impl<'data, O: ObjectFile<'data>> std::fmt::Display for ObjectLayout<'data, O> {
+impl<'data, P: Platform> std::fmt::Display for ObjectLayout<'data, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(&self.input, f)?;
         // TODO: This is mostly for debugging use. Consider only showing this if some environment
@@ -2629,9 +2626,9 @@ impl<'data, O: ObjectFile<'data>> std::fmt::Display for ObjectLayout<'data, O> {
 }
 
 impl Section {
-    fn create<'data, O: ObjectFile<'data>>(
-        header: &O::SectionHeader,
-        object_state: &ObjectLayoutState<'data, O>,
+    fn create<'data, P: Platform>(
+        header: &P::SectionHeader,
+        object_state: &ObjectLayoutState<'data, P>,
         section_index: object::SectionIndex,
         part_id: PartId,
     ) -> Result<Section> {
@@ -2672,11 +2669,11 @@ impl Section {
 
 #[inline(always)]
 pub(crate) fn process_relocation<'data, 'scope, A: Arch, R: Relocation>(
-    object: &ObjectLayoutState<'data, A::File<'data>>,
-    common: &mut CommonGroupState<'data, A::File<'data>>,
+    object: &ObjectLayoutState<'data, A::Platform>,
+    common: &mut CommonGroupState<'data, A::Platform>,
     rel: &R,
-    section: &<A::File<'data> as ObjectFile<'data>>::SectionHeader,
-    resources: &'scope GraphResources<'data, '_, A::File<'data>>,
+    section: &<A::Platform as Platform>::SectionHeader,
+    resources: &'scope GraphResources<'data, '_, A::Platform>,
     queue: &mut LocalWorkQueue,
     is_debug_section: bool,
     scope: &Scope<'scope>,
@@ -2691,7 +2688,7 @@ pub(crate) fn process_relocation<'data, 'scope, A: Arch, R: Relocation>(
         flags.merge(resources.local_flags_for_symbol(local_symbol_id));
         let rel_offset = rel.offset();
         let r_type = rel.raw_type();
-        let section_flags = <A::File<'data> as ObjectFile<'data>>::section_flags(section);
+        let section_flags = <A::Platform as Platform>::section_flags(section);
 
         let rel_info = if let Some(relaxation) = A::new_relaxation(
             r_type,
@@ -2795,7 +2792,7 @@ pub(crate) fn process_relocation<'data, 'scope, A: Arch, R: Relocation>(
             }
 
             queue.send_symbol_request::<A>(symbol_id, resources, scope);
-            if should_emit_undefined_error::<A::File<'data>>(
+            if should_emit_undefined_error::<A::Platform>(
                 object.object.symbol(local_sym_index)?,
                 object.file_id,
                 symbol_db.file_id_for_symbol(symbol_id),
@@ -2900,8 +2897,8 @@ impl<'data> PreludeLayoutState<'data> {
 
     fn activate<'scope, A: Arch>(
         &mut self,
-        common: &mut CommonGroupState<'data, A::File<'data>>,
-        resources: &'scope GraphResources<'data, '_, A::File<'data>>,
+        common: &mut CommonGroupState<'data, A::Platform>,
+        resources: &'scope GraphResources<'data, '_, A::Platform>,
         queue: &mut LocalWorkQueue,
         scope: &Scope<'scope>,
     ) -> Result {
@@ -2953,7 +2950,7 @@ impl<'data> PreludeLayoutState<'data> {
     /// even if nothing in the code references them.
     fn mark_defsyms_as_used<'scope, A: Arch>(
         &self,
-        resources: &'scope GraphResources<'data, '_, A::File<'data>>,
+        resources: &'scope GraphResources<'data, '_, A::Platform>,
         queue: &mut LocalWorkQueue,
         scope: &Scope<'scope>,
     ) {
@@ -3006,7 +3003,7 @@ impl<'data> PreludeLayoutState<'data> {
 
     fn load_entry_point<'scope, A: Arch>(
         &mut self,
-        resources: &'scope GraphResources<'data, '_, A::File<'data>>,
+        resources: &'scope GraphResources<'data, '_, A::Platform>,
         queue: &mut LocalWorkQueue,
         scope: &Scope<'scope>,
     ) {
@@ -3039,9 +3036,9 @@ impl<'data> PreludeLayoutState<'data> {
         }
     }
 
-    fn pre_finalise_sizes<O: ObjectFile<'data>>(
+    fn pre_finalise_sizes<P: Platform>(
         &mut self,
-        common: &mut CommonGroupState<'data, O>,
+        common: &mut CommonGroupState<'data, P>,
         uses_tlsld: &AtomicBool,
         args: &Args,
         output_kind: OutputKind,
@@ -3057,11 +3054,11 @@ impl<'data> PreludeLayoutState<'data> {
             }
         }
 
-        O::pre_finalise_sizes_prelude(common, args);
+        P::pre_finalise_sizes_prelude(common, args);
     }
 
-    fn finalise_sizes<O: ObjectFile<'data>>(
-        common: &mut CommonGroupState<'data, O>,
+    fn finalise_sizes<P: Platform>(
+        common: &mut CommonGroupState<'data, P>,
         merged_strings: &OutputSectionMap<MergedStringsSection<'data>>,
     ) {
         merged_strings.for_each(|section_id, merged| {
@@ -3078,16 +3075,16 @@ impl<'data> PreludeLayoutState<'data> {
     /// of the section headers table, which depends on which sections we're writing, which depends
     /// on which sections are non-empty. We also decide which internal symtab entries we'll write
     /// here, since that also depends on which sections we're writing.
-    fn apply_late_size_adjustments<O: ObjectFile<'data>>(
+    fn apply_late_size_adjustments<P: Platform>(
         &mut self,
-        common: &mut CommonGroupState<'data, O>,
+        common: &mut CommonGroupState<'data, P>,
         total_sizes: &mut OutputSectionPartMap<u64>,
         must_keep_sections: OutputSectionMap<bool>,
         output_sections: &mut OutputSections,
         output_order: &OutputOrder,
-        program_segments: &ProgramSegments<O::ProgramSegmentDef>,
+        program_segments: &ProgramSegments<P::ProgramSegmentDef>,
         per_symbol_flags: &mut PerSymbolFlags,
-        resources: &FinaliseSizesResources<'data, '_, O>,
+        resources: &FinaliseSizesResources<'data, '_, P>,
     ) -> Result {
         // Total section  sizes have already been computed. So any allocations we do need to update
         // both `total_sizes` and the size records in `common`. We track the extra sizes in
@@ -3123,11 +3120,11 @@ impl<'data> PreludeLayoutState<'data> {
     /// Allocates space for our internal symbols. For unreferenced symbols, we also update the
     /// symbol so that it is treated as referenced, but only for symbols in sections that we're
     /// going to emit.
-    fn allocate_symbol_table_sizes<O: ObjectFile<'data>>(
+    fn allocate_symbol_table_sizes<P: Platform>(
         &self,
         output_sections: &OutputSections,
         per_symbol_flags: &mut PerSymbolFlags,
-        symbol_db: &SymbolDb<'data, O>,
+        symbol_db: &SymbolDb<'data, P>,
         extra_sizes: &mut OutputSectionPartMap<u64>,
     ) -> Result<(), Error> {
         if symbol_db.args.strip_all() {
@@ -3166,15 +3163,15 @@ impl<'data> PreludeLayoutState<'data> {
         )
     }
 
-    fn determine_header_sizes<O: ObjectFile<'data>>(
+    fn determine_header_sizes<P: Platform>(
         &mut self,
         total_sizes: &OutputSectionPartMap<u64>,
         extra_sizes: &mut OutputSectionPartMap<u64>,
         must_keep_sections: OutputSectionMap<bool>,
         output_sections: &mut OutputSections,
-        program_segments: &ProgramSegments<O::ProgramSegmentDef>,
+        program_segments: &ProgramSegments<P::ProgramSegmentDef>,
         output_order: &OutputOrder,
-        resources: &FinaliseSizesResources<'data, '_, O>,
+        resources: &FinaliseSizesResources<'data, '_, P>,
         symbol_flags: &PerSymbolFlags,
     ) {
         use output_section_id::OrderEvent;
@@ -3192,7 +3189,7 @@ impl<'data> PreludeLayoutState<'data> {
         });
 
         // Keep any sections that we've said we want to keep regardless.
-        O::apply_force_keep_sections(&mut keep_sections, resources.symbol_db.args);
+        P::apply_force_keep_sections(&mut keep_sections, resources.symbol_db.args);
 
         // Keep any sections that have a start/stop symbol which is referenced.
         symbol_flags
@@ -3228,7 +3225,7 @@ impl<'data> PreludeLayoutState<'data> {
             if section_info.ty.is_null() && section_id != output_section_id::FILE_HEADER {
                 if section_id.is_custom() {
                     output_sections.section_infos.get_mut(section_id).ty =
-                        <crate::elf::File as ObjectFile>::default_section_type();
+                        Elf::default_section_type();
                 } else {
                     *keep_sections.get_mut(section_id) = false;
                 }
@@ -3280,7 +3277,7 @@ impl<'data> PreludeLayoutState<'data> {
         // Always keep the program headers segment even though we don't emit any sections in it.
         keep_segments[0] = true;
 
-        O::update_segment_keep_list(
+        P::update_segment_keep_list(
             program_segments,
             &mut keep_segments,
             resources.symbol_db.args,
@@ -3319,11 +3316,11 @@ impl<'data> PreludeLayoutState<'data> {
         self.header_info = Some(header_info);
     }
 
-    fn finalise_layout<O: ObjectFile<'data>>(
+    fn finalise_layout<P: Platform>(
         self,
         memory_offsets: &mut OutputSectionPartMap<u64>,
         resolutions_out: &mut ResolutionWriter,
-        resources: &FinaliseLayoutResources<'_, 'data, O>,
+        resources: &FinaliseLayoutResources<'_, 'data, P>,
     ) -> Result<PreludeLayout<'data>> {
         let header_layout = resources
             .section_layouts
@@ -3375,10 +3372,10 @@ impl<'data> PreludeLayoutState<'data> {
 }
 
 impl<'data> InternalSymbols<'data> {
-    fn activate_symbols<O: ObjectFile<'data>>(
+    fn activate_symbols<P: Platform>(
         &self,
-        common: &mut CommonGroupState<'data, O>,
-        resources: &GraphResources<'data, '_, O>,
+        common: &mut CommonGroupState<'data, P>,
+        resources: &GraphResources<'data, '_, P>,
     ) -> Result {
         for (offset, def_info) in self.symbol_definitions.iter().enumerate() {
             let symbol_id = self.start_symbol_id.add_usize(offset);
@@ -3413,10 +3410,10 @@ impl<'data> InternalSymbols<'data> {
         Ok(())
     }
 
-    fn allocate_symbol_table_sizes<O: ObjectFile<'data>>(
+    fn allocate_symbol_table_sizes<P: Platform>(
         &self,
         sizes: &mut OutputSectionPartMap<u64>,
-        symbol_db: &SymbolDb<'data, O>,
+        symbol_db: &SymbolDb<'data, P>,
         mut should_keep_symbol: impl FnMut(SymbolId, &InternalSymDefInfo) -> bool,
     ) -> Result {
         // Allocate space in the symbol table for the symbols that we define.
@@ -3438,17 +3435,17 @@ impl<'data> InternalSymbols<'data> {
             };
             sizes.increment(symtab_part, size_of::<elf::SymtabEntry>() as u64);
             let symbol_name = symbol_db.symbol_name(symbol_id)?;
-            let symbol_name = O::RawSymbolName::parse(symbol_name.bytes()).name();
+            let symbol_name = P::RawSymbolName::parse(symbol_name.bytes()).name();
             sizes.increment(part_id::STRTAB, symbol_name.len() as u64 + 1);
         }
         Ok(())
     }
 
-    fn finalise_layout<O: ObjectFile<'data>>(
+    fn finalise_layout<P: Platform>(
         &self,
         memory_offsets: &mut OutputSectionPartMap<u64>,
         resolutions_out: &mut ResolutionWriter,
-        resources: &FinaliseLayoutResources<'_, 'data, O>,
+        resources: &FinaliseLayoutResources<'_, 'data, P>,
     ) -> Result {
         // Define symbols that are optionally put at the start/end of some sections.
         for (local_index, &def_info) in self.symbol_definitions.iter().enumerate() {
@@ -3467,9 +3464,9 @@ impl<'data> InternalSymbols<'data> {
     }
 }
 
-fn create_start_end_symbol_resolution<'data, O: ObjectFile<'data>>(
+fn create_start_end_symbol_resolution<'data, P: Platform>(
     memory_offsets: &mut OutputSectionPartMap<u64>,
-    resources: &FinaliseLayoutResources<'_, 'data, O>,
+    resources: &FinaliseLayoutResources<'_, 'data, P>,
     def_info: InternalSymDefInfo,
     symbol_id: SymbolId,
 ) -> Option<Resolution> {
@@ -3543,8 +3540,8 @@ fn create_start_end_symbol_resolution<'data, O: ObjectFile<'data>>(
     ))
 }
 
-fn should_emit_undefined_error<'data, O: ObjectFile<'data>>(
-    symbol: &O::Symbol,
+fn should_emit_undefined_error<P: Platform>(
+    symbol: &P::Symbol,
     sym_file_id: FileId,
     sym_def_file_id: FileId,
     flags: ValueFlags,
@@ -3580,11 +3577,11 @@ impl<'data> SyntheticSymbolsLayoutState<'data> {
         }
     }
 
-    fn finalise_sizes<O: ObjectFile<'data>>(
+    fn finalise_sizes<P: Platform>(
         &self,
-        common: &mut CommonGroupState<'data, O>,
+        common: &mut CommonGroupState<'data, P>,
         per_symbol_flags: &AtomicPerSymbolFlags,
-        resources: &FinaliseSizesResources<'data, '_, O>,
+        resources: &FinaliseSizesResources<'data, '_, P>,
     ) -> Result {
         let symbol_db = resources.symbol_db;
 
@@ -3604,11 +3601,11 @@ impl<'data> SyntheticSymbolsLayoutState<'data> {
         Ok(())
     }
 
-    fn finalise_layout<O: ObjectFile<'data>>(
+    fn finalise_layout<P: Platform>(
         self,
         memory_offsets: &mut OutputSectionPartMap<u64>,
         resolutions_out: &mut ResolutionWriter,
-        resources: &FinaliseLayoutResources<'_, 'data, O>,
+        resources: &FinaliseLayoutResources<'_, 'data, P>,
     ) -> Result<SyntheticSymbolsLayout<'data>> {
         self.internal_symbols
             .finalise_layout(memory_offsets, resolutions_out, resources)?;
@@ -3619,26 +3616,26 @@ impl<'data> SyntheticSymbolsLayoutState<'data> {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> EpilogueLayoutState<'data, O> {
+impl<'data, P: Platform> EpilogueLayoutState<P> {
     fn new(
         args: &Args,
         output_kind: OutputKind,
         dynamic_symbol_definitions: &mut [DynamicSymbolDefinition],
     ) -> Self {
         EpilogueLayoutState {
-            format_specific: O::new_epilogue_layout(args, output_kind, dynamic_symbol_definitions),
+            format_specific: P::new_epilogue_layout(args, output_kind, dynamic_symbol_definitions),
         }
     }
 
     fn apply_late_size_adjustments(
         &mut self,
-        common: &mut CommonGroupState<'data, O>,
+        common: &mut CommonGroupState<'data, P>,
         total_sizes: &mut OutputSectionPartMap<u64>,
-        resources: &FinaliseSizesResources<'data, '_, O>,
+        resources: &FinaliseSizesResources<'data, '_, P>,
     ) -> Result {
         if resources.symbol_db.args.hash_style.includes_sysv() {
             let mut extra_sizes = OutputSectionPartMap::with_size(common.mem_sizes.num_parts());
-            O::apply_late_size_adjustments_epilogue(
+            P::apply_late_size_adjustments_epilogue(
                 &mut self.format_specific,
                 total_sizes,
                 &mut extra_sizes,
@@ -3655,12 +3652,12 @@ impl<'data, O: ObjectFile<'data>> EpilogueLayoutState<'data, O> {
 
     fn finalise_sizes(
         &mut self,
-        common: &mut CommonGroupState<'data, O>,
-        resources: &FinaliseSizesResources<'data, '_, O>,
+        common: &mut CommonGroupState<'data, P>,
+        resources: &FinaliseSizesResources<'data, '_, P>,
     ) {
         let symbol_db = resources.symbol_db;
 
-        O::finalise_sizes_epilogue(
+        P::finalise_sizes_epilogue(
             &mut self.format_specific,
             &mut common.mem_sizes,
             resources.dynamic_symbol_definitions,
@@ -3672,8 +3669,8 @@ impl<'data, O: ObjectFile<'data>> EpilogueLayoutState<'data, O> {
     fn finalise_layout(
         mut self,
         memory_offsets: &mut OutputSectionPartMap<u64>,
-        resources: &FinaliseLayoutResources<'_, 'data, O>,
-    ) -> Result<EpilogueLayout<'data, O>> {
+        resources: &FinaliseLayoutResources<'_, 'data, P>,
+    ) -> Result<EpilogueLayout<P>> {
         let dynsym_start_index = ((memory_offsets.get(part_id::DYNSYM)
             - resources
                 .section_layouts
@@ -3688,7 +3685,7 @@ impl<'data, O: ObjectFile<'data>> EpilogueLayoutState<'data, O> {
             resources.dynamic_symbol_definitions.len() as u64 * elf::SYMTAB_ENTRY_SIZE,
         );
 
-        O::finalise_layout_epilogue(
+        P::finalise_layout_epilogue(
             &mut self.format_specific,
             memory_offsets,
             resources.symbol_db,
@@ -3722,9 +3719,9 @@ impl HeaderInfo {
 
 /// Construct a new inactive instance, which means we don't yet load non-GC sections and only
 /// load them later if a symbol from this object is referenced.
-fn new_object_layout_state<'data, O: ObjectFile<'data>>(
-    input_state: resolution::ResolvedObject<'data, O>,
-) -> FileLayoutState<'data, O> {
+fn new_object_layout_state<'data, P: Platform>(
+    input_state: resolution::ResolvedObject<'data, P>,
+) -> FileLayoutState<'data, P> {
     // Note, this function is called for all objects from a single thread, so don't be tempted to do
     // significant work here. Do work when activate is called instead. Doing it there also means
     // that we don't do the work unless the object is actually needed.
@@ -3741,9 +3738,9 @@ fn new_object_layout_state<'data, O: ObjectFile<'data>>(
     })
 }
 
-fn new_dynamic_object_layout_state<'data, O: ObjectFile<'data>>(
-    input_state: &resolution::ResolvedDynamic<'data, O>,
-) -> FileLayoutState<'data, O> {
+fn new_dynamic_object_layout_state<'data, P: Platform>(
+    input_state: &resolution::ResolvedDynamic<'data, P>,
+) -> FileLayoutState<'data, P> {
     FileLayoutState::Dynamic(DynamicLayoutState {
         file_id: input_state.common.file_id,
         symbol_id_range: input_state.common.symbol_id_range,
@@ -3755,12 +3752,12 @@ fn new_dynamic_object_layout_state<'data, O: ObjectFile<'data>>(
     })
 }
 
-impl<'data, O: ObjectFile<'data>> ObjectLayoutState<'data, O> {
+impl<'data, P: Platform> ObjectLayoutState<'data, P> {
     #[inline(always)]
-    fn activate<'scope, A: Arch<File<'data> = O>>(
+    fn activate<'scope, A: Arch<Platform = P>>(
         &mut self,
-        common: &mut CommonGroupState<'data, O>,
-        resources: &'scope GraphResources<'data, 'scope, O>,
+        common: &mut CommonGroupState<'data, P>,
+        resources: &'scope GraphResources<'data, 'scope, P>,
         queue: &mut LocalWorkQueue,
         scope: &Scope<'scope>,
     ) -> Result {
@@ -3814,7 +3811,7 @@ impl<'data, O: ObjectFile<'data>> ObjectLayoutState<'data, O> {
         }
 
         if let Some(frame_data_section_index) = frame_section_index {
-            <A::File<'data> as ObjectFile<'data>>::load_exception_frame_data::<A>(
+            <A::Platform as Platform>::load_exception_frame_data::<A>(
                 self,
                 common,
                 frame_data_section_index,
@@ -3857,10 +3854,10 @@ impl<'data, O: ObjectFile<'data>> ObjectLayoutState<'data, O> {
         Ok(())
     }
 
-    fn handle_section_load_request<'scope, A: Arch<File<'data> = O>>(
+    fn handle_section_load_request<'scope, A: Arch<Platform = P>>(
         &mut self,
-        common: &mut CommonGroupState<'data, O>,
-        resources: &'scope GraphResources<'data, 'scope, O>,
+        common: &mut CommonGroupState<'data, P>,
+        resources: &'scope GraphResources<'data, 'scope, P>,
         queue: &mut LocalWorkQueue,
         section_index: SectionIndex,
         scope: &Scope<'scope>,
@@ -3904,20 +3901,20 @@ impl<'data, O: ObjectFile<'data>> ObjectLayoutState<'data, O> {
         Ok(())
     }
 
-    fn load_section<'scope, A: Arch<File<'data> = O>>(
+    fn load_section<'scope, A: Arch<Platform = P>>(
         &mut self,
-        common: &mut CommonGroupState<'data, O>,
+        common: &mut CommonGroupState<'data, P>,
         queue: &mut LocalWorkQueue,
         unloaded: UnloadedSection,
         section_index: SectionIndex,
-        resources: &'scope GraphResources<'data, 'scope, O>,
+        resources: &'scope GraphResources<'data, 'scope, P>,
         scope: &Scope<'scope>,
     ) -> Result {
         let part_id = unloaded.part_id;
         let header = self.object.section(section_index)?;
         let section = Section::create(header, self, section_index, part_id)?;
 
-        <A::File<'data> as ObjectFile<'data>>::load_object_section_relocations::<A>(
+        <A::Platform as Platform>::load_object_section_relocations::<A>(
             self, common, queue, resources, section, scope,
         )?;
 
@@ -3928,8 +3925,8 @@ impl<'data, O: ObjectFile<'data>> ObjectLayoutState<'data, O> {
         let section_id = section.output_section_id();
 
         if section.size > 0 {
-            O::non_empty_section_loaded::<A>(self, common, queue, unloaded, resources, scope)?;
-        } else if O::is_zero_sized_section_content(section_id) {
+            P::non_empty_section_loaded::<A>(self, common, queue, unloaded, resources, scope)?;
+        } else if P::is_zero_sized_section_content(section_id) {
             resources.keep_section(section_id);
         }
 
@@ -3938,11 +3935,11 @@ impl<'data, O: ObjectFile<'data>> ObjectLayoutState<'data, O> {
         Ok(())
     }
 
-    pub(crate) fn load_section_relocations<'scope, A: Arch<File<'data> = O>, R: Relocation>(
+    pub(crate) fn load_section_relocations<'scope, A: Arch<Platform = P>, R: Relocation>(
         &self,
-        common: &mut CommonGroupState<'data, O>,
+        common: &mut CommonGroupState<'data, P>,
         queue: &mut LocalWorkQueue,
-        resources: &'scope GraphResources<'data, '_, O>,
+        resources: &'scope GraphResources<'data, '_, P>,
         section: Section,
         relocations: impl Iterator<Item = R>,
         scope: &Scope<'scope>,
@@ -3966,7 +3963,7 @@ impl<'data, O: ObjectFile<'data>> ObjectLayoutState<'data, O> {
             .with_context(|| {
                 format!(
                     "Failed to copy section {} from file {self}",
-                    section_debug(self.object, section.index)
+                    section_debug::<P>(self.object, section.index)
                 )
             })?;
         }
@@ -3974,20 +3971,20 @@ impl<'data, O: ObjectFile<'data>> ObjectLayoutState<'data, O> {
         Ok(())
     }
 
-    fn load_debug_section<'scope, A: Arch<File<'data> = O>>(
+    fn load_debug_section<'scope, A: Arch<Platform = P>>(
         &mut self,
-        common: &mut CommonGroupState<'data, O>,
+        common: &mut CommonGroupState<'data, P>,
         queue: &mut LocalWorkQueue,
 
         part_id: PartId,
         section_index: SectionIndex,
-        resources: &'scope GraphResources<'data, '_, O>,
+        resources: &'scope GraphResources<'data, '_, P>,
         scope: &Scope<'scope>,
     ) -> Result {
         let header = self.object.section(section_index)?;
         let section = Section::create(header, self, section_index, part_id)?;
         if A::local_symbols_in_debug_info() {
-            <A::File<'data> as ObjectFile<'data>>::load_object_debug_relocations::<A>(
+            <A::Platform as Platform>::load_object_debug_relocations::<A>(
                 self, common, queue, resources, section, scope,
             )?;
         }
@@ -3999,11 +3996,11 @@ impl<'data, O: ObjectFile<'data>> ObjectLayoutState<'data, O> {
         Ok(())
     }
 
-    pub(crate) fn load_debug_relocations<'scope, A: Arch<File<'data> = O>, R: Relocation>(
+    pub(crate) fn load_debug_relocations<'scope, A: Arch<Platform = P>, R: Relocation>(
         &self,
-        common: &mut CommonGroupState<'data, O>,
+        common: &mut CommonGroupState<'data, P>,
         queue: &mut LocalWorkQueue,
-        resources: &'scope GraphResources<'data, '_, O>,
+        resources: &'scope GraphResources<'data, '_, P>,
         section: Section,
         relocations: impl Iterator<Item = R>,
         scope: &Scope<'scope>,
@@ -4022,7 +4019,7 @@ impl<'data, O: ObjectFile<'data>> ObjectLayoutState<'data, O> {
             .with_context(|| {
                 format!(
                     "Failed to copy section {} from file {self}",
-                    section_debug(self.object, section.index)
+                    section_debug::<P>(self.object, section.index)
                 )
             })?;
             ensure!(
@@ -4036,10 +4033,10 @@ impl<'data, O: ObjectFile<'data>> ObjectLayoutState<'data, O> {
 
     fn finalise_sizes(
         &mut self,
-        common: &mut CommonGroupState<'data, O>,
+        common: &mut CommonGroupState<'data, P>,
         output_sections: &OutputSections,
         per_symbol_flags: &AtomicPerSymbolFlags,
-        resources: &FinaliseSizesResources<'data, '_, O>,
+        resources: &FinaliseSizesResources<'data, '_, P>,
     ) {
         common.mem_sizes.resize(output_sections.num_parts());
         if !resources.symbol_db.args.strip_all() {
@@ -4052,13 +4049,13 @@ impl<'data, O: ObjectFile<'data>> ObjectLayoutState<'data, O> {
             }
         }
 
-        O::finalise_object_sizes(self, common);
+        P::finalise_object_sizes(self, common);
     }
 
     fn allocate_symtab_space(
         &self,
-        common: &mut CommonGroupState<'data, O>,
-        symbol_db: &SymbolDb<'data, O>,
+        common: &mut CommonGroupState<'data, P>,
+        symbol_db: &SymbolDb<'data, P>,
         per_symbol_flags: &AtomicPerSymbolFlags,
     ) {
         let _file_span = symbol_db.args.trace_span_for_file(self.file_id());
@@ -4089,7 +4086,7 @@ impl<'data, O: ObjectFile<'data>> ObjectLayoutState<'data, O> {
                 } else {
                     num_globals += 1;
                 }
-                let name = O::RawSymbolName::parse(info.name).name();
+                let name = P::RawSymbolName::parse(info.name).name();
                 strings_size += name.len() + 1;
             }
         }
@@ -4103,8 +4100,8 @@ impl<'data, O: ObjectFile<'data>> ObjectLayoutState<'data, O> {
         mut self,
         memory_offsets: &mut OutputSectionPartMap<u64>,
         resolutions_out: &mut ResolutionWriter,
-        resources: &FinaliseLayoutResources<'_, 'data, O>,
-    ) -> Result<ObjectLayout<'data, O>> {
+        resources: &FinaliseLayoutResources<'_, 'data, P>,
+    ) -> Result<ObjectLayout<'data, P>> {
         let _file_span = resources.symbol_db.args.trace_span_for_file(self.file_id());
         let symbol_id_range = self.symbol_id_range();
 
@@ -4137,7 +4134,7 @@ impl<'data, O: ObjectFile<'data>> ObjectLayoutState<'data, O> {
                     SectionResolution { address }
                 }
                 SectionSlot::FrameData(..) => {
-                    let address = O::frame_data_base_address(memory_offsets);
+                    let address = P::frame_data_base_address(memory_offsets);
                     SectionResolution { address }
                 }
                 _ => SectionResolution::none(),
@@ -4161,7 +4158,7 @@ impl<'data, O: ObjectFile<'data>> ObjectLayoutState<'data, O> {
             )?;
         }
 
-        O::finalise_object_layout(&self, memory_offsets);
+        P::finalise_object_layout(&self, memory_offsets);
 
         Ok(ObjectLayout {
             input: self.input,
@@ -4178,9 +4175,9 @@ impl<'data, O: ObjectFile<'data>> ObjectLayoutState<'data, O> {
 
     fn finalise_symbol<'scope>(
         &self,
-        resources: &FinaliseLayoutResources<'scope, 'data, O>,
+        resources: &FinaliseLayoutResources<'scope, 'data, P>,
         flags: ValueFlags,
-        local_symbol: &O::Symbol,
+        local_symbol: &P::Symbol,
         local_symbol_index: object::SymbolIndex,
         section_resolutions: &[SectionResolution],
         memory_offsets: &mut OutputSectionPartMap<u64>,
@@ -4200,9 +4197,9 @@ impl<'data, O: ObjectFile<'data>> ObjectLayoutState<'data, O> {
 
     fn create_symbol_resolution<'scope>(
         &self,
-        resources: &FinaliseLayoutResources<'scope, 'data, O>,
+        resources: &FinaliseLayoutResources<'scope, 'data, P>,
         flags: ValueFlags,
-        local_symbol: &O::Symbol,
+        local_symbol: &P::Symbol,
         local_symbol_index: object::SymbolIndex,
         section_resolutions: &[SectionResolution],
         memory_offsets: &mut OutputSectionPartMap<u64>,
@@ -4226,7 +4223,7 @@ impl<'data, O: ObjectFile<'data>> ObjectLayoutState<'data, O> {
                 );
                 output_offset + section_address
             } else {
-                match get_merged_string_output_address(
+                match get_merged_string_output_address::<P>(
                     local_symbol_index,
                     0,
                     self.object,
@@ -4246,7 +4243,7 @@ impl<'data, O: ObjectFile<'data>> ObjectLayoutState<'data, O> {
                             "Symbol is in a section that we didn't load. \
                              Symbol: {} Section: {} Res: {flags}",
                             resources.symbol_debug(symbol_id),
-                            section_debug(self.object, section_index),
+                            section_debug::<P>(self.object, section_index),
                         );
                     }
                 }
@@ -4279,10 +4276,10 @@ impl<'data, O: ObjectFile<'data>> ObjectLayoutState<'data, O> {
         )))
     }
 
-    fn load_non_hidden_symbols<'scope, A: Arch<File<'data> = O>>(
+    fn load_non_hidden_symbols<'scope, A: Arch<Platform = P>>(
         &mut self,
-        common: &mut CommonGroupState<'data, O>,
-        resources: &'scope GraphResources<'data, 'scope, O>,
+        common: &mut CommonGroupState<'data, P>,
+        resources: &'scope GraphResources<'data, 'scope, P>,
         queue: &mut LocalWorkQueue,
         export_all_dynamic: bool,
         scope: &Scope<'scope>,
@@ -4310,11 +4307,11 @@ impl<'data, O: ObjectFile<'data>> ObjectLayoutState<'data, O> {
         Ok(())
     }
 
-    fn export_dynamic<'scope, A: Arch<File<'data> = O>>(
+    fn export_dynamic<'scope, A: Arch<Platform = P>>(
         &mut self,
-        common: &mut CommonGroupState<'data, O>,
+        common: &mut CommonGroupState<'data, P>,
         symbol_id: SymbolId,
-        resources: &'scope GraphResources<'data, 'scope, O>,
+        resources: &'scope GraphResources<'data, 'scope, P>,
         queue: &mut LocalWorkQueue,
         scope: &Scope<'scope>,
     ) -> Result {
@@ -4347,7 +4344,7 @@ impl<'data, O: ObjectFile<'data>> ObjectLayoutState<'data, O> {
         Ok(())
     }
 
-    pub(crate) fn relocations(&self, index: SectionIndex) -> Result<O::RelocationList> {
+    pub(crate) fn relocations(&self, index: SectionIndex) -> Result<P::RelocationList<'data>> {
         self.object.relocations(index, &self.relocations)
     }
 }
@@ -4361,12 +4358,12 @@ impl<'data> SymbolCopyInfo<'data> {
     /// the symtab. In the process, we also return the name of the symbol, to avoid needing to read
     /// it again.
     #[inline(always)]
-    pub(crate) fn new<O: ObjectFile<'data>>(
-        object: &O,
+    pub(crate) fn new<P: Platform>(
+        object: &P::File<'data>,
         sym_index: object::SymbolIndex,
-        sym: &O::Symbol,
+        sym: &P::Symbol,
         symbol_id: SymbolId,
-        symbol_db: &SymbolDb<'data, O>,
+        symbol_db: &SymbolDb<'data, P>,
         symbol_state: ValueFlags,
         sections: &[SectionSlot],
     ) -> Option<SymbolCopyInfo<'data>> {
@@ -4407,10 +4404,10 @@ impl<'data> SymbolCopyInfo<'data> {
 }
 
 /// Returns whether the supplied symbol can be exported when we're outputting a shared object.
-fn can_export_symbol<'data, O: ObjectFile<'data>>(
-    sym: &O::Symbol,
+fn can_export_symbol<'data, P: Platform>(
+    sym: &P::Symbol,
     symbol_id: SymbolId,
-    resources: &GraphResources<'data, '_, O>,
+    resources: &GraphResources<'data, '_, P>,
     export_all_dynamic: bool,
 ) -> bool {
     if sym.is_undefined() || sym.is_local() {
@@ -4516,8 +4513,8 @@ fn allocate_plt(memory_offsets: &mut OutputSectionPartMap<u64>) -> NonZeroU64 {
     plt_address
 }
 
-impl<'data, O: ObjectFile<'data>> resolution::ResolvedFile<'data, O> {
-    fn create_layout_state(self) -> FileLayoutState<'data, O> {
+impl<'data, P: Platform> resolution::ResolvedFile<'data, P> {
+    fn create_layout_state(self) -> FileLayoutState<'data, P> {
         match self {
             resolution::ResolvedFile::Object(s) => new_object_layout_state(s),
             resolution::ResolvedFile::Dynamic(s) => new_dynamic_object_layout_state(&s),
@@ -4618,11 +4615,11 @@ impl Resolution {
     }
 
     #[inline(always)]
-    pub(crate) fn value_with_addend<'data, O: ObjectFile<'data>>(
+    pub(crate) fn value_with_addend<'data, P: Platform>(
         &self,
         addend: i64,
         symbol_index: object::SymbolIndex,
-        object_layout: &ObjectLayout<'data, O>,
+        object_layout: &ObjectLayout<'data, P>,
         merged_strings: &OutputSectionMap<MergedStringsSection>,
         merged_string_start_addresses: &MergedStringStartAddresses,
     ) -> Result<u64> {
@@ -4634,7 +4631,7 @@ impl Resolution {
         // section to see if it's a string-merge section. For string-merge symbols with names,
         // `raw_value` will have already been computed, so we can avoid computing it again.
         if self.raw_value == 0
-            && let Some(r) = get_merged_string_output_address(
+            && let Some(r) = get_merged_string_output_address::<P>(
                 symbol_index,
                 addend,
                 object_layout.object,
@@ -4687,10 +4684,10 @@ impl SymbolOutputInfos {
 
 /// Compute the output address of every loaded input section and every symbol in a single parallel
 /// pass over groups.
-fn compute_section_and_symbol_addresses<'data, O: ObjectFile<'data>>(
-    group_states: &[GroupState<'data, O>],
+fn compute_section_and_symbol_addresses<'data, P: Platform>(
+    group_states: &[GroupState<'data, P>],
     section_part_layouts: &OutputSectionPartMap<OutputRecordLayout>,
-    symbol_db: &SymbolDb<'data, O>,
+    symbol_db: &SymbolDb<'data, P>,
     output_sections: &OutputSections,
 ) -> (Vec<Vec<Vec<u64>>>, SymbolOutputInfos) {
     timing_phase!("Compute section and symbol addresses");
@@ -4728,7 +4725,7 @@ fn compute_section_and_symbol_addresses<'data, O: ObjectFile<'data>>(
                             }
                         }
 
-                        O::compute_object_addresses(obj, &mut offsets);
+                        P::compute_object_addresses(obj, &mut offsets);
 
                         // While we have the section addresses, also resolve symbol
                         // output addresses for this file's canonical definitions.
@@ -4789,9 +4786,9 @@ type RescanCandidates = Vec<Vec<SmallVec<[(usize, u64); 16]>>>;
 /// bytes newly deleted in this pass together with the set of sections that should be rescanned on
 /// the next iteration.
 fn relaxation_scan_pass<'data, A: Arch>(
-    group_states: &mut [GroupState<'data, A::File<'data>>],
+    group_states: &mut [GroupState<'data, A::Platform>],
     section_part_layouts: &OutputSectionPartMap<OutputRecordLayout>,
-    symbol_db: &SymbolDb<'data, A::File<'data>>,
+    symbol_db: &SymbolDb<'data, A::Platform>,
     per_symbol_flags: &PerSymbolFlags,
     section_part_sizes: &mut OutputSectionPartMap<u64>,
     prev_rescan: Option<&RescanSections>,
@@ -4947,13 +4944,13 @@ fn relaxation_scan_pass<'data, A: Arch>(
 }
 
 fn perform_iterative_relaxation<'data, A: Arch>(
-    group_states: &mut [GroupState<'data, A::File<'data>>],
+    group_states: &mut [GroupState<'data, A::Platform>],
     section_part_sizes: &mut OutputSectionPartMap<u64>,
     section_part_layouts: &mut OutputSectionPartMap<OutputRecordLayout>,
     output_sections: &OutputSections,
-    program_segments: &ProgramSegments<<A::File<'data> as ObjectFile<'data>>::ProgramSegmentDef>,
+    program_segments: &ProgramSegments<<A::Platform as Platform>::ProgramSegmentDef>,
     output_order: &OutputOrder,
-    symbol_db: &SymbolDb<'data, A::File<'data>>,
+    symbol_db: &SymbolDb<'data, A::Platform>,
     per_symbol_flags: &PerSymbolFlags,
 ) {
     timing_phase!("Iterative relaxation");
@@ -5004,7 +5001,7 @@ fn perform_iterative_relaxation<'data, A: Arch>(
                 .collect(),
         );
 
-        *section_part_layouts = layout_section_parts::<A::File<'data>>(
+        *section_part_layouts = layout_section_parts::<A::Platform>(
             section_part_sizes,
             output_sections,
             program_segments,
@@ -5014,14 +5011,14 @@ fn perform_iterative_relaxation<'data, A: Arch>(
     }
 }
 
-fn layout_section_parts<'data, O: ObjectFile<'data>>(
+fn layout_section_parts<P: Platform>(
     sizes: &OutputSectionPartMap<u64>,
     output_sections: &OutputSections,
-    program_segments: &ProgramSegments<O::ProgramSegmentDef>,
+    program_segments: &ProgramSegments<P::ProgramSegmentDef>,
     output_order: &OutputOrder,
     args: &Args,
 ) -> OutputSectionPartMap<OutputRecordLayout> {
-    let segment_alignments = compute_segment_alignments::<O>(
+    let segment_alignments = compute_segment_alignments::<P>(
         sizes,
         program_segments,
         output_order,
@@ -5137,9 +5134,9 @@ fn layout_section_parts<'data, O: ObjectFile<'data>>(
 
 /// Computes the maximum alignment for each LOAD segment by examining the alignments of all sections
 /// that will be placed in that segment.
-fn compute_segment_alignments<'data, O: ObjectFile<'data>>(
+fn compute_segment_alignments<P: Platform>(
     sizes: &OutputSectionPartMap<u64>,
-    program_segments: &ProgramSegments<O::ProgramSegmentDef>,
+    program_segments: &ProgramSegments<P::ProgramSegmentDef>,
     output_order: &OutputOrder,
     args: &Args,
     output_sections: &OutputSections,
@@ -5181,11 +5178,11 @@ fn compute_segment_alignments<'data, O: ObjectFile<'data>>(
     segment_alignments
 }
 
-impl<'data, O: ObjectFile<'data>> DynamicLayoutState<'data, O> {
-    fn activate<'scope, A: Arch<File<'data> = O>>(
+impl<'data, P: Platform> DynamicLayoutState<'data, P> {
+    fn activate<'scope, A: Arch<Platform = P>>(
         &mut self,
-        common: &mut CommonGroupState<'data, O>,
-        resources: &'scope GraphResources<'data, '_, O>,
+        common: &mut CommonGroupState<'data, P>,
+        resources: &'scope GraphResources<'data, '_, P>,
         queue: &mut LocalWorkQueue,
         scope: &Scope<'scope>,
     ) -> Result {
@@ -5202,9 +5199,9 @@ impl<'data, O: ObjectFile<'data>> DynamicLayoutState<'data, O> {
         self.request_all_undefined_symbols::<A>(resources, queue, scope)
     }
 
-    fn request_all_undefined_symbols<'scope, A: Arch<File<'data> = O>>(
+    fn request_all_undefined_symbols<'scope, A: Arch<Platform = P>>(
         &self,
-        resources: &'scope GraphResources<'data, '_, O>,
+        resources: &'scope GraphResources<'data, '_, P>,
         queue: &mut LocalWorkQueue,
         scope: &Scope<'scope>,
     ) -> Result {
@@ -5265,8 +5262,8 @@ impl<'data, O: ObjectFile<'data>> DynamicLayoutState<'data, O> {
 
     fn finalise_copy_relocations(
         &mut self,
-        common: &mut CommonGroupState<'data, O>,
-        symbol_db: &SymbolDb<'data, O>,
+        common: &mut CommonGroupState<'data, P>,
+        symbol_db: &SymbolDb<'data, P>,
         per_symbol_flags: &AtomicPerSymbolFlags,
     ) -> Result {
         // Skip iterating over our symbol table if we don't have any copy relocations.
@@ -5277,7 +5274,7 @@ impl<'data, O: ObjectFile<'data>> DynamicLayoutState<'data, O> {
         self.select_copy_relocation_alternatives(per_symbol_flags, common, symbol_db)
     }
 
-    fn finalise_sizes(&mut self, common: &mut CommonGroupState<'data, O>) -> Result {
+    fn finalise_sizes(&mut self, common: &mut CommonGroupState<'data, P>) -> Result {
         self.allocate_for_copy_relocations(common)?;
 
         self.object.finalise_sizes_dynamic(
@@ -5294,8 +5291,8 @@ impl<'data, O: ObjectFile<'data>> DynamicLayoutState<'data, O> {
     fn select_copy_relocation_alternatives(
         &mut self,
         per_symbol_flags: &AtomicPerSymbolFlags,
-        common: &mut CommonGroupState<'data, O>,
-        symbol_db: &SymbolDb<'data, O>,
+        common: &mut CommonGroupState<'data, P>,
+        symbol_db: &SymbolDb<'data, P>,
     ) -> Result {
         for (i, symbol) in self.object.enumerate_symbols() {
             let address = symbol.value();
@@ -5326,7 +5323,7 @@ impl<'data, O: ObjectFile<'data>> DynamicLayoutState<'data, O> {
         Ok(())
     }
 
-    fn allocate_for_copy_relocations(&self, common: &mut CommonGroupState<'data, O>) -> Result {
+    fn allocate_for_copy_relocations(&self, common: &mut CommonGroupState<'data, P>) -> Result {
         for value in self.copy_relocations.values() {
             let symbol_id = value.symbol_id;
 
@@ -5358,8 +5355,8 @@ impl<'data, O: ObjectFile<'data>> DynamicLayoutState<'data, O> {
         self,
         memory_offsets: &mut OutputSectionPartMap<u64>,
         resolutions_out: &mut ResolutionWriter,
-        resources: &FinaliseLayoutResources<'_, 'data, O>,
-    ) -> Result<DynamicLayout<'data, O>> {
+        resources: &FinaliseLayoutResources<'_, 'data, P>,
+    ) -> Result<DynamicLayout<'data, P>> {
         let copy_relocation_symbols = self
             .copy_relocations
             .values()
@@ -5435,7 +5432,7 @@ impl<'data, O: ObjectFile<'data>> DynamicLayoutState<'data, O> {
     fn copy_relocate_symbol<'scope>(
         &mut self,
         symbol_id: SymbolId,
-        resources: &GraphResources<'data, 'scope, O>,
+        resources: &GraphResources<'data, 'scope, P>,
     ) -> std::result::Result<(), Error> {
         let symbol = self
             .object
@@ -5474,7 +5471,7 @@ impl<'data, O: ObjectFile<'data>> DynamicLayoutState<'data, O> {
                 let input_address = symbol.value();
 
                 let output_address =
-                    assign_copy_relocation_address(self.object, symbol, memory_offsets)?;
+                    assign_copy_relocation_address::<P>(self.object, symbol, memory_offsets)?;
 
                 Ok((input_address, output_address))
             })
@@ -5483,11 +5480,11 @@ impl<'data, O: ObjectFile<'data>> DynamicLayoutState<'data, O> {
 }
 
 impl<'data> LinkerScriptLayoutState<'data> {
-    fn finalise_layout<O: ObjectFile<'data>>(
+    fn finalise_layout<P: Platform>(
         &self,
         memory_offsets: &mut OutputSectionPartMap<u64>,
         resolutions_out: &mut ResolutionWriter,
-        resources: &FinaliseLayoutResources<'_, 'data, O>,
+        resources: &FinaliseLayoutResources<'_, 'data, P>,
     ) -> Result {
         self.internal_symbols
             .finalise_layout(memory_offsets, resolutions_out, resources)
@@ -5505,19 +5502,19 @@ impl<'data> LinkerScriptLayoutState<'data> {
         }
     }
 
-    fn activate<O: ObjectFile<'data>>(
+    fn activate<P: Platform>(
         &self,
-        common: &mut CommonGroupState<'data, O>,
-        resources: &GraphResources<'data, '_, O>,
+        common: &mut CommonGroupState<'data, P>,
+        resources: &GraphResources<'data, '_, P>,
     ) -> Result {
         self.internal_symbols.activate_symbols(common, resources)
     }
 
-    fn finalise_sizes<O: ObjectFile<'data>>(
+    fn finalise_sizes<P: Platform>(
         &self,
-        common: &mut CommonGroupState<'data, O>,
+        common: &mut CommonGroupState<'data, P>,
         per_symbol_flags: &AtomicPerSymbolFlags,
-        resources: &FinaliseSizesResources<'data, '_, O>,
+        resources: &FinaliseSizesResources<'data, '_, P>,
     ) -> Result {
         self.internal_symbols.allocate_symbol_table_sizes(
             &mut common.mem_sizes,
@@ -5534,11 +5531,11 @@ impl<'data> LinkerScriptLayoutState<'data> {
 }
 
 impl CopyRelocationInfo {
-    fn add_symbol<'data, O: ObjectFile<'data>>(
+    fn add_symbol<'data, P: Platform>(
         &mut self,
         symbol_id: SymbolId,
         is_weak: bool,
-        resources: &GraphResources<'data, '_, O>,
+        resources: &GraphResources<'data, '_, P>,
     ) {
         if self.symbol_id == symbol_id || is_weak {
             return;
@@ -5558,9 +5555,9 @@ impl CopyRelocationInfo {
 }
 
 /// Assigns the address in BSS for the copy relocation of a symbol.
-fn assign_copy_relocation_address<'data, O: ObjectFile<'data>>(
-    file: &O,
-    local_symbol: &O::Symbol,
+fn assign_copy_relocation_address<'data, P: Platform>(
+    file: &P::File<'data>,
+    local_symbol: &P::Symbol,
     memory_offsets: &mut OutputSectionPartMap<u64>,
 ) -> Result<u64, Error> {
     let section_index = local_symbol.section_index();
@@ -5586,13 +5583,13 @@ fn take_dynsym_index(
     Ok(index)
 }
 
-impl<'data, O: ObjectFile<'data>> Layout<'data, O> {
+impl<'data, P: Platform> Layout<'data, P> {
     pub(crate) fn mem_address_of_built_in(&self, section_id: OutputSectionId) -> u64 {
         self.section_layouts.get(section_id).mem_offset
     }
 }
 
-impl<'data, O: ObjectFile<'data>> std::fmt::Debug for FileLayoutState<'data, O> {
+impl<'data, P: Platform> std::fmt::Debug for FileLayoutState<'data, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             FileLayoutState::Object(s) => f.debug_tuple("Object").field(&s.input).finish(),
@@ -5608,8 +5605,8 @@ impl<'data, O: ObjectFile<'data>> std::fmt::Debug for FileLayoutState<'data, O> 
     }
 }
 
-fn section_debug<'data, O: ObjectFile<'data>>(
-    object: &O,
+fn section_debug<'data, P: Platform>(
+    object: &P::File<'data>,
     section_index: object::SectionIndex,
 ) -> impl std::fmt::Display {
     let name = object
@@ -5653,8 +5650,8 @@ fn needs_tlsld(relocation_kind: RelocationKind) -> bool {
     )
 }
 
-impl<'data, O: ObjectFile<'data>> ObjectLayout<'data, O> {
-    pub(crate) fn relocations(&self, index: SectionIndex) -> Result<O::RelocationList> {
+impl<'data, P: Platform> ObjectLayout<'data, P> {
+    pub(crate) fn relocations(&self, index: SectionIndex) -> Result<P::RelocationList<'data>> {
         self.object.relocations(index, &self.relocations)
     }
 }
@@ -5665,12 +5662,12 @@ impl<'data, O: ObjectFile<'data>> ObjectLayout<'data, O> {
 fn test_no_disallowed_overlaps() {
     use crate::output_section_id::OrderEvent;
 
-    let mut output_sections = OutputSections::with_base_address::<elf::File>(0x1000);
-    let (output_order, program_segments) = output_sections.output_order::<crate::elf::File>();
+    let mut output_sections = OutputSections::with_base_address::<Elf>(0x1000);
+    let (output_order, program_segments) = output_sections.output_order::<Elf>();
     let args = Args::default();
     let section_part_sizes = output_sections.new_part_map::<u64>().map(|_, _| 7);
 
-    let section_part_layouts = layout_section_parts::<crate::elf::File>(
+    let section_part_layouts = layout_section_parts::<Elf>(
         &section_part_sizes,
         &output_sections,
         &program_segments,
@@ -5736,7 +5733,7 @@ fn test_no_disallowed_overlaps() {
         }
     });
 
-    let segment_layouts = compute_segment_layout::<crate::elf::File>(
+    let segment_layouts = compute_segment_layout::<Elf>(
         &section_layouts,
         &output_sections,
         &output_order,
@@ -5775,12 +5772,12 @@ fn test_no_disallowed_overlaps() {
 /// combination of flags and output kind. If this function returns an error, then we would have
 /// failed during writing anyway. By failing now, we can report the particular combination of inputs
 /// that caused the failure.
-fn verify_consistent_allocation_handling<'data, O: ObjectFile<'data>>(
+fn verify_consistent_allocation_handling<P: Platform>(
     flags: ValueFlags,
     output_kind: OutputKind,
 ) -> Result {
-    let output_sections = OutputSections::with_base_address::<O>(0);
-    let (output_order, _program_segments) = output_sections.output_order::<O>();
+    let output_sections = OutputSections::with_base_address::<P>(0);
+    let (output_order, _program_segments) = output_sections.output_order::<P>();
     let mut mem_sizes = output_sections.new_part_map();
     allocate_symbol_resolution(flags, &mut mem_sizes, output_kind);
     let mut memory_offsets = output_sections.new_part_map();
@@ -5792,7 +5789,7 @@ fn verify_consistent_allocation_handling<'data, O: ObjectFile<'data>>(
 
     let resolution = create_resolution(flags, 0, dynamic_symbol_index, &mut memory_offsets);
 
-    O::verify_resolution_allocation(
+    P::verify_resolution_allocation(
         &output_sections,
         &output_order,
         output_kind,
@@ -5811,8 +5808,8 @@ fn verify_consistent_allocation_handling<'data, O: ObjectFile<'data>>(
     Ok(())
 }
 
-impl<'scope, 'data, O: ObjectFile<'data>> FinaliseLayoutResources<'scope, 'data, O> {
-    fn symbol_debug<'a>(&'a self, symbol_id: SymbolId) -> SymbolDebug<'a, 'data, O> {
+impl<'scope, 'data, P: Platform> FinaliseLayoutResources<'scope, 'data, P> {
+    fn symbol_debug<'a>(&'a self, symbol_id: SymbolId) -> SymbolDebug<'a, 'data, P> {
         self.symbol_db
             .symbol_debug(self.per_symbol_flags, symbol_id)
     }

--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -69,6 +69,7 @@ pub(crate) mod verification;
 pub(crate) mod version_script;
 
 use crate::args::ActivatedArgs;
+use crate::elf::Elf;
 use crate::error::Context;
 use crate::error::Result;
 use crate::identity::linker_identity;
@@ -157,7 +158,7 @@ pub struct LinkerOutput<'layout_inputs> {
     /// This is just here so that we defer its destruction. This allows us to (a) measure how long
     /// it takes to drop and (b) if we forked, signal our parent that we're done, then drop it in
     /// the background.
-    layout: Option<layout::Layout<'layout_inputs, crate::elf::File<'layout_inputs>>>,
+    layout: Option<layout::Layout<'layout_inputs, Elf>>,
 }
 
 impl Linker {
@@ -207,7 +208,7 @@ impl Linker {
         }
     }
 
-    fn link_for_arch<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
+    fn link_for_arch<'data, A: Arch<Platform = Elf>>(
         &'data self,
         args: &'data Args,
     ) -> error::Result<LinkerOutput<'data>> {
@@ -235,7 +236,7 @@ impl Linker {
         result
     }
 
-    fn load_inputs_and_link<'data, A: Arch<File<'data> = crate::elf::File<'data>>>(
+    fn load_inputs_and_link<'data, A: Arch<Platform = Elf>>(
         &'data self,
         file_loader: &mut FileLoader<'data>,
         args: &'data Args,
@@ -254,7 +255,7 @@ impl Linker {
         let mut output = file_writer::Output::new(args, output_kind);
 
         let mut output_sections =
-            OutputSections::with_base_address::<elf::File>(output_kind.base_address());
+            OutputSections::with_base_address::<Elf>(output_kind.base_address());
 
         let mut layout_rules_builder = LayoutRulesBuilder::default();
 
@@ -314,7 +315,7 @@ impl Linker {
             &layout_rules,
         )?;
 
-        let layout = layout::compute::<A>(
+        let layout = layout::compute::<Elf, A>(
             symbol_db,
             per_symbol_flags,
             resolved,

--- a/libwild/src/linker_plugins.rs
+++ b/libwild/src/linker_plugins.rs
@@ -13,6 +13,7 @@ use crate::Args;
 use crate::args::Input;
 use crate::args::Modifiers;
 use crate::bail;
+use crate::elf::Elf;
 use crate::elf::RawSymbolName;
 use crate::error;
 use crate::error::Context as _;
@@ -24,7 +25,7 @@ use crate::input_data::FileLoader;
 use crate::input_data::InputRef;
 use crate::layout_rules::LayoutRulesBuilder;
 use crate::output_section_id::OutputSections;
-use crate::platform::ObjectFile;
+use crate::platform::Platform;
 use crate::platform::RawSymbolName as _;
 use crate::resolution::ResolvedFile;
 use crate::resolution::ResolvedGroup;
@@ -170,10 +171,10 @@ impl<'data> LinkerPlugin<'data> {
 
     /// Notify the plugin that all symbols have now been read. This will cause it to build
     /// additional object files that it will then pass to us for processing.
-    pub(crate) fn all_symbols_read<O: ObjectFile<'data>>(
+    pub(crate) fn all_symbols_read<P: Platform>(
         &mut self,
-        symbol_db: &mut SymbolDb<'data, O>,
-        resolver: &mut Resolver<'data, O>,
+        symbol_db: &mut SymbolDb<'data, P>,
+        resolver: &mut Resolver<'data, P>,
         file_loader: &mut FileLoader<'data>,
         per_symbol_flags: &mut PerSymbolFlags,
         output_sections: &mut OutputSections<'data>,
@@ -288,9 +289,7 @@ impl<'data> LinkerPlugin<'data> {
     }
 }
 
-fn has_loaded_lto_input<'data, O: ObjectFile<'data>>(
-    resolved_groups: &[ResolvedGroup<'data, O>],
-) -> bool {
+fn has_loaded_lto_input<'data, P: Platform>(resolved_groups: &[ResolvedGroup<'data, P>]) -> bool {
     resolved_groups.iter().any(|group| {
         group
             .files
@@ -852,7 +851,7 @@ extern "C" fn get_symbols_v3(
 
 fn get_symbol_resolution<'data>(
     sym: &mut RawPluginSymbol,
-    symbol_db: &SymbolDb<'data, crate::elf::File<'data>>,
+    symbol_db: &SymbolDb<'data, Elf>,
     symbol_id_range: SymbolIdRange,
 ) -> PluginSymbolResolution {
     // It'd be nice if we didn't have to do hashmap lookups for all the symbols again, since we
@@ -1047,14 +1046,14 @@ impl ClaimContext<'_> {
     }
 }
 
-struct AllSymbolsReadContext<'scope, 'data, O: ObjectFile<'data>> {
-    symbol_db: &'scope SymbolDb<'data, O>,
-    resolved_groups: &'scope [ResolvedGroup<'data, O>],
+struct AllSymbolsReadContext<'scope, 'data, P: Platform> {
+    symbol_db: &'scope SymbolDb<'data, P>,
+    resolved_groups: &'scope [ResolvedGroup<'data, P>],
 }
 
-impl<'scope, 'data, O: ObjectFile<'data>> AllSymbolsReadContext<'scope, 'data, O> {
+impl<'scope, 'data, P: Platform> AllSymbolsReadContext<'scope, 'data, P> {
     fn with_current(
-        cb: impl FnOnce(&mut AllSymbolsReadContext<'scope, 'data, O>) -> Status,
+        cb: impl FnOnce(&mut AllSymbolsReadContext<'scope, 'data, P>) -> Status,
     ) -> Status {
         let ptr = ALL_SYMBOLS_READ_CONTEXT.get();
         if ptr.is_null() {
@@ -1063,13 +1062,13 @@ impl<'scope, 'data, O: ObjectFile<'data>> AllSymbolsReadContext<'scope, 'data, O
             ));
             return Status::Err;
         };
-        let ctx = unsafe { &mut *(ptr as *mut AllSymbolsReadContext<'scope, 'data, O>) };
+        let ctx = unsafe { &mut *(ptr as *mut AllSymbolsReadContext<'scope, 'data, P>) };
         cb(ctx)
     }
 
     fn set_current_while<R>(&self, cb: impl FnOnce() -> R) -> R {
         ALL_SYMBOLS_READ_CONTEXT
-            .set(self as *const AllSymbolsReadContext<'scope, 'data, O> as *const libc::c_void);
+            .set(self as *const AllSymbolsReadContext<'scope, 'data, P> as *const libc::c_void);
         let r = cb();
         ALL_SYMBOLS_READ_CONTEXT.take();
         r

--- a/libwild/src/linker_plugins_disabled.rs
+++ b/libwild/src/linker_plugins_disabled.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::unnecessary_wraps)]
 #![allow(clippy::needless_pass_by_ref_mut)]
 
+use crate::elf::Elf;
 use crate::error::Result;
 use crate::input_data::FileLoader;
 use crate::layout_rules::LayoutRulesBuilder;
@@ -48,8 +49,8 @@ impl<'data> LinkerPlugin<'data> {
 
     pub(crate) fn all_symbols_read(
         &mut self,
-        _symbol_db: &mut SymbolDb<'data, crate::elf::File<'data>>,
-        _resolver: &mut Resolver<'data, crate::elf::File<'data>>,
+        _symbol_db: &mut SymbolDb<'data, Elf>,
+        _resolver: &mut Resolver<'data, Elf>,
         _file_loader: &mut FileLoader<'data>,
         _per_symbol_flags: &mut PerSymbolFlags,
         _output_sections: &mut OutputSections<'data>,

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -23,7 +23,7 @@ use crate::output_section_part_map::OutputSectionPartMap;
 use crate::part_id;
 use crate::part_id::NUM_SINGLE_PART_SECTIONS;
 use crate::part_id::PartId;
-use crate::platform::ObjectFile;
+use crate::platform::Platform;
 use crate::platform::ProgramSegmentDef;
 use crate::program_segments::ProgramSegmentId;
 use crate::program_segments::ProgramSegments;
@@ -142,16 +142,16 @@ pub(crate) struct OutputOrder {
     events: Vec<OrderEvent>,
 }
 
-pub(crate) struct OutputOrderDisplay<'a, 'data, O: ObjectFile<'data>> {
+pub(crate) struct OutputOrderDisplay<'a, 'data, P: Platform> {
     order: &'a OutputOrder,
     sections: &'a OutputSections<'data>,
-    program_segments: &'a ProgramSegments<O::ProgramSegmentDef>,
+    program_segments: &'a ProgramSegments<P::ProgramSegmentDef>,
 }
 
-struct OutputOrderBuilder<'scope, 'data, O: ObjectFile<'data>> {
+struct OutputOrderBuilder<'scope, 'data, P: Platform> {
     events: Vec<OrderEvent>,
 
-    program_segments: ProgramSegments<O::ProgramSegmentDef>,
+    program_segments: ProgramSegments<P::ProgramSegmentDef>,
 
     /// Indexes correspond to elements of `PROGRAM_SEGMENT_DEFS`.
     active_segment_kinds: Vec<Option<ProgramSegmentId>>,
@@ -160,7 +160,7 @@ struct OutputOrderBuilder<'scope, 'data, O: ObjectFile<'data>> {
     secondary: &'scope OutputSectionMap<Vec<OutputSectionId>>,
 }
 
-impl<'scope, 'data, O: ObjectFile<'data>> OutputOrderBuilder<'scope, 'data, O> {
+impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
     fn new(
         output_sections: &'scope OutputSections<'data>,
         secondary: &'scope OutputSectionMap<Vec<OutputSectionId>>,
@@ -169,7 +169,7 @@ impl<'scope, 'data, O: ObjectFile<'data>> OutputOrderBuilder<'scope, 'data, O> {
             events: Vec::new(),
             program_segments: ProgramSegments::empty(),
             output_sections,
-            active_segment_kinds: vec![None; O::program_segment_defs().len()],
+            active_segment_kinds: vec![None; P::program_segment_defs().len()],
             secondary,
         }
     }
@@ -235,20 +235,20 @@ impl<'scope, 'data, O: ObjectFile<'data>> OutputOrderBuilder<'scope, 'data, O> {
     fn should_end_current_rw_segment(&self, section_id: OutputSectionId) -> bool {
         self.active_segment_kinds
             .iter()
-            .zip(O::program_segment_defs())
+            .zip(P::program_segment_defs())
             .any(|(id, def)| {
                 id.is_some()
                     && def.should_cut_rw_segment_when_ending()
                     && !self
                         .output_sections
-                        .should_include_in_segment::<O>(section_id, *def)
+                        .should_include_in_segment::<P>(section_id, *def)
             })
     }
 
     /// Ends the currently active RW LOAD segment, if any. This is used when the RELRO segment
     /// ends to force .data and other non-RELRO sections into a new LOAD segment.
     fn end_rw_load_segment(&mut self) {
-        let rw_load_def_index = O::program_segment_defs()
+        let rw_load_def_index = P::program_segment_defs()
             .iter()
             .position(|def| def.is_loadable() && def.is_writable() && !def.is_executable());
 
@@ -287,13 +287,13 @@ impl<'scope, 'data, O: ObjectFile<'data>> OutputOrderBuilder<'scope, 'data, O> {
             }
         }
 
-        O::program_segment_defs()
+        P::program_segment_defs()
             .iter()
             .zip(self.active_segment_kinds.iter_mut())
             .for_each(|(segment_def, active_id)| {
                 let should_be_active = self
                     .output_sections
-                    .should_include_in_segment::<O>(section_id, *segment_def);
+                    .should_include_in_segment::<P>(section_id, *segment_def);
 
                 match (active_id.as_ref().copied(), should_be_active) {
                     // Remain inactive
@@ -326,12 +326,12 @@ impl<'scope, 'data, O: ObjectFile<'data>> OutputOrderBuilder<'scope, 'data, O> {
         }
     }
 
-    fn build(mut self) -> (OutputOrder, ProgramSegments<O::ProgramSegmentDef>) {
+    fn build(mut self) -> (OutputOrder, ProgramSegments<P::ProgramSegmentDef>) {
         for segment_id in self.active_segment_kinds.into_iter().flatten() {
             self.events.push(OrderEvent::SegmentEnd(segment_id));
         }
 
-        for def in O::unconditional_segment_defs() {
+        for def in P::unconditional_segment_defs() {
             let segment_id = self.program_segments.add_segment(*def);
             self.events.push(OrderEvent::SegmentStart(segment_id));
             self.events.push(OrderEvent::SegmentEnd(segment_id));
@@ -404,10 +404,10 @@ impl<'data> OutputSections<'data> {
 
     /// Returns whether we should include the specified section in a program segment with the
     /// supplied properties.
-    fn should_include_in_segment<O: ObjectFile<'data>>(
+    fn should_include_in_segment<P: Platform>(
         &self,
         section_id: OutputSectionId,
-        segment_def: O::ProgramSegmentDef,
+        segment_def: P::ProgramSegmentDef,
     ) -> bool {
         let info = self.output_info(section_id);
         segment_def.should_include_section(info, section_id)
@@ -457,10 +457,10 @@ impl OutputSectionId {
         }
     }
 
-    pub(crate) fn opt_built_in_details<'data, O: ObjectFile<'data>>(
+    pub(crate) fn opt_built_in_details<P: Platform>(
         self,
-    ) -> Option<&'static O::BuiltInSectionDetails> {
-        O::built_in_section_details().get(self.as_usize())
+    ) -> Option<&'static P::BuiltInSectionDetails> {
+        P::built_in_section_details().get(self.as_usize())
     }
 
     pub(crate) fn min_alignment(self, output_sections: &OutputSections) -> Alignment {
@@ -538,12 +538,12 @@ pub(crate) enum SecondaryOrder {
 }
 
 impl CustomSectionIds {
-    fn build_output_order_and_program_segments<'data, O: ObjectFile<'data>>(
+    fn build_output_order_and_program_segments<'data, P: Platform>(
         &self,
         output_sections: &OutputSections<'data>,
         secondary: &OutputSectionMap<Vec<OutputSectionId>>,
-    ) -> (OutputOrder, ProgramSegments<O::ProgramSegmentDef>) {
-        let mut builder = OutputOrderBuilder::<O>::new(output_sections, secondary);
+    ) -> (OutputOrder, ProgramSegments<P::ProgramSegmentDef>) {
+        let mut builder = OutputOrderBuilder::<P>::new(output_sections, secondary);
 
         builder.add_section(FILE_HEADER);
         builder.add_section(PROGRAM_HEADERS);
@@ -667,8 +667,8 @@ impl<'data> OutputSections<'data> {
         })
     }
 
-    pub(crate) fn with_base_address<O: ObjectFile<'data>>(base_address: u64) -> Self {
-        let section_infos = O::built_in_section_infos();
+    pub(crate) fn with_base_address<P: Platform>(base_address: u64) -> Self {
+        let section_infos = P::built_in_section_infos();
 
         Self {
             section_infos: OutputSectionMap::from_values(section_infos),
@@ -706,9 +706,9 @@ impl<'data> OutputSections<'data> {
         sid
     }
 
-    pub(crate) fn output_order<O: ObjectFile<'data>>(
+    pub(crate) fn output_order<P: Platform>(
         &self,
-    ) -> (OutputOrder, ProgramSegments<O::ProgramSegmentDef>) {
+    ) -> (OutputOrder, ProgramSegments<P::ProgramSegmentDef>) {
         timing_phase!("Compute output order");
 
         let mut custom = CustomSectionIds::default();
@@ -745,7 +745,7 @@ impl<'data> OutputSections<'data> {
             }
         });
 
-        custom.build_output_order_and_program_segments::<O>(self, &secondary)
+        custom.build_output_order_and_program_segments::<P>(self, &secondary)
     }
 
     #[must_use]
@@ -823,7 +823,9 @@ impl<'data> OutputSections<'data> {
 
     #[cfg(test)]
     pub(crate) fn for_testing() -> OutputSections<'static> {
-        let mut output_sections = OutputSections::with_base_address::<crate::elf::File>(0x1000);
+        use crate::elf::Elf;
+
+        let mut output_sections = OutputSections::with_base_address::<Elf>(0x1000);
         let mut add_name = |name: &'static str| {
             output_sections.add_named_section(
                 SectionName(name.as_bytes()),
@@ -862,11 +864,11 @@ impl<'a> IntoIterator for &'a OutputOrder {
 }
 
 impl OutputOrder {
-    pub(crate) fn display<'a, 'data, O: ObjectFile<'data>>(
+    pub(crate) fn display<'a, 'data, P: Platform>(
         &'a self,
         sections: &'a OutputSections<'data>,
-        program_segments: &'a ProgramSegments<O::ProgramSegmentDef>,
-    ) -> OutputOrderDisplay<'a, 'data, O> {
+        program_segments: &'a ProgramSegments<P::ProgramSegmentDef>,
+    ) -> OutputOrderDisplay<'a, 'data, P> {
         OutputOrderDisplay {
             order: self,
             sections,
@@ -875,7 +877,7 @@ impl OutputOrder {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> Display for OutputOrderDisplay<'_, 'data, O> {
+impl<'data, P: Platform> Display for OutputOrderDisplay<'_, 'data, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for event in &self.order.events {
             match event {

--- a/libwild/src/output_section_part_map.rs
+++ b/libwild/src/output_section_part_map.rs
@@ -226,7 +226,7 @@ impl<'out> OutputSectionPartMap<&'out mut [u8]> {
 #[test]
 fn test_merge_parts() {
     let output_sections = crate::output_section_id::OutputSections::for_testing();
-    let (output_order, _program_segments) = output_sections.output_order::<crate::elf::File>();
+    let (output_order, _program_segments) = output_sections.output_order::<crate::elf::Elf>();
     let mut expected_sum_of_sums = 0;
     let all_1 = output_sections.new_part_map::<u32>().output_order_map(
         &output_order,
@@ -297,7 +297,7 @@ fn test_output_order_map_consistent() {
     use itertools::Itertools;
 
     let output_sections = crate::output_section_id::OutputSections::for_testing();
-    let (output_order, _program_segments) = output_sections.output_order::<crate::elf::File>();
+    let (output_order, _program_segments) = output_sections.output_order::<crate::elf::Elf>();
     let part_map = output_sections.new_part_map::<u32>();
 
     // First, make sure that all our built-in part-ids are here. If they're not, we'd fail anyway,
@@ -346,7 +346,7 @@ fn test_output_order_map() {
     use crate::output_section_id;
 
     let output_sections = crate::output_section_id::OutputSections::for_testing();
-    let (output_order, _program_segments) = output_sections.output_order::<crate::elf::File>();
+    let (output_order, _program_segments) = output_sections.output_order::<crate::elf::Elf>();
     let mut part_map = output_sections.new_part_map::<u32>();
 
     const PART_ID1: PartId = output_section_id::DATA.part_id_with_alignment(alignment::USIZE);

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -12,6 +12,7 @@ use crate::input_data::InputRef;
 use crate::layout_rules::LayoutRulesBuilder;
 use crate::output_section_id::OutputSectionId;
 use crate::platform::ObjectFile;
+use crate::platform::Platform;
 use crate::symbol::UnversionedSymbolName;
 use crate::symbol_db::SymbolId;
 use crate::symbol_db::SymbolIdRange;
@@ -39,9 +40,9 @@ pub(crate) struct Prelude<'data> {
 }
 
 #[derive(Debug)]
-pub(crate) struct ParsedInputObject<'data, O: ObjectFile<'data>> {
+pub(crate) struct ParsedInputObject<'data, P: Platform> {
     pub(crate) input: InputRef<'data>,
-    pub(crate) object: O,
+    pub(crate) object: P::File<'data>,
     pub(crate) modifiers: Modifiers,
 }
 
@@ -190,11 +191,11 @@ impl<'data> InternalSymDefInfo<'data> {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> ParsedInputObject<'data, O> {
+impl<'data, P: Platform> ParsedInputObject<'data, P> {
     pub(crate) fn new(input: &InputBytes<'data>, args: &Args) -> Result<Box<Self>> {
         verbose_timing_phase!("Parse file");
 
-        let object = O::parse(input, args)
+        let object = P::File::parse(input, args)
             .with_context(|| format!("Failed to parse object file `{input}`"))?;
 
         Ok(Box::new(Self {
@@ -214,12 +215,12 @@ impl<'data, O: ObjectFile<'data>> ParsedInputObject<'data, O> {
 }
 
 impl<'data> Prelude<'data> {
-    pub(crate) fn new<O: ObjectFile<'data>>(args: &'data Args, output_kind: OutputKind) -> Self {
+    pub(crate) fn new<P: Platform>(args: &'data Args, output_kind: OutputKind) -> Self {
         verbose_timing_phase!("Construct prelude");
 
         let mut symbols = InternalSymbolsBuilder::default();
 
-        O::create_linker_defined_symbols(&mut symbols, output_kind);
+        P::create_linker_defined_symbols(&mut symbols, output_kind);
 
         args.undefined.iter().for_each(|name| {
             symbols.add_symbol(InternalSymDefInfo::new(
@@ -305,7 +306,7 @@ impl<'data> ProcessedLinkerScript<'data> {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> std::fmt::Display for ParsedInputObject<'data, O> {
+impl<'data, P: Platform> std::fmt::Display for ParsedInputObject<'data, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(&self.input, f)
     }

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -36,11 +36,11 @@ use std::path::PathBuf;
 /// Represents a supported architecture. Note that implementations are file-format specific.
 pub(crate) trait Arch: Send + Sync + 'static {
     type Relaxation: Relaxation;
-    type File<'data>: ObjectFile<'data>;
+    type Platform: Platform;
 
     /// Returns the identifier to be written into the output file that identifies the file as
     /// belonging to this architecture. e.g. for ELF, this is the header magic for the architecture.
-    fn arch_identifier<'a>() -> <Self::File<'a> as ObjectFile<'a>>::ArchIdentifier;
+    fn arch_identifier() -> <Self::Platform as Platform>::ArchIdentifier;
 
     /// Get dynamic relocation value specific for the architecture.
     fn get_dynamic_relocation_type(relocation: DynamicRelocationKind) -> u32;
@@ -65,7 +65,7 @@ pub(crate) trait Arch: Send + Sync + 'static {
     /// Get position of the $tp (thread pointer) in the TLS section. Each platform defines
     /// a different place based on the following article:
     /// https://maskray.me/blog/2021-02-14-all-about-thread-local-storage#tls-variants
-    fn tp_offset_start<'data>(layout: &Layout<'data, Self::File<'data>>) -> u64;
+    fn tp_offset_start<'data>(layout: &Layout<'data, Self::Platform>) -> u64;
 
     /// Classify a GNU property note.
     fn get_property_class(property_type: u32) -> Option<crate::elf::PropertyClass>;
@@ -85,16 +85,16 @@ pub(crate) trait Arch: Send + Sync + 'static {
     /// Uses debug info, if available, to get information about where in the source code a
     /// particular offset in a particular section came from.
     fn get_source_info<'data>(
-        object: &Self::File<'data>,
-        relocations: &<Self::File<'data> as ObjectFile<'data>>::RelocationSections,
-        section: &<Self::File<'data> as ObjectFile<'data>>::SectionHeader,
+        object: &<Self::Platform as Platform>::File<'data>,
+        relocations: &<Self::Platform as Platform>::RelocationSections,
+        section: &<Self::Platform as Platform>::SectionHeader,
         offset_in_section: u64,
     ) -> Result<SourceInfo>;
 
     fn collect_relaxation_deltas<'data>(
         _section_output_address: u64,
         _section_bytes: &[u8],
-        _relocations: <Self::File<'data> as ObjectFile<'data>>::RelocationList,
+        _relocations: <Self::Platform as Platform>::RelocationList<'data>,
         _existing_deltas: Option<&SectionRelaxDeltas>,
         _resolve_symbol: impl FnMut(object::SymbolIndex) -> Option<RelaxSymbolInfo>,
     ) -> (Vec<(u64, u32)>, Option<u64>) {
@@ -104,7 +104,7 @@ pub(crate) trait Arch: Send + Sync + 'static {
     }
 
     fn is_symbol_variant_pcs<'data>(
-        _object: &Self::File<'data>,
+        _object: &<Self::Platform as Platform>::File<'data>,
         _symbol_index: object::SymbolIndex,
     ) -> bool {
         false
@@ -112,20 +112,20 @@ pub(crate) trait Arch: Send + Sync + 'static {
 
     /// Tries to create a relaxation for the relocation of the specified kind, to be applied at the
     /// specified offset in the supplied section.
-    fn new_relaxation<'data>(
+    fn new_relaxation(
         relocation_kind: u32,
         section_bytes: &[u8],
         offset_in_section: u64,
         flags: ValueFlags,
         output_kind: OutputKind,
-        section_flags: <Self::File<'data> as ObjectFile<'data>>::SectionFlags,
+        section_flags: <Self::Platform as Platform>::SectionFlags,
         non_zero_address: bool,
         relax_deltas: Option<&SectionRelaxDeltas>,
     ) -> Option<Self::Relaxation>;
 
     fn process_riscv_attributes<'data>(
-        _object: &Self::File<'data>,
-        _format_specific: &mut <Self::File<'data> as ObjectFile<'data>>::FileLayoutState,
+        _object: &<Self::Platform as Platform>::File<'data>,
+        _format_specific: &mut <Self::Platform as Platform>::FileLayoutState<'data>,
         _riscv_attributes_section_index: object::SectionIndex,
     ) -> Result {
         bail!(".riscv.attribute section is supported only for riscv64 target");
@@ -151,303 +151,105 @@ pub(crate) struct RelaxSymbolInfo {
     pub is_interposable: bool,
 }
 
-/// Abstracts over the different object file formats that we support (or may support). e.g. ELF.
-pub(crate) trait ObjectFile<'data>: Send + Sync + Sized + std::fmt::Debug + 'data {
+/// A platform for which we support writing producing linked outputs.
+pub(crate) trait Platform: Send + Sync + Sized + std::fmt::Debug + 'static {
+    type File<'data>: ObjectFile<'data, Platform = Self>;
     type Symbol: Symbol;
     type SectionHeader: SectionHeader;
     type SectionFlags: SectionFlags;
+    type SectionAttributes: SectionAttributes;
     type SectionType: SectionType;
     type SegmentType: SegmentType;
-    type SectionAttributes: SectionAttributes;
-    type SectionIterator: Iterator<Item = &'data Self::SectionHeader>;
-    type DynamicTagValues: DynamicTagValues<'data>;
-    type RelocationSections: std::fmt::Debug + Default + Send + Sync + 'static;
-    type RelocationList: Send + Sync + 'data;
-    type DynamicEntry: Send + Sync + 'data;
-    type VerneedTable: VerneedTable<'data>;
-    type EpilogueLayout: Send + Sync + 'static;
-    type DynamicLayoutState: Default + Send + Sync + 'data;
-    type DynamicLayout: std::fmt::Debug + Send + Sync + 'data;
-    type NonAddressableIndexes: NonAddressableIndexes + Send + Sync + 'data;
-    type NonAddressableCounts: Default + Send + Sync + 'data;
-    type GroupLayoutExt: std::fmt::Debug + Send + Sync + 'static;
-    type CommonGroupStateExt: Default + std::fmt::Debug + Send + Sync + 'static;
-    type LayoutResourcesExt: std::fmt::Debug + Send + Sync + 'data;
     type ProgramSegmentDef: ProgramSegmentDef;
     type BuiltInSectionDetails: BuiltInSectionDetails;
+    type RelocationSections: std::fmt::Debug + Default + Send + Sync + 'static;
+    type DynamicEntry: Send + Sync + 'static;
+    type NonAddressableIndexes: NonAddressableIndexes + Send + Sync + 'static;
+    type NonAddressableCounts: Default + Send + Sync + 'static;
+    type EpilogueLayout: Send + Sync + 'static;
+    type GroupLayoutExt: std::fmt::Debug + Send + Sync + 'static;
+    type CommonGroupStateExt: Default + std::fmt::Debug + Send + Sync + 'static;
     type ArchIdentifier: Send + Sync + 'static;
 
     /// An index into the local object's symbol versions.
     type SymbolVersionIndex: Send + Sync + Copy;
 
-    /// Format-specific per-file state used during the layout phase.
-    type FileLayoutState: Default + Send + Sync + 'data;
-
     /// Format-specific properties produced by the layout phase.
     type LayoutProperties: Send + Sync + 'static;
 
+    type SectionIterator<'data>: Iterator<Item = &'data Self::SectionHeader>;
+    type DynamicTagValues<'data>: DynamicTagValues<'data>;
+    type RelocationList<'data>: Send + Sync + 'data;
+    type VerneedTable<'data>: VerneedTable<'data>;
+    type DynamicLayoutState<'data>: Default + Send + Sync + 'data;
+    type DynamicLayout<'data>: std::fmt::Debug + Send + Sync + 'data;
+    type LayoutResourcesExt<'data>: std::fmt::Debug + Send + Sync + 'data;
+
+    /// Format-specific per-file state used during the layout phase.
+    type FileLayoutState<'data>: Default + Send + Sync + 'data;
+
     /// The name of a symbol, possibly with a version.
-    type RawSymbolName: RawSymbolName<'data>;
+    type RawSymbolName<'data>: RawSymbolName<'data>;
 
     /// For platforms that don't support symbol versioning, this can just be the unit type.
-    type VersionNames;
-
-    fn parse_bytes(input: &'data [u8], is_dynamic: bool) -> Result<Self>;
-
-    /// As for `parse_bytes` but also validates that the file architecture matches what is expected
-    /// based on `args`.
-    fn parse(input: &InputBytes<'data>, args: &Args) -> Result<Self>;
-
-    fn is_dynamic(&self) -> bool;
-
-    fn num_symbols(&self) -> usize;
-
-    fn symbols(&self) -> &'data [Self::Symbol];
-
-    fn enumerate_symbols(
-        &self,
-    ) -> impl Iterator<Item = (object::SymbolIndex, &'data Self::Symbol)> {
-        self.symbols()
-            .iter()
-            .enumerate()
-            .map(|(i, sym)| (object::SymbolIndex(i), sym))
-    }
-
-    // TODO: Remove implementations of this as this default should be fine. Perhaps first check if
-    // all platforms can get a slice of symbols.
-    fn symbols_iter(&self) -> impl Iterator<Item = &'data Self::Symbol> {
-        self.symbols().iter()
-    }
-
-    fn symbol(&self, index: object::SymbolIndex) -> Result<&'data Self::Symbol>;
-
-    fn section_size(&self, header: &Self::SectionHeader) -> Result<u64>;
+    type VersionNames<'data>;
 
     fn section_flags(header: &Self::SectionHeader) -> Self::SectionFlags;
 
     fn section_attributes(header: &Self::SectionHeader) -> Self::SectionAttributes;
 
-    fn symbol_name(&self, symbol: &Self::Symbol) -> Result<&'data [u8]>;
+    /// Returns the default section type used for custom sections that don't specify a type.
+    fn default_section_type() -> Self::SectionType;
 
-    fn num_sections(&self) -> usize;
+    /// Validate that the supplied sizes are internally consistent.
+    fn validate_sizes(_mem_sizes: &OutputSectionPartMap<u64>) -> Result {
+        Ok(())
+    }
 
-    fn section_iter(&self) -> Self::SectionIterator;
+    /// Implementations can force certain sections to be kept. Only needs to be done for sections
+    /// that need to be emitted even if empty.
+    fn apply_force_keep_sections(keep_sections: &mut OutputSectionMap<bool>, args: &Args);
 
-    fn enumerate_sections(
-        &self,
-    ) -> impl Iterator<Item = (object::SectionIndex, &'data Self::SectionHeader)>;
+    /// Returns whether an input section with zero size destined for the specified output section
+    /// should be considered content and thus prevent the output section from being discarded.
+    fn is_zero_sized_section_content(section_id: OutputSectionId) -> bool;
 
-    fn section(&self, index: object::SectionIndex) -> Result<&'data Self::SectionHeader>;
-
-    fn section_by_name(
-        &self,
-        name: &str,
-    ) -> Option<(object::SectionIndex, &'data Self::SectionHeader)>;
-
-    fn symbol_section(
-        &self,
-        symbol: &Self::Symbol,
-        index: object::SymbolIndex,
-    ) -> Result<Option<object::SectionIndex>>;
-
-    fn symbol_versions(&self) -> &[Self::SymbolVersionIndex];
-
-    /// The dynamic object will be linked against. This is a chance to perform extra initialisation
-    /// of `state`.
-    fn activate_dynamic(&self, state: &mut Self::DynamicLayoutState);
-
-    fn dynamic_symbol_used(
-        &self,
-        symbol_index: object::SymbolIndex,
-        state: &mut Self::DynamicLayoutState,
-    ) -> Result;
-
-    fn finalise_sizes_dynamic(
-        &self,
-        lib_name: &[u8],
-        state: &mut Self::DynamicLayoutState,
-        mem_sizes: &mut OutputSectionPartMap<u64>,
-    ) -> Result;
-
-    fn apply_non_addressable_indexes_dynamic(
-        &self,
-        indexes: &mut Self::NonAddressableIndexes,
-        counts: &mut Self::NonAddressableCounts,
-        state: &mut Self::DynamicLayoutState,
-    ) -> Result;
-
-    fn finalise_layout_dynamic(
-        &self,
-        state: Self::DynamicLayoutState,
-        memory_offsets: &mut OutputSectionPartMap<u64>,
-        section_layouts: &OutputSectionMap<OutputRecordLayout>,
-    ) -> Self::DynamicLayout;
-
-    fn new_epilogue_layout(
-        args: &Args,
-        output_kind: OutputKind,
-        dynamic_symbol_definitions: &mut [DynamicSymbolDefinition<'_>],
-    ) -> Self::EpilogueLayout;
-
-    fn apply_non_addressable_indexes_epilogue(
-        counts: &mut Self::NonAddressableCounts,
-        state: &mut Self::EpilogueLayout,
-    );
-
-    fn apply_non_addressable_indexes<'groups>(
-        symbol_db: &SymbolDb<'data, Self>,
-        counts: &Self::NonAddressableCounts,
-        mem_sizes_iter: impl Iterator<Item = &'groups mut OutputSectionPartMap<u64>>,
-    );
-
-    fn finalise_sizes_epilogue(
-        state: &mut Self::EpilogueLayout,
-        mem_sizes: &mut OutputSectionPartMap<u64>,
-        dynamic_symbol_definitions: &[DynamicSymbolDefinition<'data>],
-        properties: &Self::LayoutProperties,
-        symbol_db: &SymbolDb<'data, Self>,
-    );
-
-    fn finalise_sizes_all(
-        mem_sizes: &mut OutputSectionPartMap<u64>,
-        symbol_db: &SymbolDb<'data, Self>,
-    );
-
-    fn apply_late_size_adjustments_epilogue(
-        state: &mut Self::EpilogueLayout,
-        current_sizes: &OutputSectionPartMap<u64>,
-        extra_sizes: &mut OutputSectionPartMap<u64>,
-        dynamic_symbol_defs: &[DynamicSymbolDefinition],
-    ) -> Result;
-
-    fn finalise_layout_epilogue(
-        epilogue_state: &mut Self::EpilogueLayout,
-        memory_offsets: &mut OutputSectionPartMap<u64>,
-        symbol_db: &SymbolDb<'data, Self>,
-        common_state: &Self::LayoutProperties,
-        dynsym_start_index: u32,
-        dynamic_symbol_defs: &[DynamicSymbolDefinition],
-    ) -> Result;
-
-    fn dynamic_tags(&self) -> Result<&'data [Self::DynamicEntry]>;
-
-    fn section_name(&self, section_header: &Self::SectionHeader) -> Result<&'data [u8]>;
-
-    /// Returns the raw section data. Doesn't handle decompression.
-    fn raw_section_data(&self, section: &Self::SectionHeader) -> Result<&'data [u8]>;
-
-    fn section_data(
-        &self,
-        section: &Self::SectionHeader,
-        member: &bumpalo_herd::Member<'data>,
-        loaded_metrics: &LoadedMetrics,
-    ) -> Result<&'data [u8]>;
-
-    /// Copies the data for the specified section into `out`, which must be the correct size.
-    /// Decompresses the data if necessary.
-    fn copy_section_data(&self, section: &Self::SectionHeader, out: &mut [u8]) -> Result;
-
-    /// Returns the contents of a section as a Cow. Will heap-allocate if the section is compressed.
-    fn section_data_cow(&self, section: &Self::SectionHeader) -> Result<Cow<'data, [u8]>>;
-
-    fn section_alignment(&self, section: &Self::SectionHeader) -> Result<u64>;
-
-    fn relocations(
-        &self,
-        index: object::SectionIndex,
-        relocations: &Self::RelocationSections,
-    ) -> Result<Self::RelocationList>;
-
-    fn parse_relocations(&self) -> Result<Self::RelocationSections>;
-
-    /// Get the version of a symbol. Only intended for diagnostic purposes since it's potentially
-    /// quite slow.
-    fn symbol_version_debug(&self, symbol_index: object::SymbolIndex) -> Option<String>;
-
-    fn section_display_name(&self, index: object::SectionIndex) -> Cow<'data, str>;
-
-    fn dynamic_tag_values(&self) -> Option<Self::DynamicTagValues>;
-
-    fn get_version_names(&self) -> Result<Self::VersionNames>;
-
-    fn get_symbol_name_and_version(
-        &self,
-        symbol: &Self::Symbol,
-        local_index: usize,
-        version_names: &Self::VersionNames,
-    ) -> Result<Self::RawSymbolName>;
-
-    fn verneed_table(&self) -> Result<Self::VerneedTable>;
-
-    fn process_gnu_note_section(
-        &self,
-        state: &mut Self::FileLayoutState,
-        section_index: object::SectionIndex,
-    ) -> Result;
-
-    fn create_layout_properties<'states, 'files, A: Arch<File<'data> = Self>>(
-        args: &Args,
-        objects: impl Iterator<Item = &'files Self>,
-        states: impl Iterator<Item = &'states Self::FileLayoutState> + Clone,
-    ) -> Result<Self::LayoutProperties>
-    where
-        'data: 'files,
-        'data: 'states;
-
-    fn load_exception_frame_data<'scope, A: Arch<File<'data> = Self>>(
-        object: &mut ObjectLayoutState<'data, Self>,
-        common: &mut layout::CommonGroupState<'data, Self>,
-        eh_frame_section_index: object::SectionIndex,
-        resources: &'scope layout::GraphResources<'data, '_, Self>,
-        queue: &mut layout::LocalWorkQueue,
-        scope: &Scope<'scope>,
-    ) -> Result;
-
-    /// Called when a section is loaded (not GCed). Implementations should process any exception
-    /// frame data related to the loaded section.
-    fn non_empty_section_loaded<'scope, A: Arch<File<'data> = Self>>(
-        object: &mut layout::ObjectLayoutState<'data, Self>,
-        common: &mut layout::CommonGroupState<'data, Self>,
-        queue: &mut layout::LocalWorkQueue,
-        unloaded: UnloadedSection,
-        resources: &'scope layout::GraphResources<'data, 'scope, Self>,
-        scope: &Scope<'scope>,
-    ) -> Result;
+    fn built_in_section_details() -> &'static [Self::BuiltInSectionDetails];
 
     fn finalise_group_layout(memory_offsets: &OutputSectionPartMap<u64>) -> Self::GroupLayoutExt;
-
-    /// Called after GC phase has completed. Mostly useful for platform-specific logging.
-    fn finalise_find_required_sections(groups: &[layout::GroupState<'data, Self>]);
-
-    fn pre_finalise_sizes_prelude(common: &mut layout::CommonGroupState<'data, Self>, args: &Args);
-
-    fn finalise_object_sizes(
-        object: &mut layout::ObjectLayoutState<'data, Self>,
-        common: &mut layout::CommonGroupState<'data, Self>,
-    );
-
-    fn finalise_object_layout(
-        object: &layout::ObjectLayoutState<'data, Self>,
-        memory_offsets: &mut OutputSectionPartMap<u64>,
-    );
-
-    fn compute_object_addresses(
-        object: &layout::ObjectLayoutState<'data, Self>,
-        memory_offsets: &mut OutputSectionPartMap<u64>,
-    );
 
     /// Resolves a reference to the frame data section.
     fn frame_data_base_address(memory_offsets: &OutputSectionPartMap<u64>) -> u64;
 
-    /// Returns whether we should check for undefined symbols in `self`. Only called for dynamic
-    /// objects.
-    fn should_enforce_undefined(&self, resources: &layout::GraphResources<'data, '_, Self>)
-    -> bool;
+    /// Called after GC phase has completed. Mostly useful for platform-specific logging.
+    fn finalise_find_required_sections<'data>(groups: &[layout::GroupState<'data, Self>]);
 
-    fn layout_resources_ext(groups: &[Group<'data, Self>]) -> Self::LayoutResourcesExt;
+    fn pre_finalise_sizes_prelude<'data>(
+        common: &mut layout::CommonGroupState<'data, Self>,
+        args: &Args,
+    );
+
+    fn finalise_object_sizes<'data>(
+        object: &mut layout::ObjectLayoutState<'data, Self>,
+        common: &mut layout::CommonGroupState<'data, Self>,
+    );
+
+    fn finalise_object_layout<'data>(
+        object: &layout::ObjectLayoutState<'data, Self>,
+        memory_offsets: &mut OutputSectionPartMap<u64>,
+    );
+
+    fn compute_object_addresses<'data>(
+        object: &layout::ObjectLayoutState<'data, Self>,
+        memory_offsets: &mut OutputSectionPartMap<u64>,
+    );
+
+    fn layout_resources_ext<'data>(
+        groups: &[Group<'data, Self>],
+    ) -> Self::LayoutResourcesExt<'data>;
 
     /// Calls `load_section_relocations` on `state` for the relocations in `section`.
-    fn load_object_section_relocations<'scope, A: Arch<File<'data> = Self>>(
+    fn load_object_section_relocations<'data, 'scope, A: Arch<Platform = Self>>(
         state: &layout::ObjectLayoutState<'data, Self>,
         common: &mut layout::CommonGroupState<'data, Self>,
         queue: &mut layout::LocalWorkQueue,
@@ -457,7 +259,7 @@ pub(crate) trait ObjectFile<'data>: Send + Sync + Sized + std::fmt::Debug + 'dat
     ) -> Result;
 
     /// Calls `load_debug_relocations` on `state` for the relocations in `section`.
-    fn load_object_debug_relocations<'scope, A: Arch<File<'data> = Self>>(
+    fn load_object_debug_relocations<'data, 'scope, A: Arch<Platform = Self>>(
         state: &layout::ObjectLayoutState<'data, Self>,
         common: &mut layout::CommonGroupState<'data, Self>,
         queue: &mut layout::LocalWorkQueue,
@@ -466,12 +268,12 @@ pub(crate) trait ObjectFile<'data>: Send + Sync + Sized + std::fmt::Debug + 'dat
         scope: &Scope<'scope>,
     ) -> Result;
 
-    fn create_dynamic_symbol_definition(
+    fn create_dynamic_symbol_definition<'data>(
         symbol_db: &SymbolDb<'data, Self>,
         symbol_id: SymbolId,
     ) -> Result<layout::DynamicSymbolDefinition<'data>>;
 
-    fn validate_section(
+    fn validate_section<'data>(
         section_info: &crate::output_section_id::SectionOutputInfo,
         section_flags: Self::SectionFlags,
         section_layout: &OutputRecordLayout,
@@ -479,14 +281,6 @@ pub(crate) trait ObjectFile<'data>: Send + Sync + Sized + std::fmt::Debug + 'dat
         output_sections: &OutputSections<'data>,
         section_id: OutputSectionId,
     ) -> Result;
-
-    /// Returns the default section type used for custom sections that don't specify a type.
-    fn default_section_type() -> Self::SectionType;
-
-    /// Validate that the supplied sizes are internally consistent.
-    fn validate_sizes(_mem_sizes: &OutputSectionPartMap<u64>) -> Result {
-        Ok(())
-    }
 
     /// Called when we detect an internal error with allocation in order to try and help determine
     /// what we did wrong.
@@ -510,22 +304,277 @@ pub(crate) trait ObjectFile<'data>: Send + Sync + Sized + std::fmt::Debug + 'dat
     /// Returns segment definitions that should be unconditionally emitted without content.
     fn unconditional_segment_defs() -> &'static [Self::ProgramSegmentDef];
 
-    fn create_linker_defined_symbols(
+    fn create_linker_defined_symbols<'data>(
         symbols: &mut crate::parsing::InternalSymbolsBuilder<'data>,
         output_kind: OutputKind,
     );
 
-    /// Implementations can force certain sections to be kept. Only needs to be done for sections
-    /// that need to be emitted even if empty.
-    fn apply_force_keep_sections(keep_sections: &mut OutputSectionMap<bool>, args: &Args);
+    fn built_in_section_infos<'data>() -> Vec<crate::output_section_id::SectionOutputInfo<'data>>;
 
-    /// Returns whether an input section with zero size destined for the specified output section
-    /// should be considered content and thus prevent the output section from being discarded.
-    fn is_zero_sized_section_content(section_id: OutputSectionId) -> bool;
+    fn create_layout_properties<'data, 'states, 'files, A: Arch<Platform = Self>>(
+        args: &Args,
+        objects: impl Iterator<Item = &'files Self::File<'data>>,
+        states: impl Iterator<Item = &'states Self::FileLayoutState<'data>> + Clone,
+    ) -> Result<Self::LayoutProperties>
+    where
+        'data: 'files,
+        'data: 'states;
 
-    fn built_in_section_details() -> &'static [Self::BuiltInSectionDetails];
+    fn load_exception_frame_data<'data, 'scope, A: Arch<Platform = Self>>(
+        object: &mut ObjectLayoutState<'data, Self>,
+        common: &mut layout::CommonGroupState<'data, Self>,
+        eh_frame_section_index: object::SectionIndex,
+        resources: &'scope layout::GraphResources<'data, '_, Self>,
+        queue: &mut layout::LocalWorkQueue,
+        scope: &Scope<'scope>,
+    ) -> Result;
 
-    fn built_in_section_infos() -> Vec<crate::output_section_id::SectionOutputInfo<'data>>;
+    /// Called when a section is loaded (not GCed). Implementations should process any exception
+    /// frame data related to the loaded section.
+    fn non_empty_section_loaded<'data, 'scope, A: Arch<Platform = Self>>(
+        object: &mut layout::ObjectLayoutState<'data, Self>,
+        common: &mut layout::CommonGroupState<'data, Self>,
+        queue: &mut layout::LocalWorkQueue,
+        unloaded: UnloadedSection,
+        resources: &'scope layout::GraphResources<'data, 'scope, Self>,
+        scope: &Scope<'scope>,
+    ) -> Result;
+
+    fn new_epilogue_layout(
+        args: &Args,
+        output_kind: OutputKind,
+        dynamic_symbol_definitions: &mut [DynamicSymbolDefinition<'_>],
+    ) -> Self::EpilogueLayout;
+
+    fn apply_non_addressable_indexes_epilogue(
+        counts: &mut Self::NonAddressableCounts,
+        state: &mut Self::EpilogueLayout,
+    );
+
+    fn apply_non_addressable_indexes<'data, 'groups>(
+        symbol_db: &SymbolDb<'data, Self>,
+        counts: &Self::NonAddressableCounts,
+        mem_sizes_iter: impl Iterator<Item = &'groups mut OutputSectionPartMap<u64>>,
+    );
+
+    fn finalise_sizes_epilogue<'data>(
+        state: &mut Self::EpilogueLayout,
+        mem_sizes: &mut OutputSectionPartMap<u64>,
+        dynamic_symbol_definitions: &[DynamicSymbolDefinition<'data>],
+        properties: &Self::LayoutProperties,
+        symbol_db: &SymbolDb<'data, Self>,
+    );
+
+    fn finalise_sizes_all<'data>(
+        mem_sizes: &mut OutputSectionPartMap<u64>,
+        symbol_db: &SymbolDb<'data, Self>,
+    );
+
+    fn apply_late_size_adjustments_epilogue(
+        state: &mut Self::EpilogueLayout,
+        current_sizes: &OutputSectionPartMap<u64>,
+        extra_sizes: &mut OutputSectionPartMap<u64>,
+        dynamic_symbol_defs: &[DynamicSymbolDefinition],
+    ) -> Result;
+
+    fn finalise_layout_epilogue<'data>(
+        epilogue_state: &mut Self::EpilogueLayout,
+        memory_offsets: &mut OutputSectionPartMap<u64>,
+        symbol_db: &SymbolDb<'data, Self>,
+        common_state: &Self::LayoutProperties,
+        dynsym_start_index: u32,
+        dynamic_symbol_defs: &[DynamicSymbolDefinition],
+    ) -> Result;
+}
+
+/// Abstracts over the different object file formats that we support (or may support). e.g. ELF.
+pub(crate) trait ObjectFile<'data>: Sized + Send + Sync + std::fmt::Debug + 'data {
+    type Platform: Platform<File<'data> = Self>;
+
+    fn parse_bytes(input: &'data [u8], is_dynamic: bool) -> Result<Self>;
+
+    /// As for `parse_bytes` but also validates that the file architecture matches what is expected
+    /// based on `args`.
+    fn parse(input: &InputBytes<'data>, args: &Args) -> Result<Self>;
+
+    fn is_dynamic(&self) -> bool;
+
+    fn num_symbols(&self) -> usize;
+
+    fn symbols(&self) -> &'data [<Self::Platform as Platform>::Symbol];
+
+    fn enumerate_symbols(
+        &self,
+    ) -> impl Iterator<
+        Item = (
+            object::SymbolIndex,
+            &'data <Self::Platform as Platform>::Symbol,
+        ),
+    > {
+        self.symbols()
+            .iter()
+            .enumerate()
+            .map(|(i, sym)| (object::SymbolIndex(i), sym))
+    }
+
+    // TODO: Remove implementations of this as this default should be fine. Perhaps first check if
+    // all platforms can get a slice of symbols.
+    fn symbols_iter(&self) -> impl Iterator<Item = &'data <Self::Platform as Platform>::Symbol> {
+        self.symbols().iter()
+    }
+
+    fn symbol(
+        &self,
+        index: object::SymbolIndex,
+    ) -> Result<&'data <Self::Platform as Platform>::Symbol>;
+
+    fn section_size(&self, header: &<Self::Platform as Platform>::SectionHeader) -> Result<u64>;
+
+    fn symbol_name(&self, symbol: &<Self::Platform as Platform>::Symbol) -> Result<&'data [u8]>;
+
+    fn num_sections(&self) -> usize;
+
+    fn section_iter(&self) -> <Self::Platform as Platform>::SectionIterator<'data>;
+
+    fn enumerate_sections(
+        &self,
+    ) -> impl Iterator<
+        Item = (
+            object::SectionIndex,
+            &'data <Self::Platform as Platform>::SectionHeader,
+        ),
+    >;
+
+    fn section(
+        &self,
+        index: object::SectionIndex,
+    ) -> Result<&'data <Self::Platform as Platform>::SectionHeader>;
+
+    fn section_by_name(
+        &self,
+        name: &str,
+    ) -> Option<(
+        object::SectionIndex,
+        &'data <Self::Platform as Platform>::SectionHeader,
+    )>;
+
+    fn symbol_section(
+        &self,
+        symbol: &<Self::Platform as Platform>::Symbol,
+        index: object::SymbolIndex,
+    ) -> Result<Option<object::SectionIndex>>;
+
+    fn symbol_versions(&self) -> &[<Self::Platform as Platform>::SymbolVersionIndex];
+
+    /// The dynamic object will be linked against. This is a chance to perform extra initialisation
+    /// of `state`.
+    fn activate_dynamic(&self, state: &mut <Self::Platform as Platform>::DynamicLayoutState<'data>);
+
+    fn dynamic_symbol_used(
+        &self,
+        symbol_index: object::SymbolIndex,
+        state: &mut <Self::Platform as Platform>::DynamicLayoutState<'data>,
+    ) -> Result;
+
+    fn finalise_sizes_dynamic(
+        &self,
+        lib_name: &[u8],
+        state: &mut <Self::Platform as Platform>::DynamicLayoutState<'data>,
+        mem_sizes: &mut OutputSectionPartMap<u64>,
+    ) -> Result;
+
+    fn apply_non_addressable_indexes_dynamic(
+        &self,
+        indexes: &mut <Self::Platform as Platform>::NonAddressableIndexes,
+        counts: &mut <Self::Platform as Platform>::NonAddressableCounts,
+        state: &mut <Self::Platform as Platform>::DynamicLayoutState<'data>,
+    ) -> Result;
+
+    fn finalise_layout_dynamic(
+        &self,
+        state: <Self::Platform as Platform>::DynamicLayoutState<'data>,
+        memory_offsets: &mut OutputSectionPartMap<u64>,
+        section_layouts: &OutputSectionMap<OutputRecordLayout>,
+    ) -> <Self::Platform as Platform>::DynamicLayout<'data>;
+
+    fn section_name(
+        &self,
+        section_header: &<Self::Platform as Platform>::SectionHeader,
+    ) -> Result<&'data [u8]>;
+
+    /// Returns the raw section data. Doesn't handle decompression.
+    fn raw_section_data(
+        &self,
+        section: &<Self::Platform as Platform>::SectionHeader,
+    ) -> Result<&'data [u8]>;
+
+    fn section_data(
+        &self,
+        section: &<Self::Platform as Platform>::SectionHeader,
+        member: &bumpalo_herd::Member<'data>,
+        loaded_metrics: &LoadedMetrics,
+    ) -> Result<&'data [u8]>;
+
+    /// Copies the data for the specified section into `out`, which must be the correct size.
+    /// Decompresses the data if necessary.
+    fn copy_section_data(
+        &self,
+        section: &<Self::Platform as Platform>::SectionHeader,
+        out: &mut [u8],
+    ) -> Result;
+
+    /// Returns the contents of a section as a Cow. Will heap-allocate if the section is compressed.
+    fn section_data_cow(
+        &self,
+        section: &<Self::Platform as Platform>::SectionHeader,
+    ) -> Result<Cow<'data, [u8]>>;
+
+    fn section_alignment(
+        &self,
+        section: &<Self::Platform as Platform>::SectionHeader,
+    ) -> Result<u64>;
+
+    fn relocations(
+        &self,
+        index: object::SectionIndex,
+        relocations: &<Self::Platform as Platform>::RelocationSections,
+    ) -> Result<<Self::Platform as Platform>::RelocationList<'data>>;
+
+    fn parse_relocations(&self) -> Result<<Self::Platform as Platform>::RelocationSections>;
+
+    /// Get the version of a symbol. Only intended for diagnostic purposes since it's potentially
+    /// quite slow.
+    fn symbol_version_debug(&self, symbol_index: object::SymbolIndex) -> Option<String>;
+
+    fn section_display_name(&self, index: object::SectionIndex) -> Cow<'data, str>;
+
+    fn dynamic_tag_values(&self) -> Option<<Self::Platform as Platform>::DynamicTagValues<'data>>;
+
+    fn get_version_names(&self) -> Result<<Self::Platform as Platform>::VersionNames<'data>>;
+
+    fn get_symbol_name_and_version(
+        &self,
+        symbol: &<Self::Platform as Platform>::Symbol,
+        local_index: usize,
+        version_names: &<Self::Platform as Platform>::VersionNames<'data>,
+    ) -> Result<<Self::Platform as Platform>::RawSymbolName<'data>>;
+
+    /// Returns whether we should check for undefined symbols in `self`. Only called for dynamic
+    /// objects.
+    fn should_enforce_undefined(
+        &self,
+        resources: &layout::GraphResources<'data, '_, Self::Platform>,
+    ) -> bool;
+
+    fn verneed_table(&self) -> Result<<Self::Platform as Platform>::VerneedTable<'data>>;
+
+    fn process_gnu_note_section(
+        &self,
+        state: &mut <Self::Platform as Platform>::FileLayoutState<'data>,
+        section_index: object::SectionIndex,
+    ) -> Result;
+
+    fn dynamic_tags(&self) -> Result<&'data [<Self::Platform as Platform>::DynamicEntry]>;
 }
 
 pub(crate) trait SectionHeader: std::fmt::Debug + Send + Sync + 'static {
@@ -662,7 +711,7 @@ pub(crate) trait DynamicTagValues<'data>: std::fmt::Debug + Send + Sync + 'data 
 }
 
 pub(crate) trait NonAddressableIndexes: Send + Sync + 'static {
-    fn new<'data, O: ObjectFile<'data>>(symbol_db: &SymbolDb<'data, O>) -> Self;
+    fn new<'data, P: Platform>(symbol_db: &SymbolDb<'data, P>) -> Self;
 }
 
 pub(crate) trait SectionAttributes: std::fmt::Debug + Send + Sync + 'static {

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -31,6 +31,7 @@ use crate::part_id::PartId;
 use crate::platform::DynamicTagValues as _;
 use crate::platform::FrameIndex;
 use crate::platform::ObjectFile;
+use crate::platform::Platform;
 use crate::platform::RawSymbolName as _;
 use crate::platform::SectionHeader as _;
 use crate::platform::Symbol as _;
@@ -62,19 +63,19 @@ use rayon::iter::ParallelIterator;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
-pub(crate) struct Resolver<'data, O: ObjectFile<'data>> {
+pub(crate) struct Resolver<'data, P: Platform> {
     undefined_symbols: Vec<UndefinedSymbol<'data>>,
-    pub(crate) resolved_groups: Vec<ResolvedGroup<'data, O>>,
+    pub(crate) resolved_groups: Vec<ResolvedGroup<'data, P>>,
 }
 
-impl<'data, O: ObjectFile<'data>> Resolver<'data, O> {
+impl<'data, P: Platform> Resolver<'data, P> {
     /// Resolves undefined symbols. In the process of resolving symbols, we decide which archive
     /// entries to load. Some symbols may not have definitions, in which case we'll note those for
     /// later processing. Can be called multiple times with additional groups having been added to
     /// the SymbolDb in between.
     pub(crate) fn resolve_symbols_and_select_archive_entries(
         &mut self,
-        symbol_db: &mut SymbolDb<'data, O>,
+        symbol_db: &mut SymbolDb<'data, P>,
     ) -> Result {
         resolve_symbols_and_select_archive_entries(self, symbol_db)
     }
@@ -85,11 +86,11 @@ impl<'data, O: ObjectFile<'data>> Resolver<'data, O> {
     /// appropriate name.
     pub(crate) fn resolve_sections_and_canonicalise_undefined(
         mut self,
-        symbol_db: &mut SymbolDb<'data, O>,
+        symbol_db: &mut SymbolDb<'data, P>,
         per_symbol_flags: &mut PerSymbolFlags,
         output_sections: &mut OutputSections<'data>,
         layout_rules: &LayoutRules<'data>,
-    ) -> Result<Vec<ResolvedGroup<'data, O>>> {
+    ) -> Result<Vec<ResolvedGroup<'data, P>>> {
         timing_phase!("Section resolution");
 
         resolve_sections(&mut self.resolved_groups, symbol_db, layout_rules)?;
@@ -115,9 +116,9 @@ impl<'data, O: ObjectFile<'data>> Resolver<'data, O> {
     }
 }
 
-fn resolve_symbols_and_select_archive_entries<'data, O: ObjectFile<'data>>(
-    resolver: &mut Resolver<'data, O>,
-    symbol_db: &mut SymbolDb<'data, O>,
+fn resolve_symbols_and_select_archive_entries<'data, P: Platform>(
+    resolver: &mut Resolver<'data, P>,
+    symbol_db: &mut SymbolDb<'data, P>,
 ) -> Result {
     timing_phase!("Resolve symbols");
 
@@ -235,14 +236,14 @@ fn resolve_symbols_and_select_archive_entries<'data, O: ObjectFile<'data>>(
     Ok(())
 }
 
-fn resolve_group<'data, 'definitions, O: ObjectFile<'data>>(
-    group: &Group<'data, O>,
+fn resolve_group<'data, 'definitions, P: Platform>(
+    group: &Group<'data, P>,
     initial_work_out: &mut Vec<LoadObjectSymbolsRequest<'definitions>>,
     definitions_out_per_file: &mut Vec<AtomicTake<&'definitions mut [SymbolId]>>,
     symbol_definitions_slice: &mut &'definitions mut [SymbolId],
-    symbol_db: &SymbolDb<'data, O>,
-    outputs: &Outputs<'data, O>,
-) -> ResolvedGroup<'data, O> {
+    symbol_db: &SymbolDb<'data, P>,
+    outputs: &Outputs<'data, P>,
+) -> ResolvedGroup<'data, P> {
     match group {
         Group::Prelude(prelude) => {
             let definitions_out = symbol_definitions_slice
@@ -362,9 +363,9 @@ fn resolve_group<'data, 'definitions, O: ObjectFile<'data>>(
     }
 }
 
-fn resolve_sections<'data, O: ObjectFile<'data>>(
-    groups: &mut [ResolvedGroup<'data, O>],
-    symbol_db: &SymbolDb<'data, O>,
+fn resolve_sections<'data, P: Platform>(
+    groups: &mut [ResolvedGroup<'data, P>],
+    symbol_db: &SymbolDb<'data, P>,
     layout_rules: &LayoutRules<'data>,
 ) -> Result {
     timing_phase!("Resolve sections");
@@ -378,7 +379,7 @@ fn resolve_sections<'data, O: ObjectFile<'data>>(
             verbose_timing_phase!("Resolve group sections");
 
             for file in &mut group.files {
-                let ResolvedFile::<O>::Object(obj) = file else {
+                let ResolvedFile::<P>::Object(obj) = file else {
                     continue;
                 };
 
@@ -431,13 +432,13 @@ impl LoadedMetrics {
     }
 }
 
-struct ResolutionResources<'data, 'scope, O: ObjectFile<'data>> {
+struct ResolutionResources<'data, 'scope, P: Platform> {
     definitions_per_file: &'scope Vec<Vec<AtomicTake<&'scope mut [SymbolId]>>>,
-    symbol_db: &'scope SymbolDb<'data, O>,
-    outputs: &'scope Outputs<'data, O>,
+    symbol_db: &'scope SymbolDb<'data, P>,
+    outputs: &'scope Outputs<'data, P>,
 }
 
-impl<'scope, 'data, O: ObjectFile<'data>> ResolutionResources<'data, 'scope, O> {
+impl<'scope, 'data, P: Platform> ResolutionResources<'data, 'scope, P> {
     /// Request loading of `file_id` if it hasn't already been requested.
     #[inline(always)]
     fn try_request_file_id(&'scope self, file_id: FileId, scope: &Scope<'scope>) {
@@ -482,11 +483,11 @@ impl<'scope, 'data, O: ObjectFile<'data>> ResolutionResources<'data, 'scope, O> 
     }
 }
 
-fn work_items_do<'definitions, 'data, O: ObjectFile<'data>>(
+fn work_items_do<'definitions, 'data, P: Platform>(
     file_id: FileId,
     mut definitions_out: &'definitions mut [SymbolId],
-    symbol_db: &SymbolDb<'data, O>,
-    outputs: &Outputs<'data, O>,
+    symbol_db: &SymbolDb<'data, P>,
+    outputs: &Outputs<'data, P>,
     mut request_callback: impl FnMut(LoadObjectSymbolsRequest<'definitions>),
 ) {
     match &symbol_db.groups[file_id.group()] {
@@ -549,16 +550,16 @@ fn work_items_do<'definitions, 'data, O: ObjectFile<'data>>(
 }
 
 #[derive(Debug)]
-pub(crate) struct ResolvedGroup<'data, O: ObjectFile<'data>> {
-    pub(crate) files: Vec<ResolvedFile<'data, O>>,
+pub(crate) struct ResolvedGroup<'data, P: Platform> {
+    pub(crate) files: Vec<ResolvedFile<'data, P>>,
 }
 
 #[derive(Debug)]
-pub(crate) enum ResolvedFile<'data, O: ObjectFile<'data>> {
+pub(crate) enum ResolvedFile<'data, P: Platform> {
     NotLoaded(NotLoaded),
     Prelude(ResolvedPrelude<'data>),
-    Object(ResolvedObject<'data, O>),
-    Dynamic(ResolvedDynamic<'data, O>),
+    Object(ResolvedObject<'data, P>),
+    Dynamic(ResolvedDynamic<'data, P>),
     LinkerScript(ResolvedLinkerScript<'data>),
     SyntheticSymbols(ResolvedSyntheticSymbols<'data>),
     #[cfg(feature = "plugins")]
@@ -633,19 +634,19 @@ pub(crate) struct ResolvedPrelude<'data> {
 
 /// Resolved state common to dynamic and regular objects.
 #[derive(Debug)]
-pub(crate) struct ResolvedCommon<'data, O: ObjectFile<'data>> {
+pub(crate) struct ResolvedCommon<'data, P: Platform> {
     pub(crate) input: InputRef<'data>,
-    pub(crate) object: &'data O,
+    pub(crate) object: &'data P::File<'data>,
     pub(crate) file_id: FileId,
     pub(crate) symbol_id_range: SymbolIdRange,
 }
 
 #[derive(Debug)]
-pub(crate) struct ResolvedObject<'data, O: ObjectFile<'data>> {
-    pub(crate) common: ResolvedCommon<'data, O>,
+pub(crate) struct ResolvedObject<'data, P: Platform> {
+    pub(crate) common: ResolvedCommon<'data, P>,
 
     pub(crate) sections: Vec<SectionSlot>,
-    pub(crate) relocations: O::RelocationSections,
+    pub(crate) relocations: P::RelocationSections,
 
     pub(crate) string_merge_extras: Vec<StringMergeSectionExtra<'data>>,
 
@@ -656,9 +657,9 @@ pub(crate) struct ResolvedObject<'data, O: ObjectFile<'data>> {
 }
 
 #[derive(Debug)]
-pub(crate) struct ResolvedDynamic<'data, O: ObjectFile<'data>> {
-    pub(crate) common: ResolvedCommon<'data, O>,
-    dynamic_tag_values: O::DynamicTagValues,
+pub(crate) struct ResolvedDynamic<'data, P: Platform> {
+    pub(crate) common: ResolvedCommon<'data, P>,
+    dynamic_tag_values: P::DynamicTagValues<'data>,
 }
 
 #[derive(Debug)]
@@ -683,8 +684,8 @@ pub(crate) struct ResolvedLtoInput {
     pub(crate) symbol_id_range: SymbolIdRange,
 }
 
-fn assign_section_ids<'data, O: ObjectFile<'data>>(
-    resolved: &mut [ResolvedGroup<'data, O>],
+fn assign_section_ids<'data, P: Platform>(
+    resolved: &mut [ResolvedGroup<'data, P>],
     output_sections: &mut OutputSections<'data>,
     args: &Args,
 ) {
@@ -744,9 +745,9 @@ fn init_fini_priority(name: &[u8]) -> Option<u16> {
     None
 }
 
-struct Outputs<'data, O: ObjectFile<'data>> {
+struct Outputs<'data, P: Platform> {
     /// Where we put objects once we've loaded them.
-    loaded: ArrayQueue<ResolvedFile<'data, O>>,
+    loaded: ArrayQueue<ResolvedFile<'data, P>>,
 
     #[cfg(feature = "plugins")]
     loaded_lto_objects: ArrayQueue<ResolvedLtoInput>,
@@ -757,7 +758,7 @@ struct Outputs<'data, O: ObjectFile<'data>> {
     undefined_symbols: SegQueue<UndefinedSymbol<'data>>,
 }
 
-impl<'data, O: ObjectFile<'data>> Outputs<'data, O> {
+impl<'data, P: Platform> Outputs<'data, P> {
     #[allow(unused_variables)]
     fn new(num_regular_objects: usize, num_lto_objects: usize) -> Self {
         Self {
@@ -770,9 +771,9 @@ impl<'data, O: ObjectFile<'data>> Outputs<'data, O> {
     }
 }
 
-fn process_object<'scope, 'data: 'scope, 'definitions, O: ObjectFile<'data>>(
+fn process_object<'scope, 'data: 'scope, 'definitions, P: Platform>(
     work_item: LoadObjectSymbolsRequest<'definitions>,
-    resources: &'scope ResolutionResources<'data, 'scope, O>,
+    resources: &'scope ResolutionResources<'data, 'scope, P>,
     scope: &Scope<'scope>,
 ) {
     let file_id = work_item.file_id;
@@ -814,9 +815,9 @@ fn process_object<'scope, 'data: 'scope, 'definitions, O: ObjectFile<'data>>(
 }
 
 #[cfg(feature = "plugins")]
-fn resolve_lto_symbols<'data, 'scope, O: ObjectFile<'data>>(
+fn resolve_lto_symbols<'data, 'scope, P: Platform>(
     obj: &crate::linker_plugins::LtoInput<'data>,
-    resources: &'scope ResolutionResources<'data, 'scope, O>,
+    resources: &'scope ResolutionResources<'data, 'scope, P>,
     definitions_out: &mut [SymbolId],
     scope: &Scope<'scope>,
 ) -> Result {
@@ -864,10 +865,10 @@ struct UndefinedSymbol<'data> {
     symbol_id: SymbolId,
 }
 
-fn load_prelude<'scope, 'data, O: ObjectFile<'data>>(
+fn load_prelude<'scope, 'data, P: Platform>(
     prelude: &crate::parsing::Prelude,
     definitions_out: &mut [SymbolId],
-    resources: &'scope ResolutionResources<'data, 'scope, O>,
+    resources: &'scope ResolutionResources<'data, 'scope, P>,
     scope: &Scope<'scope>,
 ) {
     // The start symbol could be defined within an archive entry. If it is, then we need to load
@@ -893,8 +894,8 @@ fn load_prelude<'scope, 'data, O: ObjectFile<'data>>(
     }
 }
 
-fn load_symbol_named<'scope, 'data, O: ObjectFile<'data>>(
-    resources: &'scope ResolutionResources<'data, 'scope, O>,
+fn load_symbol_named<'scope, 'data, P: Platform>(
+    resources: &'scope ResolutionResources<'data, 'scope, P>,
     definition_out: &mut SymbolId,
     name: &[u8],
     scope: &Scope<'scope>,
@@ -914,11 +915,11 @@ fn load_symbol_named<'scope, 'data, O: ObjectFile<'data>>(
 /// as the canonical one to which we'll refer. Where undefined symbols can be resolved to
 /// __start/__stop symbols that refer to the start or stop of a custom section, collect that
 /// information up and put it into `custom_start_stop_defs`.
-fn canonicalise_undefined_symbols<'data, O: ObjectFile<'data>>(
+fn canonicalise_undefined_symbols<'data, P: Platform>(
     mut undefined_symbols: Vec<UndefinedSymbol<'data>>,
     output_sections: &OutputSections,
-    groups: &[ResolvedGroup<'data, O>],
-    symbol_db: &mut SymbolDb<'data, O>,
+    groups: &[ResolvedGroup<'data, P>],
+    symbol_db: &mut SymbolDb<'data, P>,
     per_symbol_flags: &mut PerSymbolFlags,
     custom_start_stop_defs: &mut ResolvedSyntheticSymbols<'data>,
 ) {
@@ -1019,9 +1020,9 @@ fn canonicalise_undefined_symbols<'data, O: ObjectFile<'data>>(
     }
 }
 
-fn allocate_start_stop_symbol_id<'data, O: ObjectFile<'data>>(
+fn allocate_start_stop_symbol_id<'data, P: Platform>(
     name: PreHashed<UnversionedSymbolName<'data>>,
-    symbol_db: &mut SymbolDb<'data, O>,
+    symbol_db: &mut SymbolDb<'data, P>,
     per_symbol_flags: &mut PerSymbolFlags,
     custom_start_stop_defs: &mut ResolvedSyntheticSymbols<'data>,
     output_sections: &OutputSections,
@@ -1051,8 +1052,8 @@ fn allocate_start_stop_symbol_id<'data, O: ObjectFile<'data>>(
     Some(symbol_id)
 }
 
-impl<'data, O: ObjectFile<'data>> ResolvedCommon<'data, O> {
-    fn new(obj: &'data SequencedInputObject<'data, O>) -> Self {
+impl<'data, P: Platform> ResolvedCommon<'data, P> {
+    fn new(obj: &'data SequencedInputObject<'data, P>) -> Self {
         Self {
             input: obj.parsed.input,
             object: &obj.parsed.object,
@@ -1092,8 +1093,8 @@ fn apply_init_fini_secondaries<'data>(
     }
 }
 
-impl<'data, O: ObjectFile<'data>> ResolvedObject<'data, O> {
-    fn new(common: ResolvedCommon<'data, O>) -> Self {
+impl<'data, P: Platform> ResolvedObject<'data, P> {
+    fn new(common: ResolvedCommon<'data, P>) -> Self {
         Self {
             common,
             // We'll fill this the rest during section resolution.
@@ -1106,8 +1107,11 @@ impl<'data, O: ObjectFile<'data>> ResolvedObject<'data, O> {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> ResolvedDynamic<'data, O> {
-    fn new(common: ResolvedCommon<'data, O>, dynamic_tag_values: O::DynamicTagValues) -> Self {
+impl<'data, P: Platform> ResolvedDynamic<'data, P> {
+    fn new(
+        common: ResolvedCommon<'data, P>,
+        dynamic_tag_values: P::DynamicTagValues<'data>,
+    ) -> Self {
         Self {
             common,
             dynamic_tag_values,
@@ -1119,8 +1123,8 @@ impl<'data, O: ObjectFile<'data>> ResolvedDynamic<'data, O> {
     }
 }
 
-fn resolve_sections_for_object<'data, O: ObjectFile<'data>>(
-    obj: &mut ResolvedObject<'data, O>,
+fn resolve_sections_for_object<'data, P: Platform>(
+    obj: &mut ResolvedObject<'data, P>,
     args: &Args,
     allocator: &bumpalo_herd::Member<'data>,
     loaded_metrics: &LoadedMetrics,
@@ -1145,10 +1149,10 @@ fn resolve_sections_for_object<'data, O: ObjectFile<'data>>(
 }
 
 #[inline(always)]
-fn resolve_section<'data, O: ObjectFile<'data>>(
+fn resolve_section<'data, P: Platform>(
     input_section_index: SectionIndex,
-    input_section: &O::SectionHeader,
-    obj: &mut ResolvedObject<'data, O>,
+    input_section: &P::SectionHeader,
+    obj: &mut ResolvedObject<'data, P>,
     args: &Args,
     allocator: &bumpalo_herd::Member<'data>,
     loaded_metrics: &LoadedMetrics,
@@ -1290,9 +1294,9 @@ fn resolve_section<'data, O: ObjectFile<'data>>(
     Ok(slot)
 }
 
-fn resolve_symbols<'data, 'scope, O: ObjectFile<'data>>(
-    obj: &SequencedInputObject<'data, O>,
-    resources: &'scope ResolutionResources<'data, 'scope, O>,
+fn resolve_symbols<'data, 'scope, P: Platform>(
+    obj: &SequencedInputObject<'data, P>,
+    resources: &'scope ResolutionResources<'data, 'scope, P>,
     start_symbol_offset: usize,
     definitions_out: &mut [SymbolId],
     scope: &Scope<'scope>,
@@ -1360,11 +1364,11 @@ struct SymbolAttributes<'data> {
 }
 
 #[inline(always)]
-fn resolve_symbol<'data, 'scope, O: ObjectFile<'data>>(
+fn resolve_symbol<'data, 'scope, P: Platform>(
     local_symbol_id: SymbolId,
     local_symbol_attributes: &SymbolAttributes<'data>,
     definition_out: &mut SymbolId,
-    resources: &'scope ResolutionResources<'data, 'scope, O>,
+    resources: &'scope ResolutionResources<'data, 'scope, P>,
     is_dynamic: bool,
     file_id: FileId,
     scope: &Scope<'scope>,
@@ -1420,13 +1424,13 @@ fn resolve_symbol<'data, 'scope, O: ObjectFile<'data>>(
     Ok(())
 }
 
-impl<'data, O: ObjectFile<'data>> std::fmt::Display for ResolvedObject<'data, O> {
+impl<'data, P: Platform> std::fmt::Display for ResolvedObject<'data, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(&self.common.input, f)
     }
 }
 
-impl<'data, O: ObjectFile<'data>> std::fmt::Display for ResolvedDynamic<'data, O> {
+impl<'data, P: Platform> std::fmt::Display for ResolvedDynamic<'data, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(&self.common.input, f)
     }
@@ -1438,7 +1442,7 @@ impl<'data> std::fmt::Display for ResolvedLinkerScript<'data> {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> std::fmt::Display for ResolvedFile<'data, O> {
+impl<'data, P: Platform> std::fmt::Display for ResolvedFile<'data, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ResolvedFile::NotLoaded(_) => std::fmt::Display::fmt("<not loaded>", f),
@@ -1481,7 +1485,7 @@ impl SectionSlot {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> ResolvedFile<'data, O> {
+impl<'data, P: Platform> ResolvedFile<'data, P> {
     fn symbol_id_range(&self) -> SymbolIdRange {
         match self {
             ResolvedFile::NotLoaded(s) => s.symbol_id_range,
@@ -1508,7 +1512,7 @@ impl ResolvedSyntheticSymbols<'_> {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> Default for Resolver<'data, O> {
+impl<'data, P: Platform> Default for Resolver<'data, P> {
     fn default() -> Self {
         Self {
             undefined_symbols: Default::default(),

--- a/libwild/src/string_merging.rs
+++ b/libwild/src/string_merging.rs
@@ -38,6 +38,7 @@ use crate::output_section_map::OutputSectionMap;
 use crate::output_section_part_map::OutputSectionPartMap;
 use crate::part_id::PartId;
 use crate::platform::ObjectFile;
+use crate::platform::Platform;
 use crate::platform::Symbol as _;
 use crate::resolution::ResolvedFile;
 use crate::resolution::ResolvedGroup;
@@ -275,8 +276,8 @@ pub(crate) fn merge_strings<'data>(
 }
 
 impl<'data> StringMergeInputs<'data> {
-    pub(crate) fn new<O: ObjectFile<'data>>(
-        resolved: &mut [ResolvedGroup<'data, O>],
+    pub(crate) fn new<P: Platform>(
+        resolved: &mut [ResolvedGroup<'data, P>],
         output_sections: &OutputSections,
     ) -> Result<Self> {
         Ok(Self {
@@ -291,8 +292,8 @@ impl<'data> StringMergeInputs<'data> {
 // Gather up all the string-merge sections, grouping them by their output section ID. We return a
 // reference to the `MergeStringsFileSection` rather than copying it because it appears to be
 // faster.
-fn group_merge_string_sections_by_output<'data, O: ObjectFile<'data>>(
-    resolved: &mut [ResolvedGroup<'data, O>],
+fn group_merge_string_sections_by_output<'data, P: Platform>(
+    resolved: &mut [ResolvedGroup<'data, P>],
     output_sections: &OutputSections,
 ) -> Result<OutputSectionMap<Vec<StringMergeInputSection<'data>>>> {
     verbose_timing_phase!("Find merge sectionns");
@@ -994,10 +995,10 @@ impl<'data> MergeString<'data> {
 /// Looks for a merged string at `symbol_index` + `addend` in the input and if found, returns its
 /// address in the output.
 #[inline(always)]
-pub(crate) fn get_merged_string_output_address<'data, O: ObjectFile<'data>>(
+pub(crate) fn get_merged_string_output_address<'data, P: Platform>(
     symbol_index: object::SymbolIndex,
     addend: i64,
-    object: &O,
+    object: &P::File<'data>,
     sections: &[SectionSlot],
     merged_strings: &OutputSectionMap<MergedStringsSection>,
     merged_string_start_addresses: &MergedStringStartAddresses,

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -35,6 +35,7 @@ use crate::parsing::SymbolPlacement;
 use crate::parsing::SyntheticSymbols;
 use crate::platform;
 use crate::platform::ObjectFile;
+use crate::platform::Platform;
 use crate::platform::RawSymbolName as _;
 use crate::platform::SectionHeader;
 use crate::platform::Symbol;
@@ -69,10 +70,10 @@ use std::sync::atomic::Ordering;
 use symbolic_demangle::demangle;
 
 #[derive(Debug)]
-pub struct SymbolDb<'data, O: ObjectFile<'data>> {
+pub struct SymbolDb<'data, P: Platform> {
     pub(crate) args: &'data Args,
 
-    pub(crate) groups: Vec<Group<'data, O>>,
+    pub(crate) groups: Vec<Group<'data, P>>,
 
     buckets: Vec<SymbolBucket<'data>>,
 
@@ -102,8 +103,8 @@ pub struct SymbolDb<'data, O: ObjectFile<'data>> {
 /// are returned to the original SymbolDb when the AtomicSymbolDb is dropped. If the AtomicSymbolDb
 /// gets leaked, then the tables in the original SymbolDb will remain empty. Provides some, but not
 /// all of the APIs provided by SymbolDb.
-struct AtomicSymbolDb<'data, 'db, O: ObjectFile<'data>> {
-    db: &'db mut SymbolDb<'data, O>,
+struct AtomicSymbolDb<'data, 'db, P: Platform> {
+    db: &'db mut SymbolDb<'data, P>,
     definitions: Vec<AtomicSymbolId>,
 }
 
@@ -284,7 +285,7 @@ struct PendingSymbolHashBucket<'data> {
     versioned_symbols: Vec<PendingVersionedSymbol<'data>>,
 }
 
-impl<'data, O: ObjectFile<'data>> SymbolDb<'data, O> {
+impl<'data, P: Platform> SymbolDb<'data, P> {
     /// If the version script is optimized fur rust, we downgraded all symbols to local visibility.
     /// This promotes symbols marked for global visibility in a Rust version script back to global.
     /// Also adds the non-interposable flag to all local symbols.
@@ -374,7 +375,7 @@ impl<'data, O: ObjectFile<'data>> SymbolDb<'data, O> {
         per_symbol_flags: &mut PerSymbolFlags,
         output_sections: &mut OutputSections<'data>,
         layout_rules_builder: &mut LayoutRulesBuilder<'data>,
-        loaded: LoadedInputs<'data, O>,
+        loaded: LoadedInputs<'data, P>,
     ) -> Result {
         timing_phase!("Load inputs into symbol DB");
 
@@ -392,7 +393,7 @@ impl<'data, O: ObjectFile<'data>> SymbolDb<'data, O> {
 
         if self.groups.is_empty() {
             self.groups
-                .push(Group::Prelude(crate::parsing::Prelude::new::<O>(
+                .push(Group::Prelude(crate::parsing::Prelude::new::<P>(
                     self.args,
                     self.output_kind,
                 )));
@@ -623,7 +624,7 @@ impl<'data, O: ObjectFile<'data>> SymbolDb<'data, O> {
         &'a self,
         per_symbol_flags: &'a dyn FlagsForSymbol,
         symbol_id: SymbolId,
-    ) -> SymbolDebug<'a, 'data, O> {
+    ) -> SymbolDebug<'a, 'data, P> {
         SymbolDebug {
             db: self,
             symbol_id,
@@ -733,7 +734,7 @@ impl<'data, O: ObjectFile<'data>> SymbolDb<'data, O> {
         self.symbol_definitions = definitions;
     }
 
-    fn borrow_atomic<'db>(&'db mut self) -> AtomicSymbolDb<'data, 'db, O> {
+    fn borrow_atomic<'db>(&'db mut self) -> AtomicSymbolDb<'data, 'db, P> {
         let definitions = self
             .take_definitions()
             .into_iter()
@@ -771,7 +772,7 @@ impl<'data, O: ObjectFile<'data>> SymbolDb<'data, O> {
         self.symbol_definitions[symbol_id.as_usize()] = new_definition;
     }
 
-    pub(crate) fn file<'db>(&'db self, file_id: FileId) -> SequencedInput<'db, 'data, O> {
+    pub(crate) fn file<'db>(&'db self, file_id: FileId) -> SequencedInput<'db, 'data, P> {
         match &self.groups[file_id.group()] {
             Group::Prelude(prelude) => SequencedInput::Prelude(prelude),
             Group::Objects(parsed_input_objects) => {
@@ -842,7 +843,7 @@ impl<'data, O: ObjectFile<'data>> SymbolDb<'data, O> {
     pub(crate) fn symbol_strength(
         &self,
         symbol_id: SymbolId,
-        resolved: &[ResolvedGroup<'data, O>],
+        resolved: &[ResolvedGroup<'data, P>],
     ) -> SymbolStrength {
         let file_id = self.file_id_for_symbol(symbol_id);
         match &resolved[file_id.group()].files[file_id.file()] {
@@ -875,7 +876,7 @@ impl<'data, O: ObjectFile<'data>> SymbolDb<'data, O> {
     fn is_in_comdat_group(
         &self,
         symbol_id: SymbolId,
-        resolved: &[ResolvedGroup<'data, O>],
+        resolved: &[ResolvedGroup<'data, P>],
     ) -> bool {
         let file_id = self.file_id_for_symbol(symbol_id);
         let ResolvedFile::Object(obj) = &resolved[file_id.group()].files[file_id.file()] else {
@@ -990,7 +991,7 @@ impl<'data, O: ObjectFile<'data>> SymbolDb<'data, O> {
         self.groups.len() as u32
     }
 
-    pub(crate) fn add_group(&mut self, group: Group<'data, O>) {
+    pub(crate) fn add_group(&mut self, group: Group<'data, P>) {
         self.groups.push(group);
     }
 
@@ -1029,10 +1030,10 @@ impl<'out> SymbolVecWriters<'out> {
         }
     }
 
-    fn new_shard<'group, 'data, O: ObjectFile<'data>>(
+    fn new_shard<'group, 'data, P: Platform>(
         &mut self,
-        group: &'group Group<'data, O>,
-    ) -> SymbolWriterShard<'out, 'group, 'data, O> {
+        group: &'group Group<'data, P>,
+    ) -> SymbolWriterShard<'out, 'group, 'data, P> {
         let num_symbols = group.num_symbols();
         SymbolWriterShard {
             group,
@@ -1043,10 +1044,7 @@ impl<'out> SymbolVecWriters<'out> {
         }
     }
 
-    fn return_shard<'data, O: ObjectFile<'data>>(
-        &mut self,
-        shard: SymbolWriterShard<'_, '_, 'data, O>,
-    ) {
+    fn return_shard<'data, P: Platform>(&mut self, shard: SymbolWriterShard<'_, '_, 'data, P>) {
         self.symbol_definitions_writer
             .return_shard(shard.resolutions);
         self.per_symbol_flags_writer.return_shard(shard.flags);
@@ -1092,10 +1090,10 @@ impl<'data> SymbolBucket<'data> {
     /// Returns the selected non-dynamic alternative to the supplied symbol, if any.
     /// Among non-dynamic alternatives, selects the best one based on symbol binding:
     /// strong > common (largest) > weak/gnu_unique.
-    fn get_non_dynamic<O: ObjectFile<'data>>(
+    fn get_non_dynamic<P: Platform>(
         &self,
         symbol_id: SymbolId,
-        symbol_db: &SymbolDb<'data, O>,
+        symbol_db: &SymbolDb<'data, P>,
     ) -> Option<SymbolId> {
         let alternatives = self.alternative_definitions.get(&symbol_id)?;
         let mut selector = SymbolPrioritySelector::new();
@@ -1116,10 +1114,10 @@ impl<'data> SymbolBucket<'data> {
 /// symbol we're using. The symbol we select will be the first strongly defined symbol in a loaded
 /// object, or if there are no strong definitions, then the first definition in a loaded object. If
 /// a symbol definition is a common symbol, then the largest definition will be used.
-pub(crate) fn resolve_alternative_symbol_definitions<'data, O: ObjectFile<'data>>(
-    symbol_db: &mut SymbolDb<'data, O>,
+pub(crate) fn resolve_alternative_symbol_definitions<'data, P: Platform>(
+    symbol_db: &mut SymbolDb<'data, P>,
     per_symbol_flags: &mut PerSymbolFlags,
-    resolved: &[ResolvedGroup<'data, O>],
+    resolved: &[ResolvedGroup<'data, P>],
 ) -> Result {
     timing_phase!("Resolve alternative symbol definitions");
 
@@ -1185,12 +1183,12 @@ impl Visibility {
     }
 }
 
-fn process_alternatives<'data, O: ObjectFile<'data>>(
+fn process_alternatives<'data, P: Platform>(
     alternative_definitions: &mut HashMap<SymbolId, Vec<SymbolId>>,
     error_queue: &SegQueue<Error>,
-    symbol_db: &AtomicSymbolDb<'data, '_, O>,
+    symbol_db: &AtomicSymbolDb<'data, '_, P>,
     per_symbol_flags: &AtomicPerSymbolFlags,
-    resolved: &[ResolvedGroup<'data, O>],
+    resolved: &[ResolvedGroup<'data, P>],
 ) {
     for (first, alternatives) in std::mem::take(alternative_definitions) {
         // Compute the most restrictive visibility of any of the alternative definitions. This is
@@ -1241,12 +1239,12 @@ fn handle_non_default_visibility(per_symbol_flags: &AtomicPerSymbolFlags, symbol
 /// Selects which version of the symbol to use. For more information on symbol priority, see
 /// https://maskray.me/blog/2021-06-20-linker-symbol-resolution
 #[inline(always)]
-fn select_symbol<'data, O: ObjectFile<'data>>(
-    symbol_db: &AtomicSymbolDb<'data, '_, O>,
+fn select_symbol<'data, P: Platform>(
+    symbol_db: &AtomicSymbolDb<'data, '_, P>,
     per_symbol_flags: &AtomicPerSymbolFlags,
     first_id: SymbolId,
     alternatives: &[SymbolId],
-    resolved: &[ResolvedGroup<'data, O>],
+    resolved: &[ResolvedGroup<'data, P>],
 ) -> Result<SymbolId> {
     let mut selector = SymbolPrioritySelector::new();
 
@@ -1387,9 +1385,9 @@ pub(crate) fn is_mapping_symbol_name(name: &[u8]) -> bool {
     name.starts_with(b"$x") || name.starts_with(b"$d") || name == b"L0\x01"
 }
 
-fn read_symbols<'data, O: ObjectFile<'data>>(
+fn read_symbols<'data, P: Platform>(
     version_script: &VersionScript,
-    shards: &mut [SymbolWriterShard<'_, '_, 'data, O>],
+    shards: &mut [SymbolWriterShard<'_, '_, 'data, P>],
     args: &Args,
     export_list: &Option<ExportList<'data>>,
     output_kind: OutputKind,
@@ -1413,8 +1411,8 @@ fn read_symbols<'data, O: ObjectFile<'data>>(
         .collect::<Result<Vec<SymbolLoadOutputs>>>()
 }
 
-fn read_symbols_for_group<'data, O: ObjectFile<'data>>(
-    shard: &mut SymbolWriterShard<'_, '_, 'data, O>,
+fn read_symbols_for_group<'data, P: Platform>(
+    shard: &mut SymbolWriterShard<'_, '_, 'data, P>,
     version_script: &VersionScript,
     export_list: &Option<ExportList<'data>>,
     num_buckets: usize,
@@ -1469,8 +1467,8 @@ fn read_symbols_for_group<'data, O: ObjectFile<'data>>(
 }
 
 #[cfg(feature = "plugins")]
-fn load_lto_symbols<'data, O: ObjectFile<'data>>(
-    symbols_out: &mut SymbolWriterShard<'_, '_, 'data, O>,
+fn load_lto_symbols<'data, P: Platform>(
+    symbols_out: &mut SymbolWriterShard<'_, '_, 'data, P>,
     outputs: &mut SymbolLoadOutputs<'data>,
     obj: &crate::linker_plugins::LtoInput<'data>,
 ) {
@@ -1524,9 +1522,9 @@ fn populate_symbol_db<'data>(
     });
 }
 
-fn load_linker_script_symbols<'data, O: ObjectFile<'data>>(
+fn load_linker_script_symbols<'data, P: Platform>(
     script: &SequencedLinkerScript<'data>,
-    symbols_out: &mut SymbolWriterShard<'_, '_, 'data, O>,
+    symbols_out: &mut SymbolWriterShard<'_, '_, 'data, P>,
     outputs: &mut SymbolLoadOutputs<'data>,
 ) {
     for (offset, definition) in script.parsed.symbol_defs.iter().enumerate() {
@@ -1550,10 +1548,10 @@ fn load_linker_script_symbols<'data, O: ObjectFile<'data>>(
     }
 }
 
-fn load_symbols_from_file<'data, O: ObjectFile<'data>>(
-    s: &SequencedInputObject<'data, O>,
+fn load_symbols_from_file<'data, P: Platform>(
+    s: &SequencedInputObject<'data, P>,
     version_script: &VersionScript,
-    symbols_out: &mut SymbolWriterShard<'_, '_, 'data, O>,
+    symbols_out: &mut SymbolWriterShard<'_, '_, 'data, P>,
     outputs: &mut SymbolLoadOutputs<'data>,
     args: &Args,
     export_list: &Option<ExportList<'data>>,
@@ -1579,15 +1577,15 @@ fn load_symbols_from_file<'data, O: ObjectFile<'data>>(
     }
 }
 
-struct SymbolWriterShard<'out, 'group, 'data, O: ObjectFile<'data>> {
-    group: &'group Group<'data, O>,
+struct SymbolWriterShard<'out, 'group, 'data, P: Platform> {
+    group: &'group Group<'data, P>,
     resolutions: sharded_vec_writer::Shard<'out, SymbolId>,
     flags: sharded_vec_writer::Shard<'out, RawFlags>,
     file_ids: sharded_vec_writer::Shard<'out, FileId>,
     next: SymbolId,
 }
 
-impl<'out, 'group, 'data, O: ObjectFile<'data>> SymbolWriterShard<'out, 'group, 'data, O> {
+impl<'out, 'group, 'data, P: Platform> SymbolWriterShard<'out, 'group, 'data, P> {
     fn set_next(&mut self, flags: ValueFlags, resolution: SymbolId, file_id: FileId) {
         self.flags.push(flags.raw());
         self.resolutions.push(resolution);
@@ -1596,11 +1594,11 @@ impl<'out, 'group, 'data, O: ObjectFile<'data>> SymbolWriterShard<'out, 'group, 
     }
 }
 
-trait SymbolLoader<'data, O: ObjectFile<'data>> {
+trait SymbolLoader<'data, P: Platform> {
     fn load_symbols(
         &self,
         file_id: FileId,
-        symbols_out: &mut SymbolWriterShard<'_, '_, 'data, O>,
+        symbols_out: &mut SymbolWriterShard<'_, '_, 'data, P>,
         outputs: &mut SymbolLoadOutputs<'data>,
     ) -> Result {
         let base_symbol_id = symbols_out.next;
@@ -1654,9 +1652,9 @@ trait SymbolLoader<'data, O: ObjectFile<'data>> {
         Ok(())
     }
 
-    fn object(&self) -> &O;
+    fn object(&self) -> &P::File<'data>;
 
-    fn compute_value_flags(&self, symbol: &O::Symbol) -> ValueFlags;
+    fn compute_value_flags(&self, symbol: &P::Symbol) -> ValueFlags;
 
     /// Returns whether we should downgrade a symbol with the specified name to be a local.
     fn should_downgrade_to_local(&self, _name: &PreHashed<UnversionedSymbolName>) -> bool {
@@ -1669,19 +1667,19 @@ trait SymbolLoader<'data, O: ObjectFile<'data>> {
     }
 
     /// Returns whether the supplied symbol should be ignore.
-    fn should_ignore_symbol(&self, _symbol: &O::Symbol) -> bool {
+    fn should_ignore_symbol(&self, _symbol: &P::Symbol) -> bool {
         false
     }
 
     fn get_symbol_name_and_version(
         &self,
-        symbol: &O::Symbol,
+        symbol: &P::Symbol,
         local_index: usize,
-    ) -> Result<O::RawSymbolName>;
+    ) -> Result<P::RawSymbolName<'data>>;
 }
 
-struct RegularObjectSymbolLoader<'a, 'data, O: ObjectFile<'data>> {
-    object: &'a O,
+struct RegularObjectSymbolLoader<'a, 'data, P: Platform> {
+    object: &'a P::File<'data>,
     args: &'a Args,
     version_script: &'a VersionScript<'a>,
     archive_semantics: bool,
@@ -1690,13 +1688,13 @@ struct RegularObjectSymbolLoader<'a, 'data, O: ObjectFile<'data>> {
     output_kind: OutputKind,
 }
 
-struct DynamicObjectSymbolLoader<'a, 'data, O: ObjectFile<'data>> {
-    object: &'a O,
-    version_names: O::VersionNames,
+struct DynamicObjectSymbolLoader<'a, 'data, P: Platform> {
+    object: &'a P::File<'data>,
+    version_names: P::VersionNames<'data>,
 }
 
-impl<'a, 'data, O: ObjectFile<'data>> DynamicObjectSymbolLoader<'a, 'data, O> {
-    fn new(object: &'a O) -> Result<Self> {
+impl<'a, 'data, P: Platform> DynamicObjectSymbolLoader<'a, 'data, P> {
+    fn new(object: &'a P::File<'data>) -> Result<Self> {
         let version_names = object.get_version_names()?;
         Ok(Self {
             object,
@@ -1705,10 +1703,8 @@ impl<'a, 'data, O: ObjectFile<'data>> DynamicObjectSymbolLoader<'a, 'data, O> {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> SymbolLoader<'data, O>
-    for RegularObjectSymbolLoader<'_, 'data, O>
-{
-    fn compute_value_flags(&self, sym: &O::Symbol) -> ValueFlags {
+impl<'data, P: Platform> SymbolLoader<'data, P> for RegularObjectSymbolLoader<'_, 'data, P> {
+    fn compute_value_flags(&self, sym: &P::Symbol) -> ValueFlags {
         let is_undefined = sym.is_undefined();
 
         let symbol_is_exported = || {
@@ -1785,23 +1781,21 @@ impl<'data, O: ObjectFile<'data>> SymbolLoader<'data, O>
 
     fn get_symbol_name_and_version(
         &self,
-        symbol: &O::Symbol,
+        symbol: &P::Symbol,
         _local_index: usize,
-    ) -> Result<O::RawSymbolName> {
-        Ok(<O::RawSymbolName as platform::RawSymbolName>::parse(
+    ) -> Result<P::RawSymbolName<'data>> {
+        Ok(<P::RawSymbolName<'data> as platform::RawSymbolName>::parse(
             self.object.symbol_name(symbol)?,
         ))
     }
 
-    fn object(&self) -> &O {
+    fn object(&self) -> &P::File<'data> {
         self.object
     }
 }
 
-impl<'data, O: ObjectFile<'data>> SymbolLoader<'data, O>
-    for DynamicObjectSymbolLoader<'_, 'data, O>
-{
-    fn compute_value_flags(&self, symbol: &O::Symbol) -> ValueFlags {
+impl<'data, P: Platform> SymbolLoader<'data, P> for DynamicObjectSymbolLoader<'_, 'data, P> {
+    fn compute_value_flags(&self, symbol: &P::Symbol) -> ValueFlags {
         let mut flags = ValueFlags::DYNAMIC;
         if symbol.is_func() || symbol.is_ifunc() {
             flags |= ValueFlags::FUNCTION;
@@ -1814,31 +1808,31 @@ impl<'data, O: ObjectFile<'data>> SymbolLoader<'data, O>
 
     fn get_symbol_name_and_version(
         &self,
-        symbol: &O::Symbol,
+        symbol: &P::Symbol,
         local_index: usize,
-    ) -> Result<O::RawSymbolName> {
+    ) -> Result<P::RawSymbolName<'data>> {
         self.object
             .get_symbol_name_and_version(symbol, local_index, &self.version_names)
     }
 
-    fn object(&self) -> &O {
+    fn object(&self) -> &P::File<'data> {
         self.object
     }
 
-    fn should_ignore_symbol(&self, symbol: &O::Symbol) -> bool {
+    fn should_ignore_symbol(&self, symbol: &P::Symbol) -> bool {
         // Shared objects shouldn't export hidden symbols. If for some reason they do, ignore them.
         symbol.is_hidden()
     }
 }
 
 #[derive(Clone, Copy)]
-pub(crate) struct SymbolDebug<'a, 'data, O: ObjectFile<'data>> {
-    db: &'a SymbolDb<'data, O>,
+pub(crate) struct SymbolDebug<'a, 'data, P: Platform> {
+    db: &'a SymbolDb<'data, P>,
     symbol_id: SymbolId,
     per_symbol_flags: &'a dyn FlagsForSymbol,
 }
 
-impl<'a, 'data, O: ObjectFile<'data>> std::fmt::Display for SymbolDebug<'a, 'data, O> {
+impl<'a, 'data, P: Platform> std::fmt::Display for SymbolDebug<'a, 'data, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let symbol_id = self.symbol_id;
         let definition = self.db.definition(symbol_id);
@@ -1987,9 +1981,9 @@ impl TryFrom<usize> for SymbolId {
 }
 
 impl<'data> Prelude<'data> {
-    fn load_symbols<O: ObjectFile<'data>>(
+    fn load_symbols<P: Platform>(
         &self,
-        symbols_out: &mut SymbolWriterShard<'_, '_, 'data, O>,
+        symbols_out: &mut SymbolWriterShard<'_, '_, 'data, P>,
         outputs: &mut SymbolLoadOutputs<'data>,
     ) {
         for definition in &self.symbol_definitions {
@@ -2092,7 +2086,7 @@ impl<'data> SymbolLoadOutputs<'data> {
     }
 }
 
-impl<'data, 'db, O: ObjectFile<'data>> AtomicSymbolDb<'data, 'db, O> {
+impl<'data, 'db, P: Platform> AtomicSymbolDb<'data, 'db, P> {
     fn input_symbol_visibility(&self, symbol_id: SymbolId) -> Visibility {
         self.db.input_symbol_visibility(symbol_id)
     }
@@ -2104,7 +2098,7 @@ impl<'data, 'db, O: ObjectFile<'data>> AtomicSymbolDb<'data, 'db, O> {
     fn symbol_strength(
         &self,
         symbol_id: SymbolId,
-        resolved: &[ResolvedGroup<'data, O>],
+        resolved: &[ResolvedGroup<'data, P>],
     ) -> SymbolStrength {
         self.db.symbol_strength(symbol_id, resolved)
     }
@@ -2112,7 +2106,7 @@ impl<'data, 'db, O: ObjectFile<'data>> AtomicSymbolDb<'data, 'db, O> {
     fn is_in_comdat_group(
         &self,
         symbol_id: SymbolId,
-        resolved: &[ResolvedGroup<'data, O>],
+        resolved: &[ResolvedGroup<'data, P>],
     ) -> bool {
         self.db.is_in_comdat_group(symbol_id, resolved)
     }
@@ -2121,7 +2115,7 @@ impl<'data, 'db, O: ObjectFile<'data>> AtomicSymbolDb<'data, 'db, O> {
         self.db.symbol_name_for_display(symbol_id)
     }
 
-    fn file(&'db self, file_id: FileId) -> SequencedInput<'db, 'data, O> {
+    fn file(&'db self, file_id: FileId) -> SequencedInput<'db, 'data, P> {
         self.db.file(file_id)
     }
 
@@ -2130,7 +2124,7 @@ impl<'data, 'db, O: ObjectFile<'data>> AtomicSymbolDb<'data, 'db, O> {
     }
 }
 
-impl<'data, O: ObjectFile<'data>> Drop for AtomicSymbolDb<'data, '_, O> {
+impl<'data, P: Platform> Drop for AtomicSymbolDb<'data, '_, P> {
     fn drop(&mut self) {
         // Convert our atomic tables back to non-atomic tables and return them to the symbol-db that
         // we took them from. This operation should be basically free, at least in optimised builds.

--- a/libwild/src/validation.rs
+++ b/libwild/src/validation.rs
@@ -1,6 +1,7 @@
 //! Code to double-check that we did certain things correctly. Generally only used in debug builds.
 
 use crate::bail;
+use crate::elf::Elf;
 use crate::error::Context as _;
 use crate::error::Result;
 use crate::layout::Layout;
@@ -10,7 +11,7 @@ use object::LittleEndian;
 use object::read::elf::SectionHeader as _;
 use zerocopy::FromBytes;
 
-type ElfLayout<'data> = Layout<'data, crate::elf::File<'data>>;
+type ElfLayout<'data> = Layout<'data, Elf>;
 
 pub(crate) fn validate_bytes(layout: &ElfLayout, file_bytes: &[u8]) -> Result {
     let object = crate::elf::File::parse_bytes(file_bytes, true)

--- a/libwild/src/verification.rs
+++ b/libwild/src/verification.rs
@@ -9,7 +9,7 @@ use crate::output_section_id::OutputSections;
 use crate::output_section_part_map::OutputSectionPartMap;
 use crate::part_id;
 use crate::part_id::PartId;
-use crate::platform::ObjectFile;
+use crate::platform::Platform;
 use itertools::Itertools;
 
 pub(crate) struct OffsetVerifier {
@@ -31,12 +31,12 @@ impl OffsetVerifier {
         }
     }
 
-    pub(crate) fn verify<'data, O: ObjectFile<'data>>(
+    pub(crate) fn verify<'data, P: Platform>(
         &self,
         memory_offsets: &OutputSectionPartMap<u64>,
         output_sections: &OutputSections,
         output_order: &OutputOrder,
-        files: &[FileLayout<'data, O>],
+        files: &[FileLayout<'data, P>],
     ) -> Result {
         if memory_offsets == &self.expected && self.alignments_ok(output_sections) {
             return Ok(());


### PR DESCRIPTION
Most code that was generic over ObjectFile is now generic over a new trait, Platform. This is nicer, since Platform doesn't have a lifetime.

Issue #1538