### PR TITLE
feat: handle output section header start addresses in linker scripts

### DIFF
--- a/LINKER_SCRIPT_SUPPORT.md
+++ b/LINKER_SCRIPT_SUPPORT.md
@@ -7,83 +7,83 @@ end lists the features required to link the Linux kernel.
 
 ## Top-Level Commands
 
-| Feature | Status | Notes |
-|---------|--------|-------|
-| `GROUP(files...)` | ✅ | |
-| `INPUT(files...)` | ✅ | |
-| `AS_NEEDED(files...)` | ✅ | |
-| `INCLUDE(file)` | 📅 | |
-| `OUTPUT_FORMAT(...)` | ✅ | Parsed and ignored |
-| `OUTPUT_ARCH(arch)` | ❌ | |
-| `OUTPUT(filename)` | ❌ | |
-| `SECTIONS { ... }` | ✅ | |
-| `ENTRY(symbol)` | ✅ | |
-| `VERSION { ... }` | ✅ | |
-| `PROVIDE(sym = expr)` | ✅ | |
-| `PROVIDE_HIDDEN(sym = expr)` | ✅ | |
-| `ASSERT(expr, "msg")` | ✅ | |
-| `MEMORY { ... }` | 🧪 | Region parsing supported; attribute flags and `>region` placement not yet implemented |
-| `REGION_ALIAS(alias, region)` | ❌ | |
-| `SEARCH_DIR(path)` | ❌ | |
-| `STARTUP(filename)` | ❌ | |
-| `TARGET(bfdname)` | ❌ | |
-| `NOCROSSREFS(sections...)` | ❌ | |
-| `INSERT [AFTER\|BEFORE] section` | ❌ | |
-| Top-level symbol assignment (`sym = expr`) | ✅ | |
-| Compound assignment operators (`+=`, `-=`, etc.) | ❌ | |
+| Feature                                          | Status | Notes                                                                                 |
+| ------------------------------------------------ | ------ | ------------------------------------------------------------------------------------- |
+| `GROUP(files...)`                                | ✅     |                                                                                       |
+| `INPUT(files...)`                                | ✅     |                                                                                       |
+| `AS_NEEDED(files...)`                            | ✅     |                                                                                       |
+| `INCLUDE(file)`                                  | 📅     |                                                                                       |
+| `OUTPUT_FORMAT(...)`                             | ✅     | Parsed and ignored                                                                    |
+| `OUTPUT_ARCH(arch)`                              | ❌     |                                                                                       |
+| `OUTPUT(filename)`                               | ❌     |                                                                                       |
+| `SECTIONS { ... }`                               | ✅     |                                                                                       |
+| `ENTRY(symbol)`                                  | ✅     |                                                                                       |
+| `VERSION { ... }`                                | ✅     |                                                                                       |
+| `PROVIDE(sym = expr)`                            | ✅     |                                                                                       |
+| `PROVIDE_HIDDEN(sym = expr)`                     | ✅     |                                                                                       |
+| `ASSERT(expr, "msg")`                            | ✅     |                                                                                       |
+| `MEMORY { ... }`                                 | 🧪     | Region parsing supported; attribute flags and `>region` placement not yet implemented |
+| `REGION_ALIAS(alias, region)`                    | ❌     |                                                                                       |
+| `SEARCH_DIR(path)`                               | ❌     |                                                                                       |
+| `STARTUP(filename)`                              | ❌     |                                                                                       |
+| `TARGET(bfdname)`                                | ❌     |                                                                                       |
+| `NOCROSSREFS(sections...)`                       | ❌     |                                                                                       |
+| `INSERT [AFTER\|BEFORE] section`                 | ❌     |                                                                                       |
+| Top-level symbol assignment (`sym = expr`)       | ✅     |                                                                                       |
+| Compound assignment operators (`+=`, `-=`, etc.) | ❌     |                                                                                       |
 
 ## SECTIONS Block
 
