### PR TITLE
feat: support SEGMENT_START function in Linker Script

### DIFF
--- a/LINKER_SCRIPT_SUPPORT.md
+++ b/LINKER_SCRIPT_SUPPORT.md
@@ -83,7 +83,7 @@ end lists the features required to link the Linux kernel.
 | Ternary operator (`condition ? a : b`) | 📅 | |
 | `DEFINED(sym)` | 📅 | |
 | `SIZEOF_HEADERS` | 📅 | |
-| `SEGMENT_START(segment, default)` | ✅ | Supports `"text"`, `"data"`, `"bss"`, `"rodata"`; unknown names use `default` with a warning |
+| `SEGMENT_START(segment, default)` | ✅ | Supports `"text"`, `"data"`, `"bss"`, `"rodata"`; returns `-Ttext`/`-Tdata`/`-Tbss` override if provided, otherwise `default`; unknown names are a parse error |
 
 ## MEMORY Command
 

--- a/LINKER_SCRIPT_SUPPORT.md
+++ b/LINKER_SCRIPT_SUPPORT.md
@@ -83,7 +83,7 @@ end lists the features required to link the Linux kernel.
 | Ternary operator (`condition ? a : b`) | 📅 | |
 | `DEFINED(sym)` | 📅 | |
 | `SIZEOF_HEADERS` | 📅 | |
-| `SEGMENT_START(segment, default)` | ✅ | Supports `"text"`, `"data"`, `"bss"`, `"rodata"`; returns `-Ttext`/`-Tdata`/`-Tbss` override if provided, otherwise `default`; unknown names are a parse error |
+| `SEGMENT_START(segment, default)` | ✅ | Supports `"text"`, `"data"`, `"bss"`, `"rodata"`; returns `-Ttext`/`-Tdata`/`-Tbss` override if provided, otherwise `default`; unknown segment names always return `default` |
 
 ## MEMORY Command
 

--- a/LINKER_SCRIPT_SUPPORT.md
+++ b/LINKER_SCRIPT_SUPPORT.md
@@ -83,7 +83,7 @@ end lists the features required to link the Linux kernel.
 | Ternary operator (`condition ? a : b`) | 📅 | |
 | `DEFINED(sym)` | 📅 | |
 | `SIZEOF_HEADERS` | 📅 | |
-| `SEGMENT_START(segment, default)` | 📅 | |
+| `SEGMENT_START(segment, default)` | ✅ | Supports `"text"`, `"data"`, `"bss"`, `"rodata"`; unknown names use `default` with a warning |
 
 ## MEMORY Command
 

--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -1920,6 +1920,15 @@ impl platform::Args for ElfArgs {
         }
     }
 
+    fn segment_start_override(&self, name: crate::parsing::SegmentName) -> Option<u64> {
+        match name {
+            crate::parsing::SegmentName::Text => self.ttext,
+            crate::parsing::SegmentName::Data => self.tdata,
+            crate::parsing::SegmentName::Bss => self.tbss,
+            crate::parsing::SegmentName::Rodata => None,
+        }
+    }
+
     fn version_script_path(&self) -> Option<&Path> {
         self.version_script_path.as_deref()
     }

--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -1925,7 +1925,7 @@ impl platform::Args for ElfArgs {
             crate::parsing::SegmentName::Text => self.ttext,
             crate::parsing::SegmentName::Data => self.tdata,
             crate::parsing::SegmentName::Bss => self.tbss,
-            crate::parsing::SegmentName::Rodata => None,
+            crate::parsing::SegmentName::Rodata | crate::parsing::SegmentName::Other => None,
         }
     }
 

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -24,6 +24,31 @@ fn line_number(file_bytes: &[u8], remainder: &[u8]) -> u32 {
     consumed.iter().filter(|&&b| b == b'\n').count() as u32 + 1
 }
 
+/// Evaluate a linker script expression that must be a compile-time constant.
+/// Returns `Err` for any expression that requires runtime context (symbols, location counter,
+/// etc.).
+pub(crate) fn eval_constant_expr(expr: &Expression<'_>) -> crate::error::Result<u64> {
+    match expr {
+        Expression::Number(n) => Ok(*n),
+        Expression::Add(l, r) => Ok(eval_constant_expr(l)?.wrapping_add(eval_constant_expr(r)?)),
+        Expression::Subtract(l, r) => {
+            Ok(eval_constant_expr(l)?.wrapping_sub(eval_constant_expr(r)?))
+        }
+        Expression::Multiply(l, r) => {
+            Ok(eval_constant_expr(l)?.wrapping_mul(eval_constant_expr(r)?))
+        }
+        Expression::Divide(l, r) => {
+            let d = eval_constant_expr(r)?;
+            if d == 0 {
+                return Err(crate::error!("division by zero in constant expression"));
+            }
+            Ok(eval_constant_expr(l)? / d)
+        }
+        Expression::Negate(e) => Ok(eval_constant_expr(e)?.wrapping_neg()),
+        _ => Err(crate::error!("expression is not a compile-time constant")),
+    }
+}
+
 /// Evaluate all ASSERT commands from all processed linker scripts.
 /// Must be called after layout is complete so section sizes/addresses are known.
 pub(crate) fn evaluate_assertions<'data, P: Platform>(

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -198,8 +198,8 @@ fn evaluate_expression<'data, P: Platform>(
                 })?;
             eval!(&region.length)
         }
-        // SEGMENT_START: segment layout is not available in this evaluator context,
-        // so fall back to evaluating the default expression.
+        // SEGMENT_START: segment layout and -T overrides are not available in this evaluator
+        // context, so fall back to evaluating the default expression.
         Expression::SegmentStart(_name, default_expr) => eval!(default_expr),
     }
 }

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -173,6 +173,9 @@ fn evaluate_expression<'data, P: Platform>(
                 })?;
             eval!(&region.length)
         }
+        // SEGMENT_START: segment layout is not available in this evaluator context,
+        // so fall back to evaluating the default expression.
+        Expression::SegmentStart(_name, default_expr) => eval!(default_expr),
     }
 }
 

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3304,17 +3304,20 @@ impl<'data, P: Platform> InternalSymbols<'data, P> {
     }
 }
 
