### PR TITLE
ci: run tests on Mach-O (skip ELF tests), reorder CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   test-nightly:
-    name: Test (${{ contains(matrix.runs-on, 'arm') && 'AArch64' || 'x86_64'}}, ${{ matrix.container }}${{ matrix.test-qemu && ', QEMU' || ''}})
+    name: Test Linux (${{ contains(matrix.runs-on, 'arm') && 'AArch64' || 'x86_64'}}, ${{ matrix.container }}${{ matrix.test-qemu && ', QEMU' || ''}})
 
     strategy:
       matrix:
@@ -85,9 +85,10 @@ jobs:
       - run: cargo test --profile ci --features plugins
         if: ${{ matrix.test-plugins }}
       - run: WILD_TEST_CROSS=$WILD_TEST_CROSS cargo test --profile ci --workspace
-  windows-build:
-    name: Windows build
-    runs-on: windows-latest
+
+  riscv-build:
+    name: Build Linux (RISC-V)
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -95,11 +96,62 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         id: rust-toolchain
+        with:
+          targets: riscv64gc-unknown-linux-gnu
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build --profile ci --workspace --no-default-features
+      - run: sudo apt-get update && sudo apt-get install build-essential lld gcc-riscv64-linux-gnu g++-riscv64-linux-gnu
+      - run: cp -f .cargo/config.toml.cross-riscv .cargo/config.toml
+      - run: cargo build --target riscv64gc-unknown-linux-gnu
 
-  macos-build:
-    name: macOS build
+  loongarch64-build:
+    name: Build Linux (LoongArch64)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    container:
+      image: ubuntu:25.10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - run: apt-get update && apt-get install -y build-essential lld gcc gcc-loongarch64-linux-gnu g++-loongarch64-linux-gnu curl
+      - uses: dtolnay/rust-toolchain@stable
+        id: rust-toolchain
+        with:
+          targets: loongarch64-unknown-linux-gnu
+      - uses: Swatinem/rust-cache@v2
+      - run: cp -f .cargo/config.toml.cross-loongarch64 .cargo/config.toml
+      - run: cargo build --target loongarch64-unknown-linux-gnu
+
+  wasip1-build:
+    name: Build wasip1
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    container:
+      image: ubuntu:25.10
+    steps:
+      - name: Install xz-utils
+        run: apt-get update && apt-get install -y xz-utils
+      - name: Setup Wasmtime
+        uses: bytecodealliance/actions/wasmtime/setup@v1
+        with:
+          version: '43.0.0'
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - run: apt-get install --update -y build-essential gcc gcc-multilib clang curl
+      - uses: dtolnay/rust-toolchain@stable
+        id: rust-toolchain
+        with:
+          targets: wasm32-wasip1
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --target wasm32-wasip1
+      - run: cp -f .cargo/config.toml.cross-wasm32p1 .cargo/config.toml
+      # -p libwild prevents integration tests from running. they depend on
+      # spawning processes, which isn't supported on wasi.
+      - run: cargo test --profile ci -p libwild --target wasm32-wasip1
+
+  macho-build:
+    name: Test Mach-O (AArch64)
     runs-on: macos-latest
     timeout-minutes: 10
     steps:
@@ -111,6 +163,19 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --profile ci --workspace --no-default-features
       - run: cargo test --profile ci --workspace
+
+  windows-build:
+    name: Build Windows (x86_64)
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+        id: rust-toolchain
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --profile ci --workspace --no-default-features
 
   minimal-versions:
     runs-on: ubuntu-24.04
@@ -176,70 +241,6 @@ jobs:
       - run: go install github.com/google/yamlfmt/cmd/yamlfmt@v0.21.0
       - run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       - run: yamlfmt -lint .
