### PR TITLE
port(MachO): support symbol table

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -333,11 +333,6 @@ impl platform::Platform for Elf {
     type ResolutionExt = ResolutionExt;
     type SymtabShndxEntry = SymtabShndxEntry;
 
-    fn is_default_strippable_symbol(sym: &Self::SymtabEntry, name: &[u8]) -> bool {
-        (sym.is_local() && name.starts_with(b".L"))
-            || crate::symbol_db::is_mapping_symbol_name(name)
-    }
-
     fn link_for_arch<'data>(
         linker: &'data crate::Linker,
         args: &'data Self::Args,
@@ -2914,6 +2909,11 @@ impl platform::Symbol for SymtabEntry {
 
     fn has_name(&self) -> bool {
         object::read::elf::Sym::st_name(self, LittleEndian) != 0
+    }
+
+    fn is_default_strippable(&self, name: &[u8]) -> bool {
+        (self.is_local() && name.starts_with(b".L"))
+            || crate::symbol_db::is_mapping_symbol_name(name)
     }
 
     fn debug_string(&self) -> String {

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -333,6 +333,11 @@ impl platform::Platform for Elf {
     type ResolutionExt = ResolutionExt;
     type SymtabShndxEntry = SymtabShndxEntry;
 
+    fn is_default_strippable_symbol(sym: &Self::SymtabEntry, name: &[u8]) -> bool {
+        (sym.is_local() && name.starts_with(b".L"))
+            || crate::symbol_db::is_mapping_symbol_name(name)
+    }
+
     fn link_for_arch<'data>(
         linker: &'data crate::Linker,
         args: &'data Self::Args,

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -4231,8 +4231,7 @@ impl<'data> SymbolCopyInfo<'data> {
         // needs the name, doesn't have a go and read it again.
         let name = object.symbol_name(sym).ok()?;
         if name.is_empty()
-            || (!symbol_db.args.should_output_partial_object()
-                && P::is_default_strippable_symbol(sym, name))
+            || (!symbol_db.args.should_output_partial_object() && sym.is_default_strippable(name))
         {
             return None;
         }

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -61,7 +61,6 @@ use crate::symbol_db::SymbolDebug;
 use crate::symbol_db::SymbolId;
 use crate::symbol_db::SymbolIdRange;
 use crate::symbol_db::Visibility;
-use crate::symbol_db::is_mapping_symbol_name;
 use crate::thunks;
 use crate::thunks::ThunkBlockId;
 use crate::thunks::ThunkLayoutBuilder;
@@ -4233,7 +4232,7 @@ impl<'data> SymbolCopyInfo<'data> {
         let name = object.symbol_name(sym).ok()?;
         if name.is_empty()
             || (!symbol_db.args.should_output_partial_object()
-                && ((sym.is_local() && name.starts_with(b".L")) || is_mapping_symbol_name(name)))
+                && P::is_default_strippable_symbol(sym, name))
         {
             return None;
         }

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -1275,8 +1275,7 @@ impl platform::Platform for MachO {
         }
         let entry_size = size_of::<SymtabEntry>() as u64;
         common.allocate(part_id::SYMTAB_GLOBAL, num_globals * entry_size);
-        // n_strx == 0 is treated as unnamed, so we need to start from the index 1.
-        common.allocate(part_id::STRTAB, (strings_size + 1) as u64);
+        common.allocate(part_id::STRTAB, strings_size as u64);
 
         Ok(())
     }

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -16,6 +16,7 @@ use crate::layout;
 use crate::layout::Layout;
 use crate::layout::OutputRecordLayout;
 use crate::layout::Resolution;
+use crate::layout::SymbolCopyInfo;
 use crate::layout_rules::SectionKind;
 use crate::layout_rules::SectionRule;
 use crate::macho_writer;
@@ -28,6 +29,7 @@ use crate::output_section_id::SectionOutputInfo;
 use crate::part_id;
 use crate::platform;
 use crate::platform::ObjectFile;
+use crate::platform::Symbol as _;
 use crate::symbol_db::Visibility;
 use crate::value_flags::ValueFlags;
 use gimli::LittleEndian;
@@ -86,6 +88,7 @@ pub(crate) type DylinkerCommand = object::macho::DylinkerCommand<Endianness>;
 pub(crate) type CodeSignatureCommand = object::macho::LinkeditDataCommand<Endianness>;
 pub(crate) type DyldChainedFixupsCommand = object::macho::LinkeditDataCommand<Endianness>;
 pub(crate) type ChainedFixupsHeader = DyldChainedFixupsHeader<Endianness>;
+pub(crate) type SymtabCommand = object::macho::SymtabCommand<Endianness>;
 
 // TODO: move the following data types to object crate
 
@@ -188,12 +191,6 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
     }
 
     fn symbols_iter(&self) -> impl Iterator<Item = &'data SymtabEntry> {
-        for s in self.symbols.iter() {
-            let name = s.name(LE, self.symbols.strings()).unwrap();
-            // TODO: remove
-            // dbg!(String::from_utf8_lossy(name));
-        }
-
         self.symbols.iter()
     }
 
@@ -770,10 +767,13 @@ impl platform::ProgramSegmentDef for ProgramSegmentDef {
             | output_section_id::LINK_EDIT_SEGMENT
             | output_section_id::ENTRY_POINT
             | output_section_id::INTERP
-            | output_section_id::DYLD_CHAINED_FIXUPS => SegmentType::LoadCommands,
+            | output_section_id::DYLD_CHAINED_FIXUPS
+            | output_section_id::SYMTAB_COMMAND => SegmentType::LoadCommands,
             output_section_id::TEXT | output_section_id::CSTRING => SegmentType::TextSections,
             output_section_id::DATA => SegmentType::DataSections,
-            output_section_id::CHAINED_FIXUP_TABLE => SegmentType::LinkeditSections,
+            output_section_id::CHAINED_FIXUP_TABLE
+            | output_section_id::SYMTAB_GLOBAL
+            | output_section_id::STRTAB => SegmentType::LinkeditSections,
             _ => SegmentType::Unused,
         };
 
@@ -901,6 +901,10 @@ impl platform::Platform for MachO {
     type RawSymbolName<'data> = RawSymbolName<'data>;
     type VersionNames<'data> = ();
     type VerneedTable<'data> = VerneedTable<'data>;
+
+    fn is_default_strippable_symbol(sym: &Self::SymtabEntry, name: &[u8]) -> bool {
+        sym.is_local() && name.starts_with(b"ltmp")
+    }
 
     fn link_for_arch<'data>(
         linker: &'data crate::Linker,
@@ -1222,6 +1226,7 @@ impl platform::Platform for MachO {
             part_id::DYLD_CHAINED_FIXUPS,
             size_of::<DyldChainedFixupsCommand>() as u64,
         );
+        sizes.increment(part_id::SYMTAB_COMMAND, size_of::<SymtabCommand>() as u64);
     }
 
     fn finalise_sizes_for_symbol<'data>(
@@ -1247,24 +1252,30 @@ impl platform::Platform for MachO {
         symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
         per_symbol_flags: &crate::value_flags::AtomicPerSymbolFlags,
     ) -> Result {
-        for symbol in state.object.symbols_iter() {
-            // dbg!(String::from_utf8_lossy(
-            //     symbol.name(LE, state.object.symbols.strings()).unwrap()
-            // ));
+        let mut num_globals = 0;
+        let mut strings_size = 0;
+        for ((sym_index, sym), flags) in state
+            .object
+            .enumerate_symbols()
+            .zip(per_symbol_flags.range(state.symbol_id_range))
+        {
+            let symbol_id = state.symbol_id_range.input_to_id(sym_index);
+            if let Some(info) = SymbolCopyInfo::new(
+                state.object,
+                sym_index,
+                sym,
+                symbol_id,
+                symbol_db,
+                flags.get(),
+                &state.sections,
+            ) {
+                num_globals += 1;
+                strings_size += info.name.len() + 1;
+            }
         }
-
-        // TODO
-        // let mut num_globals = 0;
-        // let mut strings_size = 0;
-        // for symbol in state.object.symbols_iter() {
-        //     // TODO: very basic
-        //     num_globals += 1;
-        //     strings_size += state.object.symbol_name(symbol)?.len() + 1;
-        // }
-        // let entry_size = size_of::<SymtabEntry>() as u64;
-        //
-        // common.allocate(part_id::SYMTAB_GLOBAL, dbg!(num_globals * entry_size));
-        // common.allocate(part_id::STRTAB, dbg!(strings_size as u64));
+        let entry_size = size_of::<SymtabEntry>() as u64;
+        common.allocate(part_id::SYMTAB_GLOBAL, num_globals * entry_size);
+        common.allocate(part_id::STRTAB, strings_size as u64);
 
         Ok(())
     }
@@ -1282,6 +1293,7 @@ impl platform::Platform for MachO {
         common: &mut crate::layout::CommonGroupState<Self>,
         symbol_db: &crate::symbol_db::SymbolDb<Self>,
     ) {
+        common.allocate(part_id::STRTAB, 1);
         common.allocate(part_id::CHAINED_FIXUP_TABLE, CHAINED_FIXUP_TABLE_SIZE);
     }
 
@@ -1341,12 +1353,15 @@ impl platform::Platform for MachO {
         builder.add_section(output_section_id::ENTRY_POINT);
         builder.add_section(output_section_id::INTERP); // DYLINKER
         builder.add_section(output_section_id::DYLD_CHAINED_FIXUPS);
+        builder.add_section(output_section_id::SYMTAB_COMMAND);
         // Content of the sections (e.g. __text, __data).
         builder.add_section(output_section_id::TEXT);
         builder.add_section(output_section_id::CSTRING);
         builder.add_section(output_section_id::DATA);
         // The rest (e.g. symbol table, string table).
         builder.add_section(output_section_id::CHAINED_FIXUP_TABLE);
+        builder.add_section(output_section_id::SYMTAB_GLOBAL);
+        builder.add_section(output_section_id::STRTAB);
 
         builder.build()
     }
@@ -1439,16 +1454,27 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         target_segment_type: Some(SegmentType::LoadCommands),
         ..DEFAULT_DEFS
     };
+    defs[output_section_id::SYMTAB_COMMAND.as_usize()] = BuiltInSectionDetails {
+        kind: SectionKind::Primary(SectionName(b"LC_SYMTAB")),
+        target_segment_type: Some(SegmentType::LoadCommands),
+        ..DEFAULT_DEFS
+    };
     defs[output_section_id::CHAINED_FIXUP_TABLE.as_usize()] = BuiltInSectionDetails {
         kind: SectionKind::Primary(SectionName(b"DYLD_CHAINED_FIXUPS_TABLE")),
         target_segment_type: Some(SegmentType::LinkeditSections),
         ..DEFAULT_DEFS
     };
-    // Multi-part generated sections
     defs[output_section_id::SYMTAB_GLOBAL.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Secondary(output_section_id::SYMTAB_LOCAL),
+        kind: SectionKind::Primary(SectionName(b"SYMTAB")),
+        target_segment_type: Some(SegmentType::LinkeditSections),
         ..DEFAULT_DEFS
     };
+    defs[output_section_id::STRTAB.as_usize()] = BuiltInSectionDetails {
+        kind: SectionKind::Primary(SectionName(b"STRTAB")),
+        target_segment_type: Some(SegmentType::LinkeditSections),
+        ..DEFAULT_DEFS
+    };
+    // Multi-part generated sections
     // Start of regular sections
     defs[output_section_id::TEXT.as_usize()] = BuiltInSectionDetails {
         kind: SectionKind::Primary(SectionName(b"__text")),

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -586,6 +586,10 @@ impl platform::Symbol for SymtabEntry {
         self.n_strx.get(LE) != 0
     }
 
+    fn is_default_strippable(&self, name: &[u8]) -> bool {
+        self.is_local() && name.starts_with(b"ltmp")
+    }
+
     fn debug_string(&self) -> String {
         // TODO
         String::new()
@@ -901,10 +905,6 @@ impl platform::Platform for MachO {
     type RawSymbolName<'data> = RawSymbolName<'data>;
     type VersionNames<'data> = ();
     type VerneedTable<'data> = VerneedTable<'data>;
-
-    fn is_default_strippable_symbol(sym: &Self::SymtabEntry, name: &[u8]) -> bool {
-        sym.is_local() && name.starts_with(b"ltmp")
-    }
 
     fn link_for_arch<'data>(
         linker: &'data crate::Linker,

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -1293,6 +1293,8 @@ impl platform::Platform for MachO {
         common: &mut crate::layout::CommonGroupState<Self>,
         symbol_db: &crate::symbol_db::SymbolDb<Self>,
     ) {
+        // Allocate one extra character as n_strx == 0 is treated as unnamed.
+        common.allocate(part_id::STRTAB, 1);
         common.allocate(part_id::CHAINED_FIXUP_TABLE, CHAINED_FIXUP_TABLE_SIZE);
     }
 

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -1293,7 +1293,6 @@ impl platform::Platform for MachO {
         common: &mut crate::layout::CommonGroupState<Self>,
         symbol_db: &crate::symbol_db::SymbolDb<Self>,
     ) {
-        common.allocate(part_id::STRTAB, 1);
         common.allocate(part_id::CHAINED_FIXUP_TABLE, CHAINED_FIXUP_TABLE_SIZE);
     }
 

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -1275,7 +1275,8 @@ impl platform::Platform for MachO {
         }
         let entry_size = size_of::<SymtabEntry>() as u64;
         common.allocate(part_id::SYMTAB_GLOBAL, num_globals * entry_size);
-        common.allocate(part_id::STRTAB, strings_size as u64);
+        // n_strx == 0 is treated as unnamed, so we need to start from the index 1.
+        common.allocate(part_id::STRTAB, (strings_size + 1) as u64);
 
         Ok(())
     }

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -74,6 +74,7 @@ use object::macho::SEG_TEXT;
 use object::slice_from_bytes_mut;
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::ParallelIterator;
+use std::io::Write;
 use std::ops::BitAnd;
 use tracing::debug_span;
 use zerocopy::FromZeros;
@@ -660,6 +661,13 @@ struct MachOSymbolTableWriter {
 
 impl MachOSymbolTableWriter {
     fn write_str(&mut self, name: &[u8], buffers: &mut OutputSectionPartMap<&mut [u8]>) -> u32 {
+        // n_strx == 0 is treated as unnamed, so we need to start from 1.
+        if self.next_strtab_offset == 0 {
+            let mut out = buffers.get_mut(part_id::STRTAB).split_off_mut(..1).unwrap();
+            out.write_all(b"\0").unwrap();
+            self.next_strtab_offset = 1;
+        }
+
         let len_with_terminator = name.len() + 1;
         let offset = self.next_strtab_offset;
         let out = buffers

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -16,6 +16,7 @@ use crate::layout::OutputRecordLayout;
 use crate::layout::PreludeLayout;
 use crate::layout::Resolution;
 use crate::layout::Section;
+use crate::layout::SymbolCopyInfo;
 use crate::macho::ChainedFixupsHeader;
 use crate::macho::DEFAULT_SEGMENT_COUNT;
 use crate::macho::DYLINKER_PATH;
@@ -31,6 +32,7 @@ use crate::macho::SectionEntry;
 use crate::macho::SegmentCommand;
 use crate::macho::SegmentSectionsInfo;
 use crate::macho::SegmentType;
+use crate::macho::SymtabCommand;
 use crate::macho::get_segment_sections;
 use crate::output_section_id;
 use crate::output_section_id::SectionName;
@@ -41,6 +43,7 @@ use crate::part_id;
 use crate::platform::Arch;
 use crate::platform::Args;
 use crate::platform::ObjectFile;
+use crate::platform::Symbol;
 use crate::resolution::SectionSlot;
 use crate::symbol_db::SymbolId;
 use crate::timing_phase;
@@ -58,8 +61,11 @@ use object::macho::LC_DYLD_CHAINED_FIXUPS;
 use object::macho::LC_LOAD_DYLINKER;
 use object::macho::LC_MAIN;
 use object::macho::LC_SEGMENT_64;
+use object::macho::LC_SYMTAB;
 use object::macho::MH_CIGAM_64;
 use object::macho::MH_EXECUTE;
+use object::macho::N_ABS;
+use object::macho::N_SECT;
 use object::macho::RelocationInfo;
 use object::macho::SEG_DATA;
 use object::macho::SEG_LINKEDIT;
@@ -74,6 +80,7 @@ use zerocopy::FromZeros;
 
 const LE: Endianness = Endianness::Little;
 type MachOLayout<'data> = Layout<'data, MachO>;
+type SymtabEntry = object::macho::Nlist64<Endianness>;
 
 pub(crate) fn write<'data, A: Arch<Platform = MachO>>(
     sized_output: &mut SizedOutput,
@@ -89,9 +96,18 @@ pub(crate) fn write<'data, A: Arch<Platform = MachO>>(
         .try_for_each(|(group, mut buffers)| -> Result {
             verbose_timing_phase!("Write group");
 
+            let mut symbol_writer = MachOSymbolTableWriter {
+                next_strtab_offset: group.strtab_start_offset,
+            };
             for file in &group.files {
-                write_file::<A>(file, &mut buffers, layout, &sized_output.trace)
-                    .with_context(|| format!("Failed copying from {file} to output file"))?;
+                write_file::<A>(
+                    file,
+                    &mut buffers,
+                    layout,
+                    &sized_output.trace,
+                    &mut symbol_writer,
+                )
+                .with_context(|| format!("Failed copying from {file} to output file"))?;
             }
             Ok(())
         })?;
@@ -104,10 +120,11 @@ fn write_file<'data, A: Arch<Platform = MachO>>(
     buffers: &mut OutputSectionPartMap<&mut [u8]>,
     layout: &MachOLayout<'data>,
     _trace: &TraceOutput,
+    symbol_writer: &mut MachOSymbolTableWriter,
 ) -> Result {
     match file {
         FileLayout::Object(s) => {
-            write_object::<A>(s, buffers, layout)?;
+            write_object::<A>(s, buffers, layout, symbol_writer)?;
         }
         FileLayout::Prelude(s) => write_prelude::<A>(s, buffers, layout)?,
         _ => {
@@ -147,6 +164,10 @@ fn write_prelude<'data, A: Arch<Platform = MachO>>(
             .map_err(|_| error!("Invalid DYLD_CHAINED_FIXUPS command allocation"))?
             .0;
     write_dyld_chained_fixups_command::<A>(layout, chained_fixups_command);
+
+    let (symtab_command, _) = from_bytes_mut(buffers.get_mut(part_id::SYMTAB_COMMAND))
+        .map_err(|_| error!("Invalid SYMTAB_COMMAND allocation"))?;
+    write_symtab_command::<A>(layout, symtab_command);
 
     let chained_fixup_table = buffers.get_mut(part_id::CHAINED_FIXUP_TABLE);
     chained_fixup_table.fill(0);
@@ -371,6 +392,7 @@ fn write_object<'data, A: Arch<Platform = MachO>>(
     object: &ObjectLayout<'data, MachO>,
     buffers: &mut OutputSectionPartMap<&mut [u8]>,
     layout: &MachOLayout<'data>,
+    symbol_writer: &mut MachOSymbolTableWriter,
 ) -> Result {
     verbose_timing_phase!("Write object", file_id = object.file_id.as_u32());
 
@@ -384,6 +406,8 @@ fn write_object<'data, A: Arch<Platform = MachO>>(
             _ => (),
         }
     }
+
+    write_symbols(object, buffers, layout, symbol_writer)?;
 
     Ok(())
 }
@@ -577,6 +601,23 @@ fn write_dyld_chained_fixups_command<A: Arch<Platform = MachO>>(
         .set(LE, chained_fixup_table.file_size as u32);
 }
 
+fn write_symtab_command<A: Arch<Platform = MachO>>(
+    layout: &MachOLayout,
+    command: &mut SymtabCommand,
+) {
+    let symtab = layout.section_layouts.get(output_section_id::SYMTAB_GLOBAL);
+    let strtab = layout.section_layouts.get(output_section_id::STRTAB);
+
+    command.cmd.set(LE, LC_SYMTAB);
+    command.cmdsize.set(LE, size_of::<SymtabCommand>() as u32);
+    command.symoff.set(LE, symtab.file_offset as u32);
+    command
+        .nsyms
+        .set(LE, (symtab.file_size / size_of::<SymtabEntry>()) as u32);
+    command.stroff.set(LE, strtab.file_offset as u32);
+    command.strsize.set(LE, strtab.file_size as u32);
+}
+
 fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
     header: &mut ChainedFixupsHeader,
     starts_in_image: &mut [U32<Endianness>],
@@ -611,4 +652,134 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
     starts_in_image[1..].fill(U32::new(LE, 0));
 
     Ok(())
+}
+
+struct MachOSymbolTableWriter {
+    next_strtab_offset: u32,
+}
+
+impl MachOSymbolTableWriter {
+    fn write_str(&mut self, name: &[u8], buffers: &mut OutputSectionPartMap<&mut [u8]>) -> u32 {
+        let len_with_terminator = name.len() + 1;
+        let offset = self.next_strtab_offset;
+        let out = buffers
+            .get_mut(part_id::STRTAB)
+            .split_off_mut(..len_with_terminator)
+            .unwrap();
+        out[..name.len()].copy_from_slice(name);
+        out[name.len()] = 0;
+        self.next_strtab_offset += len_with_terminator as u32;
+        offset
+    }
+
+    fn write_entry<'out>(
+        &mut self,
+        name: &[u8],
+        buffers: &'out mut OutputSectionPartMap<&mut [u8]>,
+    ) -> Result<&'out mut SymtabEntry> {
+        let string_offset = self.write_str(name, buffers);
+        let entry_bytes = buffers
+            .get_mut(part_id::SYMTAB_GLOBAL)
+            .split_off_mut(..size_of::<SymtabEntry>())
+            .unwrap();
+        let entry: &mut SymtabEntry = from_bytes_mut(entry_bytes)
+            .map_err(|_| error!("Invalid SYMTAB_GLOBAL entry allocation"))?
+            .0;
+        entry.n_strx.set(LE, string_offset);
+        Ok(entry)
+    }
+}
+
+fn write_symbols<'data>(
+    object: &ObjectLayout<'data, MachO>,
+    buffers: &mut OutputSectionPartMap<&mut [u8]>,
+    layout: &MachOLayout<'data>,
+    symbol_writer: &mut MachOSymbolTableWriter,
+) -> Result {
+    for ((sym_index, sym), flags) in object
+        .object
+        .enumerate_symbols()
+        .zip(layout.per_symbol_flags.raw_range(object.symbol_id_range))
+    {
+        let symbol_id = object.symbol_id_range.input_to_id(sym_index);
+        let Some(info) = SymbolCopyInfo::new(
+            object.object,
+            sym_index,
+            sym,
+            symbol_id,
+            &layout.symbol_db,
+            flags.get(),
+            &object.sections,
+        ) else {
+            continue;
+        };
+
+        let mut out = *sym;
+        if let Some(section_index) = object.object.symbol_section(sym, sym_index)? {
+            let section_id = match &object.sections[section_index.0] {
+                SectionSlot::Loaded(_) => object
+                    .section_part_id(section_index, &layout.symbol_db.section_part_ids)
+                    .output_section_id(),
+                _ => bail!(
+                    "Tried to copy a symbol in a section we didn't load. {}",
+                    layout.symbol_debug(symbol_id)
+                ),
+            };
+            let primary_id = layout.output_sections.primary_output_section(section_id);
+            out.n_type = (out.n_type & !object::macho::N_TYPE) | N_SECT;
+            out.n_sect = macho_section_index(layout, primary_id).with_context(|| {
+                format!(
+                    "No Mach-O section index for {} while writing {}",
+                    primary_id,
+                    layout.symbol_debug(symbol_id)
+                )
+            })?;
+        } else if sym.is_absolute() {
+            out.n_type = (out.n_type & !object::macho::N_TYPE) | N_ABS;
+            out.n_sect = 0;
+        } else {
+            bail!("Attempted to output a Mach-O symtab entry with an unexpected section type")
+        }
+
+        if let Some(res) = layout.local_symbol_resolution(symbol_id) {
+            out.n_value.set(LE, res.value_for_symbol_table());
+        }
+
+        let entry = symbol_writer.write_entry(info.name, buffers)?;
+        let string_offset = entry.n_strx.get(LE);
+        *entry = out;
+        entry.n_strx.set(LE, string_offset);
+    }
+
+    Ok(())
+}
+
+fn macho_section_index(
+    layout: &MachOLayout<'_>,
+    section_id: output_section_id::OutputSectionId,
+) -> Option<u8> {
+    let mut next = 1u8;
+    let mut in_section_segment = false;
+    for event in &layout.output_order {
+        match event {
+            output_section_id::OrderEvent::SegmentStart(segment_id) => {
+                let segment_type = layout.program_segments.segment_def(segment_id).segment_type;
+                in_section_segment = matches!(
+                    segment_type,
+                    SegmentType::TextSections | SegmentType::DataSections
+                );
+            }
+            output_section_id::OrderEvent::SegmentEnd(_) => {
+                in_section_segment = false;
+            }
+            output_section_id::OrderEvent::Section(current) if in_section_segment => {
+                if current == section_id {
+                    return Some(next);
+                }
+                next = next.checked_add(1)?;
+            }
+            _ => {}
+        }
+    }
+    None
 }

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -754,19 +754,26 @@ fn write_symbols<'data>(
     Ok(())
 }
 
+// TODO: This is inefficient; simplify it once load commands use a table allocator instead of
+// being modeled as a section.
 fn macho_section_index(
     layout: &MachOLayout<'_>,
     section_id: output_section_id::OutputSectionId,
-) -> Option<u8> {
-    let mut next = 1u8;
+) -> Result<u8> {
+    // The section index is one-based.
+    let mut section_idx = 1u8;
     let mut in_section_segment = false;
     for event in &layout.output_order {
         match event {
             output_section_id::OrderEvent::SegmentStart(segment_id) => {
                 let segment_type = layout.program_segments.segment_def(segment_id).segment_type;
+                // TODO: Right now, the various load commands are mapped as "sections", so we can't
+                // just take the mapped index of the output "section".
                 in_section_segment = matches!(
                     segment_type,
-                    SegmentType::TextSections | SegmentType::DataSections
+                    SegmentType::TextSections
+                        | SegmentType::DataSections
+                        | SegmentType::DataConstSections
                 );
             }
             output_section_id::OrderEvent::SegmentEnd(_) => {
@@ -774,12 +781,15 @@ fn macho_section_index(
             }
             output_section_id::OrderEvent::Section(current) if in_section_segment => {
                 if current == section_id {
-                    return Some(next);
+                    return Ok(section_idx);
                 }
-                next = next.checked_add(1)?;
+                section_idx = section_idx
+                    .checked_add(1)
+                    .ok_or(error!("Section index out of range (u8)"))?;
             }
             _ => {}
         }
     }
-    None
+
+    bail!("cannot find the output section")
 }

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -74,7 +74,6 @@ use object::macho::SEG_TEXT;
 use object::slice_from_bytes_mut;
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::ParallelIterator;
-use std::io::Write;
 use std::ops::BitAnd;
 use tracing::debug_span;
 use zerocopy::FromZeros;
@@ -661,13 +660,6 @@ struct MachOSymbolTableWriter {
 
 impl MachOSymbolTableWriter {
     fn write_str(&mut self, name: &[u8], buffers: &mut OutputSectionPartMap<&mut [u8]>) -> u32 {
-        // n_strx == 0 is treated as unnamed, so we need to start from 1.
-        if self.next_strtab_offset == 0 {
-            let mut out = buffers.get_mut(part_id::STRTAB).split_off_mut(..1).unwrap();
-            out.write_all(b"\0").unwrap();
-            self.next_strtab_offset = 1;
-        }
-
         let len_with_terminator = name.len() + 1;
         let offset = self.next_strtab_offset;
         let out = buffers

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -679,13 +679,14 @@ impl MachOSymbolTableWriter {
         name: &[u8],
         section: u8,
         symbol_type: u8,
+        desc: u16,
         value: u64,
     ) -> Result {
         let entry = self.write_entry(name, buffers)?;
         entry.n_sect = section;
         entry.n_type = symbol_type;
         entry.n_value.set(LE, value);
-        entry.n_desc.set(LE, 0);
+        entry.n_desc.set(LE, desc);
 
         Ok(())
     }
@@ -733,7 +734,7 @@ fn write_symbols<'data>(
         };
 
         let mut value = 0;
-        let (section, symbol_type) =
+        let (section, symbol_type, desc) =
             if let Some(section_index) = object.object.symbol_section(sym, sym_index)? {
                 let section_id = match &object.sections[section_index.0] {
                     SectionSlot::Loaded(_) => object
@@ -753,9 +754,11 @@ fn write_symbols<'data>(
                         layout.symbol_debug(symbol_id)
                     )
                 })?;
-                (n_sect, n_type)
+                let n_desc = sym.n_desc.get(LE);
+                (n_sect, n_type, n_desc)
             } else if sym.is_absolute() {
-                ((sym.n_type & !object::macho::N_TYPE) | N_ABS, 0)
+                let n_desc = sym.n_desc.get(LE);
+                (0, (sym.n_type & !object::macho::N_TYPE) | N_ABS, n_desc)
             } else {
                 bail!("Attempted to output a Mach-O symtab entry with an unexpected section type")
             };
@@ -764,7 +767,7 @@ fn write_symbols<'data>(
             value = res.value_for_symbol_table();
         }
 
-        symbol_writer.define_symbol(buffers, info.name, section, symbol_type, value)?;
+        symbol_writer.define_symbol(buffers, info.name, section, symbol_type, desc, value)?;
     }
 
     Ok(())

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -672,6 +672,24 @@ impl MachOSymbolTableWriter {
         offset
     }
 
