### PR TITLE
fix: import just `GLIBC_ABI_DT_RELR` version

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -918,15 +918,6 @@ impl platform::Platform for Elf {
             name: b"_TLS_MODULE_BASE_",
             symbol: elf_symbol,
         });
-
-        // When `-z pack-relative-relocs` is used, Glibc requires this special version to be
-        // defined.
-        if args.z_pack_relative_relocs {
-            symbols.add_symbol(InternalSymDefInfo::new(
-                SymbolPlacement::ImportDynamicSymbol,
-                b"GLIBC_ABI_DT_RELR",
-            ));
-        }
     }
 
     fn built_in_section_infos<'data>()

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -470,7 +470,10 @@ impl platform::Platform for Elf {
         *memory_offsets.get(part_id::EH_FRAME)
     }
 
-    fn finalise_find_required_sections(groups: &[layout::GroupState<Elf>]) {
+    fn finalise_find_required_sections<'data>(
+        groups: &mut [layout::GroupState<Elf>],
+        symbol_db: &SymbolDb<'data, Elf>,
+    ) -> Result {
         tracing::debug!(target: "metrics", total = groups
             .iter()
             .map(|g| g.common.format_specific.exception_frame_count)
@@ -480,6 +483,12 @@ impl platform::Platform for Elf {
             .iter()
             .map(|g| g.common.format_specific.exception_frame_relocations)
             .sum::<usize>(), "resolved relocations");
+
+        if symbol_db.args.is_relr_enabled() {
+            load_glibc_abi_dt_relr_version(groups, symbol_db)?;
+        }
+
+        Ok(())
     }
 
     fn activate_dynamic<'data>(
@@ -1933,6 +1942,32 @@ impl platform::Platform for Elf {
     }
 }
 
+/// Marks the symbol version associated with the dynamic symbol `GLIBC_ABI_DT_RELR` as needed.
+/// Referencing the version will cause the binary to error if it's loaded with a glibc that doesn't
+/// support relr. glibc will error at startup if we use relr and don't reference the version. If
+/// we're not linking against glibc, then the symbol (and version) will be absent. This is not an
+/// error and the binary will work fine provided the dynamic loader supports relr.
+fn load_glibc_abi_dt_relr_version(
+    groups: &mut [layout::GroupState<'_, Elf>],
+    symbol_db: &SymbolDb<Elf>,
+) -> Result {
+    if let Some(symbol_id) =
+        symbol_db.get_unversioned(&UnversionedSymbolName::prehashed(b"GLIBC_ABI_DT_RELR"))
+    {
+        let file_id = symbol_db.file_id_for_symbol(symbol_id);
+        if let layout::FileLayoutState::Dynamic(state) =
+            &mut groups[file_id.group()].files[file_id.file()]
+        {
+            let symbol_index = state.symbol_id_range.id_to_offset(symbol_id);
+            state
+                .format_specific_state
+                .mark_version_as_needed(state.object.versym[symbol_index])?;
+        }
+    }
+
+    Ok(())
+}
+
 impl<'data> platform::ObjectFile<'data> for File<'data> {
     type Platform = Elf;
 
@@ -2343,15 +2378,7 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
         state: &mut DynamicLayoutStateExt<'data>,
     ) -> Result {
         if let Some(version_index) = self.versym.get(symbol_index.0) {
-            let version_index = version_index.0.get(LittleEndian) & object::elf::VERSYM_VERSION;
-            // Versions 0 and 1 are local and global. We care about the versions after that.
-            if version_index > object::elf::VER_NDX_GLOBAL {
-                *state
-                    .symbol_versions_needed
-                    .get_mut(version_index as usize - 1)
-                    .with_context(|| format!("Invalid symbol version index {version_index}"))? =
-                    true;
-            }
+            state.mark_version_as_needed(*version_index)?;
         }
 
         Ok(())
@@ -2463,6 +2490,22 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
             // GNU ld which recursively loads all transitive dependencies of shared objects and
             // checks our shared object against those.
             && has_complete_deps(self, resources)
+    }
+}
+
+impl DynamicLayoutStateExt<'_> {
+    /// Marks the specified version as needed, provided it's not a local or global version.
+    fn mark_version_as_needed(&mut self, version_index: Versym) -> Result {
+        let version_index = version_index.0.get(LittleEndian) & object::elf::VERSYM_VERSION;
+
+        // Versions 0 and 1 are local and global. We care about the versions after that.
+        if version_index > object::elf::VER_NDX_GLOBAL {
+            *self
+                .symbol_versions_needed
+                .get_mut(version_index as usize - 1)
+                .with_context(|| format!("Invalid symbol version index {version_index}"))? = true;
+        }
+        Ok(())
     }
 }
 

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -1933,7 +1933,7 @@ fn find_required_sections<'data, A: Arch>(
 
     let mut group_states = unwrap_worker_states(&resources.worker_slots);
 
