### PR TITLE
feat: add GNU ld-compatible /DISCARD/ support

### DIFF
--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3620,10 +3620,7 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
                 self.load_debug_section::<A>(common, *part_id, section_index, resources)?;
             }
             SectionSlot::Discard => {
-                bail!(
-                    "{self}: Don't know what segment to put `{}` in, but it's referenced",
-                    self.object.section_display_name(section_index),
-                );
+                // Section is discarded, so we silently skip loading it even if it's referenced.
             }
             SectionSlot::Loaded(_)
             | SectionSlot::FrameData(..)
@@ -3880,6 +3877,10 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
                 )? {
                     Some(x) => x,
                     None => {
+                        if matches!(self.sections[section_index.0], SectionSlot::Discard) {
+                            // Symbols from explicitly discarded sections must not be emitted.
+                            return Ok(None);
+                        }
                         // Don't error for mapping symbols. They cannot have relocations refer to
                         // them, so we don't need to produce a resolution.
                         if resources.symbol_db.is_mapping_symbol(symbol_id) {
@@ -3937,6 +3938,13 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
                 continue;
             }
 
+            if let Ok(Some(section_index)) = self.object.symbol_section(sym, sym_index)
+                && matches!(self.sections[section_index.0], SectionSlot::Discard)
+            {
+                // Symbols from explicitly discarded sections must not be exported to dynsym.
+                continue;
+            }
+
             let old_flags = resources
                 .per_symbol_flags
                 .get_atomic(symbol_id)
@@ -3971,6 +3979,15 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
         // provided by the regular object. This isn't always possible, since the symbol might be
         // hidden.
         if !can_export_symbol(sym, symbol_id, resources, true) {
+            return Ok(());
+        }
+
+        if let Ok(Some(section_index)) = self
+            .object
+            .symbol_section(sym, self.symbol_id_range.id_to_input(symbol_id))
+            && matches!(self.sections[section_index.0], SectionSlot::Discard)
+        {
+            // Symbols from explicitly discarded sections must not be exported to dynsym.
             return Ok(());
         }
 

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -167,6 +167,40 @@ impl<'data> LayoutRulesBuilder<'data> {
                 for sec_cmd in &sections.commands {
                     match sec_cmd {
                         SectionCommand::Section(sec) => {
+                            if sec.output_section_name == b"/DISCARD/" {
+                                for contents_cmd in &sec.commands {
+                                    match contents_cmd {
+                                        ContentsCommand::Matcher(matcher) => {
+                                            for pattern in &matcher.input_section_name_patterns {
+                                                self.add_section_rule(SectionRule::new(
+                                                    pattern,
+                                                    matcher.input_file_pattern,
+                                                    crate::layout_rules::SectionRuleOutcome::Discard,
+                                                )?);
+                                            }
+                                        }
+                                        ContentsCommand::Align(_) => {
+                                            // Ignore align directives in /DISCARD/, since this
+                                            // pseudo-section doesn't create output sections.
+                                        }
+                                        ContentsCommand::SymbolAssignment(assignment) => {
+                                            return Err(crate::error!(
+                                                "Unsupported symbol assignment `{}` in /DISCARD/",
+                                                String::from_utf8_lossy(assignment.name)
+                                            ));
+                                        }
+                                        ContentsCommand::Provide(provide) => {
+                                            return Err(crate::error!(
+                                                "Unsupported PROVIDE `{}` in /DISCARD/",
+                                                String::from_utf8_lossy(provide.name)
+                                            ));
+                                        }
+                                    }
+                                }
+
+                                continue;
+                            }
+
                             let min_alignment = sec
                                 .alignment
                                 .unwrap_or(alignment::MIN)

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -1449,6 +1449,22 @@ mod tests {
     }
 
     #[test]
+    fn test_discard_section_command() {
+        check_section_command(
+            "/DISCARD/ : { *(.data.drop .debug_*) }",
+            &SectionCommand::Section(Section {
+                output_section_name: b"/DISCARD/",
+                commands: vec![ContentsCommand::Matcher(Matcher {
+                    must_keep: false,
+                    input_file_pattern: None,
+                    input_section_name_patterns: vec![b".data.drop", b".debug_*"],
+                })],
+                alignment: None,
+            }),
+        );
+    }
+
+    #[test]
     fn test_assert_command() {
         check_linker_script(
             r#"

--- a/wild/tests/sources/elf/linker-script-discard/linker-script-discard.c
+++ b/wild/tests/sources/elf/linker-script-discard/linker-script-discard.c
@@ -1,0 +1,8 @@
+//#Mode:dynamic
+//#RunEnabled:false
+//#LinkArgs:-shared -z now -T ./linker-script-discard.ld
+//#ExpectSym:keep_symbol section="keep"
+//#NoSym:drop_symbol
+
+int keep_symbol __attribute__((used, section(".data.keep"))) = 7;
+static int drop_symbol __attribute__((used, section(".data.drop"))) = 9;

--- a/wild/tests/sources/elf/linker-script-discard/linker-script-discard.ld
+++ b/wild/tests/sources/elf/linker-script-discard/linker-script-discard.ld
@@ -1,0 +1,9 @@
+SECTIONS {
+    keep : {
+        KEEP(*(.data.keep))
+    }
+
+    /DISCARD/ : {
+        *(.data.drop)
+    }
+}


### PR DESCRIPTION
added support for the /DISCARD/ pseudo-section in Wild linker scripts, similar to how GNU ld handles it , we now recognize /DISCARD/ blocks, turn their patterns into discard rules, and make sure any matching sections are intentionally removed instead of being treated as errors in the layout

this helps bring Wild in line with real-world linker scripts where /DISCARD/ is commonly used to strip out debug info or other unnecessary sections.

I also updated the symbol handling so that anything coming from discarded sections isn’t emitted or exported. This avoids some failures while keeping the behavior unchanged for normal sections.

fixiing: #1829 