### PR TITLE
port(MachO): support relocation handling

### DIFF
--- a/libwild/src/dwarf_address_info.rs
+++ b/libwild/src/dwarf_address_info.rs
@@ -25,7 +25,7 @@ use std::path::PathBuf;
 const SECTION_LOAD_ADDRESS: u64 = 0x1_000_000_000;
 
 /// Attempts to locate source info for `offset_in_section` within `section`.
-pub(crate) fn get_source_info<A: Arch>(
+pub(crate) fn get_source_info<A: Arch<Platform = crate::elf::Elf>>(
     object: &File,
     relocations: &RelocationSections,
     section: &object::elf::SectionHeader64<LittleEndian>,
@@ -91,7 +91,7 @@ pub(crate) fn get_source_info<A: Arch>(
 }
 
 /// Gets the data for section `id` from `object` and applies relocations to it.
-fn section_data_with_relocations<A: Arch>(
+fn section_data_with_relocations<A: Arch<Platform = crate::elf::Elf>>(
     object: &File,
     relocations: &RelocationSections,
     id: gimli::SectionId,
@@ -129,7 +129,7 @@ fn section_data_with_relocations<A: Arch>(
     Ok(data)
 }
 
-fn apply_section_relocations<A: Arch, R: Relocation>(
+fn apply_section_relocations<A: Arch<Platform = crate::elf::Elf>, R: Relocation>(
     object: &File<'_>,
     section_of_interest: &object::elf::SectionHeader64<LittleEndian>,
     section_data: &mut [u8],

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -2490,6 +2490,14 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
             // checks our shared object against those.
             && has_complete_deps(self, resources)
     }
+
+    fn symbol_offset_in_section(
+        &self,
+        symbol: &<Self::Platform as Platform>::SymtabEntry,
+        _section_index: object::SectionIndex,
+    ) -> Result<u64> {
+        Ok(symbol.value())
+    }
 }
 
 impl DynamicLayoutStateExt<'_> {

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -81,13 +81,9 @@ use foldhash::HashSet;
 use hashbrown::HashMap;
 use indexmap::IndexMap;
 use itertools::Itertools as _;
-use linker_utils::bit_misc::BitExtraction;
-use linker_utils::elf::BitMask;
 use linker_utils::elf::PageMask;
 use linker_utils::elf::RISCV_ATTRIBUTE_VENDOR_NAME;
 use linker_utils::elf::RelocationKind;
-use linker_utils::elf::RelocationKindInfo;
-use linker_utils::elf::RelocationSize;
 use linker_utils::elf::SectionFlags;
 use linker_utils::elf::SectionType;
 use linker_utils::elf::SegmentFlags;
@@ -3082,48 +3078,6 @@ pub(crate) fn get_page_mask(mask: Option<PageMask>) -> PageMaskValue {
             ..Default::default()
         },
     }
-}
-
-#[inline(always)]
-pub(crate) fn write_relocation_to_buffer(
-    rel_info: RelocationKindInfo,
-    value: u64,
-    output: &mut [u8],
-) -> Result<()> {
-    rel_info.verify(value as i64)?;
-
-    if matches!(rel_info.kind, RelocationKind::PairSubtractionULEB128(..)) {
-        // u64 always fits in 10 bytes in the ULEB format: 64 / 7 = 9.14
-        let mut writer = Cursor::new(vec![0u8; 10]);
-        let n = leb128::write::unsigned(&mut writer, value).expect("Must fit into the buffer");
-        ensure!(
-            output.len() >= n,
-            "cannot write encoded ULEB128 value of {n} bytes"
-        );
-        output[..n].copy_from_slice(&writer.into_inner()[..n]);
-    } else {
-        match rel_info.size {
-            RelocationSize::ByteSize(byte_size) => {
-                ensure!(
-                    byte_size <= output.len(),
-                    "Relocation outside of bounds of section"
-                );
-                let value_bytes = value.to_le_bytes();
-                output[..byte_size].copy_from_slice(&value_bytes[..byte_size]);
-            }
-            RelocationSize::BitMasking(BitMask {
-                range,
-                instruction: insn,
-            }) => {
-                let extracted_value = value.extract_bit_range(range.start..range.end);
-                let negative = (value as i64).is_negative();
-                let output_len = output.len();
-                insn.write_to_value(extracted_value, negative, &mut output[..output_len]);
-            }
-        }
-    }
-
-    Ok(())
 }
 
 #[derive(Default, Debug, Clone, Copy)]

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -309,6 +309,7 @@ impl platform::Platform for Elf {
     type RelocationSections = RelocationSections;
     type DynamicEntry = DynamicEntry;
     type DynamicSymbolDefinitionExt = DynamicSymbolDefinitionExt;
+    type RelocationInfo = u32;
     type LayoutExt = LayoutExt;
     type SymbolVersionIndex = Versym;
     type NonAddressableCounts = NonAddressableCounts;

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -30,7 +30,6 @@ use crate::elf::Vernaux;
 use crate::elf::Verneed;
 use crate::elf::VersionDef;
 use crate::elf::Versym;
-use crate::elf::write_relocation_to_buffer;
 use crate::ensure;
 use crate::error;
 use crate::error::Context as _;
@@ -3156,7 +3155,7 @@ fn apply_relocation<
             "relocation applied");
     }
 
-    write_relocation_to_buffer(rel_info, value, &mut out[offset_in_section..])?;
+    rel_info.write_to_buffer(value, &mut out[offset_in_section..])?;
 
     Ok(next_modifier)
 }
@@ -3284,7 +3283,7 @@ fn apply_debug_relocation<'data, A: Arch<Platform = Elf>, R: Relocation>(
         section_tombstone_value
     };
 
-    write_relocation_to_buffer(rel_info, value, &mut out[offset_in_section as usize..])?;
+    rel_info.write_to_buffer(value, &mut out[offset_in_section as usize..])?;
 
     Ok(())
 }

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3867,6 +3867,8 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
             return Ok(None);
         }
 
+        eprintln!("{}", resources.symbol_debug(symbol_id));
+
         let raw_value = if let Some(section_index) = self
             .object
             .symbol_section(local_symbol, local_symbol_index)?

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3867,8 +3867,6 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
             return Ok(None);
         }
 