-    <A::Platform as Platform>::finalise_find_required_sections(&group_states);
+    <A::Platform as Platform>::finalise_find_required_sections(&mut group_states, symbol_db)?;
 
     // Give our prelude a chance to tie up a few last sizes while we still have access to
     // `resources`.

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -2677,8 +2677,6 @@ impl<'data, P: Platform> PreludeLayoutState<'data, P> {
 
         self.mark_defsyms_as_used::<A>(resources, queue, scope);
 
-        self.load_explicit_imports::<A>(resources, queue, scope);
-
         Ok(())
     }
 
@@ -2769,43 +2767,6 @@ impl<'data, P: Platform> PreludeLayoutState<'data, P> {
                 WorkItem::LoadGlobalSymbol(symbol_id),
                 scope,
             );
-        }
-    }
-
-    fn load_explicit_imports<'scope, A: Arch>(
-        &self,
-        resources: &'scope GraphResources<'data, '_, A::Platform>,
-        queue: &mut LocalWorkQueue,
-        scope: &Scope<'scope>,
-    ) {
-        for def_info in &self.internal_symbols.symbol_definitions {
-            if def_info.placement != SymbolPlacement::ImportDynamicSymbol {
-                continue;
-            }
-
-            let Some(symbol_id) = resources
-                .symbol_db
-                .get_unversioned(&UnversionedSymbolName::prehashed(def_info.name))
-            else {
-                // No libs contain the requested symbol, skipping.
-                return;
-            };
-
-            let canonical_target_id = resources.symbol_db.definition(symbol_id);
-            let file_id = resources.symbol_db.file_id_for_symbol(canonical_target_id);
-            let flags = resources
-                .per_symbol_flags
-                .get_atomic(canonical_target_id)
-                .fetch_or(ValueFlags::EXPORT_DYNAMIC);
-
-            if !flags.has_resolution() {
-                queue.send_work::<A>(
-                    resources,
-                    file_id,
-                    WorkItem::LoadGlobalSymbol(canonical_target_id),
-                    scope,
-                );
-            }
         }
     }
 
@@ -3240,9 +3201,7 @@ fn create_start_end_symbol_resolution<'data, P: Platform>(
     }
 
     let raw_value = match def_info.placement {
-        SymbolPlacement::Undefined
-        | SymbolPlacement::ForceUndefined
-        | SymbolPlacement::ImportDynamicSymbol => 0,
+        SymbolPlacement::Undefined | SymbolPlacement::ForceUndefined => 0,
         SymbolPlacement::SectionStart(section_id) => {
             resources.section_layouts.get(section_id).mem_offset
         }

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -915,8 +915,6 @@ impl platform::Platform for MachO {
         todo!()
     }
 
-    fn finalise_find_required_sections(groups: &[crate::layout::GroupState<Self>]) {}
-
     fn activate_dynamic<'data>(
         state: &mut crate::layout::DynamicLayoutState<'data, Self>,
         common: &mut crate::layout::CommonGroupState<'data, Self>,

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -98,9 +98,6 @@ pub(crate) enum SymbolPlacement<'data> {
 
     /// Symbol will point to the start of the first loadable segment.
     LoadBaseAddress,
-
-    /// A dynamic symbol that will be loaded even if unused.
-    ImportDynamicSymbol,
 }
 
 /// Result of parsing a defsym-style expression like "0x1000", "symbol", or "symbol+0x40".

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -301,8 +301,13 @@ pub(crate) trait Platform:
         mem_offset: &mut u64,
     );
 
