### PR TITLE
chore: Include common headers by relative path in tests

### DIFF
--- a/wild/tests/sources/elf/alignment/alignment.c
+++ b/wild/tests/sources/elf/alignment/alignment.c
@@ -1,7 +1,7 @@
 //#Object:runtime.c
 //#TestUpdateInPlace:true
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 #define ALIGNMENT 65536
 

--- a/wild/tests/sources/elf/archive-activation/archive-activation.c
+++ b/wild/tests/sources/elf/archive-activation/archive-activation.c
@@ -69,7 +69,7 @@
 //#ThinArchive:runtime.c
 //#ThinArchive:empty.a
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 int bar(void);
 int does_not_exist(void);

--- a/wild/tests/sources/elf/as-needed-weak/as-needed-weak.c
+++ b/wild/tests/sources/elf/as-needed-weak/as-needed-weak.c
@@ -14,7 +14,7 @@
 //#DiffIgnore:.dynamic.DT_RELAENT
 //#DiffIgnore:rel.undefined-weak.dynamic.R_X86_64_GLOB_DAT
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 __attribute__((weak)) int fn1(void);
 

--- a/wild/tests/sources/elf/call-via-defsym/call-via-defsym.c
+++ b/wild/tests/sources/elf/call-via-defsym/call-via-defsym.c
@@ -3,7 +3,7 @@
 //#Object:call-via-defsym-1.c
 //#LinkArgs:-znow --defsym=foo=bar
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 int foo();
 int __attribute__((weak)) bar(void) { return 8; }

--- a/wild/tests/sources/elf/comments/comments.c
+++ b/wild/tests/sources/elf/comments/comments.c
@@ -3,7 +3,7 @@
 //#Object:runtime.c
 //#TestUpdateInPlace:true
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 int v0(void);
 int v1(void);

--- a/wild/tests/sources/elf/common-section/common-section.c
+++ b/wild/tests/sources/elf/common-section/common-section.c
@@ -4,7 +4,7 @@
 //#Object:runtime.c
 //#EnableLinker:lld
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 int a;
 extern int data[];

--- a/wild/tests/sources/elf/common/runtime.c
+++ b/wild/tests/sources/elf/common/runtime.c
@@ -1,4 +1,4 @@
-#include "runtime.h"
+#include "../common/runtime.h"
 
 #include <inttypes.h>
 #include <sys/types.h>

--- a/wild/tests/sources/elf/copy-relocations/copy-relocations.c
+++ b/wild/tests/sources/elf/copy-relocations/copy-relocations.c
@@ -11,7 +11,7 @@
 //#ExpectSym:_start section=".text"
 //#ExpectSym:w4
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 // These two symbols are at the same address in the shared object, so references
 // to both should point to the same copy relocation and that location should be

--- a/wild/tests/sources/elf/custom-section/custom-section.c
+++ b/wild/tests/sources/elf/custom-section/custom-section.c
@@ -13,7 +13,7 @@
 //#Config:object:default
 //#Object:custom_section0.c
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 static int foo1 __attribute__((used, section("foo"))) = 2;
 static int foo2 __attribute__((used, section("foo"))) = 5;

--- a/wild/tests/sources/elf/data-pointers/data-pointers.c
+++ b/wild/tests/sources/elf/data-pointers/data-pointers.c
@@ -10,7 +10,7 @@
 // necessary.
 //#DiffIgnore:section.got
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 extern int foo[8];
 extern int bar[8];

--- a/wild/tests/sources/elf/data/data.c
+++ b/wild/tests/sources/elf/data/data.c
@@ -5,7 +5,7 @@
 
 #include <stddef.h>
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 static char data1[] = "QQQ";
 

--- a/wild/tests/sources/elf/eh-frame/eh-frame.c
+++ b/wild/tests/sources/elf/eh-frame/eh-frame.c
@@ -6,7 +6,7 @@
 
 #include <stdint.h>
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 typedef uint32_t u32;
 