-| Feature | Status | Notes |
-|---------|--------|-------|
-| Output section definitions (`name : { ... }`) | ✅ | |
-| Input section matchers (`*(pattern)`, `file(pattern)`) | ✅ | |
-| Glob patterns in section and file names | ✅ | |
-| `KEEP(...)` to prevent garbage collection | ✅ | |
-| `PROVIDE(sym = expr)` inside sections | ✅ | |
-| `PROVIDE_HIDDEN(sym = expr)` inside sections | ✅ | |
-| Symbol assignment inside sections (`sym = .`) | 🧪 | Only assignment of the location counter (`sym = .`) is supported; arbitrary expressions on the right-hand side are not |
-| Location counter assignment (`. = expr`) | 🧪 | Hex address literals (e.g. `. = 0x1000`) supported between output sections only; not inside section contents |
-| `ALIGN(n)` on the location counter (`. = ALIGN(n)`) | ✅ | |
-| Per-section `ALIGN(n)` specifier | ✅ | |
-| `ASSERT(expr, "msg")` inside `SECTIONS` | ✅ | |
-| `OVERLAY { ... }` | ❌ | |
-| Output section type specifiers (`(NOLOAD)`, `(COPY)`, etc.) | 📅 | |
-| `FILL(value)` and `=fillexp` | 📅 | |
-| `AT(addr)` load-address specifier on output sections | 📅 | |
-| Numeric address between section name and `:` (e.g. `name 0 : { ... }`) | 📅 | |
-| `SORT_BY_NAME(...)`, `SORT_BY_ALIGNMENT(...)`, `SORT_BY_INIT_PRIORITY(...)` | 📅 | |
-| `EXCLUDE_FILE(...)` inside input section matchers | 📅 | |
-| `BYTE(expr)`, `SHORT(expr)`, `LONG(expr)`, `QUAD(expr)` output data | ❌ | |
-| `SUBALIGN(n)` forced input alignment | ❌ | |
-| `ONLY_IF_RO` / `ONLY_IF_RW` output section constraints | ❌ | |
+| Feature                                                                     | Status | Notes                                                                                                                  |
+| --------------------------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------- |
+| Output section definitions (`name : { ... }`)                               | ✅     |                                                                                                                        |
+| Input section matchers (`*(pattern)`, `file(pattern)`)                      | ✅     |                                                                                                                        |
+| Glob patterns in section and file names                                     | ✅     |                                                                                                                        |
+| `KEEP(...)` to prevent garbage collection                                   | ✅     |                                                                                                                        |
+| `PROVIDE(sym = expr)` inside sections                                       | ✅     |                                                                                                                        |
+| `PROVIDE_HIDDEN(sym = expr)` inside sections                                | ✅     |                                                                                                                        |
+| Symbol assignment inside sections (`sym = .`)                               | 🧪     | Only assignment of the location counter (`sym = .`) is supported; arbitrary expressions on the right-hand side are not |
+| Location counter assignment (`. = expr`)                                    | 🧪     | Hex address literals (e.g. `. = 0x1000`) supported between output sections only; not inside section contents           |
+| `ALIGN(n)` on the location counter (`. = ALIGN(n)`)                         | ✅     |                                                                                                                        |
+| Per-section `ALIGN(n)` specifier                                            | ✅     |                                                                                                                        |
+| `ASSERT(expr, "msg")` inside `SECTIONS`                                     | ✅     |                                                                                                                        |
+| `OVERLAY { ... }`                                                           | ❌     |                                                                                                                        |
+| Output section type specifiers (`(NOLOAD)`, `(COPY)`, etc.)                 | 📅     |                                                                                                                        |
+| `FILL(value)` and `=fillexp`                                                | 📅     |                                                                                                                        |
+| `AT(addr)` load-address specifier on output sections                        | 📅     |                                                                                                                        |
+| Numeric address between section name and `:` (e.g. `name 0 : { ... }`)      | 🧪     |                                                                                                                        |
+| `SORT_BY_NAME(...)`, `SORT_BY_ALIGNMENT(...)`, `SORT_BY_INIT_PRIORITY(...)` | 📅     |                                                                                                                        |
+| `EXCLUDE_FILE(...)` inside input section matchers                           | 📅     |                                                                                                                        |
+| `BYTE(expr)`, `SHORT(expr)`, `LONG(expr)`, `QUAD(expr)` output data         | ❌     |                                                                                                                        |
+| `SUBALIGN(n)` forced input alignment                                        | ❌     |                                                                                                                        |
+| `ONLY_IF_RO` / `ONLY_IF_RW` output section constraints                      | ❌     |                                                                                                                        |
 
 ## Expressions and Functions
 