-    /// Called after GC phase has completed. Mostly useful for platform-specific logging.
-    fn finalise_find_required_sections(groups: &[layout::GroupState<Self>]);
+    /// Called after GC phase has completed.
+    fn finalise_find_required_sections<'data>(
+        _groups: &mut [layout::GroupState<Self>],
+        _symbol_db: &SymbolDb<'data, Self>,
+    ) -> Result {
+        Ok(())
+    }
 
     /// The dynamic object will be linked against. This is a chance to perform extra initialisation
     /// of `state`.

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -1998,9 +1998,9 @@ impl<'data, P: Platform> Prelude<'data, P> {
         for definition in &self.symbol_definitions {
             let symbol_id = symbols_out.next;
             let mut flags = match definition.placement {
-                SymbolPlacement::Undefined
-                | SymbolPlacement::ForceUndefined
-                | SymbolPlacement::ImportDynamicSymbol => ValueFlags::ABSOLUTE,
+                SymbolPlacement::Undefined | SymbolPlacement::ForceUndefined => {
+                    ValueFlags::ABSOLUTE
+                }
                 SymbolPlacement::DefsymAbsolute(_) => {
                     outputs.add_non_versioned(PendingSymbol::new(symbol_id, definition.name));
                     ValueFlags::NON_INTERPOSABLE | ValueFlags::ABSOLUTE
@@ -2034,8 +2034,7 @@ impl<P: Platform> InternalSymDefInfo<'_, P> {
             SymbolPlacement::Undefined
             | SymbolPlacement::ForceUndefined
             | SymbolPlacement::DefsymAbsolute(_)
-            | SymbolPlacement::DefsymSymbol(_, _)
-            | SymbolPlacement::ImportDynamicSymbol => None,
+            | SymbolPlacement::DefsymSymbol(_, _) => None,
             SymbolPlacement::SectionStart(i) => Some(i),
             SymbolPlacement::SectionEnd(i) => Some(i),
             SymbolPlacement::SectionGroupEnd(i) => Some(i),

--- a/wild/tests/sources/elf/libc-integration/libc-integration.c
+++ b/wild/tests/sources/elf/libc-integration/libc-integration.c
@@ -118,7 +118,7 @@
 // Wild is the only linker that adds GLIBC_ABI_DT_RELR dynamic symbol
 // dependency.
 //#SkipLinker:ld
-//#ExpectDynSym:GLIBC_ABI_DT_RELR
+//#Contains:GLIBC_ABI_DT_RELR
 //#RequiresGlibc:true
 //#Contains:.relr.dyn
 

--- a/wild/tests/sources/elf/pack-relative-relocs-shared/pack-relative-relocs-shared.c
+++ b/wild/tests/sources/elf/pack-relative-relocs-shared/pack-relative-relocs-shared.c
@@ -4,8 +4,9 @@
 //#LinkArgs:-Wl,-z,now,-z,pack-relative-relocs
 //#Shared:pack-relative-relocs-shared-1.c
 //#DiffIgnore:section.rodata
-// TODO: Enable linking with ld when fixing #1817
-//#SkipLinker:ld
+//#DiffIgnore:section.data
+//#DiffIgnore:rel.R_AARCH64_ADR_GOT_PAGE.R_AARCH64_ADR_GOT_PAGE
+//#EnableLinker:lld
 
 int foo(void);
 


### PR DESCRIPTION
A self-contained mess to import just the version and not the whole symbol for #1817. If we want to go this route I'll try to clean this up, but there is not much that can be done.