--- a/wild/tests/sources/elf/entry-arg/entry-arg.c
+++ b/wild/tests/sources/elf/entry-arg/entry-arg.c
@@ -6,7 +6,7 @@
 //#ExpectSym:custom_entry section=".text"
 //#TestUpdateInPlace:true
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 void custom_entry(void) {
   runtime_init();

--- a/wild/tests/sources/elf/entry-in-shared/entry-in-shared.c
+++ b/wild/tests/sources/elf/entry-in-shared/entry-in-shared.c
@@ -6,7 +6,7 @@
 //#DiffIgnore:.dynamic.DT_RELA*
 //#Mode:dynamic
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 void _start(void) {
   runtime_init();

--- a/wild/tests/sources/elf/executable-start/executable-start.c
+++ b/wild/tests/sources/elf/executable-start/executable-start.c
@@ -13,8 +13,8 @@
 //#Shared:force-dynamic-linking.c
 //#DiffIgnore:.dynamic.DT_NEEDED
 
+#include "../common/runtime.h"
 #include "ptr_black_box.h"
-#include "runtime.h"
 
 extern char __executable_start;
 

--- a/wild/tests/sources/elf/force-undefined/force-undefined.c
+++ b/wild/tests/sources/elf/force-undefined/force-undefined.c
@@ -17,7 +17,7 @@
 //#ExpectSym:bar
 //#ExpectSym:is_archive0_loaded
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 __attribute__((weak)) int is_archive0_loaded() { return 0; }
 

--- a/wild/tests/sources/elf/global-definitions/global_references.c
+++ b/wild/tests/sources/elf/global-definitions/global_references.c
@@ -1,7 +1,7 @@
 #include <stddef.h>
 
+#include "../common/runtime.h"
 #include "global_definitions.h"
-#include "runtime.h"
 
 // Returns the passed value, but don't let the compiler make any assumptions
 // about the returned value.

--- a/wild/tests/sources/elf/gnu-unique/gnu-unique.c
+++ b/wild/tests/sources/elf/gnu-unique/gnu-unique.c
@@ -2,7 +2,7 @@
 //#Object:gnu-unique-1.cc
 //#Object:gnu-unique-2.cc
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 typedef int (*get_int_fn_t)(int);
 

--- a/wild/tests/sources/elf/got-ref-to-local/got-ref-to-local.c
+++ b/wild/tests/sources/elf/got-ref-to-local/got-ref-to-local.c
@@ -7,7 +7,7 @@
 //#Object:runtime.c
 //#Arch: x86_64
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 typedef int (*fnptr)(void);
 

--- a/wild/tests/sources/elf/hidden-ref/hidden-ref.c
+++ b/wild/tests/sources/elf/hidden-ref/hidden-ref.c
@@ -14,7 +14,7 @@
 //#Shared:hidden-ref-1.c
 //#Archive:hidden-ref-2.c
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 __attribute__((visibility(("hidden")))) int foo(void);
 

--- a/wild/tests/sources/elf/hidden-undef/hidden-undef.c
+++ b/wild/tests/sources/elf/hidden-undef/hidden-undef.c
@@ -6,7 +6,7 @@
 //#Shared:hidden-undef-lib.c
 //#ExpectError:foo
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 // foo is declared hidden — must not be resolved from the DSO above.
 __attribute__((visibility("hidden"))) int foo(void);

--- a/wild/tests/sources/elf/ifunc-address-equality/ifunc-address-equality.c
+++ b/wild/tests/sources/elf/ifunc-address-equality/ifunc-address-equality.c
@@ -9,8 +9,8 @@
 //#Config:no-pie:default
 //#CompArgs:-fno-pie
 
+#include "../common/runtime.h"
 #include "ifunc_init.h"
-#include "runtime.h"
 
 typedef void (*Func)(void);
 

--- a/wild/tests/sources/elf/ifunc-alias/ifunc-alias.c
+++ b/wild/tests/sources/elf/ifunc-alias/ifunc-alias.c
@@ -12,9 +12,9 @@
 //#CompArgs:-fno-pie
 //#DiffIgnore:section.rela.plt.link
 
+#include "../common/runtime.h"
 #include "ifunc_init.h"
 #include "init.h"
-#include "runtime.h"
 
 static int target_func(void) { return 42; }
 

--- a/wild/tests/sources/elf/ifunc/ifunc.c
+++ b/wild/tests/sources/elf/ifunc/ifunc.c
@@ -27,9 +27,9 @@
 //#ExpectSym:compute_value32$plt section=".plt.got"
 //#NoSym:compute_unused$plt
 
+#include "../common/runtime.h"
 #include "ifunc_init.h"
 #include "init.h"
-#include "runtime.h"
 
 extern int compute_value10(void);
 extern int compute_value32(void);

--- a/wild/tests/sources/elf/init-order/init-order.c
+++ b/wild/tests/sources/elf/init-order/init-order.c
@@ -4,8 +4,8 @@
 //#DiffIgnore:section.data
 //#DiffIgnore:section.rodata
 
+#include "../common/runtime.h"
 #include "init.h"
-#include "runtime.h"
 
 static int ctors_init_val = 0;
 

--- a/wild/tests/sources/elf/init-test/init-test.c
+++ b/wild/tests/sources/elf/init-test/init-test.c
@@ -5,7 +5,7 @@
 
 #include "init.h"
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 static int value = 0;
 

--- a/wild/tests/sources/elf/internal-syms/internal-syms.c
+++ b/wild/tests/sources/elf/internal-syms/internal-syms.c
@@ -3,7 +3,7 @@
 
 //#Object:runtime.c
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 struct Rela {
   long long a, b, c;

--- a/wild/tests/sources/elf/link-args/link-args.c
+++ b/wild/tests/sources/elf/link-args/link-args.c
@@ -67,7 +67,7 @@
 //#LinkArgs:-z foobar
 //#ExpectWarning:warning.*foobar
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 void _start(void) {
   runtime_init();

--- a/wild/tests/sources/elf/linker-defined-provide/linker-defined-provide.c
+++ b/wild/tests/sources/elf/linker-defined-provide/linker-defined-provide.c
@@ -51,7 +51,7 @@
 //#LinkArgs:-shared
 //#ExpectDynSym:__executable_start
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 // User defines _end - linker should not create a conflicting symbol
 char _end __attribute__((weak)) = 42;

--- a/wild/tests/sources/elf/linker-plugin-lto/linker-plugin-lto.c
+++ b/wild/tests/sources/elf/linker-plugin-lto/linker-plugin-lto.c
@@ -84,7 +84,7 @@
 //#Archive:empty.c:-flto
 //#ExpectError:(Error from linker plugin: Invalid parallelism level: foo|Wild was compiled without linker-plugin support)
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 int foo();
 

--- a/wild/tests/sources/elf/linker-script-executable/linker-script-executable.c
+++ b/wild/tests/sources/elf/linker-script-executable/linker-script-executable.c
@@ -7,7 +7,7 @@
 
 #include <stddef.h>
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 int value = 42;
 extern const char start_of_text;

--- a/wild/tests/sources/elf/linker-script-filename-match/linker-script-filename-match.c
+++ b/wild/tests/sources/elf/linker-script-filename-match/linker-script-filename-match.c
@@ -8,7 +8,7 @@
 //#ExpectSym:app_code section=".text.app"
 //#ExpectSym:begin_here section=".text"
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 extern int startup_code(void);
 extern int app_code(void);

--- a/wild/tests/sources/elf/max-page-size/max-page-size.c
+++ b/wild/tests/sources/elf/max-page-size/max-page-size.c
@@ -19,7 +19,7 @@
 // It seems that large page sizes are not permitted in RISC-V QEMU
 //#SkipArch: riscv64
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 int _start() {
   runtime_init();

--- a/wild/tests/sources/elf/mixed-verdef-verneed/mixed-verdef-verneed.c
+++ b/wild/tests/sources/elf/mixed-verdef-verneed/mixed-verdef-verneed.c
@@ -8,7 +8,7 @@
 //#DiffIgnore:.dynamic.DT_RELA*
 //#DiffIgnore:section.got
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 int from_so(void);
 

--- a/wild/tests/sources/elf/no-start/no-start.c
+++ b/wild/tests/sources/elf/no-start/no-start.c
@@ -11,7 +11,7 @@
 //#LinkArgs:-z now --gc-sections
 //#RunEnabled:false
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 // Provided this is the first function, it'll get used as the entry point - at
 // least by GNU ld. LLD doesn't set an entry point in this case.

--- a/wild/tests/sources/elf/non-string-merging/non-string-merging.c
+++ b/wild/tests/sources/elf/non-string-merging/non-string-merging.c
@@ -21,7 +21,7 @@
 //#DiffIgnore:segment.PT_DYNAMIC.*
 //#DiffIgnore:section.got
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 extern const char s1h[];
 extern const char s2h[];

--- a/wild/tests/sources/elf/old-init/old-init.c
+++ b/wild/tests/sources/elf/old-init/old-init.c
@@ -15,7 +15,7 @@
 //#EnableLinker:lld
 //#Arch: x86_64
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 int _init();
 int _fini();

--- a/wild/tests/sources/elf/output-kind/output-kind.c
+++ b/wild/tests/sources/elf/output-kind/output-kind.c
@@ -58,7 +58,7 @@
 //#SkipLinker:ld
 //#Mode:unspecified
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 void _start(void) {
   runtime_init();

--- a/wild/tests/sources/elf/pack-relative-relocs/pack-relative-relocs.c
+++ b/wild/tests/sources/elf/pack-relative-relocs/pack-relative-relocs.c
@@ -31,8 +31,8 @@
 //#EnableLinker:lld
 //#SkipLinker:ld
 
+#include "../common/runtime.h"
 #include "init.h"
-#include "runtime.h"
 
 int target = 42;
 

--- a/wild/tests/sources/elf/preinit-array/preinit-array.c
+++ b/wild/tests/sources/elf/preinit-array/preinit-array.c
@@ -11,7 +11,7 @@
 //#RequiresGlibc:true
 //#Mode:dynamic
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 int exit_code;
 

--- a/wild/tests/sources/elf/relocatables/relocatables.c
+++ b/wild/tests/sources/elf/relocatables/relocatables.c
@@ -2,7 +2,7 @@
 //#Object:runtime.c
 //#Relocatable:relocatable-1.c,relocatable-2.c
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 int add(int, int);
 int subtract(int, int);

--- a/wild/tests/sources/elf/segment-end-syms/segment-end-syms.c
+++ b/wild/tests/sources/elf/segment-end-syms/segment-end-syms.c
@@ -7,8 +7,8 @@
 
 //#Config:pie:default
 
+#include "../common/runtime.h"
 #include "ptr_black_box.h"
-#include "runtime.h"
 
 extern char _etext;
 extern char __etext;

--- a/wild/tests/sources/elf/shared-priority/shared-priority.c
+++ b/wild/tests/sources/elf/shared-priority/shared-priority.c
@@ -21,7 +21,7 @@
 //#Archive:shared-priority-1.c
 //#Shared:shared-priority-2.c
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 int foo(void);
 

--- a/wild/tests/sources/elf/shlib-archive-activation/shlib-archive-activation.c
+++ b/wild/tests/sources/elf/shlib-archive-activation/shlib-archive-activation.c
@@ -12,7 +12,7 @@
 //#Shared:shlib-archive-activation-1.c
 //#Archive:shlib-archive-activation-2.c
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 int f1(void);
 

--- a/wild/tests/sources/elf/shlib-undefined/shlib-undefined.c
+++ b/wild/tests/sources/elf/shlib-undefined/shlib-undefined.c
@@ -44,7 +44,7 @@
 // object. We probably should too.
 //#DiffIgnore:file-header.entry
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 int def1(void) { return 100; }
 

--- a/wild/tests/sources/elf/stack-size/stack-size.c
+++ b/wild/tests/sources/elf/stack-size/stack-size.c
@@ -5,7 +5,7 @@
 //#LinkArgs:-z stack-size=0x1000 -z now
 //#DiffIgnore:section.note.gnu.property
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 void _start() {
   runtime_init();

--- a/wild/tests/sources/elf/string-merging/string-merging.c
+++ b/wild/tests/sources/elf/string-merging/string-merging.c
@@ -21,7 +21,7 @@
 //#DiffIgnore:segment.PT_DYNAMIC.*
 //#DiffIgnore:section.got
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 extern const char s1h[];
 extern const char s2h[];

--- a/wild/tests/sources/elf/symbol-binding/symbol-binding.c
+++ b/wild/tests/sources/elf/symbol-binding/symbol-binding.c
@@ -7,7 +7,7 @@
 //#Object:symbol-binding-1.c
 //#Archive:symbol-binding-2.c
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 __attribute__((visibility("hidden"))) int foo(void);
 __attribute__((visibility("hidden"))) int bar(void);

--- a/wild/tests/sources/elf/symbol-priority/symbol-priority.c
+++ b/wild/tests/sources/elf/symbol-priority/symbol-priority.c
@@ -10,7 +10,7 @@
 //#DiffIgnore:.dynamic.DT_NEEDED
 //#DiffIgnore:section.got
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 // This function is defined weakly in all the files, except the last shared
 // object, which defines it strongly. The definition used should be the first

--- a/wild/tests/sources/elf/symbol-versions/symbol-versions.c
+++ b/wild/tests/sources/elf/symbol-versions/symbol-versions.c
@@ -30,7 +30,7 @@
 //#Config:with-escaping:verdef
 //#LinkArgs:--shared --version-script=./symbol-versions-with-escaping.map
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 int foo(void);
 int bar_global(void);

--- a/wild/tests/sources/elf/symver-shared/symver-shared.c
+++ b/wild/tests/sources/elf/symver-shared/symver-shared.c
@@ -13,7 +13,7 @@
 //#LinkArgs:--version-script=./symver-shared.map -znow
 //#RequiresGlibc:true
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 int call_foo_v1(void);
 

--- a/wild/tests/sources/elf/tls-common/tls-common.c
+++ b/wild/tests/sources/elf/tls-common/tls-common.c
@@ -9,7 +9,7 @@
 //#DiffIgnore:section.got
 //#DiffIgnore:.dynamic.*
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 __thread int tvar __attribute__((common));
 

--- a/wild/tests/sources/elf/tls/tls.c
+++ b/wild/tests/sources/elf/tls/tls.c
@@ -31,8 +31,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "../common/runtime.h"
 #include "init_tls.h"
-#include "runtime.h"
 
 typedef uint8_t u8;
 typedef uint64_t u64;

--- a/wild/tests/sources/elf/trivial-dynamic/trivial-dynamic.c
+++ b/wild/tests/sources/elf/trivial-dynamic/trivial-dynamic.c
@@ -31,7 +31,7 @@
 //#DiffIgnore:.dynamic.DT_SYMBOLIC
 //#ExpectDynamic:DT_FLAGS
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 int foo(void);
 

--- a/wild/tests/sources/elf/trivial/trivial.c
+++ b/wild/tests/sources/elf/trivial/trivial.c
@@ -4,7 +4,7 @@
 //#EnableLinker:lld
 //#TestUpdateInPlace:true
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 void _start(void) {
   runtime_init();

--- a/wild/tests/sources/elf/undef-transitive/undef-transitive.c
+++ b/wild/tests/sources/elf/undef-transitive/undef-transitive.c
@@ -15,7 +15,7 @@
 //#Object:undef-transitive-1.c
 //#ExpectError:foo
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 int bar(void);
 

--- a/wild/tests/sources/elf/undefined-weak-sym/undefined-weak-sym.c
+++ b/wild/tests/sources/elf/undefined-weak-sym/undefined-weak-sym.c
@@ -10,7 +10,7 @@
 //#DiffIgnore:.dynamic.DT_RELAENT
 //#DiffIgnore:rel.undefined-weak.dynamic.R_X86_64_GLOB_DAT
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 #define WEAK __attribute__((weak))
 

--- a/wild/tests/sources/elf/unresolved-symbols-object/unresolved-symbols-object.c
+++ b/wild/tests/sources/elf/unresolved-symbols-object/unresolved-symbols-object.c
@@ -34,7 +34,7 @@
 //#LinkArgs:--error-unresolved-symbols
 //#ExpectError:foo
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 int foo();
 

--- a/wild/tests/sources/elf/weak-entry/weak-entry-1.c
+++ b/wild/tests/sources/elf/weak-entry/weak-entry-1.c
@@ -1,4 +1,4 @@
-#include "runtime.h"
+#include "../common/runtime.h"
 
 void _start(void) {
   runtime_init();

--- a/wild/tests/sources/elf/weak-entry/weak-entry.c
+++ b/wild/tests/sources/elf/weak-entry/weak-entry.c
@@ -1,7 +1,7 @@
 //#Object:runtime.c
 //#Object:weak-entry-1.c
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 #define WEAK __attribute__((weak))
 

--- a/wild/tests/sources/elf/weak-fns-archive/weak-fns-archive.c
+++ b/wild/tests/sources/elf/weak-fns-archive/weak-fns-archive.c
@@ -3,7 +3,7 @@
 //#Object:runtime.c
 //#CompArgs:-fno-stack-protector
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 #if (VARIANT & 1) != 0
 int __attribute__((weak)) weak_fn1(void) {

--- a/wild/tests/sources/elf/weak-fns/weak-fns.c
+++ b/wild/tests/sources/elf/weak-fns/weak-fns.c
@@ -3,7 +3,7 @@
 //#Object:runtime.c
 //#CompArgs:-fno-stack-protector
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 #if (VARIANT & 1) != 0
 int __attribute__((weak)) weak_fn1(void) {

--- a/wild/tests/sources/elf/weak-vars-archive/weak-vars-archive.c
+++ b/wild/tests/sources/elf/weak-vars-archive/weak-vars-archive.c
@@ -3,7 +3,7 @@
 //#Object:runtime.c
 //#CompArgs:-fno-stack-protector
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 #if (VARIANT & 1) != 0
 int weak_var1 __attribute__((weak)) = 2;  // 64

--- a/wild/tests/sources/elf/weak-vars/weak-vars.c
+++ b/wild/tests/sources/elf/weak-vars/weak-vars.c
@@ -3,7 +3,7 @@
 //#Object:runtime.c
 //#CompArgs:-ffreestanding -fno-builtin -fno-stack-protector
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 #if (VARIANT & 1) != 0
 int weak_var1 __attribute__((weak)) = 2;  // 64

--- a/wild/tests/sources/elf/whole-archive/whole-archive.c
+++ b/wild/tests/sources/elf/whole-archive/whole-archive.c
@@ -2,7 +2,7 @@
 //#LinkArgs:--whole-archive
 //#Archive:whole_archive0.c
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 extern int __start_foo[];
 extern int __stop_foo[];

--- a/wild/tests/sources/elf/wrap-real-only/wrap-real-only.c
+++ b/wild/tests/sources/elf/wrap-real-only/wrap-real-only.c
@@ -2,7 +2,7 @@
 //#Object:wrap-real-only2.c
 //#LinkArgs:--wrap=foo
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 // Note that `__wrap_foo` is not defined anywhere.
 int __real_foo(void);

--- a/wild/tests/sources/elf/wrap/wrap.c
+++ b/wild/tests/sources/elf/wrap/wrap.c
@@ -9,7 +9,7 @@
 //#DiffIgnore:rel.R_X86_64_PC32.R_X86_64_PC32
 //#DiffIgnore:rel.R_AARCH64_CALL26.R_AARCH64_CALL26
 
-#include "runtime.h"
+#include "../common/runtime.h"
 
 // Defined weakly in wrap-1, but that gets overridden by the strong definition
 // in wrap-2.


### PR DESCRIPTION
This makes it easier for IDEs to find the file.