+    #[inline(always)]
+    fn define_symbol(
+        &mut self,
+        buffers: &mut OutputSectionPartMap<&mut [u8]>,
+        name: &[u8],
+        section: u8,
+        symbol_type: u8,
+        value: u64,
+    ) -> Result {
+        let entry = self.write_entry(name, buffers)?;
+        entry.n_sect = section;
+        entry.n_type = symbol_type;
+        entry.n_value.set(LE, value);
+        entry.n_desc.set(LE, 0);
+
+        Ok(())
+    }
+
     fn write_entry<'out>(
         &mut self,
         name: &[u8],
@@ -714,41 +732,39 @@ fn write_symbols<'data>(
             continue;
         };
 
-        let mut out = *sym;
-        if let Some(section_index) = object.object.symbol_section(sym, sym_index)? {
-            let section_id = match &object.sections[section_index.0] {
-                SectionSlot::Loaded(_) => object
-                    .section_part_id(section_index, &layout.symbol_db.section_part_ids)
-                    .output_section_id(),
-                _ => bail!(
-                    "Tried to copy a symbol in a section we didn't load. {}",
-                    layout.symbol_debug(symbol_id)
-                ),
+        let mut value = 0;
+        let (section, symbol_type) =
+            if let Some(section_index) = object.object.symbol_section(sym, sym_index)? {
+                let section_id = match &object.sections[section_index.0] {
+                    SectionSlot::Loaded(_) => object
+                        .section_part_id(section_index, &layout.symbol_db.section_part_ids)
+                        .output_section_id(),
+                    _ => bail!(
+                        "Tried to copy a symbol in a section we didn't load. {}",
+                        layout.symbol_debug(symbol_id)
+                    ),
+                };
+                let primary_id = layout.output_sections.primary_output_section(section_id);
+                let n_type = (sym.n_type & !object::macho::N_TYPE) | N_SECT;
+                let n_sect = macho_section_index(layout, primary_id).with_context(|| {
+                    format!(
+                        "No Mach-O section index for {} while writing {}",
+                        primary_id,
+                        layout.symbol_debug(symbol_id)
+                    )
+                })?;
+                (n_sect, n_type)
+            } else if sym.is_absolute() {
+                ((sym.n_type & !object::macho::N_TYPE) | N_ABS, 0)
+            } else {
+                bail!("Attempted to output a Mach-O symtab entry with an unexpected section type")
             };
-            let primary_id = layout.output_sections.primary_output_section(section_id);
-            out.n_type = (out.n_type & !object::macho::N_TYPE) | N_SECT;
-            out.n_sect = macho_section_index(layout, primary_id).with_context(|| {
-                format!(
-                    "No Mach-O section index for {} while writing {}",
-                    primary_id,
-                    layout.symbol_debug(symbol_id)
-                )
-            })?;
-        } else if sym.is_absolute() {
-            out.n_type = (out.n_type & !object::macho::N_TYPE) | N_ABS;
-            out.n_sect = 0;
-        } else {
-            bail!("Attempted to output a Mach-O symtab entry with an unexpected section type")
-        }
 
         if let Some(res) = layout.local_symbol_resolution(symbol_id) {
-            out.n_value.set(LE, res.value_for_symbol_table());
+            value = res.value_for_symbol_table();
         }
 
-        let entry = symbol_writer.write_entry(info.name, buffers)?;
-        let string_offset = entry.n_strx.get(LE);
-        *entry = out;
-        entry.n_strx.set(LE, string_offset);
+        symbol_writer.define_symbol(buffers, info.name, section, symbol_type, value)?;
     }
 
     Ok(())

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -188,6 +188,9 @@ fn write_prelude<'data, A: Arch<Platform = MachO>>(
             .map_err(|_| error!("Invalid chained fixups starts allocation"))?;
     write_chained_fixup_table::<A>(chained_fixups_header, starts_in_image)?;
 
