### PR TITLE
fix: More robust code to get line numbers from debug info

### DIFF
--- a/libwild/src/dwarf_address_info.rs
+++ b/libwild/src/dwarf_address_info.rs
@@ -12,6 +12,7 @@ use crate::platform::RelocationSequence as _;
 use crate::platform::SourceInfo;
 use crate::platform::SourceInfoDetails;
 use anyhow::Context;
+use linker_utils::elf::RelocationKind;
 use object::LittleEndian;
 use object::read::elf::Crel;
 use object::read::elf::RelocationSections;
@@ -144,18 +145,13 @@ fn apply_section_relocations<A: Arch<Platform = crate::elf::Elf>, R: Relocation>
             .get(LittleEndian)
             .wrapping_add(rel.addend() as u64);
 
-        let section_index = object
-            .symbol_section(symbol, sym_index)?
-            .context("Relocation for undefined symbol")?;
+        let Some(section_index) = object.symbol_section(symbol, sym_index)? else {
+            // Ignore undefined symbols.
+            continue;
+        };
         let symbol_section = object.section(section_index)?;
 
         let data_offset = rel.offset() as usize;
-
-        if symbol_section.sh_offset.get(LittleEndian)
-            == section_of_interest.sh_offset.get(LittleEndian)
-        {
-            value += SECTION_LOAD_ADDRESS;
-        }
 
         let r_type = A::relocation_from_raw(rel.raw_type())?;
 
@@ -163,11 +159,25 @@ fn apply_section_relocations<A: Arch<Platform = crate::elf::Elf>, R: Relocation>
             continue;
         };
 
-        if r_type.kind == linker_utils::elf::RelocationKind::Absolute {
-            section_data
-                .get_mut(data_offset..data_offset + num_bytes)
-                .context("Invalid relocation offset")?
-                .copy_from_slice(&value.to_le_bytes()[..num_bytes]);
+        let rel_out = section_data
+            .get_mut(data_offset..data_offset + num_bytes)
+            .context("Invalid relocation offset")?;
+
+        match r_type.kind {
+            RelocationKind::Absolute => {
+                let in_section_of_interest = symbol_section.sh_offset.get(LittleEndian)
+                    == section_of_interest.sh_offset.get(LittleEndian);
+
+                if in_section_of_interest {
+                    value += SECTION_LOAD_ADDRESS;
+                }
+
+                r_type.write_to_buffer(value, rel_out)?;
+            }
+            RelocationKind::AbsoluteAddition | RelocationKind::AbsoluteSubtraction => {
+                r_type.write_to_buffer(value, rel_out)?;
+            }
+            _ => {}
         }
     }
     Ok(())

--- a/linker-utils/src/loongarch64.rs
+++ b/linker-utils/src/loongarch64.rs
@@ -69,7 +69,7 @@ pub const fn relocation_type_from_raw(r_type: u32) -> Option<RelocationKindInfo>
         ),
         object::elf::R_LARCH_64 => (
             RelocationKind::Absolute,
-            RelocationSize::ByteSize(4),
+            RelocationSize::ByteSize(8),
             None,
             AllowedRange::no_check(),
             1,

--- a/linker-utils/src/riscv64.rs
+++ b/linker-utils/src/riscv64.rs
@@ -145,7 +145,7 @@ pub const fn relocation_type_from_raw(r_type: u32) -> Option<RelocationKindInfo>
         ),
         object::elf::R_RISCV_64 => (
             RelocationKind::Absolute,
-            RelocationSize::ByteSize(4),
+            RelocationSize::ByteSize(8),
             None,
             AllowedRange::no_check(),
             1,

--- a/wild/tests/sources/elf/source-info-from-debug/source-info-from-debug.c
+++ b/wild/tests/sources/elf/source-info-from-debug/source-info-from-debug.c
@@ -1,0 +1,29 @@
+// Tests that we're able to report the line number of an undefined symbol
+// reference using debug info.
+
+//#AbstractConfig:default
+//#Object:runtime.c
+//#ExpectError:source-info-from-debug.*27
+
+//#Config:non-lto:default
+//#CompArgs:-g
+// GNU ld reports incorrect line numbers.
+//#SkipLinker:ld
+
+//#Config:lto:default
+//#RequiresLinkerPlugin:true
+//#LinkerDriver:gcc
+//#CompArgs:-g -flto -fPIC
+//#LinkArgs:-flto -nostdlib -fPIC
+// GNU ld tries to generate a PLT, then errors
+//#SkipLinker:ld
+
+#include "../common/runtime.h"
+
+void foo(void);
+
+void _start(void) {
+  runtime_init();
+  foo();
+  exit_syscall(42);
+}


### PR DESCRIPTION
Also fixed 64 bit relocation sizes for riscv64 and loongarch64, which are used in debug info.