### PR TITLE
chore: Include diff report in test failure messages

### DIFF
--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -3595,9 +3595,8 @@ fn diff_files(config: &Config, files: Vec<PathBuf>, display: &dyn Display) -> Re
         )
     })?;
     if report.has_problems() {
-        eprintln!("{report}");
         bail!(
-            "Validation failed.\n{display}\n To revalidate:\ncargo run --bin linker-diff -- \
+            "Validation failed.\n{report}\n{display}\n To revalidate:\ncargo run --bin linker-diff -- \
              {}\nTo disable diff checking, set run_all_diffs=false in test config (see CONTRIBUTING.md)",
             diff_config.to_arg_string()
         );


### PR DESCRIPTION
In the current implementation, reports from linker-diff may become separated from messages indicating test failures when tests are run in parallel. This makes identifying which specific differences cause test failures cumbersome.