-fn segment_name_matches(name: &str, def: impl crate::platform::ProgramSegmentDef) -> bool {
+fn segment_name_matches(name: &[u8], def: impl crate::platform::ProgramSegmentDef) -> bool {
     match name {
-        "text" => def.is_executable() && !def.is_writable(),
-        "data" | "bss" => def.is_writable() && !def.is_executable(),
-        "rodata" => !def.is_writable() && !def.is_executable(),
+        b"text" => def.is_executable() && !def.is_writable(),
+        b"data" | b"bss" => def.is_writable() && !def.is_executable(),
+        // rodata lives in a dedicated RO segment when one exists, but in a typical Linux
+        // executable it shares the RX segment with .text. Match any non-writable loadable
+        // segment so we find whichever one actually contains read-only data.
+        b"rodata" => !def.is_writable(),
         _ => false,
     }
 }
 
-fn is_known_segment_name(name: &str) -> bool {
-    matches!(name, "text" | "data" | "bss" | "rodata")
+fn is_known_segment_name(name: &[u8]) -> bool {
+    matches!(name, b"text" | b"data" | b"bss" | b"rodata")
 }
 
 fn create_start_end_symbol_resolution<'data, P: Platform>(
@@ -3385,7 +3388,8 @@ fn create_start_end_symbol_resolution<'data, P: Platform>(
         SymbolPlacement::SegmentStart(name, default) => {
             if !is_known_segment_name(name) {
                 resources.symbol_db.args.warning(format!(
-                    "SEGMENT_START: unknown segment name '{name}', using default 0x{default:x}"
+                    "SEGMENT_START: unknown segment name '{}', using default 0x{default:x}",
+                    String::from_utf8_lossy(name)
                 ));
             }
             resources
@@ -3394,7 +3398,7 @@ fn create_start_end_symbol_resolution<'data, P: Platform>(
                 .iter()
                 .find(|seg| {
                     let def = resources.program_segments.segment_def(seg.id);
-                    def.is_loadable() && segment_name_matches(name, *def)
+                    def.is_loadable() && seg.sizes.mem_size > 0 && segment_name_matches(name, *def)
                 })
                 .map_or(default, |seg| seg.sizes.mem_offset)
         }

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3304,22 +3304,6 @@ impl<'data, P: Platform> InternalSymbols<'data, P> {
     }
 }
 
-fn segment_name_matches(name: &[u8], def: impl crate::platform::ProgramSegmentDef) -> bool {
-    match name {
-        b"text" => def.is_executable() && !def.is_writable(),
-        b"data" | b"bss" => def.is_writable() && !def.is_executable(),
-        // rodata lives in a dedicated RO segment when one exists, but in a typical Linux
-        // executable it shares the RX segment with .text. Match any non-writable loadable
-        // segment so we find whichever one actually contains read-only data.
-        b"rodata" => !def.is_writable(),
-        _ => false,
-    }
-}
-
-fn is_known_segment_name(name: &[u8]) -> bool {
-    matches!(name, b"text" | b"data" | b"bss" | b"rodata")
-}
-
 fn create_start_end_symbol_resolution<'data, P: Platform>(
     memory_offsets: &mut OutputSectionPartMap<u64>,
     resources: &FinaliseLayoutResources<'_, 'data, P>,
@@ -3385,23 +3369,11 @@ fn create_start_end_symbol_resolution<'data, P: Platform>(
             .find(|seg| resources.program_segments.segment_def(seg.id).is_loadable())
             .map(|seg| seg.sizes.mem_offset)?,
 
-        SymbolPlacement::SegmentStart(name, default) => {
-            if !is_known_segment_name(name) {
-                resources.symbol_db.args.warning(format!(
-                    "SEGMENT_START: unknown segment name '{}', using default 0x{default:x}",
-                    String::from_utf8_lossy(name)
-                ));
-            }
-            resources
-                .segment_layouts
-                .segments
-                .iter()
-                .find(|seg| {
-                    let def = resources.program_segments.segment_def(seg.id);
-                    def.is_loadable() && seg.sizes.mem_size > 0 && segment_name_matches(name, *def)
-                })
-                .map_or(default, |seg| seg.sizes.mem_offset)
-        }
+        SymbolPlacement::SegmentStart(name, default) => resources
+            .symbol_db
+            .args
+            .segment_start_override(name)
+            .unwrap_or(default),
     };
 
     Some(P::create_resolution(

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3313,6 +3313,10 @@ fn segment_name_matches(name: &str, def: impl crate::platform::ProgramSegmentDef
     }
 }
 
+fn is_known_segment_name(name: &str) -> bool {
+    matches!(name, "text" | "data" | "bss" | "rodata")
+}
+
 fn create_start_end_symbol_resolution<'data, P: Platform>(
     memory_offsets: &mut OutputSectionPartMap<u64>,
     resources: &FinaliseLayoutResources<'_, 'data, P>,
@@ -3378,15 +3382,22 @@ fn create_start_end_symbol_resolution<'data, P: Platform>(
             .find(|seg| resources.program_segments.segment_def(seg.id).is_loadable())
             .map(|seg| seg.sizes.mem_offset)?,
 
-        SymbolPlacement::SegmentStart(name, default) => resources
-            .segment_layouts
-            .segments
-            .iter()
-            .find(|seg| {
-                let def = resources.program_segments.segment_def(seg.id);
-                def.is_loadable() && segment_name_matches(name, *def)
-            })
-            .map_or(default, |seg| seg.sizes.mem_offset),
+        SymbolPlacement::SegmentStart(name, default) => {
+            if !is_known_segment_name(name) {
+                resources.symbol_db.args.warning(format!(
+                    "SEGMENT_START: unknown segment name '{name}', using default 0x{default:x}"
+                ));
+            }
+            resources
+                .segment_layouts
+                .segments
+                .iter()
+                .find(|seg| {
+                    let def = resources.program_segments.segment_def(seg.id);
+                    def.is_loadable() && segment_name_matches(name, *def)
+                })
+                .map_or(default, |seg| seg.sizes.mem_offset)
+        }
     };
 
     Some(P::create_resolution(

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3304,6 +3304,15 @@ impl<'data, P: Platform> InternalSymbols<'data, P> {
     }
 }
 
+fn segment_name_matches(name: &str, def: impl crate::platform::ProgramSegmentDef) -> bool {
+    match name {
+        "text" => def.is_executable() && !def.is_writable(),
+        "data" | "bss" => def.is_writable() && !def.is_executable(),
+        "rodata" => !def.is_writable() && !def.is_executable(),
+        _ => false,
+    }
+}
+
 fn create_start_end_symbol_resolution<'data, P: Platform>(
     memory_offsets: &mut OutputSectionPartMap<u64>,
     resources: &FinaliseLayoutResources<'_, 'data, P>,
@@ -3368,6 +3377,16 @@ fn create_start_end_symbol_resolution<'data, P: Platform>(
             .iter()
             .find(|seg| resources.program_segments.segment_def(seg.id).is_loadable())
             .map(|seg| seg.sizes.mem_offset)?,
+
+        SymbolPlacement::SegmentStart(name, default) => resources
+            .segment_layouts
+            .segments
+            .iter()
+            .find(|seg| {
+                let def = resources.program_segments.segment_def(seg.id);
+                def.is_loadable() && segment_name_matches(name, *def)
+            })
+            .map_or(default, |seg| seg.sizes.mem_offset),
     };
 
     Some(P::create_resolution(

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3174,6 +3174,15 @@ impl<'data, P: Platform> InternalSymbols<'data, P> {
     }
 }
 
+fn segment_name_matches(name: &str, def: impl crate::platform::ProgramSegmentDef) -> bool {
+    match name {
+        "text" => def.is_executable() && !def.is_writable(),
+        "data" | "bss" => def.is_writable() && !def.is_executable(),
+        "rodata" => !def.is_writable() && !def.is_executable(),
+        _ => false,
+    }
+}
+
 fn create_start_end_symbol_resolution<'data, P: Platform>(
     memory_offsets: &mut OutputSectionPartMap<u64>,
     resources: &FinaliseLayoutResources<'_, 'data, P>,
@@ -3238,6 +3247,16 @@ fn create_start_end_symbol_resolution<'data, P: Platform>(
             .iter()
             .find(|seg| resources.program_segments.segment_def(seg.id).is_loadable())
             .map(|seg| seg.sizes.mem_offset)?,
+
+        SymbolPlacement::SegmentStart(name, default) => resources
+            .segment_layouts
+            .segments
+            .iter()
+            .find(|seg| {
+                let def = resources.program_segments.segment_def(seg.id);
+                def.is_loadable() && segment_name_matches(name, *def)
+            })
+            .map_or(default, |seg| seg.sizes.mem_offset),
     };
 
     Some(P::create_resolution(

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3183,6 +3183,10 @@ fn segment_name_matches(name: &str, def: impl crate::platform::ProgramSegmentDef
     }
 }
 
+fn is_known_segment_name(name: &str) -> bool {
+    matches!(name, "text" | "data" | "bss" | "rodata")
+}
+
 fn create_start_end_symbol_resolution<'data, P: Platform>(
     memory_offsets: &mut OutputSectionPartMap<u64>,
     resources: &FinaliseLayoutResources<'_, 'data, P>,
@@ -3248,15 +3252,22 @@ fn create_start_end_symbol_resolution<'data, P: Platform>(
             .find(|seg| resources.program_segments.segment_def(seg.id).is_loadable())
             .map(|seg| seg.sizes.mem_offset)?,
 
-        SymbolPlacement::SegmentStart(name, default) => resources
-            .segment_layouts
-            .segments
-            .iter()
-            .find(|seg| {
-                let def = resources.program_segments.segment_def(seg.id);
-                def.is_loadable() && segment_name_matches(name, *def)
-            })
-            .map_or(default, |seg| seg.sizes.mem_offset),
+        SymbolPlacement::SegmentStart(name, default) => {
+            if !is_known_segment_name(name) {
+                resources.symbol_db.args.warning(format!(
+                    "SEGMENT_START: unknown segment name '{name}', using default 0x{default:x}"
+                ));
+            }
+            resources
+                .segment_layouts
+                .segments
+                .iter()
+                .find(|seg| {
+                    let def = resources.program_segments.segment_def(seg.id);
+                    def.is_loadable() && segment_name_matches(name, *def)
+                })
+                .map_or(default, |seg| seg.sizes.mem_offset)
+        }
     };
 
     Some(P::create_resolution(

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -40,7 +40,7 @@ fn placement_from_symbol_definition_value<'data>(
     let placement = match value {
         Expression::SegmentStart(seg_name, default_expr) => {
             let default = crate::expression_eval::eval_constant_expr(default_expr).unwrap_or(0);
-            SymbolPlacement::SegmentStart(seg_name, default)
+            SymbolPlacement::SegmentStart(*seg_name, default)
         }
         Expression::Number(n) => SymbolPlacement::DefsymAbsolute(*n),
         Expression::Symbol(sym) => {
@@ -295,7 +295,7 @@ impl<'data> LayoutRulesBuilder<'data> {
                                                         default_expr,
                                                     )
                                                     .unwrap_or(0);
-                                                SymbolPlacement::SegmentStart(name, default)
+                                                SymbolPlacement::SegmentStart(*name, default)
                                             }
                                             _other => {
                                                 // Unsupported RHS expression: skip this symbol

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -28,6 +28,77 @@ use hashbrown::HashTable;
 use std::borrow::Cow;
 use std::mem::replace;
 
+/// Evaluate a linker script expression that must be a compile-time constant.
+/// Returns `Err` for any expression that requires runtime context (symbols, location counter,
+/// etc.).
+fn eval_constant_expr(expr: &crate::linker_script::Expression<'_>) -> crate::error::Result<u64> {
+    use crate::linker_script::Expression;
+    match expr {
+        Expression::Number(n) => Ok(*n),
+        Expression::Add(l, r) => Ok(eval_constant_expr(l)?.wrapping_add(eval_constant_expr(r)?)),
+        Expression::Subtract(l, r) => {
+            Ok(eval_constant_expr(l)?.wrapping_sub(eval_constant_expr(r)?))
+        }
+        Expression::Multiply(l, r) => {
+            Ok(eval_constant_expr(l)?.wrapping_mul(eval_constant_expr(r)?))
+        }
+        Expression::Divide(l, r) => {
+            let d = eval_constant_expr(r)?;
+            if d == 0 {
+                return Err(crate::error!("division by zero in constant expression"));
+            }
+            Ok(eval_constant_expr(l)? / d)
+        }
+        Expression::Negate(e) => Ok(eval_constant_expr(e)?.wrapping_neg()),
+        _ => Err(crate::error!("expression is not a compile-time constant")),
+    }
+}
+
+/// Determine the `SymbolPlacement` for a top-level symbol definition (`name = value;`).
+///
+/// Tries to parse `value` as a full linker script expression first (to handle `SEGMENT_START`
+/// and other builtins). Falls back to the legacy `parse_symbol_expression` path for simple
+/// cases like `0x1234` or `other_symbol+8`.
+///
+/// Returns `None` if the expression is unsupported (the symbol is silently skipped).
+fn placement_from_symbol_definition_value<'data>(
+    name: &[u8],
+    value: &'data [u8],
+) -> crate::error::Result<Option<SymbolPlacement<'data>>> {
+    use crate::linker_script::Expression;
+    use winnow::BStr;
+
+    // Try parsing as a full expression first.
+    let mut input = BStr::new(value);
+    if let Ok(expr) = crate::linker_script::parse_expression_pub(&mut input) {
+        let placement = match expr {
+            Expression::SegmentStart(seg_name, default_expr) => {
+                let default = eval_constant_expr(&default_expr).unwrap_or(0);
+                let name_str = std::str::from_utf8(seg_name)
+                    .map_err(|_| crate::error!("SEGMENT_START: segment name is not valid UTF-8"))?;
+                Some(SymbolPlacement::SegmentStart(name_str, default))
+            }
+            Expression::Number(n) => Some(SymbolPlacement::DefsymAbsolute(n)),
+            // For other expressions fall through to the legacy path below.
+            _ => None,
+        };
+        if let Some(p) = placement {
+            return Ok(Some(p));
+        }
+    }
+
+    // Legacy path: handles `0x1234`, `symbol`, `symbol+offset`.
+    let value_str = std::str::from_utf8(value).map_err(|_| {
+        crate::error!(
+            "Invalid UTF-8 in symbol value for '{}'",
+            String::from_utf8_lossy(name)
+        )
+    })?;
+    Ok(Some(
+        crate::parsing::parse_symbol_expression(value_str).to_placement(),
+    ))
+}
+
 pub(crate) struct LayoutRules<'data> {
     pub(crate) section_rules: SectionRules<'data>,
 }
@@ -149,11 +220,10 @@ impl<'data> LayoutRulesBuilder<'data> {
                         .with_hidden(provide.hidden),
                 );
             } else if let linker_script::Command::SymbolDefinition { name, value } = cmd {
-                let value_str = std::str::from_utf8(value)
-                    .map_err(|_| crate::error!("Invalid UTF-8 in symbol value"))?;
-
-                let placement = crate::parsing::parse_symbol_expression(value_str).to_placement();
-                symbol_defs.push(crate::parsing::InternalSymDefInfo::new(placement, name));
+                let placement = placement_from_symbol_definition_value(name, value)?;
+                if let Some(placement) = placement {
+                    symbol_defs.push(crate::parsing::InternalSymDefInfo::new(placement, name));
+                }
             } else if let linker_script::Command::Sections(sections) = cmd {
                 let mut location = None;
 
@@ -224,17 +294,35 @@ impl<'data> LayoutRulesBuilder<'data> {
                                         last_section_id = Some(section_id);
                                     }
                                     ContentsCommand::SymbolAssignment(assignment) => {
-                                        symbol_defs.push(if let Some(id) = last_section_id {
-                                            InternalSymDefInfo::new(
-                                                SymbolPlacement::SectionEnd(id),
-                                                assignment.name,
-                                            )
-                                        } else {
-                                            InternalSymDefInfo::new(
-                                                SymbolPlacement::SectionStart(primary_section_id),
-                                                assignment.name,
-                                            )
-                                        });
+                                        use crate::linker_script::Expression;
+                                        let placement = match &assignment.expr {
+                                            Expression::LocationCounter => {
+                                                if let Some(id) = last_section_id {
+                                                    SymbolPlacement::SectionEnd(id)
+                                                } else {
+                                                    SymbolPlacement::SectionStart(
+                                                        primary_section_id,
+                                                    )
+                                                }
+                                            }
+                                            Expression::SegmentStart(name, default_expr) => {
+                                                let default =
+                                                    eval_constant_expr(default_expr).unwrap_or(0);
+                                                let name_str = std::str::from_utf8(name).map_err(|_| {
+                                                    crate::error!("SEGMENT_START: segment name is not valid UTF-8")
+                                                })?;
+                                                SymbolPlacement::SegmentStart(name_str, default)
+                                            }
+                                            _other => {
+                                                // Unsupported RHS expression: skip this symbol
+                                                // definition
+                                                continue;
+                                            }
+                                        };
+                                        symbol_defs.push(InternalSymDefInfo::new(
+                                            placement,
+                                            assignment.name,
+                                        ));
                                     }
                                     ContentsCommand::Align(a) => extra_min_alignment = *a,
                                     ContentsCommand::Provide(provide) => {

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -28,78 +28,32 @@ use hashbrown::HashTable;
 use std::borrow::Cow;
 use std::mem::replace;
 
-/// Evaluate a linker script expression that must be a compile-time constant.
-/// Returns `Err` for any expression that requires runtime context (symbols, location counter,
-/// etc.).
-fn eval_constant_expr(expr: &crate::linker_script::Expression<'_>) -> crate::error::Result<u64> {
-    use crate::linker_script::Expression;
-    match expr {
-        Expression::Number(n) => Ok(*n),
-        Expression::Add(l, r) => Ok(eval_constant_expr(l)?.wrapping_add(eval_constant_expr(r)?)),
-        Expression::Subtract(l, r) => {
-            Ok(eval_constant_expr(l)?.wrapping_sub(eval_constant_expr(r)?))
-        }
-        Expression::Multiply(l, r) => {
-            Ok(eval_constant_expr(l)?.wrapping_mul(eval_constant_expr(r)?))
-        }
-        Expression::Divide(l, r) => {
-            let d = eval_constant_expr(r)?;
-            if d == 0 {
-                return Err(crate::error!("division by zero in constant expression"));
-            }
-            Ok(eval_constant_expr(l)? / d)
-        }
-        Expression::Negate(e) => Ok(eval_constant_expr(e)?.wrapping_neg()),
-        _ => Err(crate::error!("expression is not a compile-time constant")),
-    }
-}
-
 /// Determine the `SymbolPlacement` for a top-level symbol definition (`name = value;`).
 ///
-/// Parses `value` as a full linker script expression and maps it to a `SymbolPlacement`.
-/// Returns an error if the value cannot be parsed or is not fully consumed.
+/// Maps a parsed linker script expression to a `SymbolPlacement`.
 fn placement_from_symbol_definition_value<'data>(
     name: &[u8],
-    value: &'data [u8],
+    value: &crate::linker_script::Expression<'data>,
 ) -> crate::error::Result<SymbolPlacement<'data>> {
     use crate::linker_script::Expression;
-    use winnow::BStr;
 
-    let mut input = BStr::new(value);
-    let expr = crate::linker_script::parse_expression_pub(&mut input).map_err(|_| {
-        crate::error!(
-            "Failed to parse symbol value for '{}'",
-            String::from_utf8_lossy(name)
-        )
-    })?;
-
-    // Reject partial parses — trailing non-whitespace means the expression only
-    // matched a prefix of the value.
-    if !input.trim_ascii().is_empty() {
-        return Err(crate::error!(
-            "Unexpected trailing tokens in symbol value for '{}'",
-            String::from_utf8_lossy(name)
-        ));
-    }
-
-    let placement = match expr {
+    let placement = match value {
         Expression::SegmentStart(seg_name, default_expr) => {
-            let default = eval_constant_expr(&default_expr).unwrap_or(0);
-            let name_str = std::str::from_utf8(seg_name)
-                .map_err(|_| crate::error!("SEGMENT_START: segment name is not valid UTF-8"))?;
-            SymbolPlacement::SegmentStart(name_str, default)
+            let default = crate::expression_eval::eval_constant_expr(default_expr).unwrap_or(0);
+            SymbolPlacement::SegmentStart(seg_name, default)
         }
-        Expression::Number(n) => SymbolPlacement::DefsymAbsolute(n),
+        Expression::Number(n) => SymbolPlacement::DefsymAbsolute(*n),
         Expression::Symbol(sym) => {
             let sym_str = std::str::from_utf8(sym)
                 .map_err(|_| crate::error!("Symbol name is not valid UTF-8"))?;
             SymbolPlacement::DefsymSymbol(sym_str, 0)
         }
         Expression::Add(l, r) => {
-            if let (Expression::Symbol(sym), Expression::Number(offset)) = (*l, *r) {
+            if let (Expression::Symbol(sym), Expression::Number(offset)) = (l.as_ref(), r.as_ref())
+            {
                 let sym_str = std::str::from_utf8(sym)
                     .map_err(|_| crate::error!("Symbol name is not valid UTF-8"))?;
-                SymbolPlacement::DefsymSymbol(sym_str, offset as i64)
+                SymbolPlacement::DefsymSymbol(sym_str, *offset as i64)
             } else {
                 return Err(crate::error!(
                     "Unsupported expression in symbol definition for '{}'",
@@ -108,10 +62,11 @@ fn placement_from_symbol_definition_value<'data>(
             }
         }
         Expression::Subtract(l, r) => {
-            if let (Expression::Symbol(sym), Expression::Number(offset)) = (*l, *r) {
+            if let (Expression::Symbol(sym), Expression::Number(offset)) = (l.as_ref(), r.as_ref())
+            {
                 let sym_str = std::str::from_utf8(sym)
                     .map_err(|_| crate::error!("Symbol name is not valid UTF-8"))?;
-                SymbolPlacement::DefsymSymbol(sym_str, -(offset as i64))
+                SymbolPlacement::DefsymSymbol(sym_str, -(*offset as i64))
             } else {
                 return Err(crate::error!(
                     "Unsupported expression in symbol definition for '{}'",
@@ -336,11 +291,11 @@ impl<'data> LayoutRulesBuilder<'data> {
                                             }
                                             Expression::SegmentStart(name, default_expr) => {
                                                 let default =
-                                                    eval_constant_expr(default_expr).unwrap_or(0);
-                                                let name_str = std::str::from_utf8(name).map_err(|_| {
-                                                    crate::error!("SEGMENT_START: segment name is not valid UTF-8")
-                                                })?;
-                                                SymbolPlacement::SegmentStart(name_str, default)
+                                                    crate::expression_eval::eval_constant_expr(
+                                                        default_expr,
+                                                    )
+                                                    .unwrap_or(0);
+                                                SymbolPlacement::SegmentStart(name, default)
                                             }
                                             _other => {
                                                 // Unsupported RHS expression: skip this symbol

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -56,47 +56,78 @@ fn eval_constant_expr(expr: &crate::linker_script::Expression<'_>) -> crate::err
 
 /// Determine the `SymbolPlacement` for a top-level symbol definition (`name = value;`).
 ///
-/// Tries to parse `value` as a full linker script expression first (to handle `SEGMENT_START`
-/// and other builtins). Falls back to the legacy `parse_symbol_expression` path for simple
-/// cases like `0x1234` or `other_symbol+8`.
-///
-/// Returns `None` if the expression is unsupported (the symbol is silently skipped).
+/// Parses `value` as a full linker script expression and maps it to a `SymbolPlacement`.
+/// Returns an error if the value cannot be parsed or is not fully consumed.
 fn placement_from_symbol_definition_value<'data>(
     name: &[u8],
     value: &'data [u8],
-) -> crate::error::Result<Option<SymbolPlacement<'data>>> {
+) -> crate::error::Result<SymbolPlacement<'data>> {
     use crate::linker_script::Expression;
     use winnow::BStr;
 
-    // Try parsing as a full expression first.
     let mut input = BStr::new(value);
-    if let Ok(expr) = crate::linker_script::parse_expression_pub(&mut input) {
-        let placement = match expr {
-            Expression::SegmentStart(seg_name, default_expr) => {
-                let default = eval_constant_expr(&default_expr).unwrap_or(0);
-                let name_str = std::str::from_utf8(seg_name)
-                    .map_err(|_| crate::error!("SEGMENT_START: segment name is not valid UTF-8"))?;
-                Some(SymbolPlacement::SegmentStart(name_str, default))
-            }
-            Expression::Number(n) => Some(SymbolPlacement::DefsymAbsolute(n)),
-            // For other expressions fall through to the legacy path below.
-            _ => None,
-        };
-        if let Some(p) = placement {
-            return Ok(Some(p));
-        }
-    }
-
-    // Legacy path: handles `0x1234`, `symbol`, `symbol+offset`.
-    let value_str = std::str::from_utf8(value).map_err(|_| {
+    let expr = crate::linker_script::parse_expression_pub(&mut input).map_err(|_| {
         crate::error!(
-            "Invalid UTF-8 in symbol value for '{}'",
+            "Failed to parse symbol value for '{}'",
             String::from_utf8_lossy(name)
         )
     })?;
-    Ok(Some(
-        crate::parsing::parse_symbol_expression(value_str).to_placement(),
-    ))
+
+    // Reject partial parses — trailing non-whitespace means the expression only
+    // matched a prefix of the value.
+    if !input.trim_ascii().is_empty() {
+        return Err(crate::error!(
+            "Unexpected trailing tokens in symbol value for '{}'",
+            String::from_utf8_lossy(name)
+        ));
+    }
+
+    let placement = match expr {
+        Expression::SegmentStart(seg_name, default_expr) => {
+            let default = eval_constant_expr(&default_expr).unwrap_or(0);
+            let name_str = std::str::from_utf8(seg_name)
+                .map_err(|_| crate::error!("SEGMENT_START: segment name is not valid UTF-8"))?;
+            SymbolPlacement::SegmentStart(name_str, default)
+        }
+        Expression::Number(n) => SymbolPlacement::DefsymAbsolute(n),
+        Expression::Symbol(sym) => {
+            let sym_str = std::str::from_utf8(sym)
+                .map_err(|_| crate::error!("Symbol name is not valid UTF-8"))?;
+            SymbolPlacement::DefsymSymbol(sym_str, 0)
+        }
+        Expression::Add(l, r) => {
+            if let (Expression::Symbol(sym), Expression::Number(offset)) = (*l, *r) {
+                let sym_str = std::str::from_utf8(sym)
+                    .map_err(|_| crate::error!("Symbol name is not valid UTF-8"))?;
+                SymbolPlacement::DefsymSymbol(sym_str, offset as i64)
+            } else {
+                return Err(crate::error!(
+                    "Unsupported expression in symbol definition for '{}'",
+                    String::from_utf8_lossy(name)
+                ));
+            }
+        }
+        Expression::Subtract(l, r) => {
+            if let (Expression::Symbol(sym), Expression::Number(offset)) = (*l, *r) {
+                let sym_str = std::str::from_utf8(sym)
+                    .map_err(|_| crate::error!("Symbol name is not valid UTF-8"))?;
+                SymbolPlacement::DefsymSymbol(sym_str, -(offset as i64))
+            } else {
+                return Err(crate::error!(
+                    "Unsupported expression in symbol definition for '{}'",
+                    String::from_utf8_lossy(name)
+                ));
+            }
+        }
+        _ => {
+            return Err(crate::error!(
+                "Unsupported expression in symbol definition for '{}'",
+                String::from_utf8_lossy(name)
+            ));
+        }
+    };
+
+    Ok(placement)
 }
 
 pub(crate) struct LayoutRules<'data> {
@@ -221,9 +252,7 @@ impl<'data> LayoutRulesBuilder<'data> {
                 );
             } else if let linker_script::Command::SymbolDefinition { name, value } = cmd {
                 let placement = placement_from_symbol_definition_value(name, value)?;
-                if let Some(placement) = placement {
-                    symbol_defs.push(crate::parsing::InternalSymDefInfo::new(placement, name));
-                }
+                symbol_defs.push(crate::parsing::InternalSymDefInfo::new(placement, name));
             } else if let linker_script::Command::Sections(sections) = cmd {
                 let mut location = None;
 

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -26,6 +26,77 @@ use hashbrown::HashTable;
 use std::borrow::Cow;
 use std::mem::replace;
 
+/// Evaluate a linker script expression that must be a compile-time constant.
+/// Returns `Err` for any expression that requires runtime context (symbols, location counter,
+/// etc.).
+fn eval_constant_expr(expr: &crate::linker_script::Expression<'_>) -> crate::error::Result<u64> {
+    use crate::linker_script::Expression;
+    match expr {
+        Expression::Number(n) => Ok(*n),
+        Expression::Add(l, r) => Ok(eval_constant_expr(l)?.wrapping_add(eval_constant_expr(r)?)),
+        Expression::Subtract(l, r) => {
+            Ok(eval_constant_expr(l)?.wrapping_sub(eval_constant_expr(r)?))
+        }
+        Expression::Multiply(l, r) => {
+            Ok(eval_constant_expr(l)?.wrapping_mul(eval_constant_expr(r)?))
+        }
+        Expression::Divide(l, r) => {
+            let d = eval_constant_expr(r)?;
+            if d == 0 {
+                return Err(crate::error!("division by zero in constant expression"));
+            }
+            Ok(eval_constant_expr(l)? / d)
+        }
+        Expression::Negate(e) => Ok(eval_constant_expr(e)?.wrapping_neg()),
+        _ => Err(crate::error!("expression is not a compile-time constant")),
+    }
+}
+
+/// Determine the `SymbolPlacement` for a top-level symbol definition (`name = value;`).
+///
+/// Tries to parse `value` as a full linker script expression first (to handle `SEGMENT_START`
+/// and other builtins). Falls back to the legacy `parse_symbol_expression` path for simple
+/// cases like `0x1234` or `other_symbol+8`.
+///
+/// Returns `None` if the expression is unsupported (the symbol is silently skipped).
+fn placement_from_symbol_definition_value<'data>(
+    name: &[u8],
+    value: &'data [u8],
+) -> crate::error::Result<Option<SymbolPlacement<'data>>> {
+    use crate::linker_script::Expression;
+    use winnow::BStr;
+
+    // Try parsing as a full expression first.
+    let mut input = BStr::new(value);
+    if let Ok(expr) = crate::linker_script::parse_expression_pub(&mut input) {
+        let placement = match expr {
+            Expression::SegmentStart(seg_name, default_expr) => {
+                let default = eval_constant_expr(&default_expr).unwrap_or(0);
+                let name_str = std::str::from_utf8(seg_name)
+                    .map_err(|_| crate::error!("SEGMENT_START: segment name is not valid UTF-8"))?;
+                Some(SymbolPlacement::SegmentStart(name_str, default))
+            }
+            Expression::Number(n) => Some(SymbolPlacement::DefsymAbsolute(n)),
+            // For other expressions fall through to the legacy path below.
+            _ => None,
+        };
+        if let Some(p) = placement {
+            return Ok(Some(p));
+        }
+    }
+
+    // Legacy path: handles `0x1234`, `symbol`, `symbol+offset`.
+    let value_str = std::str::from_utf8(value).map_err(|_| {
+        crate::error!(
+            "Invalid UTF-8 in symbol value for '{}'",
+            String::from_utf8_lossy(name)
+        )
+    })?;
+    Ok(Some(
+        crate::parsing::parse_symbol_expression(value_str).to_placement(),
+    ))
+}
+
 pub(crate) struct LayoutRules<'data> {
     pub(crate) section_rules: SectionRules<'data>,
 }
@@ -147,11 +218,10 @@ impl<'data> LayoutRulesBuilder<'data> {
                         .with_hidden(provide.hidden),
                 );
             } else if let linker_script::Command::SymbolDefinition { name, value } = cmd {
-                let value_str = std::str::from_utf8(value)
-                    .map_err(|_| crate::error!("Invalid UTF-8 in symbol value"))?;
-
-                let placement = crate::parsing::parse_symbol_expression(value_str).to_placement();
-                symbol_defs.push(crate::parsing::InternalSymDefInfo::new(placement, name));
+                let placement = placement_from_symbol_definition_value(name, value)?;
+                if let Some(placement) = placement {
+                    symbol_defs.push(crate::parsing::InternalSymDefInfo::new(placement, name));
+                }
             } else if let linker_script::Command::Sections(sections) = cmd {
                 let mut location = None;
 
@@ -209,17 +279,35 @@ impl<'data> LayoutRulesBuilder<'data> {
                                         last_section_id = Some(section_id);
                                     }
                                     ContentsCommand::SymbolAssignment(assignment) => {
-                                        symbol_defs.push(if let Some(id) = last_section_id {
-                                            InternalSymDefInfo::new(
-                                                SymbolPlacement::SectionEnd(id),
-                                                assignment.name,
-                                            )
-                                        } else {
-                                            InternalSymDefInfo::new(
-                                                SymbolPlacement::SectionStart(primary_section_id),
-                                                assignment.name,
-                                            )
-                                        });
+                                        use crate::linker_script::Expression;
+                                        let placement = match &assignment.expr {
+                                            Expression::LocationCounter => {
+                                                if let Some(id) = last_section_id {
+                                                    SymbolPlacement::SectionEnd(id)
+                                                } else {
+                                                    SymbolPlacement::SectionStart(
+                                                        primary_section_id,
+                                                    )
+                                                }
+                                            }
+                                            Expression::SegmentStart(name, default_expr) => {
+                                                let default =
+                                                    eval_constant_expr(default_expr).unwrap_or(0);
+                                                let name_str = std::str::from_utf8(name).map_err(|_| {
+                                                    crate::error!("SEGMENT_START: segment name is not valid UTF-8")
+                                                })?;
+                                                SymbolPlacement::SegmentStart(name_str, default)
+                                            }
+                                            _other => {
+                                                // Unsupported RHS expression: skip this symbol
+                                                // definition
+                                                continue;
+                                            }
+                                        };
+                                        symbol_defs.push(InternalSymDefInfo::new(
+                                            placement,
+                                            assignment.name,
+                                        ));
                                     }
                                     ContentsCommand::Align(a) => extra_min_alignment = *a,
                                     ContentsCommand::Provide(provide) => {

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -54,47 +54,78 @@ fn eval_constant_expr(expr: &crate::linker_script::Expression<'_>) -> crate::err
 
 /// Determine the `SymbolPlacement` for a top-level symbol definition (`name = value;`).
 ///
-/// Tries to parse `value` as a full linker script expression first (to handle `SEGMENT_START`
-/// and other builtins). Falls back to the legacy `parse_symbol_expression` path for simple
-/// cases like `0x1234` or `other_symbol+8`.
-///
-/// Returns `None` if the expression is unsupported (the symbol is silently skipped).
+/// Parses `value` as a full linker script expression and maps it to a `SymbolPlacement`.
+/// Returns an error if the value cannot be parsed or is not fully consumed.
 fn placement_from_symbol_definition_value<'data>(
     name: &[u8],
     value: &'data [u8],
-) -> crate::error::Result<Option<SymbolPlacement<'data>>> {
+) -> crate::error::Result<SymbolPlacement<'data>> {
     use crate::linker_script::Expression;
     use winnow::BStr;
 
-    // Try parsing as a full expression first.
     let mut input = BStr::new(value);
-    if let Ok(expr) = crate::linker_script::parse_expression_pub(&mut input) {
-        let placement = match expr {
-            Expression::SegmentStart(seg_name, default_expr) => {
-                let default = eval_constant_expr(&default_expr).unwrap_or(0);
-                let name_str = std::str::from_utf8(seg_name)
-                    .map_err(|_| crate::error!("SEGMENT_START: segment name is not valid UTF-8"))?;
-                Some(SymbolPlacement::SegmentStart(name_str, default))
-            }
-            Expression::Number(n) => Some(SymbolPlacement::DefsymAbsolute(n)),
-            // For other expressions fall through to the legacy path below.
-            _ => None,
-        };
-        if let Some(p) = placement {
-            return Ok(Some(p));
-        }
-    }
-
-    // Legacy path: handles `0x1234`, `symbol`, `symbol+offset`.
-    let value_str = std::str::from_utf8(value).map_err(|_| {
+    let expr = crate::linker_script::parse_expression_pub(&mut input).map_err(|_| {
         crate::error!(
-            "Invalid UTF-8 in symbol value for '{}'",
+            "Failed to parse symbol value for '{}'",
             String::from_utf8_lossy(name)
         )
     })?;
-    Ok(Some(
-        crate::parsing::parse_symbol_expression(value_str).to_placement(),
-    ))
+
+    // Reject partial parses — trailing non-whitespace means the expression only
+    // matched a prefix of the value.
+    if !input.trim_ascii().is_empty() {
+        return Err(crate::error!(
+            "Unexpected trailing tokens in symbol value for '{}'",
+            String::from_utf8_lossy(name)
+        ));
+    }
+
+    let placement = match expr {
+        Expression::SegmentStart(seg_name, default_expr) => {
+            let default = eval_constant_expr(&default_expr).unwrap_or(0);
+            let name_str = std::str::from_utf8(seg_name)
+                .map_err(|_| crate::error!("SEGMENT_START: segment name is not valid UTF-8"))?;
+            SymbolPlacement::SegmentStart(name_str, default)
+        }
+        Expression::Number(n) => SymbolPlacement::DefsymAbsolute(n),
+        Expression::Symbol(sym) => {
+            let sym_str = std::str::from_utf8(sym)
+                .map_err(|_| crate::error!("Symbol name is not valid UTF-8"))?;
+            SymbolPlacement::DefsymSymbol(sym_str, 0)
+        }
+        Expression::Add(l, r) => {
+            if let (Expression::Symbol(sym), Expression::Number(offset)) = (*l, *r) {
+                let sym_str = std::str::from_utf8(sym)
+                    .map_err(|_| crate::error!("Symbol name is not valid UTF-8"))?;
+                SymbolPlacement::DefsymSymbol(sym_str, offset as i64)
+            } else {
+                return Err(crate::error!(
+                    "Unsupported expression in symbol definition for '{}'",
+                    String::from_utf8_lossy(name)
+                ));
+            }
+        }
+        Expression::Subtract(l, r) => {
+            if let (Expression::Symbol(sym), Expression::Number(offset)) = (*l, *r) {
+                let sym_str = std::str::from_utf8(sym)
+                    .map_err(|_| crate::error!("Symbol name is not valid UTF-8"))?;
+                SymbolPlacement::DefsymSymbol(sym_str, -(offset as i64))
+            } else {
+                return Err(crate::error!(
+                    "Unsupported expression in symbol definition for '{}'",
+                    String::from_utf8_lossy(name)
+                ));
+            }
+        }
+        _ => {
+            return Err(crate::error!(
+                "Unsupported expression in symbol definition for '{}'",
+                String::from_utf8_lossy(name)
+            ));
+        }
+    };
+
+    Ok(placement)
 }
 
 pub(crate) struct LayoutRules<'data> {
@@ -219,9 +250,7 @@ impl<'data> LayoutRulesBuilder<'data> {
                 );
             } else if let linker_script::Command::SymbolDefinition { name, value } = cmd {
                 let placement = placement_from_symbol_definition_value(name, value)?;
-                if let Some(placement) = placement {
-                    symbol_defs.push(crate::parsing::InternalSymDefInfo::new(placement, name));
-                }
+                symbol_defs.push(crate::parsing::InternalSymDefInfo::new(placement, name));
             } else if let linker_script::Command::Sections(sections) = cmd {
                 let mut location = None;
 

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -121,6 +121,7 @@ pub(crate) enum ContentsCommand<'a> {
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct SymbolAssignment<'a> {
     pub(crate) name: &'a [u8],
+    pub(crate) expr: Expression<'a>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -155,7 +156,7 @@ impl<'a> Eq for AssertCommand<'a> {}
 /// - Bitwise: &, |, ^, ~, <<, >>
 /// - Logical: &&, ||
 /// - Unary: -, !, ~
-/// - Functions: SIZEOF, ALIGNOF, LENGTH, ORIGIN, ADDR, LOADADDR, ALIGN, MIN, MAX
+/// - Functions: SIZEOF, ALIGNOF, LENGTH, ORIGIN, ADDR, LOADADDR, ALIGN, MIN, MAX, SEGMENT_START
 /// - Numbers (hex/decimal), symbols, location counter (.)
 /// - Parentheses for grouping
 ///
@@ -192,6 +193,11 @@ pub(crate) enum Expression<'a> {
     /// MIN and MAX functions (take two expressions)
     Min(Box<Expression<'a>>, Box<Expression<'a>>),
     Max(Box<Expression<'a>>, Box<Expression<'a>>),
+    /// SEGMENT_START("segment-name", default) — returns the start address of the named segment,
+    /// or `default` if no matching segment exists.
+    /// The first field is the segment name bytes (e.g. b"text"), the second is the default
+    /// expression.
+    SegmentStart(&'a [u8], Box<Expression<'a>>),
     /// Bitwise AND, OR and XOR
     BitwiseAnd(Box<Expression<'a>>, Box<Expression<'a>>),
     BitwiseOr(Box<Expression<'a>>, Box<Expression<'a>>),
@@ -424,6 +430,11 @@ fn parse_memory<'input>(input: &mut &'input BStr) -> winnow::Result<Vec<MemoryRe
 /// Parse an expression - entry point for expression parsing
 fn parse_expression<'a>(input: &mut &'a BStr) -> winnow::Result<Expression<'a>> {
     parse_logical_or.parse_next(input)
+}
+
+/// Public wrapper around `parse_expression` for use in other modules.
+pub(crate) fn parse_expression_pub<'a>(input: &mut &'a BStr) -> winnow::Result<Expression<'a>> {
+    parse_expression(input)
 }
 
 /// Parse logical OR: expression || expression
@@ -750,6 +761,21 @@ fn parse_identifier_or_function<'a>(input: &mut &'a BStr) -> winnow::Result<Expr
                 ')'.parse_next(input)?;
                 Ok(Expression::Max(Box::new(first), Box::new(second)))
             }
+            b"SEGMENT_START" => {
+                multispace0.parse_next(input)?;
+                '"'.parse_next(input)?;
+                let name = take_while(1.., |b: u8| b != b'"')
+                    .verify(|s: &[u8]| !s.is_empty())
+                    .parse_next(input)?;
+                '"'.parse_next(input)?;
+                multispace0.parse_next(input)?;
+                ','.parse_next(input)?;
+                multispace0.parse_next(input)?;
+                let default_expr = parse_expression.parse_next(input)?;
+                multispace0.parse_next(input)?;
+                ')'.parse_next(input)?;
+                Ok(Expression::SegmentStart(name, Box::new(default_expr)))
+            }
             _ => Err(ContextError::default()),
         }
     } else {
@@ -964,11 +990,24 @@ fn parse_assignment<'input>(input: &mut &'input BStr) -> winnow::Result<Contents
     '='.parse_next(input)?;
     skip_comments_and_whitespace(input)?;
 
+    let expr = parse_expression.parse_next(input)?;
+
     let cmd = if name == b"." {
-        ContentsCommand::Align(parse_alignment(input)?)
+        // `. = ALIGN(n)` inside section bodies
+        if let Expression::Align(alignment_expr) = &expr {
+            if let Expression::Number(n) = alignment_expr.as_ref() {
+                let alignment = Alignment::new(*n).map_err(|_| {
+                    ContextError::from_external_error(input, LinkerScriptError::InvalidAlignment)
+                })?;
+                ContentsCommand::Align(alignment)
+            } else {
+                return Err(ContextError::default());
+            }
+        } else {
+            return Err(ContextError::default());
+        }
     } else {
-        '.'.parse_next(input)?;
-        ContentsCommand::SymbolAssignment(SymbolAssignment { name })
+        ContentsCommand::SymbolAssignment(SymbolAssignment { name, expr })
     };
 
     opt(';').parse_next(input)?;
@@ -1293,6 +1332,7 @@ mod tests {
                                 commands: vec![
                                     ContentsCommand::SymbolAssignment(SymbolAssignment {
                                         name: b"start_foo",
+                                        expr: Expression::LocationCounter,
                                     }),
                                     ContentsCommand::Matcher(Matcher {
                                         must_keep: true,
@@ -1302,6 +1342,7 @@ mod tests {
                                     ContentsCommand::Align(Alignment::new(32).unwrap()),
                                     ContentsCommand::SymbolAssignment(SymbolAssignment {
                                         name: b"end_foo",
+                                        expr: Expression::LocationCounter,
                                     }),
                                 ],
                                 alignment: Some(Alignment::new(8).unwrap()),

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -195,7 +195,7 @@ pub(crate) enum Expression<'a> {
     Max(Box<Expression<'a>>, Box<Expression<'a>>),
     /// SEGMENT_START("segment-name", default) — returns the `-T` command-line override for the
     /// named segment if one was provided, otherwise returns `default`.
-    /// The segment name is validated at parse time; unknown names are a parse error.
+    /// Unknown segment names always return `default` (matching GNU ld behavior).
     SegmentStart(crate::parsing::SegmentName, Box<Expression<'a>>),
     /// Bitwise AND, OR and XOR
     BitwiseAnd(Box<Expression<'a>>, Box<Expression<'a>>),
@@ -768,9 +768,7 @@ fn parse_identifier_or_function<'a>(input: &mut &'a BStr) -> winnow::Result<Expr
                 let default_expr = parse_expression.parse_next(input)?;
                 multispace0.parse_next(input)?;
                 ')'.parse_next(input)?;
-                let segment_name = crate::parsing::SegmentName::from_bytes(name).map_err(|_| {
-                    ContextError::from_external_error(input, LinkerScriptError::UnknownSegmentName)
-                })?;
+                let segment_name = crate::parsing::SegmentName::from_bytes(name);
                 Ok(Expression::SegmentStart(
                     segment_name,
                     Box::new(default_expr),
@@ -1108,7 +1106,6 @@ fn to_str(bytes: &[u8]) -> Result<&str> {
 enum LinkerScriptError {
     InvalidAlignment,
     UnclosedComment,
-    UnknownSegmentName,
 }
 
 impl std::error::Error for LinkerScriptError {}
@@ -1118,9 +1115,6 @@ impl std::fmt::Display for LinkerScriptError {
         match self {
             LinkerScriptError::InvalidAlignment => write!(f, "Invalid alignment"),
             LinkerScriptError::UnclosedComment => write!(f, "Unclosed comment"),
-            LinkerScriptError::UnknownSegmentName => {
-                write!(f, "Unknown SEGMENT_START segment name")
-            }
         }
     }
 }

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -70,7 +70,7 @@ pub(crate) enum Command<'a> {
     Version(&'a [u8]),
     SymbolDefinition {
         name: &'a [u8],
-        value: &'a [u8],
+        value: Expression<'a>,
     },
     Provide(ProvideSymbolDefinition<'a>),
     Assert(AssertCommand<'a>),
@@ -316,8 +316,8 @@ fn parse_command<'input>(input: &mut &'input BStr) -> winnow::Result<Command<'in
                 // Symbol definition
                 '='.parse_next(input)?;
                 skip_comments_and_whitespace(input)?;
-                let value = take_while(1.., |b| b != b';').parse_next(input)?;
-                let value = value.trim_ascii_end();
+                let value = parse_expression.parse_next(input)?;
+                skip_comments_and_whitespace(input)?;
                 opt(';').parse_next(input)?;
                 Command::SymbolDefinition { name: other, value }
             } else {
@@ -430,11 +430,6 @@ fn parse_memory<'input>(input: &mut &'input BStr) -> winnow::Result<Vec<MemoryRe
 /// Parse an expression - entry point for expression parsing
 fn parse_expression<'a>(input: &mut &'a BStr) -> winnow::Result<Expression<'a>> {
     parse_logical_or.parse_next(input)
-}
-
-/// Public wrapper around `parse_expression` for use in other modules.
-pub(crate) fn parse_expression_pub<'a>(input: &mut &'a BStr) -> winnow::Result<Expression<'a>> {
-    parse_expression(input)
 }
 
 /// Parse logical OR: expression || expression

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -193,11 +193,10 @@ pub(crate) enum Expression<'a> {
     /// MIN and MAX functions (take two expressions)
     Min(Box<Expression<'a>>, Box<Expression<'a>>),
     Max(Box<Expression<'a>>, Box<Expression<'a>>),
-    /// SEGMENT_START("segment-name", default) — returns the start address of the named segment,
-    /// or `default` if no matching segment exists.
-    /// The first field is the segment name bytes (e.g. b"text"), the second is the default
-    /// expression.
-    SegmentStart(&'a [u8], Box<Expression<'a>>),
+    /// SEGMENT_START("segment-name", default) — returns the `-T` command-line override for the
+    /// named segment if one was provided, otherwise returns `default`.
+    /// The segment name is validated at parse time; unknown names are a parse error.
+    SegmentStart(crate::parsing::SegmentName, Box<Expression<'a>>),
     /// Bitwise AND, OR and XOR
     BitwiseAnd(Box<Expression<'a>>, Box<Expression<'a>>),
     BitwiseOr(Box<Expression<'a>>, Box<Expression<'a>>),
@@ -769,7 +768,13 @@ fn parse_identifier_or_function<'a>(input: &mut &'a BStr) -> winnow::Result<Expr
                 let default_expr = parse_expression.parse_next(input)?;
                 multispace0.parse_next(input)?;
                 ')'.parse_next(input)?;
-                Ok(Expression::SegmentStart(name, Box::new(default_expr)))
+                let segment_name = crate::parsing::SegmentName::from_bytes(name).map_err(|_| {
+                    ContextError::from_external_error(input, LinkerScriptError::UnknownSegmentName)
+                })?;
+                Ok(Expression::SegmentStart(
+                    segment_name,
+                    Box::new(default_expr),
+                ))
             }
             _ => Err(ContextError::default()),
         }
@@ -1103,6 +1108,7 @@ fn to_str(bytes: &[u8]) -> Result<&str> {
 enum LinkerScriptError {
     InvalidAlignment,
     UnclosedComment,
+    UnknownSegmentName,
 }
 
 impl std::error::Error for LinkerScriptError {}
@@ -1112,6 +1118,9 @@ impl std::fmt::Display for LinkerScriptError {
         match self {
             LinkerScriptError::InvalidAlignment => write!(f, "Invalid alignment"),
             LinkerScriptError::UnclosedComment => write!(f, "Unclosed comment"),
+            LinkerScriptError::UnknownSegmentName => {
+                write!(f, "Unknown SEGMENT_START segment name")
+            }
         }
     }
 }

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -120,6 +120,7 @@ pub(crate) enum ContentsCommand<'a> {
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct SymbolAssignment<'a> {
     pub(crate) name: &'a [u8],
+    pub(crate) expr: Expression<'a>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -154,7 +155,7 @@ impl<'a> Eq for AssertCommand<'a> {}
 /// - Bitwise: &, |, ^, ~, <<, >>
 /// - Logical: &&, ||
 /// - Unary: -, !, ~
-/// - Functions: SIZEOF, ALIGNOF, LENGTH, ORIGIN, ADDR, LOADADDR, ALIGN, MIN, MAX
+/// - Functions: SIZEOF, ALIGNOF, LENGTH, ORIGIN, ADDR, LOADADDR, ALIGN, MIN, MAX, SEGMENT_START
 /// - Numbers (hex/decimal), symbols, location counter (.)
 /// - Parentheses for grouping
 ///
@@ -191,6 +192,11 @@ pub(crate) enum Expression<'a> {
     /// MIN and MAX functions (take two expressions)
     Min(Box<Expression<'a>>, Box<Expression<'a>>),
     Max(Box<Expression<'a>>, Box<Expression<'a>>),
+    /// SEGMENT_START("segment-name", default) — returns the start address of the named segment,
+    /// or `default` if no matching segment exists.
+    /// The first field is the segment name bytes (e.g. b"text"), the second is the default
+    /// expression.
+    SegmentStart(&'a [u8], Box<Expression<'a>>),
     /// Bitwise AND, OR and XOR
     BitwiseAnd(Box<Expression<'a>>, Box<Expression<'a>>),
     BitwiseOr(Box<Expression<'a>>, Box<Expression<'a>>),
@@ -423,6 +429,11 @@ fn parse_memory<'input>(input: &mut &'input BStr) -> winnow::Result<Vec<MemoryRe
 /// Parse an expression - entry point for expression parsing
 fn parse_expression<'a>(input: &mut &'a BStr) -> winnow::Result<Expression<'a>> {
     parse_logical_or.parse_next(input)
