### PR TITLE
ci: disable Go caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: '1.26.0'
+          cache: false
       - run: go install github.com/google/yamlfmt/cmd/yamlfmt@v0.21.0
       - run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       - run: yamlfmt -lint .


### PR DESCRIPTION
Should solve warning that shows up in CI logs, and we don't lose anything since we have no Go code.