-| Feature | Status | Notes |
-|---------|--------|-------|
-| Arithmetic operators: `+`, `-`, `*`, `/` | ✅ | |
-| Comparison operators: `<`, `>`, `<=`, `>=`, `==`, `!=` | ✅ | |
-| Bitwise operators: `&`, `\|`, `^`, `~`, `<<`, `>>` | ✅ | |
-| Logical operators: `&&`, `\|\|` | ✅ | |
-| Unary operators: `-`, `!`, `~` | ✅ | |
-| Numeric literals: decimal and hexadecimal | ✅ | |
-| Numeric literal K/M suffixes (e.g. `64K`, `2M`) | ✅ | |
-| Symbol references and location counter (`.`) | ✅ | |
-| Parenthesised sub-expressions | ✅ | |
-| `SIZEOF(section)` | ✅ | |
-| `ALIGNOF(section)` | ✅ | |
-| `ADDR(section)` | ✅ | |
-| `LOADADDR(section)` | 🧪 | Implemented as alias for `ADDR` (returns VMA); full LMA requires `AT(addr)` support |
-| `ALIGN(expr)` | ✅ | |
-| `LENGTH(region)` | ✅ | |
-| `ORIGIN(region)` | ✅ | |
-| `MIN(a, b)` | ✅ | |
-| `MAX(a, b)` | ✅ | |
-| Ternary operator (`condition ? a : b`) | 📅 | |
-| `DEFINED(sym)` | 📅 | |
-| `SIZEOF_HEADERS` | 📅 | |
-| `SEGMENT_START(segment, default)` | 📅 | |
+| Feature                                                | Status | Notes                                                                               |
+| ------------------------------------------------------ | ------ | ----------------------------------------------------------------------------------- |
+| Arithmetic operators: `+`, `-`, `*`, `/`               | ✅     |                                                                                     |
+| Comparison operators: `<`, `>`, `<=`, `>=`, `==`, `!=` | ✅     |                                                                                     |
+| Bitwise operators: `&`, `\|`, `^`, `~`, `<<`, `>>`     | ✅     |                                                                                     |
+| Logical operators: `&&`, `\|\|`                        | ✅     |                                                                                     |
+| Unary operators: `-`, `!`, `~`                         | ✅     |                                                                                     |
+| Numeric literals: decimal and hexadecimal              | ✅     |                                                                                     |
+| Numeric literal K/M suffixes (e.g. `64K`, `2M`)        | ✅     |                                                                                     |
+| Symbol references and location counter (`.`)           | ✅     |                                                                                     |
+| Parenthesised sub-expressions                          | ✅     |                                                                                     |
+| `SIZEOF(section)`                                      | ✅     |                                                                                     |
+| `ALIGNOF(section)`                                     | ✅     |                                                                                     |
+| `ADDR(section)`                                        | ✅     |                                                                                     |
+| `LOADADDR(section)`                                    | 🧪     | Implemented as alias for `ADDR` (returns VMA); full LMA requires `AT(addr)` support |
+| `ALIGN(expr)`                                          | ✅     |                                                                                     |
+| `LENGTH(region)`                                       | ✅     |                                                                                     |
+| `ORIGIN(region)`                                       | ✅     |                                                                                     |
+| `MIN(a, b)`                                            | ✅     |                                                                                     |
+| `MAX(a, b)`                                            | ✅     |                                                                                     |
+| Ternary operator (`condition ? a : b`)                 | 📅     |                                                                                     |
+| `DEFINED(sym)`                                         | 📅     |                                                                                     |
+| `SIZEOF_HEADERS`                                       | 📅     |                                                                                     |
+| `SEGMENT_START(segment, default)`                      | 📅     |                                                                                     |
 
 ## MEMORY Command
 
@@ -92,15 +92,15 @@ The `MEMORY` command defines named memory regions with an origin address and a l
 their expressions. Attribute flags such as `(rwx)` are not yet parsed. Placement directives that
 assign an output section to a named region (`>region`, `AT>region`) are not yet implemented.
 