+}
+
+/// Public wrapper around `parse_expression` for use in other modules.
+pub(crate) fn parse_expression_pub<'a>(input: &mut &'a BStr) -> winnow::Result<Expression<'a>> {
+    parse_expression(input)
 }
 
 /// Parse logical OR: expression || expression
@@ -749,6 +760,21 @@ fn parse_identifier_or_function<'a>(input: &mut &'a BStr) -> winnow::Result<Expr
                 ')'.parse_next(input)?;
                 Ok(Expression::Max(Box::new(first), Box::new(second)))
             }
+            b"SEGMENT_START" => {
+                multispace0.parse_next(input)?;
+                '"'.parse_next(input)?;
+                let name = take_while(1.., |b: u8| b != b'"')
+                    .verify(|s: &[u8]| !s.is_empty())
+                    .parse_next(input)?;
+                '"'.parse_next(input)?;
+                multispace0.parse_next(input)?;
+                ','.parse_next(input)?;
+                multispace0.parse_next(input)?;
+                let default_expr = parse_expression.parse_next(input)?;
+                multispace0.parse_next(input)?;
+                ')'.parse_next(input)?;
+                Ok(Expression::SegmentStart(name, Box::new(default_expr)))
+            }
             _ => Err(ContextError::default()),
         }
     } else {
@@ -954,11 +980,24 @@ fn parse_assignment<'input>(input: &mut &'input BStr) -> winnow::Result<Contents
     '='.parse_next(input)?;
     skip_comments_and_whitespace(input)?;
 