-
-  riscv-build:
-    name: RISC-V build
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain
-        with:
-          targets: riscv64gc-unknown-linux-gnu
-      - uses: Swatinem/rust-cache@v2
-      - run: sudo apt-get update && sudo apt-get install build-essential lld gcc-riscv64-linux-gnu g++-riscv64-linux-gnu
-      - run: cp -f .cargo/config.toml.cross-riscv .cargo/config.toml
-      - run: cargo build --target riscv64gc-unknown-linux-gnu
-
-  loongarch64-build:
-    name: LoongArch64 build
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    container:
-      image: ubuntu:25.10
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - run: apt-get update && apt-get install -y build-essential lld gcc gcc-loongarch64-linux-gnu g++-loongarch64-linux-gnu curl
-      - uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain
-        with:
-          targets: loongarch64-unknown-linux-gnu
-      - uses: Swatinem/rust-cache@v2
-      - run: cp -f .cargo/config.toml.cross-loongarch64 .cargo/config.toml
-      - run: cargo build --target loongarch64-unknown-linux-gnu
-
-  wasip1-build:
-    name: wasip1 build
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    container:
-      image: ubuntu:25.10
-    steps:
-      - name: Install xz-utils
-        run: apt-get update && apt-get install -y xz-utils
-      - name: Setup Wasmtime
-        uses: bytecodealliance/actions/wasmtime/setup@v1
-        with:
-          version: '43.0.0'
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - run: apt-get install --update -y build-essential gcc gcc-multilib clang curl
-      - uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain
-        with:
-          targets: wasm32-wasip1
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo build --target wasm32-wasip1
-      - run: cp -f .cargo/config.toml.cross-wasm32p1 .cargo/config.toml
-      # -p libwild prevents integration tests from running. they depend on
-      # spawning processes, which isn't supported on wasi.
-      - run: cargo test --profile ci -p libwild --target wasm32-wasip1
 
   spelling:
     name: Spell Check with Typos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
         id: rust-toolchain
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --profile ci --workspace --no-default-features
+      - run: cargo test --profile ci --workspace
 
   minimal-versions:
     runs-on: ubuntu-24.04

--- a/libwild/src/tidy_tests.rs
+++ b/libwild/src/tidy_tests.rs
@@ -6,11 +6,13 @@ use crate::error::Result;
 use std::env;
 use std::fs::read_dir;
 use std::path::Path;
-use std::process::Command;
-use std::process::Stdio;
 
 #[test]