-| Feature | Status | Notes |
-|---------|--------|-------|
-| `MEMORY { ... }` block parsing | ✅ | |
-| Region name | ✅ | |
-| `ORIGIN`/`org`/`o` attribute | ✅ | |
-| `LENGTH`/`len`/`l` attribute | ✅ | |
-| Attribute flags (`(rwx)`, `(rx)`, etc.) | 📅 | |
-| `>region` output section placement | 📅 | |
-| `AT>region` load-region placement | 📅 | |
+| Feature                                 | Status | Notes |
+| --------------------------------------- | ------ | ----- |
+| `MEMORY { ... }` block parsing          | ✅     |       |
+| Region name                             | ✅     |       |
+| `ORIGIN`/`org`/`o` attribute            | ✅     |       |
+| `LENGTH`/`len`/`l` attribute            | ✅     |       |
+| Attribute flags (`(rwx)`, `(rx)`, etc.) | 📅     |       |
+| `>region` output section placement      | 📅     |       |
+| `AT>region` load-region placement       | 📅     |       |
 
 ## Linux Kernel Requirements
 
@@ -109,17 +109,17 @@ related architecture-specific scripts. Several of these features are not yet ful
 Wild. The table below lists each such feature along with its current status, so contributors can
 see at a glance what remains before Wild can link the kernel.
 
-| Feature | Status | Notes |
-|---------|--------|-------|
-| `OVERLAY { ... }` sections | ❌ | |
-| Output section type specifiers (`(NOLOAD)`, `(COPY)`) | 📅 | |
-| `FILL(value)` and `=fillexp` | 📅 | |
-| `AT(addr)` load-address specifier on output sections | 📅 | |
-| `>region` and `AT>region` memory region placement | 📅 | |
-| `SORT_BY_NAME(...)`, `SORT_BY_ALIGNMENT(...)`, `SORT_BY_INIT_PRIORITY(...)` | 📅 | |
-| `EXCLUDE_FILE(...)` inside input section matchers | 📅 | |
-| `CONSTRUCTORS` command | 📅 | |
-| `PHDRS` command for explicit program header definition | 📅 | |
-| Ternary operator (`condition ? a : b`) | 📅 | |
-| `DEFINED(sym)` function | 📅 | |
-| `SIZEOF_HEADERS` built-in symbol | 📅 | |
+| Feature                                                                     | Status | Notes |
+| --------------------------------------------------------------------------- | ------ | ----- |
+| `OVERLAY { ... }` sections                                                  | ❌     |       |
+| Output section type specifiers (`(NOLOAD)`, `(COPY)`)                       | 📅     |       |
+| `FILL(value)` and `=fillexp`                                                | 📅     |       |
+| `AT(addr)` load-address specifier on output sections                        | 📅     |       |
+| `>region` and `AT>region` memory region placement                           | 📅     |       |
+| `SORT_BY_NAME(...)`, `SORT_BY_ALIGNMENT(...)`, `SORT_BY_INIT_PRIORITY(...)` | 📅     |       |
+| `EXCLUDE_FILE(...)` inside input section matchers                           | 📅     |       |
+| `CONSTRUCTORS` command                                                      | 📅     |       |
+| `PHDRS` command for explicit program header definition                      | 📅     |       |
+| Ternary operator (`condition ? a : b`)                                      | 📅     |       |
+| `DEFINED(sym)` function                                                     | 📅     |       |
+| `SIZEOF_HEADERS` built-in symbol                                            | 📅     |       |

--- a/LINKER_SCRIPT_SUPPORT.md
+++ b/LINKER_SCRIPT_SUPPORT.md
@@ -51,7 +51,7 @@ end lists the features required to link the Linux kernel.
 | Output section type specifiers (`(NOLOAD)`, `(COPY)`, etc.) | 📅 | |
 | `FILL(value)` and `=fillexp` | 📅 | |
 | `AT(addr)` load-address specifier on output sections | 📅 | |
-| Numeric address between section name and `:` (e.g. `name 0 : { ... }`) | 📅 | |
+| Numeric address between section name and `:` (e.g. `name 0 : { ... }`) | 🧪 | Only numeric literals are currently supported |
 | `SORT_BY_NAME(...)`, `SORT_BY_ALIGNMENT(...)`, `SORT_BY_INIT_PRIORITY(...)` | 📅 | |
 | `EXCLUDE_FILE(...)` inside input section matchers | 📅 | |
 | `BYTE(expr)`, `SHORT(expr)`, `LONG(expr)`, `QUAD(expr)` output data | ❌ | |

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -12,6 +12,8 @@ use crate::input_data::InputLinkerScript;
 use crate::input_data::InputRef;
 use crate::linker_script;
 use crate::linker_script::ContentsCommand;
