### PR TITLE
fix: do not allocate space for uninitialized tls variables

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -2367,8 +2367,6 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
 
         if let Some((compression, _, _)) = section.compression(LittleEndian, self.data)? {
             decompress_into(compression, &data[COMPRESSION_HEADER_SIZE..], out)?;
-        } else if section.sh_type(LittleEndian) == object::elf::SHT_NOBITS {
-            out.fill(0);
         } else {
             copy_section_data(data, out);
         }

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -1947,22 +1947,9 @@ fn compute_segment_layout<'data, P: Platform>(
                         rec.mem_start = rec.mem_start.min(section_layout.mem_offset);
                         rec.lma_start = rec.lma_start.min(section_layout.lma_offset);
 
-                        // `has_data_in_file` reports that .tbss has data in file, since this makes
-                        // address allocation easier - see comment in `has_data_in_file`. However,
-                        // we don't want .tbss to increase the file-size of the program segment even
-                        // though we do actually have zeros in the file. If we ever change the
-                        // behaviour of `has_data_in_file`, then this can likely be cleaned up.
-                        let section_file_size = if program_segments.is_tls_segment(rec.segment_id)
-                            && section_info.section_attributes.is_no_bits()
-                        {
-                            0
-                        } else {
-                            section_layout.file_size
-                        };
-
                         rec.file_end = rec
                             .file_end
-                            .max(section_layout.file_offset + section_file_size);
+                            .max(section_layout.file_offset + section_layout.file_size);
                         rec.mem_end = rec
                             .mem_end
                             .max(section_layout.mem_offset + section_layout.mem_size);
@@ -5196,6 +5183,13 @@ fn compute_layout_sections<'data, P: Platform>(
 
     let mut records_out = output_sections.new_part_map();
 
