### PR TITLE
refactor: Avoid direct use of elf::RawSymbolName from non-ELF code

### DIFF
--- a/libwild/src/diagnostics.rs
+++ b/libwild/src/diagnostics.rs
@@ -1,11 +1,9 @@
-use crate::elf::RawSymbolName;
 use crate::grouping::SequencedInput;
 use crate::input_data::FileId;
 use crate::input_data::PRELUDE_FILE_ID;
 use crate::platform::Args as _;
 use crate::platform::ObjectFile;
 use crate::platform::Platform;
-use crate::platform::RawSymbolName as _;
 use crate::platform::Symbol as _;
 use crate::resolution::ResolvedFile;
 use crate::resolution::ResolvedGroup;
@@ -92,7 +90,7 @@ impl SymbolInfoPrinter {
         target_ids.extend(name.parse().ok().map(SymbolId::from_usize));
 
         let symbol_id = symbol_db.get(
-            &PreHashedSymbolName::from_raw(&RawSymbolName::parse(name.as_bytes())),
+            &PreHashedSymbolName::from_raw(&P::parse_raw_symbol_name(name.as_bytes())),
             true,
         );
         let _ = writeln!(&mut out, "Global name `{name}` refers to: {symbol_id:?}");

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -54,6 +54,7 @@ use crate::platform::RelocationSequence;
 use crate::platform::SectionFlags as _;
 use crate::platform::SectionHeader as _;
 use crate::platform::Symbol as _;
+use crate::platform::VerneedTable as _;
 use crate::program_segments::ProgramSegments;
 use crate::resolution::LoadedMetrics;
 use crate::string_merging::MergedStringStartAddresses;
@@ -359,6 +360,15 @@ impl platform::Platform for Elf {
             output_sections,
             layout_rules_builder,
         )
+    }
+
+    fn resolve_lto_symbols<'data, 'scope>(
+        obj: &crate::linker_plugins::LtoInput<'data>,
+        resources: &'scope crate::resolution::ResolutionResources<'data, 'scope, Self>,
+        definitions_out: &mut [SymbolId],
+        scope: &Scope<'scope>,
+    ) -> Result {
+        crate::linker_plugins::resolve_lto_symbols(obj, resources, definitions_out, scope)
     }
 
     fn apply_force_keep_sections(keep_sections: &mut OutputSectionMap<bool>, args: &ElfArgs) {
@@ -1449,6 +1459,22 @@ impl platform::Platform for Elf {
             }
         }
         Ok(())
+    }
+
+    fn raw_symbol_name<'data>(
+        name_bytes: &'data [u8],
+        verneed_table: &Self::VerneedTable<'data>,
+        symbol_index: object::SymbolIndex,
+    ) -> Self::RawSymbolName<'data> {
+        if let Some(version_name) = verneed_table.version_name(symbol_index) {
+            RawSymbolName {
+                name: name_bytes,
+                version_name: Some(version_name),
+                is_default: false,
+            }
+        } else {
+            RawSymbolName::parse(name_bytes)
+        }
     }
 }
 
@@ -3286,6 +3312,22 @@ impl<'data> platform::RawSymbolName<'data> for RawSymbolName<'data> {
 
     fn is_default(&self) -> bool {
         self.is_default
+    }
+}
+
+impl std::fmt::Display for RawSymbolName<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", String::from_utf8_lossy(self.name))?;
+        if let Some(version) = self.version_name {
+            if self.is_default {
+                write!(f, "@@")?;
+            } else {
+                write!(f, "@")?;
+            }
+            write!(f, "{}", String::from_utf8_lossy(version))?;
+        }
+
+        Ok(())
     }
 }
 

--- a/libwild/src/linker_plugins.rs
+++ b/libwild/src/linker_plugins.rs
@@ -27,9 +27,11 @@ use crate::layout_rules::LayoutRulesBuilder;
 use crate::output_section_id::OutputSections;
 use crate::platform::Platform;
 use crate::platform::RawSymbolName as _;
+use crate::resolution::ResolutionResources;
 use crate::resolution::ResolvedFile;
 use crate::resolution::ResolvedGroup;
 use crate::resolution::Resolver;
+use crate::resolution::SymbolAttributes;
 use crate::symbol::PreHashedSymbolName;
 use crate::symbol::UnversionedSymbolName;
 use crate::symbol_db::SymbolDb;