+    let expr = parse_expression.parse_next(input)?;
+
     let cmd = if name == b"." {
-        ContentsCommand::Align(parse_alignment(input)?)
+        // `. = ALIGN(n)` inside section bodies
+        if let Expression::Align(alignment_expr) = &expr {
+            if let Expression::Number(n) = alignment_expr.as_ref() {
+                let alignment = Alignment::new(*n).map_err(|_| {
+                    ContextError::from_external_error(input, LinkerScriptError::InvalidAlignment)
+                })?;
+                ContentsCommand::Align(alignment)
+            } else {
+                return Err(ContextError::default());
+            }
+        } else {
+            return Err(ContextError::default());
+        }
     } else {
-        '.'.parse_next(input)?;
-        ContentsCommand::SymbolAssignment(SymbolAssignment { name })
+        ContentsCommand::SymbolAssignment(SymbolAssignment { name, expr })
     };
 
     opt(';').parse_next(input)?;
@@ -1265,6 +1304,7 @@ mod tests {
                                 commands: vec![
                                     ContentsCommand::SymbolAssignment(SymbolAssignment {
                                         name: b"start_foo",
+                                        expr: Expression::LocationCounter,
                                     }),
                                     ContentsCommand::Matcher(Matcher {
                                         must_keep: true,
@@ -1274,6 +1314,7 @@ mod tests {
                                     ContentsCommand::Align(Alignment::new(32).unwrap()),
                                     ContentsCommand::SymbolAssignment(SymbolAssignment {
                                         name: b"end_foo",
+                                        expr: Expression::LocationCounter,
                                     }),
                                 ],
                                 alignment: Some(Alignment::new(8).unwrap()),

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -105,25 +105,25 @@ pub(crate) enum SymbolPlacement<'data> {
     SegmentStart(SegmentName, u64),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SegmentName {
     Text,
     Rodata,
     Data,
     Bss,
+    /// Any segment name not in the known set. Wild has no `-T` override for
+    /// these, so they always resolve to the default value.
+    Other,
 }
 
 impl SegmentName {
-    pub(crate) fn from_bytes(name: &[u8]) -> crate::error::Result<Self> {
+    pub(crate) fn from_bytes(name: &[u8]) -> Self {
         match name {
-            b"text" => Ok(Self::Text),
-            b"rodata" => Ok(Self::Rodata),
-            b"data" => Ok(Self::Data),
-            b"bss" => Ok(Self::Bss),
-            other => Err(crate::error!(
-                "unknown SEGMENT_START segment name '{}'",
-                String::from_utf8_lossy(other)
-            )),
+            b"text" => Self::Text,
+            b"rodata" => Self::Rodata,
+            b"data" => Self::Data,
+            b"bss" => Self::Bss,
+            _ => Self::Other,
         }
     }
 }

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -100,9 +100,9 @@ pub(crate) enum SymbolPlacement<'data> {
     LoadBaseAddress,
 
     /// Symbol will point to the start of the named program segment.
-    /// `name` is the conventional GNU ld segment name ("text", "data", "bss", "rodata").
+    /// `name` is the conventional GNU ld segment name (e.g. b"text", b"data", b"bss", b"rodata").
     /// `default` is the fallback address when no matching segment is found.
-    SegmentStart(&'data str, u64),
+    SegmentStart(&'data [u8], u64),
 }
 
 /// Result of parsing a defsym-style expression like "0x1000", "symbol", or "symbol+0x40".

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -99,10 +99,33 @@ pub(crate) enum SymbolPlacement<'data> {
     /// Symbol will point to the start of the first loadable segment.
     LoadBaseAddress,
 
-    /// Symbol will point to the start of the named program segment.
-    /// `name` is the conventional GNU ld segment name (e.g. b"text", b"data", b"bss", b"rodata").
-    /// `default` is the fallback address when no matching segment is found.
-    SegmentStart(&'data [u8], u64),
+    /// Symbol defined via `SEGMENT_START("name", default)` in a linker script.
+    /// Resolves to the value of the corresponding `-Ttext`/`-Tdata`/`-Tbss` command-line
+    /// override if provided, otherwise to `default`.
+    SegmentStart(SegmentName, u64),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum SegmentName {
+    Text,
+    Rodata,
+    Data,
+    Bss,
+}
+
+impl SegmentName {
+    pub(crate) fn from_bytes(name: &[u8]) -> crate::error::Result<Self> {
+        match name {
+            b"text" => Ok(Self::Text),
+            b"rodata" => Ok(Self::Rodata),
+            b"data" => Ok(Self::Data),
+            b"bss" => Ok(Self::Bss),
+            other => Err(crate::error!(
+                "unknown SEGMENT_START segment name '{}'",
+                String::from_utf8_lossy(other)
+            )),
+        }
+    }
 }
 
 /// Result of parsing a defsym-style expression like "0x1000", "symbol", or "symbol+0x40".

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -98,6 +98,11 @@ pub(crate) enum SymbolPlacement<'data> {
 
     /// Symbol will point to the start of the first loadable segment.
     LoadBaseAddress,
+
+    /// Symbol will point to the start of the named program segment.
+    /// `name` is the conventional GNU ld segment name ("text", "data", "bss", "rodata").
+    /// `default` is the fallback address when no matching segment is found.
+    SegmentStart(&'data str, u64),
 }
 
 /// Result of parsing a defsym-style expression like "0x1000", "symbol", or "symbol+0x40".

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -1254,6 +1254,13 @@ pub(crate) trait Args: std::fmt::Debug + Send + Sync + 'static {
         None
     }
 
+    /// Returns the address override for a `SEGMENT_START` segment name, as set via
+    /// `-Ttext`, `-Tdata` or `-Tbss` on the command line. Returns `None` if no override
+    /// was provided, in which case `SEGMENT_START` should return its default value.
+    fn segment_start_override(&self, _name: crate::parsing::SegmentName) -> Option<u64> {
+        None
+    }
+
     fn loadable_segment_alignment(&self) -> Alignment;
 
     fn should_merge_sections(&self) -> bool;

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -2042,7 +2042,8 @@ impl<'data, P: Platform> Prelude<'data, P> {
                 | SymbolPlacement::SectionEnd(_)
                 | SymbolPlacement::SectionGroupEnd(_)
                 | SymbolPlacement::DefsymSymbol(_, _)
-                | SymbolPlacement::LoadBaseAddress => {
+                | SymbolPlacement::LoadBaseAddress
+                | SymbolPlacement::SegmentStart(_, _) => {
                     outputs.add_non_versioned(PendingSymbol::new(symbol_id, definition.name));
                     ValueFlags::NON_INTERPOSABLE
                 }
@@ -2075,6 +2076,7 @@ impl<P: Platform> InternalSymDefInfo<'_, P> {
             // outside of the selected section. It's tricky for us to find the closest section
             // at this point in the code, so we pick an arbitrary section.
             SymbolPlacement::LoadBaseAddress => Some(output_section_id::TEXT),
+            SymbolPlacement::SegmentStart(_, _) => Some(output_section_id::TEXT),
         }
     }
 }

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -2026,7 +2026,8 @@ impl<'data, P: Platform> Prelude<'data, P> {
                 | SymbolPlacement::SectionEnd(_)
                 | SymbolPlacement::SectionGroupEnd(_)
                 | SymbolPlacement::DefsymSymbol(_, _)
-                | SymbolPlacement::LoadBaseAddress => {
+                | SymbolPlacement::LoadBaseAddress
+                | SymbolPlacement::SegmentStart(_, _) => {
                     outputs.add_non_versioned(PendingSymbol::new(symbol_id, definition.name));
                     ValueFlags::NON_INTERPOSABLE
                 }
@@ -2059,6 +2060,7 @@ impl<P: Platform> InternalSymDefInfo<'_, P> {
             // outside of the selected section. It's tricky for us to find the closest section
             // at this point in the code, so we pick an arbitrary section.
             SymbolPlacement::LoadBaseAddress => Some(output_section_id::TEXT),
+            SymbolPlacement::SegmentStart(_, _) => Some(output_section_id::TEXT),
         }
     }
 }

--- a/wild/tests/sources/elf/linker-script-segment-start/linker-script-segment-start.c
+++ b/wild/tests/sources/elf/linker-script-segment-start/linker-script-segment-start.c
@@ -1,13 +1,53 @@
 //#LinkerScript:linker-script-segment-start.ld
-//#RunEnabled:false
-//#DiffEnabled:false
-//#Mode:dynamic
-//#LinkArgs:-shared -z now
-//#CompArgs:-fPIC
-// Verify that SEGMENT_START("text", 0) defines __executable_start as a symbol.
-//#ExpectSym:__executable_start
+//#Object:runtime.c
+//#Object:ptr_black_box.c
+// RISC-V: BFD complains about missing __global_pointer$ (defined in the default
+// linker script)
+//#SkipArch:riscv64
+// ld merges all sections into a single RWE segment when no PHDRS are specified,
+// while wild uses separate RO/RX/RW segments. Ignore the resulting layout
+// diffs.
+//#DiffIgnore:segment.LOAD.RWX.alignment
+//#DiffIgnore:segment.LOAD.RX.alignment
 
-extern char __executable_start __attribute__((weak));
+#include <stddef.h>
 
-/* Referenced so the symbol is kept */
-void* get_executable_start(void) { return &__executable_start; }
+#include "../common/runtime.h"
+#include "ptr_black_box.h"
+
+/* Symbols defined via SEGMENT_START for each supported segment type */
+extern char text_start;
+extern char rodata_start;
+extern char data_start;
+extern char bss_start;
+
+/* Variables in each segment to verify the segment start is <= them */
+static const int rodata_var = 42;
+static int data_var = 1;
+static int bss_var;
+
+void _start(void) {
+  runtime_init();
+
+  /* text_start must be <= _start (both in the text segment) */
+  if (ptr_to_int(&text_start) > ptr_to_int(&_start)) {
+    exit_syscall(10);
+  }
+
+  /* rodata_start must be <= rodata_var */
+  if (ptr_to_int(&rodata_start) > ptr_to_int(&rodata_var)) {
+    exit_syscall(11);
+  }
+
+  /* data_start must be <= data_var */
+  if (ptr_to_int(&data_start) > ptr_to_int(&data_var)) {
+    exit_syscall(12);
+  }
+
+  /* bss_start must be <= bss_var */
+  if (ptr_to_int(&bss_start) > ptr_to_int(&bss_var)) {
+    exit_syscall(13);
+  }
+
+  exit_syscall(42);
+}

--- a/wild/tests/sources/elf/linker-script-segment-start/linker-script-segment-start.c
+++ b/wild/tests/sources/elf/linker-script-segment-start/linker-script-segment-start.c
@@ -5,9 +5,17 @@
 // RISC-V: BFD complains about missing __global_pointer$ (defined in the default
 // linker script)
 //#SkipArch:riscv64
+// ld merges all sections into a single segment when no PHDRS are specified,
+// while wild uses separate RO/RX/RW segments.
+//#DiffIgnore:segment.LOAD.RWX.alignment
+//#DiffIgnore:segment.LOAD.RX.alignment
+// Wild uses alignment 1 for .text when the linker script doesn't specify it;
+// GNU ld uses the architecture's natural instruction alignment (4 on aarch64).
+//#DiffIgnore:section.text.alignment
 
 // Config 1: no -T flags — SEGMENT_START returns the linker script defaults.
-// text/rodata default to 0x600000, data/bss default to 0.
+// Defaults are 0x10/0x11/0x12/0x13 — distinct from actual section addresses
+// to prove SEGMENT_START returns the default, not the actual segment address.
 //#Config:no-overrides:default
 //#Variant:0
 
@@ -30,15 +38,18 @@ extern char bss_start;
 void _start(void) {
   runtime_init();
 
-  /* Variant 0: no -T flags, SEGMENT_START returns the linker script defaults.
-   * Variant 1: -T overrides passed to Wild. rodata has no -T flag so it
-   *            still returns its default 0x600000. */
+  /* Variant 0: no -T flags, SEGMENT_START returns the linker script defaults
+   * (0x10, 0x11, 0x12, 0x13). These are intentionally distinct from the actual
+   * section addresses to prove SEGMENT_START returns the default, not the
+   * segment address.
+   * Variant 1: -T overrides. rodata has no -Trodata so it still returns 0x11.
+   */
   int variant = VARIANT;
 
-  unsigned long expect_text = (variant == 0) ? 0x600000 : 0x700000;
-  unsigned long expect_rodata = 0x600000; /* no -Trodata, always default */
-  unsigned long expect_data = (variant == 0) ? 0 : 0x800000;
-  unsigned long expect_bss = (variant == 0) ? 0 : 0x900000;
+  unsigned long expect_text = (variant == 0) ? 0x10 : 0x700000;
+  unsigned long expect_rodata = 0x11; /* no -Trodata, always default */
+  unsigned long expect_data = (variant == 0) ? 0x12 : 0x800000;
+  unsigned long expect_bss = (variant == 0) ? 0x13 : 0x900000;
 
   if (ptr_to_int(&text_start) != expect_text) {
     exit_syscall(10);

--- a/wild/tests/sources/elf/linker-script-segment-start/linker-script-segment-start.c
+++ b/wild/tests/sources/elf/linker-script-segment-start/linker-script-segment-start.c
@@ -1,51 +1,58 @@
+//#AbstractConfig:default
 //#LinkerScript:linker-script-segment-start.ld
 //#Object:runtime.c
 //#Object:ptr_black_box.c
 // RISC-V: BFD complains about missing __global_pointer$ (defined in the default
 // linker script)
 //#SkipArch:riscv64
-// ld merges all sections into a single RWE segment when no PHDRS are specified,
-// while wild uses separate RO/RX/RW segments. Ignore the resulting layout
-// diffs.
-//#DiffIgnore:segment.LOAD.RWX.alignment
-//#DiffIgnore:segment.LOAD.RX.alignment
 
-#include <stddef.h>
+// Config 1: no -T flags — SEGMENT_START returns the linker script defaults.
+// text/rodata default to 0x600000, data/bss default to 0.
+//#Config:no-overrides:default
+//#Variant:0
 
+// Config 2: -Ttext/-Tdata/-Tbss overrides. Both Wild and GNU ld honor these
+// alongside a linker script. lld ignores -T* when a linker script is present,
+// so we skip it here.
+//#Config:with-T-overrides:default
+//#SkipLinker:lld
+//#LinkArgs:-Ttext=0x700000 -Tdata=0x800000 -Tbss=0x900000
+//#Variant:1
+
+#include "../common/ptr_black_box.h"
 #include "../common/runtime.h"
-#include "ptr_black_box.h"
 
-/* Symbols defined via SEGMENT_START for each supported segment type */
 extern char text_start;
 extern char rodata_start;
 extern char data_start;
 extern char bss_start;
 
-/* Variables in each segment to verify the segment start is <= them */
-static const int rodata_var = 42;
-static int data_var = 1;
-static int bss_var;
-
 void _start(void) {
   runtime_init();
 
-  /* text_start must be <= _start (both in the text segment) */
-  if (ptr_to_int(&text_start) > ptr_to_int(&_start)) {
+  /* Variant 0: no -T flags, SEGMENT_START returns the linker script defaults.
+   * Variant 1: -T overrides passed to Wild. rodata has no -T flag so it
+   *            still returns its default 0x600000. */
+  int variant = VARIANT;
+
+  unsigned long expect_text = (variant == 0) ? 0x600000 : 0x700000;
+  unsigned long expect_rodata = 0x600000; /* no -Trodata, always default */
+  unsigned long expect_data = (variant == 0) ? 0 : 0x800000;
+  unsigned long expect_bss = (variant == 0) ? 0 : 0x900000;
+
+  if (ptr_to_int(&text_start) != expect_text) {
     exit_syscall(10);
   }
 
-  /* rodata_start must be <= rodata_var */
-  if (ptr_to_int(&rodata_start) > ptr_to_int(&rodata_var)) {
+  if (ptr_to_int(&rodata_start) != expect_rodata) {
     exit_syscall(11);
   }
 
-  /* data_start must be <= data_var */
-  if (ptr_to_int(&data_start) > ptr_to_int(&data_var)) {
+  if (ptr_to_int(&data_start) != expect_data) {
     exit_syscall(12);
   }
 
-  /* bss_start must be <= bss_var */
-  if (ptr_to_int(&bss_start) > ptr_to_int(&bss_var)) {
+  if (ptr_to_int(&bss_start) != expect_bss) {
     exit_syscall(13);
   }
 

--- a/wild/tests/sources/elf/linker-script-segment-start/linker-script-segment-start.c
+++ b/wild/tests/sources/elf/linker-script-segment-start/linker-script-segment-start.c
@@ -1,0 +1,13 @@
+//#LinkerScript:linker-script-segment-start.ld
+//#RunEnabled:false
+//#DiffEnabled:false
+//#Mode:dynamic
+//#LinkArgs:-shared -z now
+//#CompArgs:-fPIC
+// Verify that SEGMENT_START("text", 0) defines __executable_start as a symbol.
+//#ExpectSym:__executable_start
+
+extern char __executable_start __attribute__((weak));
+
+/* Referenced so the symbol is kept */
+void* get_executable_start(void) { return &__executable_start; }

--- a/wild/tests/sources/elf/linker-script-segment-start/linker-script-segment-start.ld
+++ b/wild/tests/sources/elf/linker-script-segment-start/linker-script-segment-start.ld
@@ -1,8 +1,16 @@
-__executable_start = SEGMENT_START("text", 0);
+ENTRY(_start)
+
+text_start = SEGMENT_START("text", 0x600000);
+rodata_start = SEGMENT_START("rodata", 0x600000);
+data_start = SEGMENT_START("data", 0);
+bss_start = SEGMENT_START("bss", 0);
 
 SECTIONS {
-    .text : { *(.text .text.*) }
-    .rodata : { *(.rodata .rodata.*) }
-    .data : { *(.data .data.*) }
-    .bss : { *(.bss .bss.*) }
+  . = 0x600000;
+  .text : {
+    *(.text .text.*)
+  }
+  .rodata : { *(.rodata .rodata.*) }
+  .data : { *(.data .data.*) }
+  .bss : { *(.bss .bss.*) }
 }

--- a/wild/tests/sources/elf/linker-script-segment-start/linker-script-segment-start.ld
+++ b/wild/tests/sources/elf/linker-script-segment-start/linker-script-segment-start.ld
@@ -1,0 +1,8 @@
+__executable_start = SEGMENT_START("text", 0);
+
+SECTIONS {
+    .text : { *(.text .text.*) }
+    .rodata : { *(.rodata .rodata.*) }
+    .data : { *(.data .data.*) }
+    .bss : { *(.bss .bss.*) }
+}

--- a/wild/tests/sources/elf/linker-script-segment-start/linker-script-segment-start.ld
+++ b/wild/tests/sources/elf/linker-script-segment-start/linker-script-segment-start.ld
@@ -1,9 +1,9 @@
 ENTRY(_start)
 
-text_start = SEGMENT_START("text", 0x600000);
-rodata_start = SEGMENT_START("rodata", 0x600000);
-data_start = SEGMENT_START("data", 0);
-bss_start = SEGMENT_START("bss", 0);
+text_start = SEGMENT_START("text", 0x10);
+rodata_start = SEGMENT_START("rodata", 0x11);
+data_start = SEGMENT_START("data", 0x12);
+bss_start = SEGMENT_START("bss", 0x13);
 
 SECTIONS {
   . = 0x600000;


### PR DESCRIPTION
Implements SEGMENT_START("name", default) in linker script parsing and resolution. Fixes linking of binaries that use __executable_start = SEGMENT_START("text", 0) in their linker scripts.

Closes  #1098