### PR TITLE
port(MachO): make __DATA segment optional

### DIFF
--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -61,6 +61,7 @@ pub(crate) const MACHO_COMMAND_ALIGNMENT: usize = 8;
 
 /// A path to the default dynamic linker.
 pub(crate) const DYLINKER_PATH: &[u8] = b"/usr/lib/dyld";
+// TODO: optionality of __DATA and __CONST_DATA segments not respected
 pub(crate) const DEFAULT_SEGMENT_COUNT: usize = 4;
 pub(crate) const CHAINED_FIXUP_TABLE_SIZE: u64 =
     (size_of::<ChainedFixupsHeader>() + size_of::<u32>() * (DEFAULT_SEGMENT_COUNT + 1 + 1)) as u64;
@@ -80,7 +81,7 @@ pub(crate) type CodeSignatureCommand = object::macho::LinkeditDataCommand<Endian
 pub(crate) type DyldChainedFixupsCommand = object::macho::LinkeditDataCommand<Endianness>;
 pub(crate) type ChainedFixupsHeader = DyldChainedFixupsHeader<Endianness>;
 
-// TODO: move to object crate
+// TODO: move the following data types to object crate
 
 // values for dyld_chained_fixups_header.imports_format
 #[allow(non_camel_case_types)]
@@ -708,7 +709,13 @@ impl platform::ProgramSegmentDef for ProgramSegmentDef {
     }
 
     fn always_keep(self) -> bool {
-        true
+        matches!(
+            self.segment_type,
+            SegmentType::Text
+                | SegmentType::LoadCommands
+                | SegmentType::TextSections
+                | SegmentType::LinkeditSections
+        )
     }
 
     fn is_loadable(self) -> bool {
@@ -1164,13 +1171,17 @@ impl platform::Platform for MachO {
                     * count_sections_for_segment_type(output_sections, SegmentType::TextSections))
                 as u64,
         );
-        sizes.increment(
-            part_id::DATA_SEGMENT,
-            (size_of::<SegmentCommand>()
-                + size_of::<SectionEntry>()
-                    * count_sections_for_segment_type(output_sections, SegmentType::DataSections))
-                as u64,
-        );
+        if has_active_segment(header_info, SegmentType::DataSections) {
+            sizes.increment(
+                part_id::DATA_SEGMENT,
+                (size_of::<SegmentCommand>()
+                    + size_of::<SectionEntry>()
+                        * count_sections_for_segment_type(
+                            output_sections,
+                            SegmentType::DataSections,
+                        )) as u64,
+            );
+        }
         sizes.increment(
             part_id::LINK_EDIT_SEGMENT,
             size_of::<SegmentCommand>() as u64,
@@ -1452,6 +1463,14 @@ const PROGRAM_SEGMENT_DEFS: &[ProgramSegmentDef] = &[
     },
 ];
 
+fn has_active_segment(header_info: &crate::layout::HeaderInfo, segment_type: SegmentType) -> bool {
+    header_info.active_segment_ids.iter().any(|id| {
+        PROGRAM_SEGMENT_DEFS
+            .get(id.as_usize())
+            .is_some_and(|def| def.segment_type == segment_type)
+    })
+}
+
 fn count_sections_for_segment_type(
     output_sections: &crate::output_section_id::OutputSections<MachO>,
     segment_type: SegmentType,
@@ -1474,7 +1493,7 @@ pub(crate) struct SegmentSectionsInfo<'data> {
 pub(crate) fn get_segment_sections<'data>(
     layout: &Layout<'data, MachO>,
     segment_type: SegmentType,
-) -> SegmentSectionsInfo<'data> {
+) -> Option<SegmentSectionsInfo<'data>> {
     let mut in_matching_segment = false;
     let mut sections = Vec::new();
     let mut segment_id = None;
@@ -1506,14 +1525,15 @@ pub(crate) fn get_segment_sections<'data>(
     }
 
     let segment_id = segment_id.expect("must be visited in the output order");
-    SegmentSectionsInfo {
+    let segment_size = layout
+        .segment_layouts
+        .segments
+        .iter()
+        .find(|seg| seg.id == segment_id)
+        .map(|seg| seg.sizes);
+
+    segment_size.map(|segment_size| SegmentSectionsInfo {
         segment_sections: sections,
-        segment_size: layout
-            .segment_layouts
-            .segments
-            .iter()
-            .find(|seg| seg.id == segment_id)
-            .unwrap()
-            .sizes,
-    }
+        segment_size,
+    })
 }

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -118,7 +118,7 @@ fn write_prelude<'data, A: Arch<Platform = MachO>>(
     let header: &mut FileHeader = from_bytes_mut(buffers.get_mut(part_id::FILE_HEADER))
         .map_err(|_| error!("Invalid file header allocation"))?
         .0;
-    populate_file_header::<A>(layout, &prelude.header_info, header);
+    populate_file_header::<A>(layout, &prelude.header_info, header)?;
 
     write_segment_commands::<A>(layout, buffers)?;
 
@@ -126,7 +126,7 @@ fn write_prelude<'data, A: Arch<Platform = MachO>>(
         from_bytes_mut(buffers.get_mut(part_id::ENTRY_POINT))
             .map_err(|_| error!("Invalid ENTRY_POINT command allocation"))?
             .0;
-    write_entry_point_command::<A>(layout, entry_point_command);
+    write_entry_point_command::<A>(layout, entry_point_command)?;
 
     let (dylinker_command, dylinker_path_buffer): (&mut DylinkerCommand, &mut [u8]) =
         from_bytes_mut(buffers.get_mut(part_id::INTERP))
