### PR TITLE
test: remove regex from linker plugin test

### DIFF
--- a/wild/tests/sources/elf/linker-plugin-lto/linker-plugin-lto.c
+++ b/wild/tests/sources/elf/linker-plugin-lto/linker-plugin-lto.c
@@ -82,7 +82,7 @@
 //#SkipLinker:ld
 //#LinkArgs:-Wl,-znow -flto -nostdlib -Wl,-plugin-opt=jobs=foo
 //#Archive:empty.c:-flto
-//#ExpectError:(Error from linker plugin: Invalid parallelism level: (foo|\%s)|Wild was compiled without linker-plugin support)
+//#ExpectError:(Error from linker plugin: Invalid parallelism level: foo|Wild was compiled without linker-plugin support)
 
 #include "runtime.h"
 


### PR DESCRIPTION
Wild would previously output `%s` but now properly outputs `foo`. We want to be sure that we don't regress, not that we accept both forms.