+    // Fill up one extra character as n_strx == 0 is treated as unnamed.
+    buffers.get_mut(part_id::STRTAB).fill(0);
+
     Ok(())
 }
 

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -110,6 +110,7 @@ pub(crate) const DYLD_CHAINED_FIXUPS: OutputSectionId =
     part_id::DYLD_CHAINED_FIXUPS.output_section_id();
 pub(crate) const CHAINED_FIXUP_TABLE: OutputSectionId =
     part_id::CHAINED_FIXUP_TABLE.output_section_id();
+pub(crate) const SYMTAB_COMMAND: OutputSectionId = part_id::SYMTAB_COMMAND.output_section_id();
 
 // Regular sections copied from the input objects.
 pub(crate) const RODATA: OutputSectionId = OutputSectionId::regular(0);

--- a/libwild/src/output_section_part_map.rs
+++ b/libwild/src/output_section_part_map.rs
@@ -260,6 +260,7 @@ fn test_merge_parts() {
         output_section_id::ENTRY_POINT,
         output_section_id::DYLD_CHAINED_FIXUPS,
         output_section_id::CHAINED_FIXUP_TABLE,
+        output_section_id::SYMTAB_COMMAND,
     ];
     let mut sum_of_sums = 0;
     sum_of_1s.for_each(|section_id, sum| {

--- a/libwild/src/part_id.rs
+++ b/libwild/src/part_id.rs
@@ -59,8 +59,9 @@ pub(crate) const LINK_EDIT_SEGMENT: PartId = PartId(35);
 pub(crate) const ENTRY_POINT: PartId = PartId(36);
 pub(crate) const DYLD_CHAINED_FIXUPS: PartId = PartId(37);
 pub(crate) const CHAINED_FIXUP_TABLE: PartId = PartId(38);
+pub(crate) const SYMTAB_COMMAND: PartId = PartId(39);
 
-pub(crate) const NUM_SINGLE_PART_SECTIONS: u32 = 39;
+pub(crate) const NUM_SINGLE_PART_SECTIONS: u32 = 40;
 
 #[cfg(test)]
 pub(crate) const NUM_BUILT_IN_PARTS: usize = NUM_SINGLE_PART_SECTIONS as usize

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -257,9 +257,6 @@ pub(crate) trait Platform:
     /// For platforms that don't support symbol versioning, this can just be the unit type.
     type VerneedTable<'data>: VerneedTable<'data>;
 
-    /// Returns whether a symbol should be omitted from the output symtab by default.
-    fn is_default_strippable_symbol(sym: &Self::SymtabEntry, name: &[u8]) -> bool;
-
     /// Invoke the linker for requested architecture.
     fn link_for_arch<'data>(
         linker: &'data crate::Linker,
@@ -972,6 +969,9 @@ pub(crate) trait Symbol: std::fmt::Debug + Copy + Send + Sync + 'static {
     fn size(&self) -> u64;
 
     fn has_name(&self) -> bool;
+
+    /// Returns whether this symbol should be omitted from the output symtab by default.
+    fn is_default_strippable(&self, name: &[u8]) -> bool;
 
     fn debug_string(&self) -> String;
 

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -257,6 +257,9 @@ pub(crate) trait Platform:
     /// For platforms that don't support symbol versioning, this can just be the unit type.
     type VerneedTable<'data>: VerneedTable<'data>;
 
+    /// Returns whether a symbol should be omitted from the output symtab by default.
+    fn is_default_strippable_symbol(sym: &Self::SymtabEntry, name: &[u8]) -> bool;
+
     /// Invoke the linker for requested architecture.
     fn link_for_arch<'data>(
         linker: &'data crate::Linker,

--- a/libwild/src/verification.rs
+++ b/libwild/src/verification.rs
@@ -119,6 +119,7 @@ pub(crate) fn clear_ignored(expected: &mut OutputSectionPartMap<u64>) {
         part_id::ENTRY_POINT,
         part_id::DYLD_CHAINED_FIXUPS,
         part_id::CHAINED_FIXUP_TABLE,
+        part_id::SYMTAB_COMMAND,
     ];
 
     for part_id in IGNORED {

--- a/wild/tests/sources/macho/trivial/trivial.c
+++ b/wild/tests/sources/macho/trivial/trivial.c
@@ -1,4 +1,5 @@
 //#Object:runtime.c
+//#ExpectSym:_main
 //#TestUpdateInPlace:true
 
 #include "../common/runtime.h"


### PR DESCRIPTION
The PR newly emits the symbol table for the global symbols:
```
❯ llvm-m-readelf -s a.out

File: a.out
Format: Mach-O arm64
Arch: aarch64
AddressSize: 64bit
Symbols [
  Symbol {
    Name: _baz (1)
    Extern
    Type: Section (0xE)
    Section: __text (0x1)
    RefType: UndefinedNonLazy (0x0)
    Flags [ (0x0)
    ]
    Value: 0x1000002A0
  }
  Symbol {
    Name: _main (6)
    Extern
    Type: Section (0xE)
    Section: __text (0x1)
    RefType: UndefinedNonLazy (0x0)
    Flags [ (0x0)
    ]
    Value: 0x1000002AC
  }
  Symbol {
    Name: _value (12)
    Extern
    Type: Section (0xE)
    Section: __data (0x3)
    RefType: UndefinedNonLazy (0x0)
    Flags [ (0x0)
    ]
    Value: 0x100004000
  }
  Symbol {
    Name: _bar (19)
    Extern
    Type: Section (0xE)
    Section: __text (0x1)
    RefType: UndefinedNonLazy (0x0)
    Flags [ (0x0)
    ]
    Value: 0x1000002CC
  }
  Symbol {
    Name: _foo (24)
    Extern
    Type: Section (0xE)
    Section: __text (0x1)
    RefType: UndefinedNonLazy (0x0)
    Flags [ (0x0)
    ]
    Value: 0x1000002E0
  }
```

by having that, the disassembly output looks much nicer:
```
❯ llvm-m-objdump -d a.out

a.out:  file format mach-o arm64

Disassembly of section __TEXT,__text:

00000001000002a0 <_baz>:
1000002a0: 90000028     adrp    x8, 0x100004000 <_value>
1000002a4: b9800100     ldrsw   x0, [x8]
1000002a8: d65f03c0     ret

00000001000002ac <_main>:
1000002ac: d10083ff     sub     sp, sp, #0x20
1000002b0: a9017bfd     stp     x29, x30, [sp, #0x10]
1000002b4: 910043fd     add     x29, sp, #0x10
1000002b8: b81fc3bf     stur    wzr, [x29, #-0x4]
1000002bc: 94000009     bl      0x1000002e0 <_foo>
1000002c0: a9417bfd     ldp     x29, x30, [sp, #0x10]
1000002c4: 910083ff     add     sp, sp, #0x20
1000002c8: d65f03c0     ret

00000001000002cc <_bar>:
1000002cc: a9bf7bfd     stp     x29, x30, [sp, #-0x10]!
1000002d0: 910003fd     mov     x29, sp
1000002d4: 97fffff3     bl      0x1000002a0 <_baz>
1000002d8: a8c17bfd     ldp     x29, x30, [sp], #0x10
1000002dc: d65f03c0     ret

00000001000002e0 <_foo>:
1000002e0: a9bf7bfd     stp     x29, x30, [sp, #-0x10]!
1000002e4: 910003fd     mov     x29, sp
1000002e8: 97fffff9     bl      0x1000002cc <_bar>
1000002ec: a8c17bfd     ldp     x29, x30, [sp], #0x10
1000002f0: d65f03c0     ret
```

Issue #757