+#[cfg(target_os = "linux")]
 fn check_sources_format() -> Result {
+    use std::process::Command;
+    use std::process::Stdio;
+
     if std::env::var_os("WILD_TEST_IGNORE_FORMAT").is_some() {
         return Ok(());
     }

--- a/linker-diff/src/utils.rs
+++ b/linker-diff/src/utils.rs
@@ -53,6 +53,7 @@ pub fn decode_insn_with_objdump(insn: &[u8], address: u64, arch: ArchKind) -> Re
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn test_align_up() {
     // Some distributions don't enable the features in objdump required for disassembly of aarch64,
     // so we only check that we can disassemble if we're running on aarch64 or if test

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -283,82 +283,80 @@ fn collect_tests(tests: &mut Vec<Trial>, filter: &Filter) -> Result {
 
     let host_arch = get_host_architecture();
 
-    let Some(platform) = PlatformKind::host() else {
-        return Ok(());
-    };
+    for platform in [PlatformKind::Elf, PlatformKind::MachO] {
+        let linkers = platform.available_linkers()?;
 
-    let linkers = platform.available_linkers()?;
+        let platform_name = platform.to_str();
 
-    let platform_name = platform.to_str();
-
-    if filter.excludes(platform_name) {
-        return Ok(());
-    }
-
-    let root = src_path(platform_name);
-    let dir = std::fs::read_dir(&root)
-        .with_context(|| format!("Failed to read directory {}", root.display()))?;
-
-    let is_nextest = std::env::var("NEXTEST").is_ok();
-
-    for entry in dir {
-        let entry = entry?;
-        let path = entry.path();
-        if path.ends_with("common") {
+        if filter.excludes(platform_name) {
             continue;
         }
 
-        let base_name = path
-            .file_name()
-            .context("Missing filename")?
-            .to_str()
-            .context("Non-UTF-8 path")?
-            .to_owned();
+        let root = src_path(platform_name);
+        let dir = std::fs::read_dir(&root)
+            .with_context(|| format!("Failed to read directory {}", root.display()))?;
 
-        for &arch in platform.supported_architectures() {
-            let name_prefix = format!("{platform_name}/{arch}/{base_name}");
-            if filter.excludes(&name_prefix) {
+        let is_nextest = std::env::var("NEXTEST").is_ok();
+
+        for entry in dir {
+            let entry = entry?;
+            let path = entry.path();
+            if path.ends_with("common") {
                 continue;
             }
 
-            let primary_source_file = identify_primary_source(&path, &base_name)?;
+            let base_name = path
+                .file_name()
+                .context("Missing filename")?
+                .to_str()
+                .context("Non-UTF-8 path")?
+                .to_owned();
 
-            let configs = parse_configs(
-                &primary_source_file,
-                &Config::new(
-                    base_name.clone(),
-                    platform,
-                    arch,
-                    path.clone(),
-                    &test_config,
-                    &linkers,
-                ),
-            )?;
-
-            let program_inputs = ProgramInputs::new(primary_source_file.clone())?;
-
-            for config in configs {
-                if config.should_skip(arch) {
+            for &arch in platform.supported_architectures() {
+                let name_prefix = format!("{platform_name}/{arch}/{base_name}");
+                if filter.excludes(&name_prefix) {
                     continue;
                 }
 
-                let full_name = format!("{name_prefix}/{}", config.config_name);
-                let test_config = test_config.clone();
-                let program_inputs = program_inputs.clone();
+                let primary_source_file = identify_primary_source(&path, &base_name)?;
 
-                // Nextest spawns a process for every test, so emitting a large number of tests
-                // that we'll ignore at runtime is a bit wasteful. There are various different
-                // criteria for ignoring tests, but the biggest one is that the architecture
-                // isn't enabled. So we just filter for that and only when running under
-                // nextest. For the normal test runner, it doesn't matter much.
-                if is_nextest && arch != host_arch && !test_config.qemu_arch.contains(&arch) {
-                    continue;
+                let configs = parse_configs(
+                    &primary_source_file,
+                    &Config::new(
+                        base_name.clone(),
+                        platform,
+                        arch,
+                        path.clone(),
+                        &test_config,
+                        &linkers,
+                    ),
+                )?;
+
+                let program_inputs = ProgramInputs::new(primary_source_file.clone())?;
+
+                for config in configs {
+                    if config.should_skip(arch) {
+                        continue;
+                    }
+
+                    let full_name = format!("{name_prefix}/{}", config.config_name);
+                    let test_config = test_config.clone();
+                    let program_inputs = program_inputs.clone();
+
+                    // Nextest spawns a process for every test, so emitting a large number of tests
+                    // that we'll ignore at runtime is a bit wasteful. There are various different
+                    // criteria for ignoring tests, but the biggest one is that the architecture
+                    // isn't enabled. So we just filter for that and only when running under
+                    // nextest. For the normal test runner, it doesn't matter much.
+                    if is_nextest && arch != host_arch && !test_config.qemu_arch.contains(&arch) {
+                        continue;
+                    }
+
+                    tests.push(libtest_mimic::Trial::ignorable_test(full_name, move || {
+                        run_integration_test(arch, &program_inputs, config, &test_config)
+                            .map_err(|e| libtest_mimic::Failed::from(e.to_string()))
+                    }));
                 }
-
-                tests.push(libtest_mimic::Trial::ignorable_test(full_name, move || {
-                    run_integration_test(arch, &program_inputs, config, &test_config)
-                        .map_err(|e| libtest_mimic::Failed::from(e.to_string()))
-                }));
             }
         }
     }
@@ -1292,7 +1290,7 @@ impl Config {
             remove_sections: Vec::new(),
             compiler: platform.default_c_compiler().to_owned(),
             should_diff: platform.diff_supported(),
-            should_run: true,
+            should_run: platform.can_execute_on_host(),
             run_dyn_sym: None,
             should_error: false,
             expect_stderr: Default::default(),
@@ -2571,7 +2569,7 @@ fn add_cross_args(
         return;
     }
 
-    if cross_arch.is_some() {
+    if !platform.is_host() || cross_arch.is_some() {
         let arch = cross_arch.unwrap_or_else(get_host_architecture);
         let target = get_target(compiler_args)
             .cloned()
@@ -4587,6 +4585,11 @@ fn run_integration_test(
 
     let cross_arch = (arch != get_host_architecture()).then_some(arch);
 
+    // For cross-platform tests (e.g., Mac binaries on Linux), link but don't execute
+    if !config.platform.can_execute_on_host() {
+        config.should_run = false;
+    }
+
     config.rustc_channel = test_config.rustc_channel;
 
     if !test_config.allow_rust_musl_target && config.requires_rust_musl {
@@ -4849,6 +4852,14 @@ impl PlatformKind {
             PlatformKind::Elf => "gnu",
             PlatformKind::MachO => "darwin",
         }
+    }
+
+    fn is_host(self) -> bool {
+        Some(self) == PlatformKind::host()
+    }
+
+    fn can_execute_on_host(self) -> bool {
+        self.is_host()
     }
 
     fn diff_supported(self) -> bool {

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -283,80 +283,82 @@ fn collect_tests(tests: &mut Vec<Trial>, filter: &Filter) -> Result {
 
     let host_arch = get_host_architecture();
 
-    for platform in [PlatformKind::Elf, PlatformKind::MachO] {
-        let linkers = platform.available_linkers()?;
+    let Some(platform) = PlatformKind::host() else {
+        return Ok(());
+    };
 
-        let platform_name = platform.to_str();
+    let linkers = platform.available_linkers()?;
 
-        if filter.excludes(platform_name) {
+    let platform_name = platform.to_str();
+
+    if filter.excludes(platform_name) {
+        return Ok(());
+    }
+
+    let root = src_path(platform_name);
+    let dir = std::fs::read_dir(&root)
+        .with_context(|| format!("Failed to read directory {}", root.display()))?;
+
+    let is_nextest = std::env::var("NEXTEST").is_ok();
+
+    for entry in dir {
+        let entry = entry?;
+        let path = entry.path();
+        if path.ends_with("common") {
             continue;
         }
 
-        let root = src_path(platform_name);
-        let dir = std::fs::read_dir(&root)
-            .with_context(|| format!("Failed to read directory {}", root.display()))?;
+        let base_name = path
+            .file_name()
+            .context("Missing filename")?
+            .to_str()
+            .context("Non-UTF-8 path")?
+            .to_owned();
 
-        let is_nextest = std::env::var("NEXTEST").is_ok();
-
-        for entry in dir {
-            let entry = entry?;
-            let path = entry.path();
-            if path.ends_with("common") {
+        for &arch in platform.supported_architectures() {
+            let name_prefix = format!("{platform_name}/{arch}/{base_name}");
+            if filter.excludes(&name_prefix) {
                 continue;
             }
 
-            let base_name = path
-                .file_name()
-                .context("Missing filename")?
-                .to_str()
-                .context("Non-UTF-8 path")?
-                .to_owned();
+            let primary_source_file = identify_primary_source(&path, &base_name)?;
 
-            for &arch in platform.supported_architectures() {
-                let name_prefix = format!("{platform_name}/{arch}/{base_name}");
-                if filter.excludes(&name_prefix) {
+            let configs = parse_configs(
+                &primary_source_file,
+                &Config::new(
+                    base_name.clone(),
+                    platform,
+                    arch,
+                    path.clone(),
+                    &test_config,
+                    &linkers,
+                ),
+            )?;
+
+            let program_inputs = ProgramInputs::new(primary_source_file.clone())?;
+
+            for config in configs {
+                if config.should_skip(arch) {
                     continue;
                 }
 
-                let primary_source_file = identify_primary_source(&path, &base_name)?;
+                let full_name = format!("{name_prefix}/{}", config.config_name);
+                let test_config = test_config.clone();
+                let program_inputs = program_inputs.clone();
 
-                let configs = parse_configs(
-                    &primary_source_file,
-                    &Config::new(
-                        base_name.clone(),
-                        platform,
-                        arch,
-                        path.clone(),
-                        &test_config,
-                        &linkers,
-                    ),
-                )?;
-
-                let program_inputs = ProgramInputs::new(primary_source_file.clone())?;
-
-                for config in configs {
-                    if config.should_skip(arch) {
-                        continue;
-                    }
-
-                    let full_name = format!("{name_prefix}/{}", config.config_name);
-                    let test_config = test_config.clone();
-                    let program_inputs = program_inputs.clone();
-
-                    // Nextest spawns a process for every test, so emitting a large number of tests
-                    // that we'll ignore at runtime is a bit wasteful. There are various different
-                    // criteria for ignoring tests, but the biggest one is that the architecture
-                    // isn't enabled. So we just filter for that and only when running under
-                    // nextest. For the normal test runner, it doesn't matter much.
-                    if is_nextest && arch != host_arch && !test_config.qemu_arch.contains(&arch) {
-                        continue;
-                    }
-
-                    tests.push(libtest_mimic::Trial::ignorable_test(full_name, move || {
-                        run_integration_test(arch, &program_inputs, config, &test_config)
-                            .map_err(|e| libtest_mimic::Failed::from(e.to_string()))
-                    }));
+                // Nextest spawns a process for every test, so emitting a large number of tests
+                // that we'll ignore at runtime is a bit wasteful. There are various different
+                // criteria for ignoring tests, but the biggest one is that the architecture
+                // isn't enabled. So we just filter for that and only when running under
+                // nextest. For the normal test runner, it doesn't matter much.
+                if is_nextest && arch != host_arch && !test_config.qemu_arch.contains(&arch) {
+                    continue;
                 }
+
+                tests.push(libtest_mimic::Trial::ignorable_test(full_name, move || {
+                    run_integration_test(arch, &program_inputs, config, &test_config)
+                        .map_err(|e| libtest_mimic::Failed::from(e.to_string()))
+                }));
             }
         }
     }
@@ -1290,7 +1292,7 @@ impl Config {
             remove_sections: Vec::new(),
             compiler: platform.default_c_compiler().to_owned(),
             should_diff: platform.diff_supported(),
-            should_run: platform.can_execute_on_host(),
+            should_run: true,
             run_dyn_sym: None,
             should_error: false,
             expect_stderr: Default::default(),
@@ -2569,7 +2571,7 @@ fn add_cross_args(
         return;
     }
 
-    if !platform.is_host() || cross_arch.is_some() {
+    if cross_arch.is_some() {
         let arch = cross_arch.unwrap_or_else(get_host_architecture);
         let target = get_target(compiler_args)
             .cloned()
@@ -4585,11 +4587,6 @@ fn run_integration_test(
 
     let cross_arch = (arch != get_host_architecture()).then_some(arch);
 
-    // For cross-platform tests (e.g., Mac binaries on Linux), link but don't execute
-    if !config.platform.can_execute_on_host() {
-        config.should_run = false;
-    }
-
     config.rustc_channel = test_config.rustc_channel;
 
     if !test_config.allow_rust_musl_target && config.requires_rust_musl {
@@ -4852,14 +4849,6 @@ impl PlatformKind {
             PlatformKind::Elf => "gnu",
             PlatformKind::MachO => "darwin",
         }
-    }
-
-    fn is_host(self) -> bool {
-        Some(self) == PlatformKind::host()
-    }
-
-    fn can_execute_on_host(self) -> bool {
-        self.is_host()
     }
 
     fn diff_supported(self) -> bool {

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -284,6 +284,11 @@ fn collect_tests(tests: &mut Vec<Trial>, filter: &Filter) -> Result {
     let host_arch = get_host_architecture();
 
     for platform in [PlatformKind::Elf, PlatformKind::MachO] {
+        // Right now, the Mach-O provided Clang and the ld linker do not support the ELF format.
+        if platform == PlatformKind::Elf && cfg!(target_os = "macos") {
+            continue;
+        }
+
         let linkers = platform.available_linkers()?;
 
         let platform_name = platform.to_str();

--- a/wild/tests/sources/macho/trivial/trivial.c
+++ b/wild/tests/sources/macho/trivial/trivial.c
@@ -1,6 +1,7 @@
 //#Object:runtime.c
 //#ExpectSym:_main
 //#TestUpdateInPlace:true
+//#RunEnabled: false
 
 #include "../common/runtime.h"
 


### PR DESCRIPTION
With the `integration_tests`, the ELF tests are run (linked) even on Mach-O, but there are 2 fundamental problems with the approach:

1. `/usr/bin/ld` on Mach-O is a system linker that does not support the ELF options:

```
❯ ld -v
@(#)PROGRAM:ld PROJECT:ld-1230.1
BUILD 06:36:05 Dec  2 2025
configured to support archs: armv6 armv7 armv7s arm64 arm64e arm64_32 i386 x86_64 x86_64h armv6m armv7k armv7m armv7em armv8m.main armv8.1m.main
will use ld-classic for: armv6 armv7 armv7s i386 armv6m armv7k armv7m armv7em
LTO support using: LLVM version 17.0.0 (static support for 29, runtime is 29)
TAPI support using: Apple TAPI version 17.0.0 (tapi-1700.3.8)
```

2. The system compiler (e.g. `gcc`) does not produce ELF files:

```
            cargo run --bin wild -- -flavor gnu -static --gc-sections --wrap=foo --wrap=bar --wrap=baz -o /Users/apple/Programming/wild/wild/tests/build/elf/aarch64/wrap/default/wrap.c.wild /Users/apple/Programming/wild/wild/tests/build/elf/aarch64/wrap/default/wrap.c.o /Users/apple/Programming/wild/wild/tests/build/elf/aarch64/wrap/default/runtime.c.o /Users/apple/Programming/wild/wild/tests/build/elf/aarch64/wrap/default/wrap-1.c.o /Users/apple/Programming/wild/wild/tests/build/elf/aarch64/wrap/default/wrap-2.c.o --validate-output --write-layout --write-trace --dependency-file=/Users/apple/Programming/wild/wild/tests/build/elf/aarch64/wrap/default/wrap.c.wild.deps
        Failed to parse object file `/Users/apple/Programming/wild/wild/tests/build/elf/aarch64/wrap/default/wrap.c.o`
        Unsupported ELF header
```

That's why I tentatively suggest dropping the cross-platform capability of the integrations tests. Thoughts once that @davidlattimore?