+use crate::linker_script::Expression;
+use crate::linker_script::Location;
 use crate::linker_script::SectionCommand;
 use crate::output_section_id;
 use crate::output_section_id::OutputSectionId;
@@ -172,10 +174,23 @@ impl<'data> LayoutRulesBuilder<'data> {
                                 .unwrap_or(alignment::MIN)
                                 .max(replace(&mut extra_min_alignment, alignment::MIN));
 
+                            let section_location = match &sec.start_address_expression {
+                                Some(Expression::Number(address)) => {
+                                    location.take();
+                                    Some(Location { address: *address })
+                                }
+                                Some(_) => {
+                                    return Err(crate::error!(
+                                        "Only numeric output section start expressions are currently supported"
+                                    ));
+                                }
+                                None => location.take(),
+                            };
+
                             let primary_section_id = output_sections.add_named_section(
                                 SectionName(sec.output_section_name),
                                 min_alignment,
-                                location.take(),
+                                section_location,
                             );
 
                             let mut last_section_id = None;

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -100,6 +100,7 @@ pub(crate) struct Section<'a> {
     pub(crate) output_section_name: &'a [u8],
     pub(crate) commands: Vec<ContentsCommand<'a>>,
     pub(crate) alignment: Option<Alignment>,
+    pub(crate) start_address_expression: Option<Expression<'a>>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -894,6 +895,14 @@ fn parse_section_command<'input>(
         return Ok(cmd);
     }
 
+    let start_address_expression = if input.starts_with(b":") {
+        None
+    } else {
+        Some(parse_expression.parse_next(input)?)
+    };
+
+    skip_comments_and_whitespace(input)?;
+
     ':'.parse_next(input)?;
 
     skip_comments_and_whitespace(input)?;
@@ -915,6 +924,7 @@ fn parse_section_command<'input>(
         output_section_name: name,
         commands,
         alignment,
+        start_address_expression,
     }))
 }
 
@@ -1227,6 +1237,24 @@ mod tests {
                     }),
                 ],
                 alignment: None,
+                start_address_expression: None,
+            }),
+        );
+    }
+
+    #[test]
+    fn test_section_command_with_start_address_expression() {
+        check_section_command(
+            "__ksymtab 0 : ALIGN(8) { *(___ksymtab+) }",
+            &SectionCommand::Section(Section {
+                output_section_name: b"__ksymtab",
+                commands: vec![ContentsCommand::Matcher(Matcher {
+                    must_keep: false,
+                    input_file_pattern: None,
+                    input_section_name_patterns: vec![b"___ksymtab+"],
+                })],
+                alignment: Some(Alignment::new(8).unwrap()),
+                start_address_expression: Some(Expression::Number(0)),
             }),
         );
     }
@@ -1277,6 +1305,7 @@ mod tests {
                                     }),
                                 ],
                                 alignment: Some(Alignment::new(8).unwrap()),
+                                start_address_expression: None,
                             }),
                         ],
                     }),
@@ -1412,6 +1441,7 @@ mod tests {
                     }),
                 ],
                 alignment: None,
+                start_address_expression: None,
             }),
         );
     }
@@ -1428,6 +1458,7 @@ mod tests {
                     input_section_name_patterns: vec![b".ctors"],
                 })],
                 alignment: None,
+                start_address_expression: None,
             }),
         );
     }
@@ -1444,6 +1475,7 @@ mod tests {
                     input_section_name_patterns: vec![b".init"],
                 })],
                 alignment: None,
+                start_address_expression: None,
             }),
         );
     }
@@ -1468,6 +1500,7 @@ mod tests {
                                 input_section_name_patterns: vec![b".text"],
                             })],
                             alignment: None,
+                            start_address_expression: None,
                         })],
                     }),
                     Command::Assert(AssertCommand {
@@ -1503,6 +1536,7 @@ mod tests {
                                 input_section_name_patterns: vec![b".text"],
                             })],
                             alignment: None,
