### PR TITLE
feat: evaluate expressions within PROVIDE with `evaluate_expression`

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -588,14 +588,6 @@ pub(crate) enum BSymbolicKind {
     NonWeak,
 }
 
-#[derive(Debug)]
-pub(crate) enum DefsymValue {
-    /// A numeric value (address)
-    Value(u64),
-    /// Reference to another symbol with an optional offset
-    SymbolWithOffset(String, i64),
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum UnresolvedSymbols {
     /// Report all unresolved symbols.

--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -10,7 +10,6 @@ use crate::arch::Architecture;
 use crate::args::CommonArgs;
 use crate::args::CopyRelocations;
 use crate::args::CopyRelocationsDisabledReason;
-use crate::args::DefsymValue;
 use crate::args::FileWriteMode;
 use crate::args::Modifiers;
 use crate::args::RelocationModel;
@@ -84,7 +83,7 @@ pub struct ElfArgs {
     pub(crate) plugin_args: Vec<CString>,
 
     /// Symbol definitions from `--defsym` options. Each entry is (symbol_name, value_or_symbol).
-    pub(crate) defsym: Vec<(String, DefsymValue)>,
+    pub(crate) defsym: Vec<(String, String)>,
 
     /// Section start addresses from `--section-start` options. Maps section name to address.
     pub(crate) section_start: HashMap<Vec<u8>, u64>,
@@ -374,18 +373,6 @@ impl ElfArgs {
 
 fn parse_number(s: &str) -> Result<u64> {
     crate::parsing::parse_number(s).map_err(|_| crate::error!("Invalid number: {}", s))
-}
-
-fn parse_defsym_expression(s: &str) -> DefsymValue {
-    use crate::parsing::ParsedSymbolExpression;
-    use crate::parsing::parse_symbol_expression;
-
-    match parse_symbol_expression(s) {
-        ParsedSymbolExpression::Absolute(value) => DefsymValue::Value(value),
-        ParsedSymbolExpression::SymbolWithOffset(sym, offset) => {
-            DefsymValue::SymbolWithOffset(sym.to_owned(), offset)
-        }
-    }
 }
 
 // Parse the supplied input arguments, which should not include the program name.
@@ -1459,11 +1446,9 @@ fn setup_argument_parser() -> ArgumentParser<ElfArgs> {
                 bail!("Invalid --defsym format. Expected: --defsym=symbol=value");
             }
             let symbol_name = parts[0].to_owned();
-            let value_str = parts[1];
+            let value_str = parts[1].to_owned();
 
-            let defsym_value = parse_defsym_expression(value_str);
-
-            args.defsym.push((symbol_name, defsym_value));
+            args.defsym.push((symbol_name, value_str));
             Ok(())
         });
 
@@ -1960,7 +1945,7 @@ impl platform::Args for ElfArgs {
         self.export_list_path.as_deref()
     }
 
-    fn defsym(&self) -> &[(String, DefsymValue)] {
+    fn defsym(&self) -> &[(String, String)] {
         &self.defsym
     }
 

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -55,6 +55,7 @@ use crate::layout::Section;
 use crate::layout::SymbolCopyInfo;
 use crate::layout::SyntheticSymbolsLayout;
 use crate::layout::compute_allocations;
+use crate::linker_script::Expression;
 use crate::output_section_id;
 use crate::output_section_id::OrderEvent;
 use crate::output_section_id::OutputOrder;
@@ -64,6 +65,7 @@ use crate::output_section_map::OutputSectionMap;
 use crate::output_section_part_map::OutputSectionPartMap;
 use crate::output_trace::HexU64;
 use crate::output_trace::TraceOutput;
+use crate::parsing::SymbolLoc;
 use crate::part_id;
 use crate::part_id::PartId;
 use crate::platform;
@@ -4411,6 +4413,43 @@ fn get_symbol_attributes(layout: &ElfLayout, symbol_id: SymbolId) -> Result<(Sym
     }
 }
 
+fn get_defsym_attributes(
+    layout: &ElfLayout,
+    def_info: &crate::parsing::InternalSymDefInfo<Elf>,
+) -> Result<(SymbolSection, u8), error::Error> {
+    let crate::parsing::SymbolPlacement::Redirect(redirect) = &def_info.placement else {
+        unreachable!()
+    };
+    if let Expression::Symbol(target_name) = redirect.expression {
+        let target_symbol_id =
+            layout
+                .symbol_db
+                .get_unversioned(&crate::symbol::UnversionedSymbolName::prehashed(
+                    target_name,
+                ));
+
+        if let Some(target_id) = target_symbol_id {
+            get_symbol_attributes(layout, target_id)
+        } else {
+            Err(redirect.missing_target(target_name))
+        }
+    } else if let SymbolLoc::SectionStart(os) = redirect.loc {
+        let shndx = layout
+            .output_sections
+            .output_index_of_section(os)
+            .unwrap_or(0);
+        Ok((SymbolSection::Index(shndx), object::elf::STT_NOTYPE))
+    } else if let SymbolLoc::SectionEnd(os) = redirect.loc {
+        let shndx = layout
+            .output_sections
+            .output_index_of_section(os)
+            .unwrap_or(0);
+        Ok((SymbolSection::Index(shndx), object::elf::STT_NOTYPE))
+    } else {
+        Ok((object::elf::SHN_ABS.into(), object::elf::STT_NOTYPE))
+    }
+}
+
 fn write_prelude_dynsym(
     dynsym_writer: &mut SymbolTableWriter,
     layout: &ElfLayout,
@@ -4435,7 +4474,6 @@ fn write_internal_dynsym(
     if matches!(
         def_info.placement,
         crate::parsing::SymbolPlacement::Redirect(_)
-            | crate::parsing::SymbolPlacement::DefsymAbsolute(_)
     ) {
         return write_defsym_dynsym(dynsym_writer, layout, symbol_id, def_info);
     }
@@ -4477,36 +4515,13 @@ fn write_defsym_dynsym(
     symbol_id: SymbolId,
     def_info: &crate::parsing::InternalSymDefInfo<Elf>,
 ) -> Result {
-    debug_assert!(matches!(
-        def_info.placement,
-        crate::parsing::SymbolPlacement::Redirect(_)
-            | crate::parsing::SymbolPlacement::DefsymAbsolute(_)
-    ));
+    let (shndx, st_type) = get_defsym_attributes(layout, def_info)?;
 
     let resolution = layout
         .local_symbol_resolution(symbol_id)
         .with_context(|| format!("Missing resolution for {}", layout.symbol_debug(symbol_id)))?;
     let address = resolution.raw_value;
     let name = layout.symbol_db.symbol_name(symbol_id)?;
-
-    // For DefsymSymbol, try to get the attributes (section, type) from the target symbol
-    let (shndx, st_type) =
-        if let crate::parsing::SymbolPlacement::Redirect(redirect) = def_info.placement {
-            let target_symbol_id =
-                layout
-                    .symbol_db
-                    .get_unversioned(&crate::symbol::UnversionedSymbolName::prehashed(
-                        redirect.target_name,
-                    ));
-
-            if let Some(target_id) = target_symbol_id {
-                get_symbol_attributes(layout, target_id)?
-            } else {
-                return redirect.missing_target();
-            }
-        } else {
-            (object::elf::SHN_ABS.into(), object::elf::STT_NOTYPE)
-        };
 
     let entry = dynsym_writer
         .define_symbol(false, shndx, address, 0, name.bytes())
@@ -4695,22 +4710,12 @@ fn write_internal_symbols(
 
         let symbol_name = layout.symbol_db.symbol_name(symbol_id)?;
 
-        // For DefsymSymbol, get attributes from the target symbol
-        let (mut shndx, st_type) = if let crate::parsing::SymbolPlacement::Redirect(redirect) =
-            def_info.placement
-        {
-            let target_symbol_id =
-                layout
-                    .symbol_db
-                    .get_unversioned(&crate::symbol::UnversionedSymbolName::prehashed(
-                        redirect.target_name,
-                    ));
-
-            if let Some(target_id) = target_symbol_id {
-                get_symbol_attributes(layout, target_id)?
-            } else {
-                return redirect.missing_target();
-            }
+        // For Redirect, get attributes from the target symbol
+        let (mut shndx, st_type) = if matches!(
+            def_info.placement,
+            crate::parsing::SymbolPlacement::Redirect(_)
+        ) {
+            get_defsym_attributes(layout, def_info)?
         } else {
             let shndx = def_info
                 .section_id()

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -15,6 +15,7 @@ use crate::linker_script::MemoryRegion;
 use crate::output_section_id::OutputSections;
 use crate::output_section_id::SectionName;
 use crate::output_section_map::OutputSectionMap;
+use crate::parsing::SymbolLoc;
 use crate::platform::Platform;
 
 /// Compute 1-based line number by counting newlines before `remainder` in `file_bytes`.
@@ -67,10 +68,20 @@ pub(crate) fn evaluate_assertions<'data, P: Platform>(
                 let line = line_number(parsed.file_bytes, assertion.remainder);
                 let result = evaluate_expression(
                     &assertion.expression,
+                    SymbolLoc::None,
                     section_layouts,
                     output_sections,
-                    warning_callback,
                     &parsed.memory_regions,
+                    &|name| {
+                        // Symbol resolution in ASSERT is not yet implemented. Rather than failing the
+                        // link (which would be our fault, not the user's), emit a warning and skip the
+                        // assertion by returning 1 (true).
+                        warning_callback(Warning::new(format!(
+                            "ASSERT: symbol references not yet supported ('{}'), skipping assertion",
+                            String::from_utf8_lossy(name)
+                        )));
+                        Ok(1)
+                    },
                 )
                 .with_context(|| format!("{}:{}: Failed to evaluate ASSERT", parsed.input, line))?;
 
@@ -84,21 +95,23 @@ pub(crate) fn evaluate_assertions<'data, P: Platform>(
     Ok(())
 }
 
-fn evaluate_expression<'data, P: Platform>(
+pub(crate) fn evaluate_expression<'data, P: Platform>(
     expr: &Expression<'data>,
+    expr_loc: SymbolLoc,
     section_layouts: &OutputSectionMap<OutputRecordLayout>,
     output_sections: &OutputSections<'data, P>,
-    warning_callback: &WarningCallback,
     memory_regions: &[MemoryRegion<'data>],
+    symbol_resolution_callback: &dyn Fn(&[u8]) -> Result<u64>,
 ) -> Result<u64> {
     macro_rules! eval {
         ($e:expr) => {
             evaluate_expression(
                 $e,
+                expr_loc,
                 section_layouts,
                 output_sections,
-                warning_callback,
                 memory_regions,
+                symbol_resolution_callback,
             )
         };
     }
@@ -106,19 +119,16 @@ fn evaluate_expression<'data, P: Platform>(
     match expr {
         Expression::Number(n) => Ok(*n),
 
-        // '.' is not meaningful outside of section layout context; treat as 0
-        Expression::LocationCounter => Ok(0),
+        Expression::LocationCounter => match expr_loc {
+            SymbolLoc::SectionStart(id) => Ok(section_layouts.get(id).mem_offset),
+            SymbolLoc::SectionEnd(id) => {
+                let layout = section_layouts.get(id);
+                Ok(layout.mem_offset + layout.mem_size)
+            }
+            SymbolLoc::None => Ok(0),
+        },
 
-        Expression::Symbol(name) => {
-            // Symbol resolution in ASSERT is not yet implemented. Rather than failing the
-            // link (which would be our fault, not the user's), emit a warning and skip the
-            // assertion by returning 1 (true).
-            warning_callback(Warning::new(format!(
-                "ASSERT: symbol references not yet supported ('{}'), skipping assertion",
-                String::from_utf8_lossy(name)
-            )));
-            Ok(1)
-        }
+        Expression::Symbol(name) => symbol_resolution_callback(name),
 
         Expression::Add(l, r) => Ok(eval!(l)?.wrapping_add(eval!(r)?)),
         Expression::Subtract(l, r) => Ok(eval!(l)?.wrapping_sub(eval!(r)?)),
@@ -254,7 +264,6 @@ mod tests {
     use crate::grouping::SequencedLinkerScript;
     use crate::input_data::FileId;
     use crate::linker_script::AssertCommand;
-    use crate::output_section_id::OutputSections;
     use crate::parsing::ProcessedLinkerScript;
     use crate::symbol_db::SymbolIdRange;
 
@@ -269,7 +278,7 @@ mod tests {
 
     fn eval_const(expr: &Expression<'static>) -> Result<u64> {
         let (layouts, sections) = dummy_context();
-        evaluate_expression::<Elf>(expr, &layouts, &sections, &|_| {}, &[])
+        evaluate_expression::<Elf>(expr, SymbolLoc::None, &layouts, &sections, &[], &|_| Ok(1))
     }
 
     #[test]
@@ -564,12 +573,6 @@ mod tests {
     }
 
     #[test]
-    fn test_symbol_skips_with_ok() {
-        // Symbol references are not yet supported; should return Ok(1) (skip, not fail)
-        assert_eq!(eval_const(&Expression::Symbol(b"__bss_start")).unwrap(), 1);
-    }
-
-    #[test]
     fn test_alignof_evaluation() {
         // Test that evaluating ALIGNOF for a non-existent section returns 0
         assert_eq!(
@@ -607,7 +610,7 @@ mod tests {
             message: b"should pass",
             remainder: b"",
         }]);
-        assert!(evaluate_assertions::<Elf>(&[group], &layouts, &sections, &|_| {}).is_ok(),);
+        assert!(evaluate_assertions::<Elf>(&[group], &layouts, &sections, &|_| {}).is_ok());
     }
 
     #[test]
@@ -638,7 +641,14 @@ mod tests {
             },
         ];
         let eval = |expr: &Expression| {
-            evaluate_expression::<Elf>(expr, &layouts, &sections, &|_| {}, &regions)
+            evaluate_expression::<Elf>(
+                expr,
+                SymbolLoc::None,
+                &layouts,
+                &sections,
+                &regions,
+                &|_| Ok(0),
+            )
         };
         assert_eq!(eval(&Expression::Origin(b"rom")).unwrap(), 0x08000000);
         assert_eq!(eval(&Expression::Length(b"rom")).unwrap(), 0x100000);

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -347,7 +347,12 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         &group_layouts,
         &mut symbol_resolutions.resolutions,
     );
-    update_redirect_resolutions(&symbol_db, &mut symbol_resolutions.resolutions)?;
+    update_redirect_resolutions(
+        &symbol_db,
+        &mut symbol_resolutions.resolutions,
+        &output_sections,
+        &section_layouts,
+    )?;
     crate::gc_stats::maybe_write_gc_stats(&group_layouts, &symbol_db)?;
 
     // Evaluate ASSERT commands from all linker scripts now that layout is complete.
@@ -409,6 +414,8 @@ struct FinaliseSizesResources<'data, 'scope, P: Platform> {
 fn update_redirect_resolutions<'data, P: Platform>(
     symbol_db: &SymbolDb<'data, P>,
     resolutions: &mut [Option<Resolution<P>>],
+    output_sections: &OutputSections<P>,
+    section_layouts: &OutputSectionMap<OutputRecordLayout>,
 ) -> Result {
     verbose_timing_phase!("Update symdef resolutions");
 
@@ -418,7 +425,14 @@ fn update_redirect_resolutions<'data, P: Platform>(
         match group {
             Group::Prelude(prelude) => {
                 for def_info in &prelude.symbol_definitions {
-                    update_defsym_symbol_resolution(symbol_id, def_info, symbol_db, resolutions)?;
+                    update_defsym_symbol_resolution(
+                        symbol_id,
+                        def_info,
+                        symbol_db,
+                        resolutions,
+                        output_sections,
+                        section_layouts,
+                    )?;
                     symbol_id = symbol_id.next();
                 }
             }
@@ -430,6 +444,8 @@ fn update_redirect_resolutions<'data, P: Platform>(
                             def_info,
                             symbol_db,
                             resolutions,
+                            output_sections,
+                            section_layouts,
                         )?;
                         symbol_id = symbol_id.next();
                     }
@@ -449,31 +465,36 @@ fn update_defsym_symbol_resolution<'data, P: Platform>(
     def_info: &InternalSymDefInfo<P>,
     symbol_db: &SymbolDb<'data, P>,
     resolutions: &mut [Option<Resolution<P>>],
+    output_sections: &OutputSections<P>,
+    section_layouts: &OutputSectionMap<OutputRecordLayout>,
 ) -> Result {
-    let SymbolPlacement::Redirect(redirect) = def_info.placement else {
-        return Ok(());
+    if let SymbolPlacement::Redirect(redirect) = &def_info.placement {
+        let value = crate::expression_eval::evaluate_expression(
+            &redirect.expression,
+            redirect.loc,
+            section_layouts,
+            output_sections,
+            &[],
+            &|name| {
+                let Some(target_symbol_id) =
+                    symbol_db.get_unversioned(&UnversionedSymbolName::prehashed(name))
+                else {
+                    return Err(redirect.missing_target(name));
+                };
+
+                let canonical_target_id = symbol_db.definition(target_symbol_id);
+                Ok(resolutions[canonical_target_id.as_usize()]
+                    .as_ref()
+                    .map_or(0, |r| r.raw_value))
+            },
+        )?;
+
+        let Some(resolution) = &mut resolutions[symbol_id.as_usize()] else {
+            return Ok(());
+        };
+
+        resolution.raw_value = value;
     };
-
-    if !symbol_db.is_canonical(symbol_id) {
-        return Ok(());
-    }
-
-    let name = UnversionedSymbolName::prehashed(redirect.target_name);
-
-    let target_symbol_id = symbol_db.get_unversioned(&name);
-
-    let Some(target_symbol_id) = target_symbol_id else {
-        return redirect.missing_target();
-    };
-
-    let canonical_target_id = symbol_db.definition(target_symbol_id);
-    if let Some(target_value) = resolutions[canonical_target_id.as_usize()]
-        .as_ref()
-        .map(|r| r.raw_value)
-        && let Some(resolution) = &mut resolutions[symbol_id.as_usize()]
-    {
-        resolution.raw_value = (target_value as i64).wrapping_add(redirect.offset) as u64;
-    }
 
     Ok(())
 }
@@ -2843,41 +2864,41 @@ impl<'data, P: Platform> PreludeLayoutState<'data, P> {
                 continue;
             }
 
-            match def_info.placement {
-                SymbolPlacement::DefsymAbsolute(_) => {
-                    resources
-                        .per_symbol_flags
-                        .get_atomic(symbol_id)
-                        .or_assign(ValueFlags::DIRECT);
-                }
+            match &def_info.placement {
                 SymbolPlacement::Redirect(redirect) => {
                     resources
                         .per_symbol_flags
                         .get_atomic(symbol_id)
                         .or_assign(ValueFlags::DIRECT);
 
-                    // Also mark the target symbol as used and queue it for loading to prevent it
-                    // from being GC'd.
-                    if let Some(target_symbol_id) = resources
-                        .symbol_db
-                        .get_unversioned(&UnversionedSymbolName::prehashed(redirect.target_name))
-                    {
-                        let canonical_target_id = resources.symbol_db.definition(target_symbol_id);
-                        let file_id = resources.symbol_db.file_id_for_symbol(canonical_target_id);
-                        let old_flags = resources
-                            .per_symbol_flags
-                            .get_atomic(canonical_target_id)
-                            .fetch_or(ValueFlags::DIRECT);
+                    // Also mark any symbols in the expression as used and queue it for loading to
+                    // prevent it from being GC'd.
+                    redirect.expression.visit_expressions(&mut |e| {
+                        if let crate::linker_script::Expression::Symbol(target_name) = e
+                            && let Some(target_symbol_id) = resources
+                                .symbol_db
+                                .get_unversioned(&UnversionedSymbolName::prehashed(target_name))
+                        {
+                            let canonical_target_id =
+                                resources.symbol_db.definition(target_symbol_id);
+                            let file_id =
+                                resources.symbol_db.file_id_for_symbol(canonical_target_id);
+                            let old_flags = resources
+                                .per_symbol_flags
+                                .get_atomic(canonical_target_id)
+                                .fetch_or(ValueFlags::DIRECT);
 
-                        if !old_flags.has_resolution() {
-                            queue.send_work::<A>(
-                                resources,
-                                file_id,
-                                WorkItem::LoadGlobalSymbol(canonical_target_id),
-                                scope,
-                            );
+                            if !old_flags.has_resolution() {
+                                queue.send_work::<A>(
+                                    resources,
+                                    file_id,
+                                    WorkItem::LoadGlobalSymbol(canonical_target_id),
+                                    scope,
+                                );
+                            }
                         }
-                    }
+                        true
+                    });
                 }
                 _ => {}
             }
@@ -3315,7 +3336,7 @@ impl<'data, P: Platform> InternalSymbols<'data, P> {
         resources: &FinaliseLayoutResources<'_, 'data, P>,
     ) -> Result {
         // Define symbols that are optionally put at the start/end of some sections.
-        for (local_index, &def_info) in self.symbol_definitions.iter().enumerate() {
+        for (local_index, def_info) in self.symbol_definitions.iter().enumerate() {
             let symbol_id = self.start_symbol_id.add_usize(local_index);
 
             let resolution =
@@ -3334,7 +3355,7 @@ impl<'data, P: Platform> InternalSymbols<'data, P> {
 fn create_internal_symbol_resolution<'data, P: Platform>(
     memory_offsets: &mut OutputSectionPartMap<u64>,
     resources: &FinaliseLayoutResources<'_, 'data, P>,
-    def_info: InternalSymDefInfo<P>,
+    def_info: &InternalSymDefInfo<P>,
     symbol_id: SymbolId,
 ) -> Option<Resolution<P>> {
     if !resources.symbol_db.is_canonical(symbol_id) {
@@ -3354,12 +3375,10 @@ fn create_internal_symbol_resolution<'data, P: Platform>(
         SymbolPlacement::SectionStart(section_id) => {
             resources.section_layouts.get(section_id).mem_offset
         }
-
         SymbolPlacement::SectionEnd(section_id) => {
             let sec = resources.section_layouts.get(section_id);
             sec.mem_offset + sec.mem_size
         }
-
         SymbolPlacement::SectionGroupEnd(section_id) => {
             let mut end = {
                 let sec = resources.section_layouts.get(section_id);
@@ -3379,16 +3398,12 @@ fn create_internal_symbol_resolution<'data, P: Platform>(
             }
             end
         }
-
-        SymbolPlacement::DefsymAbsolute(value) => value,
-
         SymbolPlacement::Redirect(_) => {
             // For redirects to other symbols, we defer resolution until later when all symbols have
             // been resolved. This is handled by update_redirect_resolutions() which is called after
             // layout is complete.
             0
         }
-
         SymbolPlacement::LoadBaseAddress => resources
             .segment_layouts
             .segments

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -22,6 +22,7 @@ use crate::parsing::InternalSymDefInfo;
 use crate::parsing::ProcessedLinkerScript;
 use crate::parsing::Redirect;
 use crate::parsing::RedirectKind;
+use crate::parsing::SymbolLoc;
 use crate::parsing::SymbolPlacement;
 use crate::platform::Platform;
 use crate::platform::SectionHeader;
@@ -29,67 +30,6 @@ use glob::Pattern;
 use hashbrown::HashTable;
 use std::borrow::Cow;
 use std::mem::replace;
-
-/// Determine the `SymbolPlacement` for a top-level symbol definition (`name = value;`).
-///
-/// Maps a parsed linker script expression to a `SymbolPlacement`.
-fn placement_from_symbol_definition_value<'data>(
-    name: &[u8],
-    value: &crate::linker_script::Expression<'data>,
-) -> crate::error::Result<SymbolPlacement<'data>> {
-    use crate::linker_script::Expression;
-
-    let placement = match value {
-        Expression::SegmentStart(seg_name, default_expr) => {
-            let default = crate::expression_eval::eval_constant_expr(default_expr).unwrap_or(0);
-            SymbolPlacement::SegmentStart(*seg_name, default)
-        }
-        Expression::Number(n) => SymbolPlacement::DefsymAbsolute(*n),
-        Expression::Symbol(sym) => SymbolPlacement::Redirect(Redirect {
-            kind: RedirectKind::Script,
-            target_name: sym,
-            offset: 0,
-        }),
-        Expression::Add(l, r) => {
-            if let (Expression::Symbol(sym), Expression::Number(offset)) = (l.as_ref(), r.as_ref())
-            {
-                SymbolPlacement::Redirect(Redirect {
-                    kind: RedirectKind::Script,
-                    target_name: sym,
-                    offset: *offset as i64,
-                })
-            } else {
-                return Err(crate::error!(
-                    "Unsupported expression in symbol definition for '{}'",
-                    String::from_utf8_lossy(name)
-                ));
-            }
-        }
-        Expression::Subtract(l, r) => {
-            if let (Expression::Symbol(sym), Expression::Number(offset)) = (l.as_ref(), r.as_ref())
-            {
-                SymbolPlacement::Redirect(Redirect {
-                    kind: RedirectKind::Script,
-                    target_name: sym,
-                    offset: -(*offset as i64),
-                })
-            } else {
-                return Err(crate::error!(
-                    "Unsupported expression in symbol definition for '{}'",
-                    String::from_utf8_lossy(name)
-                ));
-            }
-        }
-        _ => {
-            return Err(crate::error!(
-                "Unsupported expression in symbol definition for '{}'",
-                String::from_utf8_lossy(name)
-            ));
-        }
-    };
-
-    Ok(placement)
-}
 
 pub(crate) struct LayoutRules<'data> {
     pub(crate) section_rules: SectionRules<'data>,
@@ -203,16 +143,26 @@ impl<'data> LayoutRulesBuilder<'data> {
 
         for cmd in &input.script.commands {
             if let linker_script::Command::Provide(provide) = cmd {
-                let value_str = std::str::from_utf8(provide.value)
-                    .map_err(|_| crate::error!("Invalid UTF-8 in PROVIDE symbol value"))?;
-
-                let placement = crate::parsing::parse_symbol_expression(value_str).to_placement();
+                let placement = SymbolPlacement::Redirect(Redirect {
+                    kind: RedirectKind::Script,
+                    expression: provide.value.clone(),
+                    loc: SymbolLoc::None,
+                });
                 symbol_defs.push(
                     crate::parsing::InternalSymDefInfo::new(placement, provide.name)
                         .with_hidden(provide.hidden),
                 );
             } else if let linker_script::Command::SymbolDefinition { name, value } = cmd {
-                let placement = placement_from_symbol_definition_value(name, value)?;
+                let placement = if let Expression::SegmentStart(name, expr) = value {
+                    let default = crate::expression_eval::eval_constant_expr(expr).unwrap_or(0);
+                    SymbolPlacement::SegmentStart(*name, default)
+                } else {
+                    SymbolPlacement::Redirect(Redirect {
+                        kind: RedirectKind::Script,
+                        expression: value.to_owned(),
+                        loc: SymbolLoc::None,
+                    })
+                };
                 symbol_defs.push(crate::parsing::InternalSymDefInfo::new(placement, name));
             } else if let linker_script::Command::Sections(sections) = cmd {
                 let mut location = None;
@@ -317,11 +267,15 @@ impl<'data> LayoutRulesBuilder<'data> {
                                     ContentsCommand::Align(a) => extra_min_alignment = *a,
                                     ContentsCommand::Provide(provide) => {
                                         let placement = if let Some(id) = last_section_id {
-                                            SymbolPlacement::SectionEnd(id)
+                                            SymbolLoc::SectionEnd(id)
                                         } else {
-                                            SymbolPlacement::SectionStart(primary_section_id)
+                                            SymbolLoc::SectionStart(primary_section_id)
                                         };
-
+                                        let placement = SymbolPlacement::Redirect(Redirect {
+                                            kind: RedirectKind::Script,
+                                            expression: provide.value.clone(),
+                                            loc: placement,
+                                        });
                                         symbol_defs.push(
                                             InternalSymDefInfo::new(placement, provide.name)
                                                 .with_hidden(provide.hidden),

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -127,7 +127,7 @@ pub(crate) struct SymbolAssignment<'a> {
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct ProvideSymbolDefinition<'a> {
     pub(crate) name: &'a [u8],
-    pub(crate) value: &'a [u8],
+    pub(crate) value: Expression<'a>,
     pub(crate) hidden: bool,
 }
 
@@ -222,6 +222,52 @@ pub(crate) struct Matcher<'a> {
     pub(crate) input_file_pattern: Option<&'a [u8]>,
 
     pub(crate) input_section_name_patterns: Vec<&'a [u8]>,
+}
+
+impl<'a> Expression<'a> {
+    pub(crate) fn visit_expressions(&self, cb: &mut impl FnMut(&Self) -> bool) {
+        if !cb(self) {
+            return;
+        };
+        match self {
+            Expression::Number(_)
+            | Expression::LocationCounter
+            | Expression::Sizeof(_)
+            | Expression::Alignof(_)
+            | Expression::Origin(_)
+            | Expression::Length(_)
+            | Expression::Addr(_)
+            | Expression::Loadaddr(_)
+            | Expression::Symbol(_) => {}
+            Expression::Add(l, r)
+            | Expression::Subtract(l, r)
+            | Expression::Multiply(l, r)
+            | Expression::Divide(l, r)
+            | Expression::LessThan(l, r)
+            | Expression::GreaterThan(l, r)
+            | Expression::LessEqual(l, r)
+            | Expression::GreaterEqual(l, r)
+            | Expression::Equal(l, r)
+            | Expression::NotEqual(l, r)
+            | Expression::Min(l, r)
+            | Expression::Max(l, r)
+            | Expression::BitwiseAnd(l, r)
+            | Expression::BitwiseOr(l, r)
+            | Expression::BitwiseXor(l, r)
+            | Expression::LeftShift(l, r)
+            | Expression::RightShift(l, r)
+            | Expression::LogicalAnd(l, r)
+            | Expression::LogicalOr(l, r) => {
+                l.visit_expressions(cb);
+                r.visit_expressions(cb);
+            }
+            Expression::Align(e)
+            | Expression::LogicalNot(e)
+            | Expression::BitwiseNot(e)
+            | Expression::Negate(e) => e.visit_expressions(cb),
+            Expression::SegmentStart(_, default_expr) => default_expr.visit_expressions(cb),
+        }
+    }
 }
 
 impl<'data> LinkerScript<'data> {
@@ -340,8 +386,7 @@ fn parse_provide<'input>(
     skip_comments_and_whitespace(input)?;
     '='.parse_next(input)?;
     skip_comments_and_whitespace(input)?;
-    let value = take_while(1.., |b| b != b')' && b != b';').parse_next(input)?;
-    let value = value.trim_ascii_end();
+    let value = parse_expression.parse_next(input)?;
     skip_comments_and_whitespace(input)?;
     ')'.parse_next(input)?;
     skip_comments_and_whitespace(input)?;
@@ -427,7 +472,7 @@ fn parse_memory<'input>(input: &mut &'input BStr) -> winnow::Result<Vec<MemoryRe
 }
 
 /// Parse an expression - entry point for expression parsing
-fn parse_expression<'a>(input: &mut &'a BStr) -> winnow::Result<Expression<'a>> {
+pub(crate) fn parse_expression<'a>(input: &mut &'a BStr) -> winnow::Result<Expression<'a>> {
     parse_logical_or.parse_next(input)
 }
 

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -1,8 +1,6 @@
 use crate::OutputKind;
 use crate::OutputSections;
-use crate::args::DefsymValue;
 use crate::args::Modifiers;
-use crate::bail;
 use crate::error::Context as _;
 use crate::error::Result;
 use crate::input_data::FileId;
@@ -10,6 +8,7 @@ use crate::input_data::InputBytes;
 use crate::input_data::InputLinkerScript;
 use crate::input_data::InputRef;
 use crate::layout_rules::LayoutRulesBuilder;
+use crate::linker_script::Expression;
 use crate::output_section_id::OutputSectionId;
 use crate::platform::Args;
 use crate::platform::ObjectFile;
@@ -63,7 +62,7 @@ pub(crate) struct SyntheticSymbols {
     pub(crate) symbol_id_range: SymbolIdRange,
 }
 
-#[derive(Clone, Copy, derive_more::Debug)]
+#[derive(Clone, derive_more::Debug)]
 pub(crate) struct InternalSymDefInfo<'data, P: Platform> {
     pub(crate) symbol: P::SymtabEntry,
     pub(crate) placement: SymbolPlacement<'data>,
@@ -71,7 +70,7 @@ pub(crate) struct InternalSymDefInfo<'data, P: Platform> {
     pub(crate) name: &'data [u8],
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub(crate) enum SymbolPlacement<'data> {
     /// Symbol 0 - the undefined symbol.
     Undefined,
@@ -90,9 +89,6 @@ pub(crate) enum SymbolPlacement<'data> {
     /// An undefined symbol supplied by the user, e.g. via `--undefined=symbol-name`.
     ForceUndefined,
 
-    /// A symbol defined via --defsym with an absolute address.
-    DefsymAbsolute(u64),
-
     /// A symbol that redirects to some other symbol.
     Redirect(Redirect<'data>),
 
@@ -105,11 +101,18 @@ pub(crate) enum SymbolPlacement<'data> {
     SegmentStart(SegmentName, u64),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum SymbolLoc {
+    SectionStart(OutputSectionId),
+    SectionEnd(OutputSectionId),
+    None,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Redirect<'data> {
     pub(crate) kind: RedirectKind,
-    pub(crate) target_name: &'data [u8],
-    pub(crate) offset: i64,
+    pub(crate) expression: Expression<'data>,
+    pub(crate) loc: SymbolLoc,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -138,71 +141,6 @@ impl SegmentName {
             b"bss" => Self::Bss,
             _ => Self::Other,
         }
-    }
-}
-
-/// Result of parsing a defsym-style expression like "0x1000", "symbol", or "symbol+0x40".
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ParsedSymbolExpression<'a> {
-    /// An absolute numeric value.
-    Absolute(u64),
-    /// A symbol reference with an optional offset.
-    SymbolWithOffset(&'a str, i64),
-}
-
-impl<'a> ParsedSymbolExpression<'a> {
-    pub(crate) fn to_placement(self) -> SymbolPlacement<'a> {
-        match self {
-            ParsedSymbolExpression::Absolute(value) => SymbolPlacement::DefsymAbsolute(value),
-            ParsedSymbolExpression::SymbolWithOffset(sym, offset) => {
-                SymbolPlacement::Redirect(Redirect {
-                    kind: RedirectKind::Script,
-                    target_name: sym.as_bytes(),
-                    offset,
-                })
-            }
-        }
-    }
-}
-
-pub fn parse_symbol_expression(s: &str) -> ParsedSymbolExpression<'_> {
-    let mut symbol = None;
-    let mut offset: i64 = 0;
-    let mut token_start = 0;
-    let mut current_sign: i64 = 1;
-
-    // Handle leading sign
-    if s.starts_with('-') {
-        current_sign = -1;
-        token_start = 1;
-    } else if s.starts_with('+') {
-        token_start = 1;
-    }
-
-    for (i, ch) in s.bytes().enumerate().skip(token_start) {
-        if ch == b'+' || ch == b'-' {
-            let token = s[token_start..i].trim();
-            if let Ok(val) = parse_number(token) {
-                offset = offset.wrapping_add(current_sign * val as i64);
-            } else if symbol.is_none() && !token.is_empty() {
-                symbol = Some(token);
-            }
-            current_sign = if ch == b'+' { 1 } else { -1 };
-            token_start = i + 1;
-        }
-    }
-
-    // Process the last token
-    let token = s[token_start..].trim();
-    if let Ok(val) = parse_number(token) {
-        offset = offset.wrapping_add(current_sign * val as i64);
-    } else if symbol.is_none() && !token.is_empty() {
-        symbol = Some(token);
-    }
-
-    match symbol {
-        Some(sym) => ParsedSymbolExpression::SymbolWithOffset(sym, offset),
-        None => ParsedSymbolExpression::Absolute(offset as u64),
     }
 }
 
@@ -266,7 +204,7 @@ impl<'data, P: Platform> ParsedInputObject<'data, P> {
 }
 
 impl<'data, P: Platform> Prelude<'data, P> {
-    pub(crate) fn new(args: &'data P::Args, output_kind: OutputKind) -> Self {
+    pub(crate) fn new(args: &'data P::Args, output_kind: OutputKind) -> Result<Self> {
         verbose_timing_phase!("Construct prelude");
 
         let mut symbols = InternalSymbolsBuilder::default();
@@ -281,23 +219,25 @@ impl<'data, P: Platform> Prelude<'data, P> {
         });
 
         // Add symbols defined via the command line.
-        args.defsym().iter().for_each(|(name, value)| {
-            let placement = match value {
-                DefsymValue::Value(addr) => SymbolPlacement::DefsymAbsolute(*addr),
-                DefsymValue::SymbolWithOffset(target, offset) => {
-                    SymbolPlacement::Redirect(Redirect {
-                        kind: RedirectKind::DefSym,
-                        target_name: target.as_bytes(),
-                        offset: *offset,
-                    })
-                }
-            };
-            symbols.add_symbol(InternalSymDefInfo::new(placement, name.as_bytes()));
-        });
+        args.defsym()
+            .iter()
+            .try_for_each(|(name, value)| -> Result<()> {
+                let mut value = winnow::BStr::new(value);
+                let expr = crate::linker_script::parse_expression(&mut value)
+                    .with_context(|| format!("Failed to parse --defsym {name}={value}"))?;
 
-        Self {
+                let placement = SymbolPlacement::Redirect(Redirect {
+                    kind: RedirectKind::DefSym,
+                    expression: expr,
+                    loc: SymbolLoc::None,
+                });
+                symbols.add_symbol(InternalSymDefInfo::new(placement, name.as_bytes()));
+                Ok(())
+            })?;
+
+        Ok(Self {
             symbol_definitions: symbols.symbol_definitions,
-        }
+        })
     }
 
     pub(crate) fn symbol_name(&self, symbol_id: SymbolId) -> UnversionedSymbolName<'data> {
@@ -374,20 +314,16 @@ impl<'data, P: Platform> std::fmt::Display for ProcessedLinkerScript<'data, P> {
 }
 
 impl Redirect<'_> {
-    pub(crate) fn missing_target(&self) -> Result {
+    pub(crate) fn missing_target(&self, target_name: &[u8]) -> crate::error::Error {
         match self.kind {
-            RedirectKind::DefSym => {
-                bail!(
-                    "Symbol '{}' referenced by --defsym does not exist",
-                    String::from_utf8_lossy(self.target_name)
-                )
-            }
-            RedirectKind::Script => {
-                bail!(
-                    "Undefined symbol '{}' referenced in expression",
-                    String::from_utf8_lossy(self.target_name)
-                )
-            }
+            RedirectKind::DefSym => crate::error!(
+                "Symbol '{}' referenced by --defsym does not exist",
+                String::from_utf8_lossy(target_name)
+            ),
+            RedirectKind::Script => crate::error!(
+                "Undefined symbol '{}' referenced in expression",
+                String::from_utf8_lossy(target_name)
+            ),
         }
     }
 }

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -1,7 +1,6 @@
 use crate::OutputKind;
 use crate::Result;
 use crate::alignment::Alignment;
-use crate::args::DefsymValue;
 use crate::bail;
 use crate::error::Warning;
 use crate::grouping::Group;
@@ -1239,7 +1238,7 @@ pub(crate) trait Args: std::fmt::Debug + Send + Sync + 'static {
         crate::args::UnresolvedSymbols::ReportAll
     }
 
-    fn defsym(&self) -> &[(String, DefsymValue)] {
+    fn defsym(&self) -> &[(String, String)] {
         &[]
     }
 

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -28,6 +28,8 @@ use crate::output_section_id::OutputSections;
 use crate::parsing;
 use crate::parsing::InternalSymDefInfo;
 use crate::parsing::Prelude;
+use crate::parsing::Redirect;
+use crate::parsing::SymbolLoc;
 use crate::parsing::SymbolPlacement;
 use crate::parsing::SyntheticSymbols;
 use crate::part_id;
@@ -408,7 +410,7 @@ impl<'data, P: Platform> SymbolDb<'data, P> {
                 .push(Group::Prelude(crate::parsing::Prelude::new(
                     self.args,
                     self.output_kind,
-                )));
+                )?));
         }
 
         grouping::create_groups(self, parsed_objects, processed_linker_scripts);
@@ -2005,22 +2007,29 @@ impl<'data, P: Platform> Prelude<'data, P> {
     ) {
         for definition in &self.symbol_definitions {
             let symbol_id = symbols_out.next;
-            let mut flags = match definition.placement {
+            let mut flags = match &definition.placement {
                 SymbolPlacement::Undefined | SymbolPlacement::ForceUndefined => {
                     ValueFlags::ABSOLUTE
-                }
-                SymbolPlacement::DefsymAbsolute(_) => {
-                    outputs.add_non_versioned(PendingSymbol::new(symbol_id, definition.name));
-                    ValueFlags::NON_INTERPOSABLE | ValueFlags::ABSOLUTE
                 }
                 SymbolPlacement::SectionStart(_)
                 | SymbolPlacement::SectionEnd(_)
                 | SymbolPlacement::SectionGroupEnd(_)
-                | SymbolPlacement::Redirect(_)
                 | SymbolPlacement::LoadBaseAddress
                 | SymbolPlacement::SegmentStart(_, _) => {
                     outputs.add_non_versioned(PendingSymbol::new(symbol_id, definition.name));
                     ValueFlags::NON_INTERPOSABLE
+                }
+                SymbolPlacement::Redirect(redirect) => {
+                    outputs.add_non_versioned(PendingSymbol::new(symbol_id, definition.name));
+                    let mut flags = ValueFlags::NON_INTERPOSABLE | ValueFlags::ABSOLUTE;
+                    redirect.expression.visit_expressions(&mut |e| {
+                        if matches!(e, crate::linker_script::Expression::Symbol(_)) {
+                            flags.remove(ValueFlags::ABSOLUTE);
+                            return false;
+                        }
+                        true
+                    });
+                    flags
                 }
             };
             if definition.symbol.is_hidden() {
@@ -2038,11 +2047,14 @@ impl std::fmt::Display for SymbolId {
 }
 
 impl<P: Platform> InternalSymDefInfo<'_, P> {
-    pub(crate) fn section_id(self) -> Option<OutputSectionId> {
+    pub(crate) fn section_id(&self) -> Option<OutputSectionId> {
         match self.placement {
+            SymbolPlacement::Redirect(Redirect {
+                loc: SymbolLoc::SectionEnd(i) | SymbolLoc::SectionStart(i),
+                ..
+            }) => Some(i),
             SymbolPlacement::Undefined
             | SymbolPlacement::ForceUndefined
-            | SymbolPlacement::DefsymAbsolute(_)
             | SymbolPlacement::Redirect(_) => None,
             SymbolPlacement::SectionStart(i) => Some(i),
             SymbolPlacement::SectionEnd(i) => Some(i),

--- a/wild/tests/sources/elf/linker-script-provide/linker-script-provide.c
+++ b/wild/tests/sources/elf/linker-script-provide/linker-script-provide.c
@@ -5,6 +5,9 @@
 //#ExpectSym:provided_absolute address=0x1000
 //#ExpectDynSym:provided_absolute address=0x1000
 //#ExpectSym:provided_hidden_absolute address=0x2000
+//#ExpectSym:provided_symbol address=0x1000
+//#ExpectSym:provided_expr1 address=0x3000
+//#ExpectSym:provided_expr2 address=0xffffffff81000000
 //#NoDynSym:provided_hidden_absolute
 //#ExpectSym:__text_start
 //#ExpectSym:__text_end
@@ -32,13 +35,17 @@
 
 extern char provided_absolute __attribute__((weak));
 extern char provided_hidden_absolute __attribute__((weak));
+extern char provided_symbol __attribute__((weak));
+extern char provided_expr1 __attribute__((weak));
+extern char provided_expr2 __attribute__((weak));
 extern char __text_start __attribute__((weak));
 extern char __text_end __attribute__((weak));
 extern char __data_start __attribute__((weak));
 extern char __data_end __attribute__((weak));
 
 void* get_provided(void) {
-  return &provided_absolute + (long)&provided_hidden_absolute;
+  return &provided_absolute + (long)&provided_hidden_absolute +
+         (long)&provided_symbol + (long)&provided_expr1 + (long)&provided_expr2;
 }
 
 unsigned long get_text_size(void) {

--- a/wild/tests/sources/elf/linker-script-provide/linker-script-provide.ld
+++ b/wild/tests/sources/elf/linker-script-provide/linker-script-provide.ld
@@ -1,5 +1,8 @@
 PROVIDE(provided_absolute = 0x1000);
 PROVIDE_HIDDEN(provided_hidden_absolute = 0x2000);
+PROVIDE(provided_symbol = provided_absolute);
+PROVIDE(provided_expr1 = provided_symbol + provided_hidden_absolute);
+PROVIDE(provided_expr2 = (0xffffffff80000000 + (((provided_absolute * 0x1000) + (provided_hidden_absolute * 0x100 - 1)) & ~(0x200000 - 1))));
 PROVIDE(unreferenced_sym = 0x4000);
 
 SECTIONS {


### PR DESCRIPTION
This PR adds support for the `PROVIDE`/`PROVIDE_HIDDEN` commands to parse and evaluate expressions using the `evaluate_expression` function. This PR also lets us evaluate complex expressions within `--defsym` arguements.

Currently, `SEGMENT_START` isn't yet handled by `evaluate_expression`.