### PR TITLE
test: Allow running external tests with third-party linkers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,6 +175,8 @@ git submodule update --init --recursive
 cargo test --features mold_tests
 ```
 
+The output will be placed under `fakes-debug/out/test/`.
+
 You can use this command instead of the second one to run all external tests together:
 
 ```sh
@@ -194,6 +196,20 @@ WILD_IGNORE_SKIP=mold cargo test --features mold_tests
 # Run all external tests without skipping any test
 WILD_IGNORE_SKIP=all cargo test --features external_tests
 ```
+
+### Running external tests with other linkers
+
+When debugging a failing test, it can be useful to see how other linkers (such as GNU ld or lld) behave on the same test. You can use the `WILD_EXTERNAL_LINKER` environment variable to run test scripts with a different linker:
+
+```sh
+WILD_EXTERNAL_LINKER=ld cargo test --features mold_tests discard.sh
+
+WILD_EXTERNAL_LINKER=lld cargo test --features mold_tests allow-multiple-definition.sh
+```
+
+The skip list is still applied, so `expect_failure` tests work as usual. This is useful for determining whether a test that fails with wild also fails with another linker, or whether the failure is specific to wild.
+
+When using a third-party linker, the path to the temporary directory is printed to stderr, so you can inspect the output files (e.g. under `/tmp/foo/out/test/`).
 
 ## Commit messages
 

--- a/wild/tests/external_tests/mod.rs
+++ b/wild/tests/external_tests/mod.rs
@@ -6,8 +6,10 @@ use crate::Result;
 use libtest_mimic::Trial;
 use std::env;
 use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command;
 use std::process::Output;
+use std::sync::OnceLock;
 
 pub(super) fn collect_tests(tests: &mut Vec<Trial>, filter: &Filter) -> Result {
     #[cfg(feature = "mold_tests")]
@@ -18,6 +20,138 @@ pub(super) fn collect_tests(tests: &mut Vec<Trial>, filter: &Filter) -> Result {
     let _ = (tests, filter);
 
     Ok(())
+}
+
+#[derive(Clone, Debug)]
+enum ExternalLinker {
+    Wild,
+    ThirdParty { name: String, path: PathBuf },
+}
+
+impl ExternalLinker {
+    fn is_wild(&self) -> bool {
+        matches!(self, ExternalLinker::Wild)
+    }
+
+    fn name(&self) -> &str {
+        match self {
+            ExternalLinker::Wild => "wild",
+            ExternalLinker::ThirdParty { name, .. } => name.as_str(),
+        }
+    }
+}
+
+fn get_external_linker() -> &'static ExternalLinker {
+    static VALUE: OnceLock<ExternalLinker> = OnceLock::new();
+    VALUE.get_or_init(|| {
+        let Ok(val) = env::var("WILD_EXTERNAL_LINKER") else {
+            return ExternalLinker::Wild;
+        };
+        let val = val.trim();
+        if val.is_empty() || val.eq_ignore_ascii_case("wild") {
+            return ExternalLinker::Wild;
+        }
+
+        let (name, search_names): (&str, &[&str]) = match val.to_ascii_lowercase().as_str() {
+            "ld" | "bfd" => ("ld", &["ld.bfd", "ld"]),
+            "lld" => ("lld", &["ld.lld"]),
+            "mold" => ("mold", &["mold"]),
+            "gold" => ("gold", &["ld.gold", "gold"]),
+            _ => {
+                let p = PathBuf::from(&val);
+                if p.exists() {
+                    return ExternalLinker::ThirdParty {
+                        name: val.to_string(),
+                        path: std::fs::canonicalize(&p)
+                            .expect("failed to canonicalize WILD_EXTERNAL_LINKER path"),
+                    };
+                }
+
+                let path = which::which(&val).unwrap_or_else(|_| {
+                    panic!("WILD_EXTERNAL_LINKER={val}: not found as a file and not on PATH")
+                });
+
+                return ExternalLinker::ThirdParty {
+                    name: val.to_string(),
+                    path,
+                };
+            }
+        };
+
+        let path = search_names
+            .iter()
+            .find_map(|n| which::which(n).ok())
+            .unwrap_or_else(|| {
+                panic!(
+                    "WILD_EXTERNAL_LINKER={val}: could not find any of [{}] on PATH",
+                    search_names.join(", ")
+                )
+            });
+
+        ExternalLinker::ThirdParty {
+            name: name.to_string(),
+            path,
+        }
+    })
+}
+
+fn get_fakes_dir() -> &'static Path {
+    static DIR: OnceLock<FakesDir> = OnceLock::new();
+    DIR.get_or_init(|| FakesDir::new(get_external_linker()))
+        .path()
+}
+
+enum FakesDir {
+    Static(PathBuf),
+    Temp(tempfile::TempDir),
+}
+
+impl FakesDir {
+    fn new(linker: &ExternalLinker) -> Self {
+        match linker {
+            ExternalLinker::Wild => {
+                let current_dir = env::current_dir().expect("failed to get current directory");
+                let fakes = current_dir.parent().unwrap().join("fakes-debug");
+                assert!(
+                    fakes.exists(),
+                    "fakes-debug directory not found at {}",
+                    fakes.display()
+                );
+                FakesDir::Static(fakes)
+            }
+            ExternalLinker::ThirdParty { path, name } => {
+                let tmp = tempfile::tempdir()
+                    .expect("failed to create temp directory for external linker fakes");
+                let tmp_path = tmp.path();
+
+                for link_name in &["mold", "ld", "ld.lld"] {
+                    let link = tmp_path.join(link_name);
+                    std::os::unix::fs::symlink(path, &link).unwrap_or_else(|e| {
+                        panic!(
+                            "failed to create symlink {} -> {}: {e}",
+                            link.display(),
+                            path.display()
+                        )
+                    });
+                }
+
+                eprintln!(
+                    "external_tests: using linker '{name}' ({}) via fakes dir {}",
+                    path.display(),
+                    tmp_path.display()
+                );
+
+                FakesDir::Temp(tmp)
+            }
+        }
+    }
+
+    fn path(&self) -> &Path {
+        match self {
+            FakesDir::Static(p) => p.as_path(),
+            FakesDir::Temp(t) => t.path(),
+        }
+    }
 }
 
 #[allow(unused)]
@@ -37,17 +171,24 @@ fn should_not_ignore_tests(external_test: &str) -> bool {
 }
 
 #[allow(unused)]
+fn using_third_party_linker() -> bool {
+    !get_external_linker().is_wild()
+}
+
+#[allow(unused)]
+fn external_linker_name() -> &'static str {
+    get_external_linker().name()
+}
+
+#[allow(unused)]
 fn run_external_test(external_test: &Path, extra_env: &[(&str, &str)]) -> Result<Output> {
-    let path = env::var("PATH")?;
-    let current_dir = env::current_dir()?;
-    let wild_dir = current_dir.parent().unwrap().join("fakes-debug");
+    let fakes_dir = get_fakes_dir();
 
     let mut command = Command::new("bash");
     command
-        .current_dir("../fakes-debug")
+        .current_dir(fakes_dir)
         .arg("-c")
-        .arg(format!("{} 2>&1", external_test.display()))
-        .env("PATH", format!("{wild_dir:?}:{path}"));
+        .arg(format!("{} 2>&1", external_test.display()));
 
     for (key, value) in extra_env {
         command.env(key, value);

--- a/wild/tests/external_tests/mold_tests.rs
+++ b/wild/tests/external_tests/mold_tests.rs
@@ -1,7 +1,9 @@
 use crate::Architecture;
 use crate::Result;
+use crate::external_tests::external_linker_name;
 use crate::external_tests::run_external_test;
 use crate::external_tests::should_not_ignore_tests;
+use crate::external_tests::using_third_party_linker;
 use crate::get_host_architecture;
 use crate::get_wild_test_cross;
 use libtest_mimic::Failed;
@@ -61,18 +63,26 @@ pub(crate) fn collect_tests(tests: &mut Vec<Trial>, filter: &crate::Filter) -> R
         return Ok(());
     }
 
+    let third_party = using_third_party_linker();
+    let linker_name = external_linker_name();
     let test_dir_path = crate::base_dir().join("../external_test_suites/mold/test");
     let dir = std::fs::read_dir(&test_dir_path)
         .with_context(|| format!("Failed to read directory {}", test_dir_path.display()))?;
+
     for ent in dir {
         let ent = ent?;
         let path = ent.path();
 
         if path.extension().is_some_and(|ext| ext == "sh") {
-            let name = format!(
-                "{PREFIX}/test/{}",
-                String::from_utf8_lossy(path.file_name().unwrap().as_encoded_bytes())
-            );
+            let file_name =
+                String::from_utf8_lossy(path.file_name().unwrap().as_encoded_bytes()).to_string();
+
+            let name = if third_party {
+                format!("{PREFIX}[{linker_name}]/test/{file_name}")
+            } else {
+                format!("{PREFIX}/test/{file_name}")
+            };
+
             if !should_skip_mold_test(&path) && !should_skip_by_local_config(&path) {
                 tests.push(Trial::test(name, move || {
                     check_mold_tests_regression(path).map_err(|e| Failed::from(e.to_string()))
@@ -109,11 +119,19 @@ fn check_mold_tests_regression(mold_test: PathBuf) -> Result {
 fn verify_skipped_mold_tests_still_fail(mold_test: PathBuf) -> Result {
     let output = run_mold_test(&mold_test)?;
     if output.status.success() {
-        return Err(format!(
-            "Test `{}` is in skip list but now passes. Should be removed from skip list.",
-            mold_test.display()
-        )
-        .into());
+        let linker = external_linker_name();
+        let message = if using_third_party_linker() {
+            format!(
+                "Test `{}` is in the skip list (fails with wild) but passes with '{linker}'. This indicates the failure may be wild-specific.",
+                mold_test.display()
+            )
+        } else {
+            format!(
+                "Test `{}` is in skip list but now passes. Should be removed from skip list.",
+                mold_test.display()
+            )
+        };
+        return Err(message.into());
     }
 
     Ok(())


### PR DESCRIPTION
If external linker tests fail, it is useful to verify whether the behavior matches that of linkers such as GNU ld. However, our existing test infrastructure made this difficult. By introducing the `WILD_EXTERNAL_LINKER` environment variable, we can now easily test behavior with different external linkers.