+                            start_address_expression: None,
                         }),
                         SectionCommand::Assert(AssertCommand {
                             expression: Expression::LessThan(

--- a/wild/tests/sources/elf/linker-script-section-start/linker-script-section-start.c
+++ b/wild/tests/sources/elf/linker-script-section-start/linker-script-section-start.c
@@ -1,20 +1,13 @@
 //#LinkerScript:linker-script-section-start.ld
-//#LinkerDriver:gcc
-//#LinkArgs:-no-pie
+//#Object:runtime.c
+//#DiffIgnore:segment.LOAD.RW.alignment
+// RISC-V: BFD complains about missing __global_pointer$ (defined in the default
+// linker script)
+//#SkipArch:riscv64
 //#ExpectSym:foo address=0x1000000
-//#DiffIgnore:section.rodata.alignment
-//#DiffIgnore:section.data
-//#DiffIgnore:section.sdata
-//#SkipArch:loongarch64
 
-/* BFD rejects similar absolute-placement code on loongarch with relocation
-   truncation. */
+#include "../common/runtime.h"
 
-#include <stdio.h>
+__attribute__((used, section(".foo"))) int foo = 7;
 
-__attribute__((section(".foo"))) void foo() { printf("foo\n"); }
-
-int main() {
-  foo();
-  return 42;
-}
+void begin_here(void) { exit_syscall(42); }

--- a/wild/tests/sources/elf/linker-script-section-start/linker-script-section-start.c
+++ b/wild/tests/sources/elf/linker-script-section-start/linker-script-section-start.c
@@ -1,0 +1,19 @@
+//#LinkerScript:linker-script-section-start.ld
+//#LinkerDriver:gcc
+//#LinkArgs:-no-pie
+//#ExpectSym:foo address=0x1000000
+//#DiffIgnore:section.rodata.alignment
+//#DiffIgnore:section.data
+//#DiffIgnore:section.sdata
+//#SkipArch:loongarch64
+
+/* BFD rejects similar absolute-placement code on loongarch with relocation truncation. */
+
+#include <stdio.h>
+
+__attribute__((section(".foo"))) void foo() { printf("foo\n"); }
+
+int main() {
+  foo();
+  return 42;
+}

--- a/wild/tests/sources/elf/linker-script-section-start/linker-script-section-start.c
+++ b/wild/tests/sources/elf/linker-script-section-start/linker-script-section-start.c
@@ -7,7 +7,8 @@
 //#DiffIgnore:section.sdata
 //#SkipArch:loongarch64
 
-/* BFD rejects similar absolute-placement code on loongarch with relocation truncation. */
+/* BFD rejects similar absolute-placement code on loongarch with relocation
+   truncation. */
 
 #include <stdio.h>
 

--- a/wild/tests/sources/elf/linker-script-section-start/linker-script-section-start.ld
+++ b/wild/tests/sources/elf/linker-script-section-start/linker-script-section-start.ld
@@ -1,8 +1,10 @@
+ENTRY(begin_here)
+
 SECTIONS
 {
-    .foo 0x1000000 : { *(.foo) }
-    .text : { *(.text) }
-    .rodata : { *(.rodata*) }
-    .data : { *(.data) }
-    .bss : { *(.bss) }
+    . = 0x600000;
+    .text : { *(.text .text.*) }
+    .foo 0x1000000 : { KEEP(*(.foo)) }
+    .data : { *(.data .data.*) }
+    .bss : { *(.bss .bss.*) }
 }

--- a/wild/tests/sources/elf/linker-script-section-start/linker-script-section-start.ld
+++ b/wild/tests/sources/elf/linker-script-section-start/linker-script-section-start.ld
@@ -1,0 +1,8 @@
+SECTIONS
+{
+    .foo 0x1000000 : { *(.foo) }
+    .text : { *(.text) }
+    .rodata : { *(.rodata*) }
+    .data : { *(.data) }
+    .bss : { *(.bss) }
+}


### PR DESCRIPTION
This PR adds support for output section headers that specify a numeric start address between the section name and `:` in linker scripts, such as `__ksymtab 0 : ALIGN(8) { ... }`.

It parses and stores that header value, lowers numeric expressions into the existing section location path during linker-script processing, and adds parser and integration test coverage for the new syntax.

Closes #1660.