-        eprintln!("{}", resources.symbol_debug(symbol_id));
-
         let raw_value = if let Some(section_index) = self
             .object
             .symbol_section(local_symbol, local_symbol_index)?

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3874,7 +3874,7 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
             if let Some(section_address) = section_resolutions[section_index.0].address() {
                 let input_offset = self
                     .object
-                    .symbol_value_in_section(local_symbol, section_index)?;
+                    .symbol_offset_in_section(local_symbol, section_index)?;
                 let output_offset = opt_input_to_output(
                     self.section_relax_deltas.get(section_index.0),
                     input_offset,

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3872,7 +3872,9 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
             .symbol_section(local_symbol, local_symbol_index)?
         {
             if let Some(section_address) = section_resolutions[section_index.0].address() {
-                let input_offset = local_symbol.value();
+                let input_offset = self
+                    .object
+                    .symbol_value_in_section(local_symbol, section_index)?;
                 let output_offset = opt_input_to_output(
                     self.section_relax_deltas.get(section_index.0),
                     input_offset,

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -999,7 +999,7 @@ impl platform::Platform for MachO {
     ) -> crate::error::Result {
         // TODO
         for rel in state.relocations(section_index)?.relocations {
-            A::relocation_from_raw(dbg!(rel.info(LE)));
+            dbg!(A::relocation_from_raw(rel.info(LE))?);
         }
         Ok(())
     }

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -1560,7 +1560,7 @@ pub(crate) fn get_segment_sections<'data>(
 #[inline(always)]
 fn process_relocation<'data, 'scope, A: platform::Arch<Platform = MachO>>(
     object: &layout::ObjectLayoutState<'data, MachO>,
-    common: &mut layout::CommonGroupState<'data, MachO>,
+    common: &layout::CommonGroupState<'data, MachO>,
     rel: &Relocation,
     section: layout::Section,
     resources: &'scope layout::GraphResources<'data, '_, MachO>,

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -218,13 +218,14 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
         Ok(symbol.name(LE, self.symbols.strings())?)
     }
 
-    // On Mach-O the symbol value is the global offset, not a relative to the start of a section.
-    fn symbol_value_in_section(
+    fn symbol_offset_in_section(
         &self,
         symbol: &<Self::Platform as platform::Platform>::SymtabEntry,
         section_index: object::SectionIndex,
     ) -> crate::error::Result<u64> {
         let section = self.section(section_index)?;
+        // On Mach-O the symbol value is the global offset, not a relative to the start of a
+        // section.
         symbol
             .n_value
             .get(LE)

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -265,6 +265,7 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
         _index: object::SymbolIndex,
     ) -> crate::error::Result<Option<object::SectionIndex>> {
         if symbol.n_type & N_TYPE == N_SECT && symbol.n_sect != 0 {
+            // The index is one-based, NO_SECT == 0, marks a missing section for the symbol.
             Ok(Some(object::SectionIndex(usize::from(symbol.n_sect - 1))))
         } else {
             Ok(None)
@@ -1569,6 +1570,7 @@ fn process_relocation<'data, 'scope, A: platform::Arch<Platform = MachO>>(
     scope: &rayon::Scope<'scope>,
 ) -> Result {
     let rel_info = rel.info(LE);
+    // r_extern == true if the reference points to a symbol
     if rel_info.r_extern {
         let local_sym_index = SymbolIndex(rel_info.r_symbolnum as usize);
         let symbol_db = resources.symbol_db;

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -24,6 +24,7 @@ use crate::output_section_id::SectionName;
 use crate::output_section_id::SectionOutputInfo;
 use crate::part_id;
 use crate::platform;
+use crate::platform::ObjectFile;
 use crate::symbol_db::Visibility;
 use gimli::LittleEndian;
 use object::Endian;
@@ -852,6 +853,7 @@ impl platform::Platform for MachO {
     type RelocationSections = ();
     type DynamicEntry = ();
     type DynamicSymbolDefinitionExt = ();
+    type RelocationInfo = object::macho::RelocationInfo;
     type NonAddressableIndexes = NonAddressableIndexes;
     type NonAddressableCounts = ();
     type EpilogueLayoutExt = ();
@@ -996,9 +998,9 @@ impl platform::Platform for MachO {
         scope: &rayon::Scope<'scope>,
     ) -> crate::error::Result {
         // TODO
-        // for rel in state.relocations(section_index)?.relocations {
-        //     dbg!(rel.info(LE));
-        // }
+        for rel in state.relocations(section_index)?.relocations {
+            A::relocation_from_raw(dbg!(rel.info(LE)));
+        }
         Ok(())
     }
 
@@ -1221,6 +1223,12 @@ impl platform::Platform for MachO {
         symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
         per_symbol_flags: &crate::value_flags::AtomicPerSymbolFlags,
     ) -> Result {
+        for symbol in state.object.symbols_iter() {
+            dbg!(String::from_utf8_lossy(
+                symbol.name(LE, state.object.symbols.strings()).unwrap()
+            ));
+        }
+
         // TODO
         // let mut num_globals = 0;
         // let mut strings_size = 0;

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -218,6 +218,20 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
         Ok(symbol.name(LE, self.symbols.strings())?)
     }
 
+    // On Mach-O the symbol value is the global offset, not a relative to the start of a section.
+    fn symbol_value_in_section(
+        &self,
+        symbol: &<Self::Platform as platform::Platform>::SymtabEntry,
+        section_index: object::SectionIndex,
+    ) -> crate::error::Result<u64> {
+        let section = self.section(section_index)?;
+        symbol
+            .n_value
+            .get(LE)
+            .checked_sub(section.addr.get(LE))
+            .ok_or_else(|| error!("Mach-O symbol value is before its section address"))
+    }
+
     fn num_sections(&self) -> usize {
         self.sections.len()
     }

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -7,12 +7,15 @@ use crate::alignment;
 use crate::alignment::Alignment;
 use crate::alignment::MACHO_PAGE_ALIGNMENT;
 use crate::args::macho::MachOArgs;
+use crate::elf::ResolutionExt;
 use crate::ensure;
 use crate::error;
 use crate::error::Result;
 use crate::file_writer::copy_section_data;
+use crate::layout;
 use crate::layout::Layout;
 use crate::layout::OutputRecordLayout;
+use crate::layout::Resolution;
 use crate::layout_rules::SectionKind;
 use crate::layout_rules::SectionRule;
 use crate::macho_writer;
@@ -26,9 +29,11 @@ use crate::part_id;
 use crate::platform;
 use crate::platform::ObjectFile;
 use crate::symbol_db::Visibility;
+use crate::value_flags::ValueFlags;
 use gimli::LittleEndian;
 use object::Endian;
 use object::Endianness;
+use object::SymbolIndex;
 use object::U32;
 use object::macho;
 use object::macho::N_ABS;
@@ -260,7 +265,7 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
         _index: object::SymbolIndex,
     ) -> crate::error::Result<Option<object::SectionIndex>> {
         if symbol.n_type & N_TYPE == N_SECT && symbol.n_sect != 0 {
-            Ok(Some(object::SectionIndex(usize::from(symbol.n_sect))))
+            Ok(Some(object::SectionIndex(usize::from(symbol.n_sect - 1))))
         } else {
             Ok(None)
         }
@@ -527,7 +532,8 @@ impl platform::SectionFlags for SectionFlags {
 // Documentation link for Nlist64 type: https://leopard-adc.pepas.com/documentation/DeveloperTools/Conceptual/MachORuntime/Reference/reference.html
 impl platform::Symbol for SymtabEntry {
     fn as_common(&self) -> Option<platform::CommonSymbol> {
-        todo!()
+        // TODO
+        None
     }
 
     fn is_undefined(&self) -> bool {
@@ -785,7 +791,7 @@ pub(crate) struct DynamicTagValues<'data> {
 
 #[derive(Debug)]
 pub(crate) struct RelocationList<'data> {
-    relocations: &'data [Relocation],
+    pub(crate) relocations: &'data [Relocation],
 }
 
 impl<'data> platform::RelocationList<'data> for RelocationList<'data> {
@@ -999,7 +1005,7 @@ impl platform::Platform for MachO {
     ) -> crate::error::Result {
         // TODO
         for rel in state.relocations(section_index)?.relocations {
-            dbg!(A::relocation_from_raw(rel.info(LE))?);
+            process_relocation::<A>(state, common, rel, section, resources, queue, false, scope)?;
         }
         Ok(())
     }
@@ -1224,9 +1230,9 @@ impl platform::Platform for MachO {
         per_symbol_flags: &crate::value_flags::AtomicPerSymbolFlags,
     ) -> Result {
         for symbol in state.object.symbols_iter() {
-            dbg!(String::from_utf8_lossy(
-                symbol.name(LE, state.object.symbols.strings()).unwrap()
-            ));
+            // dbg!(String::from_utf8_lossy(
+            //     symbol.name(LE, state.object.symbols.strings()).unwrap()
+            // ));
         }
 
         // TODO
@@ -1275,7 +1281,12 @@ impl platform::Platform for MachO {
         dynamic_symbol_index: Option<std::num::NonZeroU32>,
         memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
     ) -> crate::layout::Resolution<Self> {
-        todo!()
+        Resolution {
+            raw_value,
+            dynamic_symbol_index,
+            format_specific: (),
+            flags,
+        }
     }
 
     fn raw_symbol_name<'data>(
@@ -1544,4 +1555,39 @@ pub(crate) fn get_segment_sections<'data>(
         segment_sections: sections,
         segment_size,
     })
+}
+
+#[inline(always)]
+fn process_relocation<'data, 'scope, A: platform::Arch<Platform = MachO>>(
+    object: &layout::ObjectLayoutState<'data, MachO>,
+    common: &mut layout::CommonGroupState<'data, MachO>,
+    rel: &Relocation,
+    section: layout::Section,
+    resources: &'scope layout::GraphResources<'data, '_, MachO>,
+    queue: &mut layout::LocalWorkQueue,
+    is_debug_section: bool,
+    scope: &rayon::Scope<'scope>,
+) -> Result {
+    let rel_info = rel.info(LE);
+    if rel_info.r_extern {
+        let local_sym_index = SymbolIndex(rel_info.r_symbolnum as usize);
+        let symbol_db = resources.symbol_db;
+        let local_symbol_id = object.symbol_id_range.input_to_id(local_sym_index);
+        let symbol_id = symbol_db.definition(local_symbol_id);
+        let mut flags = resources.local_flags_for_symbol(symbol_id);
+        flags.merge(resources.local_flags_for_symbol(local_symbol_id));
+        let rel_offset = rel_info.r_address;
+
+        let rel_info = A::relocation_from_raw(rel_info)?;
+        let mut flags_to_add = layout::resolution_flags(rel_info.kind);
+
+        let atomic_flags = &resources.per_symbol_flags.get_atomic(symbol_id);
+        let previous_flags = atomic_flags.fetch_or(flags_to_add);
+
+        if !previous_flags.has_resolution() {
+            queue.send_symbol_request::<A>(symbol_id, resources, scope);
+        }
+    }
+
+    Ok(())
 }

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -826,7 +826,9 @@ impl<'data> platform::RawSymbolName<'data> for RawSymbolName<'data> {
     }
 
     fn is_default(&self) -> bool {
-        false
+        // This port does not use symbol versioning, so every symbol is treated as
+        // the default version.
+        true
     }
 }
 

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -455,7 +455,7 @@ impl platform::SectionHeader for SectionHeader {
     }
 
     fn is_executable(&self) -> bool {
-        todo!()
+        self.sectname.starts_with(b"__text")
     }
 
     fn is_tls(&self) -> bool {

--- a/libwild/src/macho_aarch64.rs
+++ b/libwild/src/macho_aarch64.rs
@@ -64,12 +64,12 @@ impl crate::platform::Arch for MachOAArch64 {
         rel: object::macho::RelocationInfo,
     ) -> crate::error::Result<RelocationKindInfo> {
         let rel_size_in_bytes = 1 << rel.r_type;
+        let rel_size = RelocationSize::ByteSize(rel_size_in_bytes);
         let rel_kind = if rel.r_pcrel {
             RelocationKind::Relative
         } else {
             RelocationKind::Absolute
         };
-        let rel_size = RelocationSize::ByteSize(rel_size_in_bytes);
 
         let (kind, size, mask, range, alignment) = match rel.r_type {
             object::macho::ARM64_RELOC_UNSIGNED => {

--- a/libwild/src/macho_aarch64.rs
+++ b/libwild/src/macho_aarch64.rs
@@ -5,7 +5,7 @@ use crate::bail;
 use crate::macho::MachO;
 use linker_utils::elf::AArch64Instruction;
 use linker_utils::elf::AllowedRange;
-use linker_utils::elf::PAGE_MASK_4GB;
+use linker_utils::elf::PAGE_MASK_4KB;
 use linker_utils::elf::PageMask;
 use linker_utils::elf::RelocationKind;
 use linker_utils::elf::RelocationKindInfo;
@@ -90,7 +90,7 @@ impl crate::platform::Arch for MachOAArch64 {
                 (
                     rel_kind,
                     RelocationSize::bit_mask_aarch64(12, 33, AArch64Instruction::Adr),
-                    Some(PageMask::SymbolPlusAddendAndPosition(PAGE_MASK_4GB)),
+                    Some(PageMask::SymbolPlusAddendAndPosition(PAGE_MASK_4KB)),
                     AllowedRange::from_bit_size(33, Sign::Signed),
                     1,
                 )

--- a/libwild/src/macho_aarch64.rs
+++ b/libwild/src/macho_aarch64.rs
@@ -3,7 +3,10 @@
 
 use crate::bail;
 use crate::macho::MachO;
+use linker_utils::elf::AArch64Instruction;
 use linker_utils::elf::AllowedRange;
+use linker_utils::elf::PAGE_MASK_4GB;
+use linker_utils::elf::PageMask;
 use linker_utils::elf::RelocationKind;
 use linker_utils::elf::RelocationKindInfo;
 use linker_utils::elf::RelocationSize;
@@ -68,13 +71,35 @@ impl crate::platform::Arch for MachOAArch64 {
         };
         let rel_size = RelocationSize::ByteSize(rel_size_in_bytes);
 
-        let (range, alignment) = match rel.r_type {
-            object::macho::ARM64_RELOC_UNSIGNED => (AllowedRange::no_check(), 0),
-            object::macho::ARM64_RELOC_BRANCH26 => (
-                AllowedRange::from_bit_size(28, Sign::Signed),
-                // TODO: use RelocationSize::bit_mask_aarch64(2, 28, AArch64Instruction::JumpCall),
-                0,
-            ),
+        let (size, mask, range, alignment) = match rel.r_type {
+            object::macho::ARM64_RELOC_UNSIGNED => (rel_size, None, AllowedRange::no_check(), 1),
+            object::macho::ARM64_RELOC_BRANCH26 => {
+                debug_assert_eq!(rel_size, RelocationSize::ByteSize(4));
+                (
+                    RelocationSize::bit_mask_aarch64(2, 28, AArch64Instruction::JumpCall),
+                    None,
+                    AllowedRange::from_bit_size(28, Sign::Signed),
+                    4,
+                )
+            }
+            object::macho::ARM64_RELOC_PAGE21 => {
+                debug_assert_eq!(rel_size, RelocationSize::ByteSize(4));
+                (
+                    RelocationSize::bit_mask_aarch64(12, 33, AArch64Instruction::Adr),
+                    Some(PageMask::SymbolPlusAddendAndPosition(PAGE_MASK_4GB)),
+                    AllowedRange::from_bit_size(33, Sign::Signed),
+                    1,
+                )
+            }
+            object::macho::ARM64_RELOC_PAGEOFF12 => {
+                debug_assert_eq!(rel_size, RelocationSize::ByteSize(4));
+                (
+                    RelocationSize::bit_mask_aarch64(0, 12, AArch64Instruction::Add),
+                    None,
+                    AllowedRange::no_check(),
+                    1,
+                )
+            }
             _ => bail!("Unknown relocation: {}", rel.r_type),
         };
         Ok(RelocationKindInfo {

--- a/libwild/src/macho_aarch64.rs
+++ b/libwild/src/macho_aarch64.rs
@@ -2,6 +2,7 @@
 #![allow(unused_variables)]
 
 use crate::macho::MachO;
+use linker_utils::elf::AllowedRange;
 
 pub(crate) struct MachOAArch64;
 
@@ -52,9 +53,16 @@ impl crate::platform::Arch for MachOAArch64 {
     }
 
     fn relocation_from_raw(
-        r_type: u32,
+        r_type: <Self::Platform as crate::platform::Platform>::RelocationInfo,
     ) -> crate::error::Result<linker_utils::elf::RelocationKindInfo> {
-        todo!()
+        Ok(linker_utils::elf::RelocationKindInfo {
+            alignment: 0,
+            bias: 0,
+            kind: linker_utils::elf::RelocationKind::Absolute,
+            mask: None,
+            range: AllowedRange::no_check(),
+            size: linker_utils::elf::RelocationSize::ByteSize(1),
+        })
     }
 
     fn rel_type_to_string(r_type: u32) -> std::borrow::Cow<'static, str> {

--- a/libwild/src/macho_aarch64.rs
+++ b/libwild/src/macho_aarch64.rs
@@ -1,8 +1,13 @@
 // TODO
 #![allow(unused_variables)]
 
+use crate::bail;
 use crate::macho::MachO;
 use linker_utils::elf::AllowedRange;
+use linker_utils::elf::RelocationKind;
+use linker_utils::elf::RelocationKindInfo;
+use linker_utils::elf::RelocationSize;
+use linker_utils::elf::Sign;
 
 pub(crate) struct MachOAArch64;
 
@@ -53,15 +58,32 @@ impl crate::platform::Arch for MachOAArch64 {
     }
 
     fn relocation_from_raw(
-        r_type: <Self::Platform as crate::platform::Platform>::RelocationInfo,
-    ) -> crate::error::Result<linker_utils::elf::RelocationKindInfo> {
-        Ok(linker_utils::elf::RelocationKindInfo {
-            alignment: 0,
+        rel: object::macho::RelocationInfo,
+    ) -> crate::error::Result<RelocationKindInfo> {
+        let rel_size_in_bytes = 1 << rel.r_type;
+        let rel_kind = if rel.r_pcrel {
+            RelocationKind::Relative
+        } else {
+            RelocationKind::Absolute
+        };
+        let rel_size = RelocationSize::ByteSize(rel_size_in_bytes);
+
+        let (range, alignment) = match rel.r_type {
+            object::macho::ARM64_RELOC_UNSIGNED => (AllowedRange::no_check(), 0),
+            object::macho::ARM64_RELOC_BRANCH26 => (
+                AllowedRange::from_bit_size(28, Sign::Signed),
+                // TODO: use RelocationSize::bit_mask_aarch64(2, 28, AArch64Instruction::JumpCall),
+                0,
+            ),
+            _ => bail!("Unknown relocation: {}", rel.r_type),
+        };
+        Ok(RelocationKindInfo {
+            alignment,
             bias: 0,
-            kind: linker_utils::elf::RelocationKind::Absolute,
+            kind: rel_kind,
             mask: None,
-            range: AllowedRange::no_check(),
-            size: linker_utils::elf::RelocationSize::ByteSize(1),
+            range,
+            size: rel_size,
         })
     }
 

--- a/libwild/src/macho_aarch64.rs
+++ b/libwild/src/macho_aarch64.rs
@@ -99,7 +99,7 @@ impl crate::platform::Arch for MachOAArch64 {
                 debug_assert_eq!(rel_size, RelocationSize::ByteSize(4));
                 (
                     RelocationKind::AbsoluteLowPart,
-                    RelocationSize::bit_mask_aarch64(0, 12, AArch64Instruction::Add),
+                    RelocationSize::bit_mask_aarch64(0, 12, AArch64Instruction::MachOLow12),
                     None,
                     AllowedRange::no_check(),
                     1,

--- a/libwild/src/macho_aarch64.rs
+++ b/libwild/src/macho_aarch64.rs
@@ -71,11 +71,14 @@ impl crate::platform::Arch for MachOAArch64 {
         };
         let rel_size = RelocationSize::ByteSize(rel_size_in_bytes);
 
-        let (size, mask, range, alignment) = match rel.r_type {
-            object::macho::ARM64_RELOC_UNSIGNED => (rel_size, None, AllowedRange::no_check(), 1),
+        let (kind, size, mask, range, alignment) = match rel.r_type {
+            object::macho::ARM64_RELOC_UNSIGNED => {
+                (rel_kind, rel_size, None, AllowedRange::no_check(), 1)
+            }
             object::macho::ARM64_RELOC_BRANCH26 => {
                 debug_assert_eq!(rel_size, RelocationSize::ByteSize(4));
                 (
+                    rel_kind,
                     RelocationSize::bit_mask_aarch64(2, 28, AArch64Instruction::JumpCall),
                     None,
                     AllowedRange::from_bit_size(28, Sign::Signed),
@@ -85,6 +88,7 @@ impl crate::platform::Arch for MachOAArch64 {
             object::macho::ARM64_RELOC_PAGE21 => {
                 debug_assert_eq!(rel_size, RelocationSize::ByteSize(4));
                 (
+                    rel_kind,
                     RelocationSize::bit_mask_aarch64(12, 33, AArch64Instruction::Adr),
                     Some(PageMask::SymbolPlusAddendAndPosition(PAGE_MASK_4GB)),
                     AllowedRange::from_bit_size(33, Sign::Signed),
@@ -94,6 +98,7 @@ impl crate::platform::Arch for MachOAArch64 {
             object::macho::ARM64_RELOC_PAGEOFF12 => {
                 debug_assert_eq!(rel_size, RelocationSize::ByteSize(4));
                 (
+                    RelocationKind::AbsoluteLowPart,
                     RelocationSize::bit_mask_aarch64(0, 12, AArch64Instruction::Add),
                     None,
                     AllowedRange::no_check(),
@@ -105,10 +110,10 @@ impl crate::platform::Arch for MachOAArch64 {
         Ok(RelocationKindInfo {
             alignment,
             bias: 0,
-            kind: rel_kind,
-            mask: None,
+            kind,
+            mask,
             range,
-            size: rel_size,
+            size,
         })
     }
 

--- a/libwild/src/macho_aarch64.rs
+++ b/libwild/src/macho_aarch64.rs
@@ -63,7 +63,7 @@ impl crate::platform::Arch for MachOAArch64 {
     fn relocation_from_raw(
         rel: object::macho::RelocationInfo,
     ) -> crate::error::Result<RelocationKindInfo> {
-        let rel_size_in_bytes = 1 << rel.r_type;
+        let rel_size_in_bytes = 1 << rel.r_length;
         let rel_size = RelocationSize::ByteSize(rel_size_in_bytes);
         let rel_kind = if rel.r_pcrel {
             RelocationKind::Relative

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -46,6 +46,7 @@ use crate::timing_phase;
 use crate::value_flags::ValueFlags;
 use crate::verbose_timing_phase;
 use linker_utils::elf::RelocationKind;
+use linker_utils::utils::or_from_slice;
 use object::BigEndian;
 use object::Endianness;
 use object::SymbolIndex;
@@ -412,7 +413,7 @@ fn apply_relocation<'data, A: Arch<Platform = MachO>>(
     section_address: u64,
     rel: RelocationInfo,
     layout: &MachOLayout<'data>,
-    _out: &mut [u8],
+    out: &mut [u8],
 ) -> Result {
     let offset_in_section = u64::from(rel.r_address);
     let place = section_address + offset_in_section;
@@ -428,19 +429,24 @@ fn apply_relocation<'data, A: Arch<Platform = MachO>>(
     let _addend = rel.r_address;
     let (resolution, _symbol_index, local_symbol_id) = get_resolution(rel, object_layout, layout)?;
 
+    let value = match rel_info.kind {
+        // TODO: assuming it's JUMP26
+        RelocationKind::Relative => (resolution.raw_value.wrapping_sub(place)) >> 2,
+        _ => todo!(),
+    };
+
     tracing::trace!(
             ?rel_info.kind,
             %rel_info.size,
+            value,
+            value_hex = %HexU64::new(value),
             symbol_name = %layout.symbol_db.symbol_name_for_display(local_symbol_id),
             "relocation applied");
 
-    let _value = match rel_info.kind {
-        RelocationKind::Relative => {
-            assert_ne!(resolution.raw_value, 0);
-            resolution.raw_value
-        }
-        _ => todo!(),
-    };
+    or_from_slice(
+        &mut out[offset_in_section as usize..offset_in_section as usize + 4],
+        &(value as u32).to_le_bytes(),
+    );
 
     Ok(())
 }

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -429,9 +429,10 @@ fn apply_relocation<'data, A: Arch<Platform = MachO>>(
     let _addend = rel.r_address;
     let (resolution, _symbol_index, local_symbol_id) = get_resolution(rel, object_layout, layout)?;
 
+    const MASK: u64 = (1 << 27) - 1;
     let value = match rel_info.kind {
         // TODO: assuming it's JUMP26
-        RelocationKind::Relative => (resolution.raw_value.wrapping_sub(place)) >> 2,
+        RelocationKind::Relative => ((resolution.raw_value.wrapping_sub(place)) >> 2) & MASK,
         _ => todo!(),
     };
 

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -40,13 +40,11 @@ use crate::part_id;
 use crate::platform::Arch;
 use crate::platform::Args;
 use crate::platform::ObjectFile;
-use crate::platform::RelocationList;
 use crate::resolution::SectionSlot;
 use crate::symbol_db::SymbolId;
 use crate::timing_phase;
 use crate::value_flags::ValueFlags;
 use crate::verbose_timing_phase;
-use gimli::LittleEndian;
 use linker_utils::elf::RelocationKind;
 use object::BigEndian;
 use object::Endianness;
@@ -61,7 +59,6 @@ use object::macho::LC_MAIN;
 use object::macho::LC_SEGMENT_64;
 use object::macho::MH_CIGAM_64;
 use object::macho::MH_EXECUTE;
-use object::macho::Relocation;
 use object::macho::RelocationInfo;
 use object::macho::SEG_DATA;
 use object::macho::SEG_LINKEDIT;
@@ -396,13 +393,11 @@ fn write_object_section<'data, A: Arch<Platform = MachO>>(
     section_index: object::SectionIndex,
     buffers: &mut OutputSectionPartMap<&mut [u8]>,
 ) -> Result {
-    let mut out = write_section_raw(object_layout, layout, section, section_index, buffers)?;
+    let out = write_section_raw(object_layout, layout, section, section_index, buffers)?;
 
     let section_address = object_layout.section_resolutions[section_index.0]
         .address()
         .context("Attempted to apply relocations to a section that we didn't load")?;
-    dbg!(section_address);
-    let object_section = object_layout.object.section(section_index)?;
 
     for rel in object_layout.relocations(section_index)?.relocations {
         apply_relocation::<A>(object_layout, section_address, rel.info(LE), layout, out)?;
@@ -417,7 +412,7 @@ fn apply_relocation<'data, A: Arch<Platform = MachO>>(
     section_address: u64,
     rel: RelocationInfo,
     layout: &MachOLayout<'data>,
-    out: &mut [u8],
+    _out: &mut [u8],
 ) -> Result {
     let offset_in_section = u64::from(rel.r_address);
     let place = section_address + offset_in_section;
@@ -430,8 +425,8 @@ fn apply_relocation<'data, A: Arch<Platform = MachO>>(
     .entered();
 
     let rel_info = A::relocation_from_raw(rel)?;
-    let mut addend = rel.r_address;
-    let (resolution, symbol_index, local_symbol_id) = get_resolution(rel, object_layout, layout)?;
+    let _addend = rel.r_address;
+    let (resolution, _symbol_index, local_symbol_id) = get_resolution(rel, object_layout, layout)?;
 
     tracing::trace!(
             ?rel_info.kind,
@@ -439,10 +434,10 @@ fn apply_relocation<'data, A: Arch<Platform = MachO>>(
             symbol_name = %layout.symbol_db.symbol_name_for_display(local_symbol_id),
             "relocation applied");
 
-    let value = match rel_info.kind {
+    let _value = match rel_info.kind {
         RelocationKind::Relative => {
-            dbg!(resolution);
-            todo!()
+            assert_ne!(resolution.raw_value, 0);
+            resolution.raw_value
         }
         _ => todo!(),
     };

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -13,6 +13,7 @@ use crate::layout::Layout;
 use crate::layout::ObjectLayout;
 use crate::layout::OutputRecordLayout;
 use crate::layout::PreludeLayout;
+use crate::layout::Resolution;
 use crate::layout::Section;
 use crate::macho::ChainedFixupsHeader;
 use crate::macho::DEFAULT_SEGMENT_COUNT;
@@ -33,16 +34,23 @@ use crate::macho::get_segment_sections;
 use crate::output_section_id;
 use crate::output_section_id::SectionName;
 use crate::output_section_part_map::OutputSectionPartMap;
+use crate::output_trace::HexU64;
 use crate::output_trace::TraceOutput;
 use crate::part_id;
 use crate::platform::Arch;
 use crate::platform::Args;
 use crate::platform::ObjectFile;
+use crate::platform::RelocationList;
 use crate::resolution::SectionSlot;
+use crate::symbol_db::SymbolId;
 use crate::timing_phase;
+use crate::value_flags::ValueFlags;
 use crate::verbose_timing_phase;
+use gimli::LittleEndian;
+use linker_utils::elf::RelocationKind;
 use object::BigEndian;
 use object::Endianness;
+use object::SymbolIndex;
 use object::U32;
 use object::from_bytes_mut;
 use object::macho;
@@ -53,6 +61,8 @@ use object::macho::LC_MAIN;
 use object::macho::LC_SEGMENT_64;
 use object::macho::MH_CIGAM_64;
 use object::macho::MH_EXECUTE;
+use object::macho::Relocation;
+use object::macho::RelocationInfo;
 use object::macho::SEG_DATA;
 use object::macho::SEG_LINKEDIT;
 use object::macho::SEG_PAGEZERO;
@@ -380,16 +390,64 @@ fn write_object<'data, A: Arch<Platform = MachO>>(
 }
 
 fn write_object_section<'data, A: Arch<Platform = MachO>>(
-    object: &ObjectLayout<'data, MachO>,
+    object_layout: &ObjectLayout<'data, MachO>,
     layout: &MachOLayout<'data>,
     section: &Section,
     section_index: object::SectionIndex,
     buffers: &mut OutputSectionPartMap<&mut [u8]>,
 ) -> Result {
-    write_section_raw(object, layout, section, section_index, buffers)?;
-    Ok(())
+    let mut out = write_section_raw(object_layout, layout, section, section_index, buffers)?;
 
-    // TODO: process relocations
+    let section_address = object_layout.section_resolutions[section_index.0]
+        .address()
+        .context("Attempted to apply relocations to a section that we didn't load")?;
+    dbg!(section_address);
+    let object_section = object_layout.object.section(section_index)?;
+
+    for rel in object_layout.relocations(section_index)?.relocations {
+        apply_relocation::<A>(object_layout, section_address, rel.info(LE), layout, out)?;
+    }
+
+    Ok(())
+}
+
+#[inline(always)]
+fn apply_relocation<'data, A: Arch<Platform = MachO>>(
+    object_layout: &ObjectLayout<'data, MachO>,
+    section_address: u64,
+    rel: RelocationInfo,
+    layout: &MachOLayout<'data>,
+    out: &mut [u8],
+) -> Result {
+    let offset_in_section = u64::from(rel.r_address);
+    let place = section_address + offset_in_section;
+
+    let _span = tracing::trace_span!(
+        "relocation",
+        address = place,
+        address_hex = %HexU64::new(place)
+    )
+    .entered();
+
+    let rel_info = A::relocation_from_raw(rel)?;
+    let mut addend = rel.r_address;
+    let (resolution, symbol_index, local_symbol_id) = get_resolution(rel, object_layout, layout)?;
+
+    tracing::trace!(
+            ?rel_info.kind,
+            %rel_info.size,
+            symbol_name = %layout.symbol_db.symbol_name_for_display(local_symbol_id),
+            "relocation applied");
+
+    let value = match rel_info.kind {
+        RelocationKind::Relative => {
+            dbg!(resolution);
+            todo!()
+        }
+        _ => todo!(),
+    };
+
+    Ok(())
 }
 
 fn write_section_raw<'out, 'data>(
@@ -425,6 +483,38 @@ fn write_section_raw<'out, 'data>(
     } else {
         Ok(&mut [])
     }
+}
+
+fn get_resolution<'data>(
+    rel: RelocationInfo,
+    object_layout: &ObjectLayout<'data, MachO>,
+    layout: &MachOLayout,
+) -> Result<(Resolution<MachO>, SymbolIndex, SymbolId)> {
+    let symbol_index = SymbolIndex(rel.r_symbolnum as usize);
+    let local_symbol_id = object_layout.symbol_id_range.input_to_id(symbol_index);
+    let sym = object_layout.object.symbol(symbol_index)?;
+    let section_index = object_layout.object.symbol_section(sym, symbol_index)?;
+    let resolution = layout
+        .merged_symbol_resolution(local_symbol_id)
+        .or_else(|| {
+            section_index.and_then(|section_index| {
+                let section_address =
+                    object_layout.section_resolutions[section_index.0].address()?;
+                Some(Resolution {
+                    raw_value: section_address,
+                    dynamic_symbol_index: None,
+                    flags: ValueFlags::empty(),
+                    format_specific: Default::default(),
+                })
+            })
+        })
+        .with_context(|| {
+            format!(
+                "Missing resolution for: {}",
+                layout.symbol_debug(local_symbol_id)
+            )
+        })?;
+    Ok((resolution, symbol_index, local_symbol_id))
 }
 
 fn write_entry_point_command<A: Arch<Platform = MachO>>(

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -1,4 +1,5 @@
 use crate::bail;
+use crate::elf::get_page_mask;
 use crate::ensure;
 use crate::error;
 use crate::error::Context;
@@ -67,6 +68,7 @@ use object::macho::SEG_TEXT;
 use object::slice_from_bytes_mut;
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::ParallelIterator;
+use std::ops::BitAnd;
 use tracing::debug_span;
 use zerocopy::FromZeros;
 
@@ -428,8 +430,14 @@ fn apply_relocation<'data, A: Arch<Platform = MachO>>(
     let _addend = rel.r_address;
     let (resolution, _symbol_index, local_symbol_id) = get_resolution(rel, object_layout, layout)?;
 
+    let mask = get_page_mask(rel_info.mask);
     let value = match rel_info.kind {
-        RelocationKind::Relative => resolution.raw_value.wrapping_sub(place),
+        RelocationKind::Absolute => resolution.raw_value.bitand(mask.symbol_plus_addend),
+        RelocationKind::AbsoluteLowPart => resolution.raw_value.bitand(mask.symbol_plus_addend),
+        RelocationKind::Relative => resolution
+            .raw_value
+            .bitand(mask.symbol_plus_addend)
+            .wrapping_sub(place.bitand(mask.place)),
         _ => todo!(),
     };
 

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -46,7 +46,6 @@ use crate::timing_phase;
 use crate::value_flags::ValueFlags;
 use crate::verbose_timing_phase;
 use linker_utils::elf::RelocationKind;
-use linker_utils::utils::or_from_slice;
 use object::BigEndian;
 use object::Endianness;
 use object::SymbolIndex;
@@ -429,10 +428,8 @@ fn apply_relocation<'data, A: Arch<Platform = MachO>>(
     let _addend = rel.r_address;
     let (resolution, _symbol_index, local_symbol_id) = get_resolution(rel, object_layout, layout)?;
 
-    const MASK: u64 = (1 << 27) - 1;
     let value = match rel_info.kind {
-        // TODO: assuming it's JUMP26
-        RelocationKind::Relative => ((resolution.raw_value.wrapping_sub(place)) >> 2) & MASK,
+        RelocationKind::Relative => resolution.raw_value.wrapping_sub(place),
         _ => todo!(),
     };
 
@@ -444,10 +441,7 @@ fn apply_relocation<'data, A: Arch<Platform = MachO>>(
             symbol_name = %layout.symbol_db.symbol_name_for_display(local_symbol_id),
             "relocation applied");
 
-    or_from_slice(
-        &mut out[offset_in_section as usize..offset_in_section as usize + 4],
-        &(value as u32).to_le_bytes(),
-    );
+    rel_info.write_to_buffer(value, &mut out[offset_in_section as usize..])?;
 
     Ok(())
 }

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -68,7 +68,9 @@ pub(crate) trait Arch: Send + Sync + 'static {
     fn write_plt_entry(plt_entry: &mut [u8], got_address: u64, plt_address: u64) -> Result;
 
     /// Make architecture-specific parsing of the relocation types.
-    fn relocation_from_raw(r_type: u32) -> Result<RelocationKindInfo>;
+    fn relocation_from_raw(
+        r_type: <Self::Platform as Platform>::RelocationInfo,
+    ) -> Result<RelocationKindInfo>;
 
     /// Get string representation of a relocation specific for the architecture.
     fn rel_type_to_string(r_type: u32) -> Cow<'static, str>;
@@ -186,6 +188,7 @@ pub(crate) trait Platform:
     type RelocationSections: std::fmt::Debug + Default + Send + Sync + 'static;
     type DynamicEntry: Send + Sync + 'static;
     type DynamicSymbolDefinitionExt: Copy + Send + Sync + std::fmt::Debug + 'static;
+    type RelocationInfo: Copy + Send + Sync + 'static;
     type NonAddressableIndexes: NonAddressableIndexes + Send + Sync + 'static;
     type NonAddressableCounts: Default + Send + Sync + 'static;
     type EpilogueLayoutExt: Send + Sync + 'static;

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -707,13 +707,12 @@ pub(crate) trait ObjectFile<'data>: Sized + Send + Sync + std::fmt::Debug + 'dat
         symbol: &<Self::Platform as Platform>::SymtabEntry,
     ) -> Result<&'data [u8]>;
 
-    fn symbol_value_in_section(
+    // Get the offset of a symbol relative to the section identified by `section_index`.
+    fn symbol_offset_in_section(
         &self,
         symbol: &<Self::Platform as Platform>::SymtabEntry,
-        _section_index: object::SectionIndex,
-    ) -> Result<u64> {
-        Ok(symbol.value())
-    }
+        section_index: object::SectionIndex,
+    ) -> Result<u64>;
 
     fn num_sections(&self) -> usize;
 

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -707,6 +707,14 @@ pub(crate) trait ObjectFile<'data>: Sized + Send + Sync + std::fmt::Debug + 'dat
         symbol: &<Self::Platform as Platform>::SymtabEntry,
     ) -> Result<&'data [u8]>;
 
+    fn symbol_value_in_section(
+        &self,
+        symbol: &<Self::Platform as Platform>::SymtabEntry,
+        _section_index: object::SectionIndex,
+    ) -> Result<u64> {
+        Ok(symbol.value())
+    }
+
     fn num_sections(&self) -> usize;
 
     fn section_iter(&self) -> <Self::Platform as Platform>::SectionIterator<'data>;

--- a/linker-utils/src/aarch64.rs
+++ b/linker-utils/src/aarch64.rs
@@ -1028,6 +1028,22 @@ impl AArch64Instruction {
             AArch64Instruction::JumpCall => {
                 mask = extracted_value as u32;
             }
+            AArch64Instruction::MachOLow12 => {
+                // The relocation value is scaled by the access size for ADD, LDR and STR
+                // instructions. The following logic is taken from LLVM
+                // (encodePageOff12).
+                let insn = u32_from_slice(&dest[0..4]);
+                let mut scale = 0;
+                if (insn & 0x3b00_0000) == 0x3900_0000 {
+                    // load/store
+                    scale = insn >> 30;
+                    if scale == 0 && (insn & 0x0480_0000) == 0x0480_0000 {
+                        // 128-bit variant
+                        scale = 4;
+                    }
+                }
+                mask = (extracted_value as u32) >> scale;
+            }
         }
         // Read the original value and combine it with the prepared mask.
         or_from_slice(dest, &mask.to_le_bytes());
@@ -1066,6 +1082,7 @@ impl AArch64Instruction {
             AArch64Instruction::Bcond => (value >> 5).low_bits_signed(19),
             // C6.2.33
             AArch64Instruction::JumpCall => value.low_bits_signed(26),
+            AArch64Instruction::MachOLow12 => todo!(),
         };
 
         (extracted_value, negative)

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -1268,6 +1268,8 @@ pub enum AArch64Instruction {
     TstBr,
     Bcond,
     JumpCall,
+    // Mach-O specific
+    MachOLow12,
 }
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -1,3 +1,4 @@
+use crate::bit_misc::BitExtraction;
 use crate::bit_misc::BitRange;
 use anyhow::Result;
 use object::LittleEndian;
@@ -5,6 +6,7 @@ use object::read::elf::ProgramHeader as _;
 use object::read::elf::SectionHeader;
 use std::borrow::Cow;
 use std::fmt;
+use std::io::Cursor;
 
 macro_rules! const_name_by_value {
     ($needle: expr, $( $const:ident ),* $(,)?) => {
@@ -1514,7 +1516,7 @@ pub struct RelocationKindInfo {
 
 impl RelocationKindInfo {
     #[inline(always)]
-    pub fn verify(&self, value: i64) -> Result<()> {
+    fn verify(&self, value: i64) -> Result<()> {
         anyhow::ensure!(
             (value as usize).is_multiple_of(self.alignment),
             "Relocation {value} not aligned to {} bytes",
@@ -1527,6 +1529,44 @@ impl RelocationKindInfo {
                 self.range.min, self.range.max
             )
         );
+        Ok(())
+    }
+
+    #[inline(always)]
+    pub fn write_to_buffer(self, value: u64, output: &mut [u8]) -> Result<()> {
+        self.verify(value as i64)?;
+
+        if matches!(self.kind, RelocationKind::PairSubtractionULEB128(..)) {
+            // u64 always fits in 10 bytes in the ULEB format: 64 / 7 = 9.14
+            let mut writer = Cursor::new(vec![0u8; 10]);
+            let n = leb128::write::unsigned(&mut writer, value).expect("Must fit into the buffer");
+            anyhow::ensure!(
+                output.len() >= n,
+                "cannot write encoded ULEB128 value of {n} bytes"
+            );
+            output[..n].copy_from_slice(&writer.into_inner()[..n]);
+        } else {
+            match self.size {
+                RelocationSize::ByteSize(byte_size) => {
+                    anyhow::ensure!(
+                        byte_size <= output.len(),
+                        "Relocation outside of bounds of section"
+                    );
+                    let value_bytes = value.to_le_bytes();
+                    output[..byte_size].copy_from_slice(&value_bytes[..byte_size]);
+                }
+                RelocationSize::BitMasking(BitMask {
+                    range,
+                    instruction: insn,
+                }) => {
+                    let extracted_value = value.extract_bit_range(range.start..range.end);
+                    let negative = (value as i64).is_negative();
+                    let output_len = output.len();
+                    insn.write_to_value(extracted_value, negative, &mut output[..output_len]);
+                }
+            }
+        }
+
         Ok(())
     }
 }

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -1390,7 +1390,8 @@ impl fmt::Display for RelocationSize {
 }
 
 impl RelocationSize {
-    pub(crate) const fn bit_mask_aarch64(
+    #[must_use]
+    pub const fn bit_mask_aarch64(
         bit_start: u32,
         bit_end: u32,
         instruction: AArch64Instruction,
@@ -1402,7 +1403,8 @@ impl RelocationSize {
         ))
     }
 
-    pub(crate) const fn bit_mask_riscv(
+    #[must_use]
+    pub const fn bit_mask_riscv(
         bit_start: u32,
         bit_end: u32,
         instruction: RiscVInstruction,
@@ -1414,7 +1416,8 @@ impl RelocationSize {
         ))
     }
 
-    pub(crate) const fn bit_mask_loongarch64(
+    #[must_use]
+    pub const fn bit_mask_loongarch64(
         bit_start: u32,
         bit_end: u32,
         instruction: LoongArch64Instruction,


### PR DESCRIPTION
With the change, I can link a multi-input file test-case like this:
```foo.c
int baz();

int bar() {
  return baz();
}

int foo() {
  return bar();
}
...
int value = 42;

int foo();
long baz() {
  return value;
}

int main() {
  return foo();
}
```

As of now, the change only handles symbol relocations, but I am planning to add also sections as a target of relocations. There's one specialty where Mach-O scales relocation values for the low 12-bits of `MachOLow12` based on the size of the load or a store instruction (needs to be decoded from the instruction stream).

Issue: #757 