### PR TITLE
fix: bad allocation for versioned internal symbol

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -1527,7 +1527,7 @@ impl platform::Platform for Elf {
         };
         sizes.increment(symtab_part, size_of::<elf::SymtabEntry>() as u64);
         let symbol_name = symbol_db.symbol_name(symbol_id)?;
-        let symbol_name = RawSymbolName::parse(symbol_name.bytes()).name();
+        let symbol_name = symtab_name_for_strtab(symbol_name.bytes());
         sizes.increment(part_id::STRTAB, symbol_name.len() as u64 + 1);
 
         Ok(())

--- a/wild/tests/sources/elf/versioned-script-symbol/versioned-script-symbol.c
+++ b/wild/tests/sources/elf/versioned-script-symbol/versioned-script-symbol.c
@@ -1,0 +1,7 @@
+//#CompArgs:-fPIC
+//#RunEnabled:false
+//#LinkArgs:--shared -znow ./versioned-script-symbol.map
+//#ExpectSym:mysql_affected_rows@libmysqlclient_18
+//#DiffIgnore:section.got
+
+int foo(void) { return 42; }

--- a/wild/tests/sources/elf/versioned-script-symbol/versioned-script-symbol.map
+++ b/wild/tests/sources/elf/versioned-script-symbol/versioned-script-symbol.map
@@ -1,0 +1,10 @@
+VERSION {
+  libmysqlclient_18 {
+    global:
+      bar;
+    local:
+      *;
+  };
+};
+
+"mysql_affected_rows@libmysqlclient_18" = foo;


### PR DESCRIPTION
Noticed that when building the `mariadb-connector-c` package:
```
thread '<unnamed>' (834909) panicked at libwild/src/elf_writer.rs:5696:74:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
collect2: error: ld returned 101 exit status
```