### PR TITLE
fix: use correct addend for relocs referencing STT_SECTION

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -1707,6 +1707,16 @@ fn write_rela_sections<'data>(
                         .flatten()
                 })
                 .unwrap_or(0);
+            let addend = sym
+                .and_then(|s| {
+                    let sym_entry = object.object.symbol(s).ok()?;
+                    if sym_entry.st_type() != object::elf::STT_SECTION {
+                        return None;
+                    }
+                    let sec_idx = object.object.symbol_section(sym_entry, s).ok()??;
+                    object.section_resolutions[sec_idx.0].address()
+                })
+                .map_or(addend, |offset| addend + offset as i64);
             out.r_offset.set(e, section_address + offset);
             out.r_addend.set(e, addend);
             out.set_r_info(e, false, sym_idx, r_type);

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -27,7 +27,6 @@ tests = [
   "oformat-binary.sh",
   "omagic.sh",
   "package-metadata.sh",
-  "relocatable-exception.sh",
   "relocatable-merge-sections.sh",
   "repro.sh",                          # Note in this test's second half that it uses a custom environment variable called `MOLD_REPRO`. While Wild currently doesn't support `--repro`, it will eventually be moved to the "ignore" group once support is added.
   "require-defined.sh",


### PR DESCRIPTION
When linking with the -r flag, we now correctly increment the addend of relocations referencing `STT_SECTION`, when multiple input sections are merged.