@@ -42,6 +44,7 @@ use bumpalo_herd::Herd;
 use colosseum::sync::Arena;
 use crossbeam_utils::atomic::AtomicCell;
 use libloading::Library;
+use rayon::Scope;
 use std::cell::Cell;
 use std::cell::RefCell;
 use std::ffi::CStr;
@@ -1234,4 +1237,46 @@ impl<'data> Store<'data> {
             Store::Loaded(loaded_plugin) => Ok(*loaded_plugin),
         }
     }
+}
+
+pub(crate) fn resolve_lto_symbols<'data, 'scope>(
+    obj: &crate::linker_plugins::LtoInput<'data>,
+    resources: &'scope ResolutionResources<'data, 'scope, Elf>,
+    definitions_out: &mut [SymbolId],
+    scope: &Scope<'scope>,
+) -> Result {
+    obj.symbols
+        .iter()
+        .enumerate()
+        .zip(definitions_out)
+        .try_for_each(
+            |((local_symbol_index, local_symbol), definition)| -> Result {
+                if !local_symbol.is_definition() {
+                    let mut name_info = Elf::parse_raw_symbol_name(local_symbol.name.bytes());
+                    if let Some(version) = local_symbol.version {
+                        name_info.version_name = Some(version);
+                    }
+
+                    let symbol_attributes = SymbolAttributes {
+                        name_info,
+                        is_local: false,
+                        default_visibility: local_symbol.visibility == object::elf::STV_DEFAULT,
+                        is_weak: local_symbol.kind
+                            == Some(crate::linker_plugins::SymbolKind::WeakUndef),
+                    };
+
+                    crate::resolution::resolve_symbol(
+                        obj.symbol_id_range.offset_to_id(local_symbol_index),
+                        &symbol_attributes,
+                        definition,
+                        resources,
+                        false,
+                        obj.file_id,
+                        scope,
+                    )?;
+                }
+
+                Ok(())
+            },
+        )
 }

--- a/libwild/src/linker_plugins_disabled.rs
+++ b/libwild/src/linker_plugins_disabled.rs
@@ -11,7 +11,9 @@ use crate::layout_rules::LayoutRulesBuilder;
 use crate::output_section_id::OutputSections;
 use crate::resolution::Resolver;
 use crate::symbol_db::SymbolDb;
+use crate::symbol_db::SymbolId;
 use crate::value_flags::PerSymbolFlags;
+use rayon::Scope;
 use std::marker::PhantomData;
 
 pub(crate) struct LoadedPlugin {}
@@ -59,4 +61,17 @@ impl<'data> LinkerPlugin<'data> {
     ) -> Result {
         Ok(())
     }
+}
+
+pub(crate) struct LtoInput<'data> {
+    _p: PhantomData<&'data ()>,
+}
+
+pub(crate) fn resolve_lto_symbols<'data, 'scope>(
+    _obj: &LtoInput<'data>,
+    _resources: &'scope crate::resolution::ResolutionResources<'data, 'scope, Elf>,
+    _definitions_out: &mut [SymbolId],
+    _scope: &Scope<'scope>,
+) -> Result {
+    Ok(())
 }

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -243,6 +243,16 @@ pub(crate) trait Platform: Copy + Send + Sync + Sized + std::fmt::Debug + 'stati
         unimplemented!();
     }
 
+    #[allow(dead_code)]
+    fn resolve_lto_symbols<'data, 'scope>(
+        _obj: &crate::linker_plugins::LtoInput<'data>,
+        _resources: &'scope crate::resolution::ResolutionResources<'data, 'scope, Self>,
+        _definitions_out: &mut [SymbolId],
+        _scope: &Scope<'scope>,
+    ) -> Result {
+        Ok(())
+    }
+
     fn section_flags(header: &Self::SectionHeader) -> Self::SectionFlags;
 
     fn section_attributes(header: &Self::SectionHeader) -> Self::SectionAttributes;
@@ -491,6 +501,16 @@ pub(crate) trait Platform: Copy + Send + Sync + Sized + std::fmt::Debug + 'stati
         got: &Self::SectionHeader,
         got_data: &[u8],
     ) -> Result;
