### PR TITLE
test: Allow substring matching in test filters

### DIFF
--- a/.github/workflows/external_tests.yml
+++ b/.github/workflows/external_tests.yml
@@ -36,5 +36,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         id: rust-toolchain
       - uses: Swatinem/rust-cache@v2
-      - name: Run mold external tests
-        run: WILD_TEST_CROSS=all cargo test --features mold_tests -- external_test_suites/mold
+      - name: Check regressions
+        run: WILD_TEST_CROSS=all cargo test --features mold_tests external_test_suites/mold -- --skip expect_failure
+      - name: Check tests that should fail still fail
+        run: WILD_TEST_CROSS=all cargo test --features mold_tests expect_failure

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -4106,12 +4106,14 @@ impl PlatformKind {
 
 struct Filter {
     filter: Option<String>,
+    exact: bool,
 }
 
 impl Filter {
     fn new(args: &libtest_mimic::Arguments) -> Self {
         Self {
             filter: args.filter.clone(),
+            exact: args.exact,
         }
     }
 
@@ -4126,6 +4128,10 @@ impl Filter {
             return false;
         };
 
-        !filter.starts_with(prefix) && !prefix.starts_with(filter)
+        if self.exact {
+            !filter.starts_with(prefix) && !prefix.starts_with(filter)
+        } else {
+            false
+        }
     }
 }


### PR DESCRIPTION
When I want to run specific external tests without executing unnecessary ones, I typically specify a substring of the test name, like `cargo test --features mold_tests foobar`. However, the migration to libtest-mimic removed this feature. This PR adds an `--exact` flag branch to maintain performance with cargo-nextest.

Additionally, it restores the traditional two-step configuration for external test CI: first detecting regressions, then verifying expected failures.