### PR TITLE
args: warn when --sort-section is used

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -2406,6 +2406,15 @@ fn setup_argument_parser() -> ArgumentParser {
 
     parser
         .declare_with_param()
+        .long("sort-section")
+        .help("Specify section sorting criteria")
+        .execute(|_args, _modifier_stack, value| {
+            warn_unsupported(&format!("--sort-section={value}"))?;
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
         .long("sysroot")
         .help("Set system root")
         .execute(|args, _modifier_stack, value| {
@@ -2787,6 +2796,7 @@ mod tests {
         "-x",
         "--discard-all",
         "--dependency-file=deps.d",
+        "--sort-section=alignment",
     ];
 
     const FILE_OPTIONS: &[&str] = &["-pie"];


### PR DESCRIPTION
`--sort-section` was previously unrecognized, causing builds like musl to fail with an error. This PR accepts the flag and emits a warning that it is not yet supported, consistent with how other unsupported flags like `--icf` are handled.

not a full implementation of `--sort-section` - actual section sorting is tracked in #1661.

also Added `--sort-section=alignment` to the args test in `INPUT1`.

Related to #1659