### PR TITLE
fix: check for static link of dynamic object

### DIFF
--- a/libwild/src/input_data.rs
+++ b/libwild/src/input_data.rs
@@ -718,9 +718,16 @@ impl<'data, P: Platform> TemporaryState<'data, P> {
             modifiers: input_ref.file.modifiers,
         };
 
-        let object = ParsedInputObject::new(&input_bytes, self.args);
+        let object = InputRecord::Object(ParsedInputObject::new(&input_bytes, self.args));
 
-        Ok(InputRecord::Object(object))
+        if object.is_dynamic_object() && !input_ref.file.modifiers.allow_shared {
+            bail!(
+                "Attempted static link of dynamic object {}",
+                input_ref.file.filename.display()
+            );
+        }
+
+        Ok(object)
     }
 }
 

--- a/wild/tests/sources/elf/no-dynamic-in-static/no-dynamic-in-static.c
+++ b/wild/tests/sources/elf/no-dynamic-in-static/no-dynamic-in-static.c
@@ -1,0 +1,5 @@
+//#Mode:static
+//#Shared:force-dynamic-linking.c
+//#ExpectError:(?i)Attempted static link of dynamic object
+
+int main() { return 42; }


### PR DESCRIPTION
The allow_shared modifier currently only applies if given a library name as an input, but is ignored if given a filename. This PR adds a check to see whether a shared object given as a filename is allowed to be linked.

Split off from #1884.