+    // TLS sections without data (like .tbss) overlap normal sections in memory.
+    // This is possible because every thread copies the TLS segments (see TLS PHDR)
+    // to construct thread local data. However, uninitialized TLS data is assumed to be zero
+    // and therefore no copy happens. It would be wasteful to reserve that address in the TLS
+    // template, so we don't do it.
+    let mut tls_memsave: Option<u64> = None;
+
     for event in output_order {
         match event {
             OrderEvent::SetLocation(expr, loc, idx) => {
@@ -5262,6 +5256,19 @@ fn compute_layout_sections<'data, P: Platform>(
             OrderEvent::Section(section_id) => {
                 let section_info = output_sections.output_info(section_id);
                 let section_offset = pending_location.take();
+
+                let is_tls_nobits = section_info.section_attributes.is_tls()
+                    && section_info.section_attributes.is_no_bits();
+                if is_tls_nobits {
+                    // Save our current mem_offset as we enter our first nobits TLS section
+                    if tls_memsave.is_none() {
+                        tls_memsave = Some(mem_offset);
+                    }
+                } else if let Some(tls_memsave) = tls_memsave.take() {
+                    // Restore offsets when exiting nobits TLS sections
+                    mem_offset = tls_memsave;
+                }
+
                 let part_id_range = section_id.part_id_range();
                 let max_alignment = sizes.max_alignment(part_id_range.clone(), output_sections);
                 let region = section_info

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -970,12 +970,8 @@ impl<'data, P: Platform> OutputSections<'data, P> {
     }
 
     pub(crate) fn has_data_in_file(&self, section_id: OutputSectionId) -> bool {
-        // Note, we treat TLS sections (e.g. .tbss) as having data in the file, even if they're
-        // NOBITS. This allows us to more easily place .tbss before other PROGBITS sections.
-        // Effectively .tbss is NOBITS, but we put zero padding of the same size in the file. GNU ld
-        // doesn't do this. It instead puts .tbss and the subsequent section at the same address.
         let attributes = self.output_info(section_id).section_attributes;
-        !attributes.is_no_bits() || attributes.is_tls()
+        !attributes.is_no_bits()
     }
 
     pub(crate) fn output_info(&self, id: OutputSectionId) -> &SectionOutputInfo<'data, P> {

--- a/linker-diff/src/section_map.rs
+++ b/linker-diff/src/section_map.rs
@@ -219,6 +219,16 @@ impl<'data> IndexedLayout<'data> {
         Ok(index)
     }
 
+    fn is_section_tls(&self, section: &SectionInfo) -> Result<bool> {
+        if let object::File::Elf64(elf_file) = &self.files[section.section_id.file_index].file {
+            let elf_section = elf_file.section_by_index(section.section_id.section_index)?;
+            if let object::SectionFlags::Elf { sh_flags, .. } = elf_section.flags() {
+                return Ok(sh_flags.contains(linker_utils::elf::shf::TLS));
+            }
+        }
+        Ok(false)
+    }
+
     fn validate_no_overlaps(&self) -> Result {
         let mut sections = self
             .files
@@ -234,11 +244,14 @@ impl<'data> IndexedLayout<'data> {
             if let Some(last) = last
                 && section.addresses.start < last.addresses.end
             {
-                bail!(
-                    "{} overlaps with {}",
-                    DisplaySection::new(last, &self.files),
-                    DisplaySection::new(section, &self.files)
-                );
+                // Allow TLS sections to overlap non-TLS sections (disallow TLS-TLS overlap though)
+                if self.is_section_tls(last)? == self.is_section_tls(section)? {
+                    bail!(
+                        "{} overlaps with {}",
+                        DisplaySection::new(last, &self.files),
+                        DisplaySection::new(section, &self.files)
+                    );
+                }
             }
             last = Some(section);
         }

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -4763,10 +4763,12 @@ impl Assertions {
 
             if !found {
                 bail!(
-                    "Expected program header `{}' with flags {:?} and sections {:?} not found.",
+                    "Expected program header `{}' with flags {:?}, sections {:?}, mem-size {:?} and filesize {:?} not found.",
                     expected.ptype,
                     expected.assertions.flags,
                     expected.assertions.sections,
+                    expected.assertions.mem_size,
+                    expected.assertions.file_size,
                 );
             }
         }

--- a/wild/tests/sources/elf/tls-custom/tls-custom-1.s
+++ b/wild/tests/sources/elf/tls-custom/tls-custom-1.s
@@ -7,3 +7,8 @@ tbss_a:
 .globl tcustom_a
 tcustom_a:
 .zero 1024
+
+.section .tcustomdata,"awT",@bits
+.globl tcustomdata_a
+tcustomdata_a:
+.fill 2048,1,42

--- a/wild/tests/sources/elf/tls-custom/tls-custom.c
+++ b/wild/tests/sources/elf/tls-custom/tls-custom.c
@@ -17,7 +17,7 @@
 // It is probably best to ignore that difference.
 //#DiffIgnore:rel.R_X86_64_32.R_X86_64_PC32
 //#DiffMatchAny:true
-//#ExpectProgramHeader:TLS memsz=0x1000,filesz=0x800
+//#ExpectProgramHeader:TLS mem-size=0x1000,file-size=0x800
 
 extern __thread char tbss_a[1024];
 extern __thread char tcustom_a[1024];

--- a/wild/tests/sources/elf/tls-custom/tls-custom.c
+++ b/wild/tests/sources/elf/tls-custom/tls-custom.c
@@ -3,16 +3,25 @@
 //#SkipArch: ppc64le
 //#LinkerDriver:gcc
 //#Object:tls-custom-1.s
-//#ReferenceLinkers:bfd,lld
+// GNU ld seems to have a bug as it overlaps the .tcustom and .tcustomdata sections,
+// leading to non null-initialized data.
+//#ReferenceLinkers:lld
 //#LinkArgs:-Wl,--gc-sections
 //#DiffIgnore:.dynamic.DT_FLAGS_1.NOW
 // At least some versions of GNU ld for risc-v export these symbols for some reason.
 //#DiffIgnore:dynsym.tbss_a.section
 //#DiffIgnore:dynsym.tcustom_a.section
+//#DiffIgnore:section.got.plt.entsize
+//#DiffIgnore:section.gnu.version_r.alignment
+// Wild produces the same relaxations as GNU ld, only lld seems to diverge.
+// It is probably best to ignore that difference.
+//#DiffIgnore:rel.R_X86_64_32.R_X86_64_PC32
 //#DiffMatchAny:true
+//#ExpectProgramHeader:TLS memsz=0x1000,filesz=0x800
 
 extern __thread char tbss_a[1024];
 extern __thread char tcustom_a[1024];
+extern __thread char tcustomdata_a[2048];
 
 int main() {
   if (tbss_a[0] != 0) {
@@ -20,6 +29,9 @@ int main() {
   }
   if (tcustom_a[1023] != 0) {
     return 101;
+  }
+  if (tcustomdata_a[42] != 42) {
+    return 104;
   }
 
   tbss_a[0] = 70;


### PR DESCRIPTION
I noticed the tls-common test failed on my machine depending on which environment and versions of compilers I used. It seems like the ``TLS`` program header is generated incorrectly for zero initialized tls variables.

E.g. in the tls-common we have a variable `tvar` that is in `.tbss`. However, the TLS program header is `filesz=4,memsz=4` which doesn't zero-initialize it but loads bytes from the elf binary. It just so happens that all CIs and your local setup contained zeros in the binary at the exact place for this to nevertheless work. The correct TLS program header would be `filesz=0,memsz=4`.

So this pull request does/will do two things:

- [x] Implement program header assertions in testing so this bug actually errors out deterministically. Now a test can contain `//#ExpectProgramHeader:PT_TLS filesz=0,memsz=4` and it will only accept if a program header with at least these properties exists. Implemented by https://github.com/wild-linker/wild/pull/2190 .
- [x] Fix the actual bug.