### PR TITLE
fix: format linker plugin messages via C shim and prints full log messages.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,6 +863,7 @@ dependencies = [
  "blake3",
  "bumpalo-herd",
  "bytesize",
+ "cc",
  "colored",
  "colosseum",
  "crossbeam-queue",

--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -56,6 +56,9 @@ zstd = { workspace = true }
 [target.'cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
 perf-event = { workspace = true }
 
+[build-dependencies]
+cc = "1.1.12"
+
 [dev-dependencies]
 ar = { workspace = true }
 tempfile = { workspace = true }

--- a/libwild/build.rs
+++ b/libwild/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    if std::env::var("CARGO_FEATURE_PLUGINS").is_ok() {
+        cc::Build::new()
+            .file("src/plugin_message_shim.c")
+            .compile("plugin_message_shim");
+    }
+}

--- a/libwild/src/linker_plugins.rs
+++ b/libwild/src/linker_plugins.rs
@@ -361,7 +361,12 @@ impl LoadedPlugin {
         // Linker plugins handle entries of this vector serially, which means the message callback
         // should be registered first. Otherwise, they won't be able to indicate the problem with
         // entries preceding the callback and, for example, silently skip invalid arguments.
-        transfer_vector.push(LdPluginTv::fn_ptr2(Tag::Message, message));
+        // The message callback is variadic (printf-style), so we register the C trampoline
+        // directly as a raw pointer value rather than going through fn_ptr2.
+        transfer_vector.push(LdPluginTv {
+            tag: Tag::Message as u32,
+            value: wild_plugin_message_callback as *const () as usize,
+        });
 
         for arg in &args.plugin_args {
             transfer_vector.push(LdPluginTv::c_str(Tag::Option, arg));
@@ -992,26 +997,28 @@ extern "C" fn add_input_library(lib_name: *const libc::c_char) -> Status {
     Status::Ok
 }
 
-/// This function is called when the plugin wants to emit a message. It's supposed to accept varargs
-/// similar to printf. Unfortunately that's not exactly easy for us to do, so we just report the
-/// format string.
-extern "C" fn message(level: libc::c_int, format: *const libc::c_char) -> Status {
-    catch_panics(|| {
-        let Some(level) = MessageLevel::from_raw(level) else {
-            return Status::Err;
-        };
+unsafe extern "C" {
+    /// C trampoline that accepts the plugin's printf-style varargs, formats them via vsnprintf,
+    /// then calls `wild_handle_plugin_message` with the resulting string. Defined in
+    /// `plugin_message_shim.c`.
+    fn wild_plugin_message_callback(level: libc::c_int, fmt: *const libc::c_char, ...);
+}
 
-        let format = unsafe { CStr::from_ptr(format) };
+/// Called by the C shim `wild_plugin_message_callback` with the already-formatted message string.
+/// The `no_mangle` is required so the C shim can link against it by name.
+#[unsafe(no_mangle)]
+extern "C" fn wild_handle_plugin_message(level: libc::c_int, message: *const libc::c_char) {
+    let Some(level) = MessageLevel::from_raw(level) else {
+        return;
+    };
 
-        if level == MessageLevel::Error || level == MessageLevel::Fatal {
-            println!("Linker plugin {level}: {}", format.to_string_lossy());
-            ERROR_MESSAGE.replace(Some(format.to_string_lossy().to_string()));
-        } else {
-            println!("Linker plugin {level}: {}", format.to_string_lossy());
-        }
+    let text = unsafe { CStr::from_ptr(message) }.to_string_lossy();
 
-        Status::Ok
-    })
+    println!("Linker plugin {level}: {text}");
+
+    if level == MessageLevel::Error || level == MessageLevel::Fatal {
+        ERROR_MESSAGE.replace(Some(text.into_owned()));
+    }
 }
 
 /// Runs `body`, catching any panics. In the case of a panic, the return status is changed to an

--- a/libwild/src/plugin_message_shim.c
+++ b/libwild/src/plugin_message_shim.c
@@ -1,0 +1,46 @@
+/*
+ * Trampoline for the linker plugin message callback.
+ *
+ * The Gold plugin API defines the message callback as:
+ *   ld_plugin_status (*ld_plugin_message)(int level, const char *format, ...)
+ *
+ * Rust cannot implement C variadic functions on stable, so we implement the
+ * callback here in C. It formats the printf-style message and forwards the
+ * result to wild_handle_plugin_message (defined in linker_plugins.rs).
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Rust function we call with the fully-formatted message string. */
+extern void wild_handle_plugin_message(int level, const char *message);
+
+void wild_plugin_message_callback(int level, const char *fmt, ...) {
+    va_list args1, args2;
+    va_start(args1, fmt);
+    va_copy(args2, args1);
+
+    int len = vsnprintf(NULL, 0, fmt, args1);
+    va_end(args1);
+
+    if (len < 0) {
+        va_end(args2);
+        /* Fall back to the raw format string if sizing failed. */
+        wild_handle_plugin_message(level, fmt);
+        return;
+    }
+
+    char *buf = malloc((size_t)len + 1);
+    if (buf == NULL) {
+        va_end(args2);
+        wild_handle_plugin_message(level, fmt);
+        return;
+    }
+
+    vsnprintf(buf, (size_t)len + 1, fmt, args2);
+    va_end(args2);
+
+    wild_handle_plugin_message(level, buf);
+    free(buf);
+}

--- a/wild/tests/sources/elf/linker-plugin-lto/linker-plugin-lto.c
+++ b/wild/tests/sources/elf/linker-plugin-lto/linker-plugin-lto.c
@@ -82,7 +82,7 @@
 //#SkipLinker:ld
 //#LinkArgs:-Wl,-znow -flto -nostdlib -Wl,-plugin-opt=jobs=foo
 //#Archive:empty.c:-flto
-//#ExpectError:(Error from linker plugin: Invalid parallelism level: \%s|Wild was compiled without linker-plugin support)
+//#ExpectError:(Error from linker plugin: Invalid parallelism level: (foo|\%s)|Wild was compiled without linker-plugin support)
 
 #include "runtime.h"
 


### PR DESCRIPTION
#1662 fixes linker plugin message handling by correctly formatting printf-style variadic arguments.
Introduced a small C shim that accepts the variadic arguments and formats the message via vsnprintf and sends the formatted string back to rust.
Works on stable rust and avoids c_variadics until its stable.
Added a test to verify fomatting correctness.