+
+    fn raw_symbol_name<'data>(
+        name_bytes: &'data [u8],
+        verneed_table: &Self::VerneedTable<'data>,
+        symbol_index: object::SymbolIndex,
+    ) -> Self::RawSymbolName<'data>;
+
+    fn parse_raw_symbol_name<'data>(name_bytes: &'data [u8]) -> Self::RawSymbolName<'data> {
+        <Self::RawSymbolName<'data> as RawSymbolName>::parse(name_bytes)
+    }
 }
 
 /// Abstracts over the different object file formats that we support (or may support). e.g. ELF.
@@ -805,7 +825,7 @@ pub(crate) trait RelocationSequence<'data> {
     fn num_relocations(&self) -> usize;
 }
 
-pub(crate) trait RawSymbolName<'data>: Send + Sync + 'data {
+pub(crate) trait RawSymbolName<'data>: Send + Sync + std::fmt::Display + 'data {
     fn parse(bytes: &'data [u8]) -> Self;
 
     fn name(&self) -> &'data [u8];

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -6,7 +6,6 @@ use crate::LayoutRules;
 use crate::alignment::Alignment;
 use crate::bail;
 use crate::debug_assert_bail;
-use crate::elf::RawSymbolName;
 use crate::error::Context as _;
 use crate::error::Error;
 use crate::error::Result;
@@ -32,10 +31,8 @@ use crate::platform::DynamicTagValues as _;
 use crate::platform::FrameIndex;
 use crate::platform::ObjectFile;
 use crate::platform::Platform;
-use crate::platform::RawSymbolName as _;
 use crate::platform::SectionHeader as _;
 use crate::platform::Symbol as _;
-use crate::platform::VerneedTable as _;
 use crate::string_merging::StringMergeSectionExtra;
 use crate::string_merging::StringMergeSectionSlot;
 use crate::symbol::PreHashedSymbolName;
@@ -432,7 +429,7 @@ impl LoadedMetrics {
     }
 }
 
-struct ResolutionResources<'data, 'scope, P: Platform> {
+pub(crate) struct ResolutionResources<'data, 'scope, P: Platform> {
     definitions_per_file: &'scope Vec<Vec<AtomicTake<&'scope mut [SymbolId]>>>,
     symbol_db: &'scope SymbolDb<'data, P>,
     outputs: &'scope Outputs<'data, P>,
@@ -807,54 +804,11 @@ fn process_object<'scope, 'data: 'scope, 'definitions, P: Platform>(
         Group::LtoInputs(objects) => {
             let obj = &objects[file_id.file()];
             resources.handle_result(
-                resolve_lto_symbols(obj, resources, definitions_out, scope)
+                P::resolve_lto_symbols(obj, resources, definitions_out, scope)
                     .with_context(|| format!("Failed to resolve symbols in {obj}")),
             );
         }
     }
-}
-
-#[cfg(feature = "plugins")]
-fn resolve_lto_symbols<'data, 'scope, P: Platform>(
-    obj: &crate::linker_plugins::LtoInput<'data>,
-    resources: &'scope ResolutionResources<'data, 'scope, P>,
-    definitions_out: &mut [SymbolId],
-    scope: &Scope<'scope>,
-) -> Result {
-    obj.symbols
-        .iter()
-        .enumerate()
-        .zip(definitions_out)
-        .try_for_each(
-            |((local_symbol_index, local_symbol), definition)| -> Result {
-                if !local_symbol.is_definition() {
-                    let mut name_info = RawSymbolName::parse(local_symbol.name.bytes());
-                    if let Some(version) = local_symbol.version {
-                        name_info.version_name = Some(version);
-                    }
-
-                    let symbol_attributes = SymbolAttributes {
-                        name_info,
-                        is_local: false,
-                        default_visibility: local_symbol.visibility == object::elf::STV_DEFAULT,
-                        is_weak: local_symbol.kind
-                            == Some(crate::linker_plugins::SymbolKind::WeakUndef),
-                    };
-
-                    resolve_symbol(
-                        obj.symbol_id_range.offset_to_id(local_symbol_index),
-                        &symbol_attributes,
-                        definition,
-                        resources,
-                        false,
-                        obj.file_id,
-                        scope,
-                    )?;
-                }
-
-                Ok(())
-            },
-        )
 }
 
 struct UndefinedSymbol<'data> {
@@ -1297,7 +1251,7 @@ fn resolve_symbols<'data, 'scope, P: Platform>(
     definitions_out: &mut [SymbolId],
     scope: &Scope<'scope>,
 ) -> Result {
-    let verneed = obj.parsed.object.verneed_table()?;
+    let verneed_table = obj.parsed.object.verneed_table()?;
 
     obj.parsed.object.symbols()[start_symbol_offset..]
         .iter()
@@ -1318,17 +1272,11 @@ fn resolve_symbols<'data, 'scope, P: Platform>(
 
                 let name_bytes = obj.parsed.object.symbol_name(local_symbol)?;
 
-                let name_info = if let Some(version_name) =
-                    verneed.version_name(object::SymbolIndex(local_symbol_index))
-                {
-                    RawSymbolName {
-                        name: name_bytes,
-                        version_name: Some(version_name),
-                        is_default: false,
-                    }
-                } else {
-                    RawSymbolName::parse(name_bytes)
-                };
+                let name_info = P::raw_symbol_name(
+                    name_bytes,
+                    &verneed_table,
+                    object::SymbolIndex(local_symbol_index),
+                );
 
                 let symbol_attributes = SymbolAttributes {
                     name_info,
@@ -1352,17 +1300,17 @@ fn resolve_symbols<'data, 'scope, P: Platform>(
 }
 
 #[derive(Debug)]
-struct SymbolAttributes<'data> {
-    is_local: bool,
-    default_visibility: bool,
-    is_weak: bool,
-    name_info: RawSymbolName<'data>,
+pub(crate) struct SymbolAttributes<'data, P: Platform> {
+    pub(crate) is_local: bool,
+    pub(crate) default_visibility: bool,
+    pub(crate) is_weak: bool,
+    pub(crate) name_info: P::RawSymbolName<'data>,
 }
 
 #[inline(always)]
-fn resolve_symbol<'data, 'scope, P: Platform>(
+pub(crate) fn resolve_symbol<'data, 'scope, P: Platform>(
     local_symbol_id: SymbolId,
-    local_symbol_attributes: &SymbolAttributes<'data>,
+    local_symbol_attributes: &SymbolAttributes<'data, P>,
     definition_out: &mut SymbolId,
     resources: &'scope ResolutionResources<'data, 'scope, P>,
     is_dynamic: bool,

--- a/libwild/src/symbol.rs
+++ b/libwild/src/symbol.rs
@@ -1,4 +1,5 @@
 use crate::hash::PreHashed;
+use crate::platform;
 use std::fmt::Display;
 use std::ops::BitXor as _;
 
@@ -69,10 +70,10 @@ impl Display for UnversionedSymbolName<'_> {
 
 impl<'data> PreHashedSymbolName<'data> {
     pub(crate) fn from_raw(
-        name_info: &crate::elf::RawSymbolName<'data>,
+        name_info: &impl platform::RawSymbolName<'data>,
     ) -> PreHashedSymbolName<'data> {
-        let name = UnversionedSymbolName::prehashed(name_info.name);
-        if let Some(version) = name_info.version_name {
+        let name = UnversionedSymbolName::prehashed(name_info.name());
+        if let Some(version) = name_info.version_name() {
             PreHashedSymbolName::Versioned(VersionedSymbolName::prehashed(name, version))
         } else {
             PreHashedSymbolName::Unversioned(name)

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -4,7 +4,6 @@
 use crate::InputLinkerScript;
 use crate::OutputKind;
 use crate::bail;
-use crate::elf::RawSymbolName;
 use crate::error;
 use crate::error::Context as _;
 use crate::error::Error;
@@ -2112,22 +2111,6 @@ impl ShardKey for SymbolId {
                 .try_into()
                 .expect("Symbol ID overflowed 32 bits"),
         )
-    }
-}
-
-impl Display for RawSymbolName<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", String::from_utf8_lossy(self.name))?;
-        if let Some(version) = self.version_name {
-            if self.is_default {
-                write!(f, "@@")?;
-            } else {
-                write!(f, "@")?;
-            }
-            write!(f, "{}", String::from_utf8_lossy(version))?;
-        }
-
-        Ok(())
     }
 }
 


### PR DESCRIPTION
Issue #1538