### PR TITLE
fix: GC of sections referenced from debug info

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -3,6 +3,7 @@ flate = "flate"
 rela = "rela"
 ot = "ot"
 FRE = "FRE"
+aranges = "aranges"
 
 [files]
 extend-exclude = [

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -691,45 +691,6 @@ impl platform::Platform for Elf {
         Ok(())
     }
 
-    fn load_object_debug_relocations<'data, 'scope, A: Arch<Platform = Self>>(
-        state: &layout::ObjectLayoutState<'data, Self>,
-        common: &mut layout::CommonGroupState<'data, Self>,
-        queue: &mut layout::LocalWorkQueue,
-        resources: &'scope layout::GraphResources<'data, '_, Self>,
-        section: layout::Section,
-        scope: &Scope<'scope>,
-    ) -> Result {
-        if resources.symbol_db.args.should_output_partial_object {
-            return Ok(());
-        }
-        match state.relocations(section.index)? {
-            RelocationList::Rela(relocations) => {
-                load_debug_relocations::<A, Rela>(
-                    state,
-                    common,
-                    queue,
-                    resources,
-                    section,
-                    relocations.rel_iter(),
-                    scope,
-                )?;
-            }
-            RelocationList::Crel(relocations) => {
-                load_debug_relocations::<A, Crel>(
-                    state,
-                    common,
-                    queue,
-                    resources,
-                    section,
-                    relocations.flat_map(|r| r.ok()),
-                    scope,
-                )?;
-            }
-        }
-
-        Ok(())
-    }
-
     fn create_dynamic_symbol_definition<'data>(
         symbol_db: &SymbolDb<'data, Self>,
         symbol_id: SymbolId,
@@ -4640,41 +4601,6 @@ fn load_section_relocations<'scope, 'data, A: Arch<Platform = Elf>, R: Relocatio
                 layout::section_debug::<Elf>(state.object, section.index)
             )
         })?;
