### PR TITLE
fix: Only emit `__global_pointer$` on RISC-V

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -607,6 +607,7 @@ impl platform::Platform for Elf {
     fn create_linker_defined_symbols(
         symbols: &mut crate::parsing::InternalSymbolsBuilder,
         output_kind: OutputKind,
+        args: &ElfArgs,
     ) {
         // The undefined symbol must always be symbol 0.
         symbols
@@ -672,11 +673,12 @@ impl platform::Platform for Elf {
             .set_hidden(hidden);
         symbols.section_end(output_section_id::BSS, "__end").hide();
 
-        // TODO: define the symbol only on RISC-V target
-        symbols.section_start(
-            output_section_id::DATA,
-            crate::elf::GLOBAL_POINTER_SYMBOL_NAME,
-        );
+        if args.arch == Architecture::RISCV64 {
+            symbols.section_start(
+                output_section_id::DATA,
+                crate::elf::GLOBAL_POINTER_SYMBOL_NAME,
+            );
+        }
 
         symbols
             .section_end(output_section_id::DATA, "edata")

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -229,7 +229,7 @@ impl<'data> Prelude<'data> {
 
         let mut symbols = InternalSymbolsBuilder::default();
 
-        P::create_linker_defined_symbols(&mut symbols, output_kind);
+        P::create_linker_defined_symbols(&mut symbols, output_kind, args);
 
         args.force_undefined_symbol_names().iter().for_each(|name| {
             symbols.add_symbol(InternalSymDefInfo::new(

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -313,6 +313,7 @@ pub(crate) trait Platform: Copy + Send + Sync + Sized + std::fmt::Debug + 'stati
     fn create_linker_defined_symbols(
         symbols: &mut crate::parsing::InternalSymbolsBuilder,
         output_kind: OutputKind,
+        args: &Self::Args,
     );
 
     fn built_in_section_infos<'data>()

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -128,7 +128,6 @@ tests = [
 [skipped_groups.arch_riscv64]
 reason = "RISC-V specific tests"
 tests = [
-  "arch-riscv64-global-pointer.sh",
   "arch-riscv64-relax-align.sh",
   "arch-riscv64-relax-got.sh",
   "arch-riscv64-reloc-overflow.sh",
@@ -150,6 +149,7 @@ tests  = ["tls-common.sh", "tls-le-error.sh"]
 [skipped_groups.ignore]
 reason = "We ignore these tests for some reasons"
 tests = [
+  "arch-riscv64-global-pointer.sh", # GNU ld and lld do not export `__global_pointer$` to `.dynsym`.
   "arch-riscv64-obj-compatible.sh", # Different message formats
   "arch-riscv64-relax-j.sh",        # Passes when `--no-gc-sections` is passed.
   "arch-x86_64-empty-arg.sh",       # Different message formats


### PR DESCRIPTION
Since this symbol won't be referenced from input files for non-RISC-V architectures, it doesn't pose a practical issue. However, considering there are other (not implemented in Wild yet) architecture-specific symbols present, making the correction would be beneficial.