### PR TITLE
feat: support `--nmagic`

### DIFF
--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -126,6 +126,8 @@ pub struct ElfArgs {
     pub(crate) should_output_executable: bool,
     pub(crate) should_output_partial_object: bool,
 
+    pub(crate) nmagic: bool,
+
     rpath_set: IndexSet<String>,
 
     pub experimental_sframe: bool,
@@ -313,6 +315,8 @@ impl Default for ElfArgs {
             pack_dyn_relocs: PackDynRelocs::None,
             use_android_relr_tags: false,
 
+            nmagic: false,
+
             unresolved_symbols: UnresolvedSymbols::ReportAll,
             error_unresolved_symbols: true,
             allow_multiple_definitions: false,
@@ -412,6 +416,18 @@ pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(
         || args.pack_dyn_relocs == PackDynRelocs::AndroidRelr
     {
         args.warn_unsupported("--pack-dyn-relocs=android")?;
+    }
+
+    if args.nmagic {
+        // GNU_RELRO requires segments to start on page boundaries and cover an entire page
+        args.relro = false;
+        if args.max_page_size.is_some() {
+            args.warning("-z max-page-size is incompatible with --nmagic");
+        }
+        args.common_mut()
+            .inputs
+            .iter_mut()
+            .for_each(|input| input.modifiers.allow_shared = false);
     }
 
     Ok(())
@@ -1795,6 +1811,25 @@ fn setup_argument_parser() -> ArgumentParser<ElfArgs> {
             Ok(())
         });
 
+    parser
+        .declare()
+        .short("n")
+        .long("nmagic")
+        .help("Disable page alignment of sections and disable linking against shared libraries")
+        .execute(|args, _modifier_stack| {
+            args.nmagic = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("no-nmagic")
+        .help("Page align sections (default)")
+        .execute(|args, _modifier_stack| {
+            args.nmagic = false;
+            Ok(())
+        });
+
     add_silently_ignored_flags(&mut parser);
     add_default_flags(&mut parser);
 
@@ -1998,6 +2033,10 @@ impl platform::Args for ElfArgs {
     }
 
     fn loadable_segment_alignment(&self) -> Alignment {
+        if self.nmagic {
+            return Alignment { exponent: 0 };
+        }
+
         if let Some(max_page_size) = self.max_page_size {
             return max_page_size;
         }

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -815,6 +815,13 @@ impl platform::Platform for Elf {
                 }
             }
         }
+
+        // The PHDR program header should only be present if --nmagic is not set
+        for (segment_def, keep) in program_segments.into_iter().zip(keep_segments.iter_mut()) {
+            if segment_def.segment_type == pt::PHDR {
+                *keep = !args.nmagic;
+            }
+        }
     }
 
     fn program_segment_defs() -> &'static [ProgramSegmentDef] {
@@ -4313,7 +4320,7 @@ impl platform::ProgramSegmentDef for ProgramSegmentDef {
     }
 
     fn always_keep(self) -> bool {
-        self.segment_type == pt::PHDR
+        false
     }
 
     fn is_loadable(self) -> bool {

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -21,7 +21,6 @@ tests = [
   "init-in-dso.sh",
   "init.sh",
   "library.sh",
-  "nmagic.sh",
   "oformat-binary.sh",
   "omagic.sh",
   "package-metadata.sh",
@@ -166,6 +165,7 @@ tests = [
   "many-output-sections.sh",        # Different message formats
   "mold-wrapper.sh",
   "mold-wrapper2.sh",
+  "nmagic.sh",                      # end is only emitted if .bss section exists. LLD also fails.
   "no-allow-shlib-undefined.sh",    # Different message formats
   "no-allow-shlib-undefined3.sh",   # Different message formats
   "no-allow-shlib-undefined4.sh",   # GNU ld and LLD also fail

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -54,8 +54,8 @@
 //! argument. If no ExpectComment directives are given then .comment isn't checked. The argument may
 //! end with '*' which matches anything.
 //!
-//! ExpectLoadAlignment:{alignment} Checks that the first PT_LOAD segment in the output binary has
-//! the specified alignment.
+//! ExpectLoadAlignment:{alignment} {alignment} ... Checks that the first N PT_LOAD segments in the
+//! output binary have the specified alignment.
 //!
 //! ExpectProgramHeader:{type} Checks that the output binary contains a program header of the
 //! specified type.
@@ -1168,7 +1168,7 @@ struct Assertions {
     does_not_contain: Vec<String>,
     contains_strings: Vec<String>,
     expect_dynamic: bool,
-    expected_load_alignment: Option<u64>,
+    expected_load_alignments: Vec<u64>,
     expected_dynamic_entries: Vec<String>,
     absent_dynamic_entries: Vec<String>,
     expected_section_bytes: Vec<ExpectedSectionBytes>,
@@ -1525,16 +1525,19 @@ fn process_directive(
             .absent_dynamic_entries
             .push(arg.trim().to_owned()),
         "ExpectLoadAlignment" => {
-            let alignment_str = arg.trim();
-            let alignment = if let Some(hex) = alignment_str.strip_prefix("0x") {
-                u64::from_str_radix(hex, 16)
-                    .with_context(|| format!("Invalid hex alignment: {alignment_str}"))?
-            } else {
-                alignment_str
-                    .parse()
-                    .with_context(|| format!("Invalid alignment: {alignment_str}"))?
-            };
-            config.assertions.expected_load_alignment = Some(alignment);
+            let alignment_strs = arg.split(" ").map(str::trim);
+            let alignments = alignment_strs.map(|alignment_str| {
+                if let Some(hex) = alignment_str.strip_prefix("0x") {
+                    u64::from_str_radix(hex, 16)
+                        .with_context(|| format!("Invalid hex alignment: {alignment_str}"))
+                } else {
+                    alignment_str
+                        .parse::<u64>()
+                        .with_context(|| format!("Invalid alignment: {alignment_str}"))
+                }
+            });
+            config.assertions.expected_load_alignments =
+                alignments.collect::<Result<Vec<u64>>>()?;
         }
         "ExpectProgramHeader" => {
             let header_type: ProgramHeaderType = arg
@@ -3491,7 +3494,7 @@ impl Assertions {
                 if !self.no_dynsym.is_empty() {
                     bail!("NoDynSym is not supported for MachO",);
                 }
-                if self.expected_load_alignment.is_some() {
+                if !self.expected_load_alignments.is_empty() {
                     bail!("ExpectLoadAlignment is not supported for MachO",);
                 }
                 if !self.expected_dynamic_entries.is_empty() {
@@ -3625,24 +3628,27 @@ impl Assertions {
         &self,
         obj: &object::read::elf::ElfFile64<'data, object::Endianness>,
     ) -> Result {
-        let Some(expected) = self.expected_load_alignment else {
-            return Ok(());
-        };
-
+        let mut expected_load_alignments = self.expected_load_alignments.iter();
         let endian = obj.endian();
         let segments = obj.elf_program_headers();
         for segment in segments {
             if segment.p_type(endian) == object::elf::PT_LOAD {
                 let alignment = segment.p_align(endian);
-                if alignment != expected {
+                let Some(expected) = expected_load_alignments.next() else {
+                    return Ok(());
+                };
+
+                if alignment != *expected {
                     bail!("Expected LOAD segment alignment {expected:#x}, but got {alignment:#x}");
                 }
-
-                return Ok(());
             }
         }
 
-        bail!("No LOAD segment found");
+        if expected_load_alignments.count() > 0 {
+            bail!("No LOAD segment found");
+        }
+
+        Ok(())
     }
 
     fn verify_symbols_absent<'a, I>(

--- a/wild/tests/sources/elf/nmagic/nmagic.c
+++ b/wild/tests/sources/elf/nmagic/nmagic.c
@@ -1,0 +1,29 @@
+//#Config:default
+//#LinkArgs:--nmagic -z relro
+//#Object:runtime.c
+//#NoProgramHeader:PHDR
+//#NoProgramHeader:INTERP
+//#NoProgramHeader:GNU_RELRO
+//#DoesNotContain:relro
+// ld merges the first two LOAD segments with --nmagic, while wild and LLD do not
+//#SkipLinker:ld
+//#EnableLinker:lld
+//#RunEnabled:false
+//#ExpectLoadAlignment:0x8 0x20
+
+//#Config:warn-max-page-size:default
+//#LinkArgs:--nmagic -z max-page-size=65536
+//#ExpectWarningWild:-z max-page-size is incompatible with --nmagic
+
+//#Config:no-dynamic-linking:default
+//#Shared:force-dynamic-linking.c
+//#ExpectError:(?i)Attempted static link of dynamic object
+
+#include "../common/runtime.h"
+
+// Force the .text section to align to 32 bytes rather than the target architecture's instruction
+// size to smooth out any differences when testing.
+__attribute__((aligned(32))) void _start(void) {
+  runtime_init();
+  exit_syscall(42);
+}


### PR DESCRIPTION
`--nmagic` disables page alignment for loadable sections and prevents linking against shared libraries. Support for `--omagic` will follow once this is cleaned up and merged.

ld will merge the R and RX loadable segments with `--nmagic`, whereas lld will not. I have chosen to match the LLD behaviour.

~~I'm aware of two shortcomings so far in this PR:~~

- ~~Cross testing is disabled because QEMU apparently requires loadable segments to be page-aligned. This is rather unfortunate, as the tests in nmagic.c are passing on my x64 laptop, but failing in aarch64 CI, and I don't have an aarch64 box to test on.~~
- ~~ld and lld both don't write the PHDR program header entry with --nmagic, whereas wild with this PR does. Advice on how to match that behaviour would be appreciated.~~