@@ -165,20 +165,30 @@ fn populate_file_header<A: Arch<Platform = MachO>>(
     layout: &MachOLayout,
     _header_info: &HeaderInfo,
     header: &mut FileHeader,
-) {
-    let load_commands_info = get_segment_sections(layout, SegmentType::LoadCommands);
+) -> Result {
+    let load_commands_info = get_segment_sections(layout, SegmentType::LoadCommands)
+        .ok_or_else(|| error!("LoadCommands segment is mandatory"))?;
 
     header.magic = U32::new(BigEndian, MH_CIGAM_64);
     header.cputype = U32::new(LE, CPU_TYPE_ARM64);
     header.cpusubtype = U32::new(LE, 0);
     header.filetype = U32::new(LE, MH_EXECUTE);
-    header.ncmds = U32::new(LE, load_commands_info.segment_sections.len() as u32);
+    // TODO: a cleaner way how to filter out sections being part of the final output?
+    header.ncmds = U32::new(
+        LE,
+        load_commands_info
+            .segment_sections
+            .iter()
+            .filter(|s| s.0.mem_size > 0)
+            .count() as u32,
+    );
     header.sizeofcmds = U32::new(LE, load_commands_info.segment_size.file_size as u32);
     header.flags = U32::new(
         LE,
         macho::MH_PIE | macho::MH_DYLDLINK | macho::MH_NOUNDEFS | macho::MH_TWOLEVEL,
     );
     header.reserved = U32::new(LE, 0);
+    Ok(())
 }
 
 fn split_segment_command_buffer(
@@ -214,10 +224,13 @@ fn write_segment_commands<A: Arch<Platform = MachO>>(
         0,
     );
 
-    let text_segment_sections =
-        get_segment_sections(layout, SegmentType::TextSections).segment_sections;
+    let text_segment_sections = get_segment_sections(layout, SegmentType::TextSections)
+        .ok_or_else(|| error!("TextSections segment is mandatory"))?
+        .segment_sections;
     // The __TEXT segment in the layout includes also all the commands!
-    let text_segment_size = get_segment_sections(layout, SegmentType::Text).segment_size;
+    let text_segment_size = get_segment_sections(layout, SegmentType::Text)
+        .ok_or_else(|| error!("Text segment is mandatory"))?
+        .segment_size;
     let (text_segment, text_sections) = split_segment_command_buffer(
         buffers.get_mut(part_id::TEXT_SEGMENT),
         text_segment_sections.len(),
@@ -235,28 +248,30 @@ fn write_segment_commands<A: Arch<Platform = MachO>>(
     );
     write_sections(SEG_TEXT, text_sections, &text_segment_sections)?;
 
-    let data_segment_sections =
-        get_segment_sections(layout, SegmentType::DataSections).segment_sections;
-    let data_segment_size = get_segment_sections(layout, SegmentType::DataSections).segment_size;
-    let (data_segment, data_sections) = split_segment_command_buffer(
-        buffers.get_mut(part_id::DATA_SEGMENT),
-        data_segment_sections.len(),
-    )?;
-    write_segment(
-        layout,
-        part_id::DATA_SEGMENT,
-        SEG_DATA,
-        data_segment,
-        data_segment_size.file_offset as u64,
-        data_segment_size.file_size as u64,
-        data_segment_size.mem_offset,
-        data_segment_size.mem_size,
-        data_segment_sections.len(),
-    );
-    write_sections(SEG_DATA, data_sections, &data_segment_sections)?;
+    if let Some(data_segment_info) = get_segment_sections(layout, SegmentType::DataSections) {
+        let data_segment_sections = data_segment_info.segment_sections;
+        let data_segment_size = data_segment_info.segment_size;
+        let (data_segment, data_sections) = split_segment_command_buffer(
+            buffers.get_mut(part_id::DATA_SEGMENT),
+            data_segment_sections.len(),
+        )?;
+        write_segment(
+            layout,
+            part_id::DATA_SEGMENT,
+            SEG_DATA,
+            data_segment,
+            data_segment_size.file_offset as u64,
+            data_segment_size.file_size as u64,
+            data_segment_size.mem_offset,
+            data_segment_size.mem_size,
+            data_segment_sections.len(),
+        );
+        write_sections(SEG_DATA, data_sections, &data_segment_sections)?;
+    }
 
-    let linkedit_segment_size =
-        get_segment_sections(layout, SegmentType::LinkeditSections).segment_size;
+    let linkedit_segment_size = get_segment_sections(layout, SegmentType::LinkeditSections)
+        .ok_or_else(|| error!("LinkeditSections segment is mandatory"))?
+        .segment_size;
     let linkedit_segment =
         split_segment_command_buffer(buffers.get_mut(part_id::LINK_EDIT_SEGMENT), 0)?.0;
     write_segment(
@@ -415,9 +430,10 @@ fn write_section_raw<'out, 'data>(
 fn write_entry_point_command<A: Arch<Platform = MachO>>(
     layout: &MachOLayout,
     command: &mut EntryPointCommand,
-) {
+) -> Result {
     let SegmentSectionsInfo { segment_size, .. } =
-        get_segment_sections(layout, SegmentType::TextSections);
+        get_segment_sections(layout, SegmentType::TextSections)
+            .ok_or_else(|| error!("TextSections segment is mandatory"))?;
 
     command.cmd.set(LE, LC_MAIN);
     command
@@ -425,6 +441,7 @@ fn write_entry_point_command<A: Arch<Platform = MachO>>(
         .set(LE, size_of::<EntryPointCommand>() as u32);
     command.entryoff.set(LE, segment_size.file_offset as u64);
     command.stacksize.set(LE, 0);
+    Ok(())
 }
 
 fn write_dylinker_command<A: Arch<Platform = MachO>>(


### PR DESCRIPTION
With the change, the linker will not crash if the input files do not utilize the `__DATA` segment.

Issue: #757