### PR TITLE
fix: Clear opcode and immediate fields before rewriting MOVZ/MOVN relocations in AArch64

### DIFF
--- a/linker-utils/src/aarch64.rs
+++ b/linker-utils/src/aarch64.rs
@@ -8,6 +8,7 @@ use crate::elf::RelocationKindInfo;
 use crate::elf::RelocationSize;
 use crate::elf::Sign;
 use crate::relaxation::RelocationModifier;
+use crate::utils::and_from_slice;
 use crate::utils::or_from_slice;
 use crate::utils::u32_from_slice;
 
@@ -986,13 +987,17 @@ impl AArch64Instruction {
             }
             // C6.2.253, C6.2.254
             AArch64Instruction::Movnz => {
+                // Clear all bits except rd[4:0] and hw[22:21]
+                and_from_slice(dest, &0x0060_001F_u32.to_le_bytes());
                 let mut value = extracted_value as i64;
                 mask = 0u32;
                 if negative {
                     value = !value;
+                    // MOVN opcode: sf=1, opc=00, fixed=100101
+                    mask |= 0x9280_0000;
                 } else {
-                    // Set opcode for MOVZ instruction
-                    mask |= 1 << 30;
+                    // MOVZ opcode: sf=1, opc=10, fixed=100101
+                    mask |= 0xd280_0000;
                 }
                 mask |= ((value as u64).extract_bit_range(0..16) as u32) << 5;
             }

--- a/wild/tests/sources/elf/aarch64-movnz-nonzero-imm/aarch64-movnz-nonzero-imm.s
+++ b/wild/tests/sources/elf/aarch64-movnz-nonzero-imm/aarch64-movnz-nonzero-imm.s
@@ -1,0 +1,37 @@
+/*
+//#Arch: aarch64
+//#LinkArgs: -nostdlib -static
+*/
+
+.section .text, "ax", @progbits
+
+.globl target
+.type target, @function
+target:
+    nop
+.size target, .-target
+
+# Padding so the negative offset is large enough to be unambiguous.
+# 256 nops = 1024 bytes.
+.rept 256
+    nop
+.endr
+
+.globl _start
+.type _start, @function
+_start:
+    .reloc ., R_AARCH64_MOVW_PREL_G0, target
+    movz x0, #0x1234
+
+    # If x0 >= 0 (MOVZ was wrongly kept), branch to failure.
+    tbz x0, #63, .Lfail
+
+    mov x0, #42
+    mov x8, #93
+    svc #0
+
+.Lfail:
+    mov x0, #1
+    mov x8, #93
+    svc #0
+.size _start, .-_start


### PR DESCRIPTION
context: https://github.com/wild-linker/wild/pull/1791#issuecomment-4179379123

The `Movnz` variant of `write_to_value()` selects between MOVZ (bit 30 = 1) and MOVN (bit 30 = 0) at link time depending on the sign of the resolved value. Since it used only `or_from_slice()`, bit 30 could never be cleared, so a MOVZ placeholder in the object file could not be rewritten to MOVN. The immediate field was also corrupted by leftover bits.