### PR TITLE
fix: Don't skip undefined symbol error due to previous weak ref

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -4634,17 +4634,17 @@ fn process_relocation<'data, 'scope, A: Arch<Platform = Elf>, R: Relocation>(
             }
 
             queue.send_symbol_request::<A>(symbol_id, resources, scope);
-
-            layout::check_for_undefined::<A>(
-                object,
-                section,
-                rel_offset,
-                local_sym_index,
-                flags,
-                symbol_id,
-                resources,
-            )?;
         }
+
+        layout::check_for_undefined::<A>(
+            object,
+            section,
+            rel_offset,
+            local_sym_index,
+            flags,
+            symbol_id,
+            resources,
+        )?;
 
         if flags_to_add.needs_copy_relocation() && !previous_flags.needs_copy_relocation() {
             queue.send_copy_relocation_request::<A>(symbol_id, resources, scope);

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -3635,6 +3635,7 @@ fn integration_test(
         "tls-local-dynamic.c",
         "undefined_symbols.c",
         "undefined-with-gc-refs.c",
+        "undefined-weak-and-strong.c",
         "shlib-undefined.c",
         "whole_archive.c",
         "entry_arg.c",

--- a/wild/tests/sources/undefined-weak-and-strong-1.c
+++ b/wild/tests/sources/undefined-weak-and-strong-1.c
@@ -1,0 +1,3 @@
+void foo(void);
+
+void call_foo(void) { foo(); }

--- a/wild/tests/sources/undefined-weak-and-strong.c
+++ b/wild/tests/sources/undefined-weak-and-strong.c
@@ -1,0 +1,16 @@
+// Verifies that we error when there's a strong reference to an undefined symbol
+// even if we previously encountered a weak reference.
+
+//#CompArgs:-ffunction-sections
+//#LinkArgs:--gc-sections
+//#Object:undefined-weak-and-strong-1.c
+//#ExpectError:foo
+
+void __attribute__((weak)) foo(void);
+
+void call_foo(void);
+
+void _start(void) {
+  foo();
+  call_foo();
+}


### PR DESCRIPTION
Issue #1739