-    }
-
-    Ok(())
-}
-
-fn load_debug_relocations<'scope, 'data, A: Arch<Platform = Elf>, R: Relocation>(
-    state: &layout::ObjectLayoutState<'data, Elf>,
-    common: &mut CommonGroupState<'data, Elf>,
-    queue: &mut layout::LocalWorkQueue,
-    resources: &'scope layout::GraphResources<'data, '_, Elf>,
-    section: layout::Section,
-    relocations: impl Iterator<Item = R>,
-    scope: &Scope<'scope>,
-) -> Result {
-    for rel in relocations {
-        let modifier = process_relocation::<A, R>(
-            state,
-            common,
-            &rel,
-            state.object.section(section.index)?,
-            resources,
-            queue,
-            true,
-            scope,
-        )
-        .with_context(|| {
-            format!(
-                "Failed to copy section {} from file {state}",
-                layout::section_debug::<Elf>(state.object, section.index)
-            )
-        })?;
-        ensure!(
-            modifier == RelocationModifier::Normal,
-            "All debug relocations must be processed"
-        );
     }
 
     Ok(())

--- a/libwild/src/elf_aarch64.rs
+++ b/libwild/src/elf_aarch64.rs
@@ -95,10 +95,6 @@ impl crate::platform::Arch for ElfAArch64 {
         Ok(())
     }
 
-    fn local_symbols_in_debug_info() -> bool {
-        false
-    }
-
     fn tp_offset_start(layout: &Layout<Elf>) -> u64 {
         layout.tls_start_address_aarch64()
     }

--- a/libwild/src/elf_loongarch64.rs
+++ b/libwild/src/elf_loongarch64.rs
@@ -77,10 +77,6 @@ impl crate::platform::Arch for ElfLoongArch64 {
         0
     }
 
-    fn local_symbols_in_debug_info() -> bool {
-        true
-    }
-
     fn tp_offset_start(layout: &crate::layout::Layout<Elf>) -> u64 {
         layout.tls_start_address()
     }

--- a/libwild/src/elf_riscv64.rs
+++ b/libwild/src/elf_riscv64.rs
@@ -95,10 +95,6 @@ impl crate::platform::Arch for ElfRiscV64 {
         RISCV_TLS_DTV_OFFSET
     }
 
-    fn local_symbols_in_debug_info() -> bool {
-        true
-    }
-
     fn tp_offset_start(layout: &crate::layout::Layout<Elf>) -> u64 {
         layout.tls_start_address()
     }

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2981,7 +2981,24 @@ fn apply_debug_relocation<'data, A: Arch<Platform = Elf>, R: Relocation>(
         .merged_symbol_resolution(object_layout.symbol_id_range.input_to_id(symbol_index))
         .or_else(|| {
             section_index.and_then(|section_index| {
-                object_layout.section_resolutions[section_index.0].full_resolution()
+                let section_address =
+                    object_layout.section_resolutions[section_index.0].address()?;
+                // Include the symbol's offset within the section (adjusted for any relaxation
+                // deltas). This is necessary on architectures like RISC-V and LoongArch64 where
+                // debug info references local symbols (e.g. .LFB0, .LFE0) whose value is their
+                // offset within the section, rather than section symbols where the offset is
+                // encoded in the relocation addend.
+                let output_offset = opt_input_to_output(
+                    object_layout.section_relax_deltas.get(section_index.0),
+                    crate::platform::Symbol::value(sym),
+                );
+
+                Some(Resolution {
+                    raw_value: section_address + output_offset,
+                    dynamic_symbol_index: None,
+                    flags: ValueFlags::empty(),
+                    format_specific: Default::default(),
+                })
             })
         });
 

--- a/libwild/src/elf_x86_64.rs
+++ b/libwild/src/elf_x86_64.rs
@@ -87,10 +87,6 @@ impl crate::platform::Arch for ElfX86_64 {
         x86_64_rel_type_to_string(r_type)
     }
 
-    fn local_symbols_in_debug_info() -> bool {
-        false
-    }
-
     fn tp_offset_start(layout: &crate::layout::Layout<Elf>) -> u64 {
         layout.tls_end_address()
     }

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3580,14 +3580,7 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
             SectionSlot::UnloadedDebugInfo(part_id) => {
                 // On RISC-V, the debug info sections contain relocations to local symbols (e.g.
                 // labels).
-                self.load_debug_section::<A>(
-                    common,
-                    queue,
-                    *part_id,
-                    section_index,
-                    resources,
-                    scope,
-                )?;
+                self.load_debug_section::<A>(common, *part_id, section_index, resources)?;
             }
             SectionSlot::Discard => {
                 bail!(
@@ -3649,20 +3642,20 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
     fn load_debug_section<'scope, A: Arch<Platform = P>>(
         &mut self,
         common: &mut CommonGroupState<'data, P>,
-        queue: &mut LocalWorkQueue,
-
         part_id: PartId,
         section_index: SectionIndex,
         resources: &'scope GraphResources<'data, '_, P>,
-        scope: &Scope<'scope>,
     ) -> Result {
         let header = self.object.section(section_index)?;
         let section = Section::create(header, self, section_index, part_id)?;
-        if A::local_symbols_in_debug_info() {
-            <A::Platform as Platform>::load_object_debug_relocations::<A>(
-                self, common, queue, resources, section, scope,
-            )?;
-        }
+
+        // Note: We intentionally do NOT process debug relocations here. On some architectures (like
+        // RISC-V and LoongArch64), debug sections reference local symbols (e.g. .LFB0, .LFE0) in
+        // code sections. Processing those relocations during GC would send symbol requests that
+        // load those code sections, defeating garbage collection. Instead, debug relocations are
+        // resolved at write time in `apply_debug_relocation`, which uses tombstone values for
+        // symbols in GC'd sections and computes addresses from section resolutions for symbols in
+        // live sections.
 
         tracing::debug!(loaded_debug_section = %self.object.section_display_name(section_index),);
         common.section_loaded(part_id, header, section, resources.output_sections);

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -808,17 +808,6 @@ impl platform::Platform for MachO {
         todo!()
     }
 
-    fn load_object_debug_relocations<'data, 'scope, A: platform::Arch<Platform = Self>>(
-        state: &crate::layout::ObjectLayoutState<'data, Self>,
-        common: &mut crate::layout::CommonGroupState<'data, Self>,
-        queue: &mut crate::layout::LocalWorkQueue,
-        resources: &'scope crate::layout::GraphResources<'data, '_, Self>,
-        section: crate::layout::Section,
-        scope: &rayon::Scope<'scope>,
-    ) -> crate::error::Result {
-        todo!()
-    }
-
     fn create_dynamic_symbol_definition<'data>(
         symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
         symbol_id: crate::symbol_db::SymbolId,

--- a/libwild/src/macho_aarch64.rs
+++ b/libwild/src/macho_aarch64.rs
@@ -61,10 +61,6 @@ impl crate::platform::Arch for MachOAArch64 {
         todo!()
     }
 
-    fn local_symbols_in_debug_info() -> bool {
-        todo!()
-    }
-
     fn tp_offset_start(layout: &crate::layout::Layout<Self::Platform>) -> u64 {
         todo!()
     }

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -78,9 +78,6 @@ pub(crate) trait Arch: Send + Sync + 'static {
         0
     }
 
-    /// Some architectures use debug info relocation that depend on local symbols.
-    fn local_symbols_in_debug_info() -> bool;
-
     /// Get position of the $tp (thread pointer) in the TLS section. Each platform defines
     /// a different place based on the following article:
     /// https://maskray.me/blog/2021-02-14-all-about-thread-local-storage#tls-variants
@@ -348,16 +345,6 @@ pub(crate) trait Platform: Copy + Send + Sync + Sized + std::fmt::Debug + 'stati
 
     /// Calls `load_section_relocations` on `state` for the relocations in `section`.
     fn load_object_section_relocations<'data, 'scope, A: Arch<Platform = Self>>(
-        state: &layout::ObjectLayoutState<'data, Self>,
-        common: &mut layout::CommonGroupState<'data, Self>,
-        queue: &mut layout::LocalWorkQueue,
-        resources: &'scope layout::GraphResources<'data, '_, Self>,
-        section: layout::Section,
-        scope: &Scope<'scope>,
-    ) -> Result;
-
-    /// Calls `load_debug_relocations` on `state` for the relocations in `section`.
-    fn load_object_debug_relocations<'data, 'scope, A: Arch<Platform = Self>>(
         state: &layout::ObjectLayoutState<'data, Self>,
         common: &mut layout::CommonGroupState<'data, Self>,
         queue: &mut layout::LocalWorkQueue,

--- a/wild/tests/sources/elf/link-args/link-args.c
+++ b/wild/tests/sources/elf/link-args/link-args.c
@@ -1,6 +1,4 @@
 //#AbstractConfig:default
-// TODO: #795
-//#SkipArch: riscv64,loongarch64
 
 //#Config:strip-all:default
 //#Object:runtime.c

--- a/wild/tests/sources/elf/riscv-gc-debug-ref/riscv-gc-debug-ref.s
+++ b/wild/tests/sources/elf/riscv-gc-debug-ref/riscv-gc-debug-ref.s
@@ -1,0 +1,32 @@
+/*
+//#Arch: riscv64
+//#CompArgs: -march=rv64gc
+//#LinkArgs: -nostdlib -static --gc-sections
+//#NoSym:unused_func
+//#ExpectSym:_start
+*/
+
+.section .text._start,"ax",@progbits
+.globl _start
+.type _start, @function
+_start:
+.LFB0:
+        li      a7, 93
+        li      a0, 42
+        ecall
+.LFE0:
+        .size _start, .-_start
+        .section .text.unused_func,"ax",@progbits
+        .globl unused_func
+        .type unused_func, @function
+
+unused_func:
+.LFB1:
+        ret
+.LFE1:
+        .size unused_func, .-unused_func
+        .section .debug_aranges,"",@progbits
+        .8byte  .LFB0
+        .8byte  .LFE0 - .LFB0
+        .8byte  .LFB1
+        .8byte  .LFE1 - .LFB1


### PR DESCRIPTION
close #795 

On RISC-V and LoongArch64, debug info sections reference local symbols (e.g. `.LFB0`, `.LFE0`) in code sections via relocations. Previously, processing these relocations during the GC graph traversal sent symbol requests that loaded the referenced code sections, defeating `--gc-sections`.

Fix this by not processing debug relocations during the layout phase at all. Instead, resolve them entirely at write time in
`apply_debug_relocation()`:
- For symbols in live sections, compute the address from the section resolution plus the symbol's offset.
- For symbols in GC'd sections, fall through to the existing DWARF tombstone value path.