### PR TITLE
test: Add test for hidden symbol that can only be resolved from a DSO

### DIFF
--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -175,6 +175,7 @@ tests = [
   "empty-input.sh",                 # Different message formats
   "gc-sections.sh",                 # Passes when `--no-gc-sections` is passed.
   "hash-style.sh",                  # Wild doesn't support `--hash-style=none`.
+  "hidden-undef.sh",                # Wild correctly errors, but message format differs from mold's.
   "help.sh",
   "invalid-version-script.sh",      # Different message formats
   "linker-script-error.sh",         # Different message formats
@@ -229,7 +230,6 @@ tests = [
   "discard.sh",
   "dynamic-linker.sh",
   "glibc-2.22-bug.sh",
-  "hidden-undef.sh",
   "initfirst.sh",
   "mergeable-strings.sh",
   "missing-error.sh",

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -3543,6 +3543,7 @@ fn integration_test(
         "symbol-priority.c",
         "symbol-binding.c",
         "hidden-ref.c",
+        "hidden-undef.c",
         "trivial_asm.s",
         "non-alloc.s",
         "gnu-unique.c",

--- a/wild/tests/sources/hidden-undef-lib.c
+++ b/wild/tests/sources/hidden-undef-lib.c
@@ -1,0 +1,1 @@
+int foo(void) { return 1; }

--- a/wild/tests/sources/hidden-undef.c
+++ b/wild/tests/sources/hidden-undef.c
@@ -1,0 +1,17 @@
+// Tests that linking fails when a hidden symbol is only available from a DSO.
+
+//#Object:runtime.c
+//#Mode:dynamic
+//#RunEnabled:false
+//#Shared:hidden-undef-lib.c
+//#ExpectError:foo
+
+#include "runtime.h"
+
+// foo is declared hidden — must not be resolved from the DSO above.
+__attribute__((visibility("hidden"))) int foo(void);
+
+void _start(void) {
+  runtime_init();
+  exit_syscall(foo());
+}


### PR DESCRIPTION
Wild already behaves correctly when a hidden symbol can only be resolved from a shared library (DSO) it errors with an undefined symbol. I confirmed that GNU ld and mold behave the same way. However, Wild didn’t have an integration test for this error case.

This PR adds a new test hidden-undef.c to verify that linking fails when a hidden symbol is declared in the main object but only defined in a shared library.

It also moves hidden-undef.sh from the misc group to ignore in mold_skip_tests.toml, since Wild’s behaviour is correct but the error message format differs from mold’s.