### PR TITLE
chore: Always compile external test driver

### DIFF
--- a/libwild/src/save_dir.rs
+++ b/libwild/src/save_dir.rs
@@ -462,12 +462,9 @@ fn create_symlink(target: &Path, dest_path: &Path) -> Result {
     #[cfg(windows)]
     {
         use std::os::windows::fs::FileTypeExt as _;
-        let is_dir = std::fs::metadata(target)
-            .map(|meta| meta.is_dir())
-            .unwrap_or(false);
-        let is_symlink_dir = std::fs::symlink_metadata(target)
-            .map(|meta| meta.file_type().is_symlink_dir())
-            .unwrap_or(false);
+        let is_dir = std::fs::metadata(target).is_ok_and(|meta| meta.is_dir());
+        let is_symlink_dir =
+            std::fs::symlink_metadata(target).is_ok_and(|meta| meta.file_type().is_symlink_dir());
         let result = if is_dir || is_symlink_dir {
             std::os::windows::fs::symlink_dir(target, dest_path)
         } else {

--- a/wild/tests/external_tests/mod.rs
+++ b/wild/tests/external_tests/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "mold_tests")]
 mod mold_tests;
 
 use crate::Filter;
@@ -13,8 +12,7 @@ use std::process::Output;
 use std::sync::OnceLock;
 
 pub(super) fn collect_tests(tests: &mut Vec<Trial>, filter: &Filter) -> Result {
-    #[cfg(feature = "mold_tests")]
-    {
+    if cfg!(feature = "mold_tests") {
         mold_tests::collect_tests(tests, filter)?;
     }
 

--- a/wild/tests/external_tests/mold_tests.rs
+++ b/wild/tests/external_tests/mold_tests.rs
@@ -151,8 +151,8 @@ fn load_skip_tests_config() -> &'static Option<Vec<String>> {
 
                 config
                     .skipped_groups
-                    .into_iter()
-                    .flat_map(|(_, group)| group.tests)
+                    .into_values()
+                    .flat_map(|group| group.tests)
                     .collect()
             })
             .ok()


### PR DESCRIPTION
This makes maintaining this code easier. Also, fix a few clippy warnings now showing up in conditionally compiled code - which was the trigger for this change.