### PR TITLE
port(Macho): introduce feature and smaller refactoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         id: rust-toolchain
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build --profile ci --workspace --no-default-features
+      - run: cargo build --profile ci --workspace --no-default-features --features macho
       - run: cargo test --profile ci --workspace
 
   windows-build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,8 +161,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         id: rust-toolchain
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build --profile ci --workspace --no-default-features --features macho
-      - run: cargo test --profile ci --workspace
+      - run: cargo build --profile ci --workspace --no-default-features
+      - run: cargo test --profile ci --workspace --features macho
 
   windows-build:
     name: Build Windows (x86_64)

--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -81,5 +81,8 @@ wip = []
 # Experimental support for linking WebAssembly. Currently incomplete.
 wasm = []
 
+# Experimental support for linking Mach-O. Currently incomplete.
+macho = []
+
 [lints]
 workspace = true

--- a/libwild/src/args/macho.rs
+++ b/libwild/src/args/macho.rs
@@ -1,11 +1,13 @@
 use crate::alignment::MACHO_PAGE_ALIGNMENT;
 use crate::args::ArgumentParser;
 use crate::args::CommonArgs;
+use crate::args::FileWriteMode;
 use crate::args::Modifiers;
 use crate::args::RelocationModel;
 use crate::bail;
 use crate::error::Result;
 use crate::platform;
+use crate::platform::Args;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -146,6 +148,21 @@ fn setup_argument_parser() -> ArgumentParser<MachOArgs> {
                 Some(v) => Some(super::parse_time_phase_options(v)?),
                 None => Some(Vec::new()),
             };
+            Ok(())
+        });
+    parser
+        .declare()
+        .long("validate-output")
+        .execute(|args, _modifier_stack| {
+            args.common_mut().validate_output = true;
+            Ok(())
+        });
+    parser
+        .declare()
+        .long("update-in-place")
+        .help("Update file in place")
+        .execute(|args, _modifier_stack| {
+            args.common_mut().file_write_mode = Some(FileWriteMode::UpdateInPlace);
             Ok(())
         });
 

--- a/libwild/src/args/macho.rs
+++ b/libwild/src/args/macho.rs
@@ -1,21 +1,11 @@
-// TODO
-#![allow(unused_variables)]
-#![allow(unused)]
-
-use crate::alignment::Alignment;
 use crate::alignment::MACHO_PAGE_ALIGNMENT;
 use crate::args::ArgumentParser;
 use crate::args::CommonArgs;
-use crate::args::FILES_PER_GROUP_ENV;
 use crate::args::Modifiers;
-use crate::args::REFERENCE_LINKER_ENV;
 use crate::args::RelocationModel;
 use crate::bail;
-use crate::ensure;
 use crate::error::Result;
 use crate::platform;
-use crate::save_dir::SaveDir;
-use jobserver::Client;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -65,7 +55,7 @@ impl platform::Args for MachOArgs {
         false
     }
 
-    fn entry_symbol_name<'a>(&'a self, linker_script_entry: Option<&'a [u8]>) -> &'a [u8] {
+    fn entry_symbol_name<'a>(&'a self, _linker_script_entry: Option<&'a [u8]>) -> &'a [u8] {
         // TODO: probably add option
         b"_main"
     }
@@ -90,7 +80,7 @@ impl platform::Args for MachOArgs {
         todo!()
     }
 
-    fn should_export_dynamic(&self, lib_name: &[u8]) -> bool {
+    fn should_export_dynamic(&self, _lib_name: &[u8]) -> bool {
         todo!()
     }
 

--- a/libwild/src/args/macho.rs
+++ b/libwild/src/args/macho.rs
@@ -10,6 +10,7 @@ use crate::args::FILES_PER_GROUP_ENV;
 use crate::args::Modifiers;
 use crate::args::REFERENCE_LINKER_ENV;
 use crate::args::RelocationModel;
+use crate::bail;
 use crate::ensure;
 use crate::error::Result;
 use crate::platform;
@@ -124,6 +125,11 @@ pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(
         let arg = arg.as_ref();
 
         arg_parser.handle_argument(args, &mut modifier_stack, arg, &mut input)?;
+    }
+
+    if !args.common.unrecognized_options.is_empty() {
+        let options_list = args.common.unrecognized_options.join(", ");
+        bail!("unrecognized option(s): {}", options_list);
     }
 
     Ok(())

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -135,6 +135,9 @@ pub(crate) struct DyldChainedFixupsHeader {
 //     // followed by pool of dyld_chain_starts_in_segment data
 // };
 
+// Code signature data structures are always stored big-endian, regardless of
+// the target architecture's byte order.
+//
 // Data structures mirroring the following URL:
 // https://github.com/apple-oss-distributions/xnu/blob/94d3b452840153a99b38a3a9659680b2a006908e/osfmk/kern/cs_blobs.h.
 
@@ -1033,6 +1036,12 @@ impl platform::Platform for MachO {
         linker: &'data crate::Linker,
         args: &'data Self::Args,
     ) -> crate::error::Result<crate::LinkerOutput<'data>> {
+        if !cfg!(feature = "macho") {
+            crate::bail!(
+                "Mach-O support is still experimental. Rebuild with `--features macho` to enable it."
+            );
+        }
+
         linker.link_for_arch::<MachO, crate::macho_aarch64::MachOAArch64>(args)
     }
 

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -1,13 +1,10 @@
 // TODO
-#![allow(unused_variables)]
 #![allow(unused)]
 
 use crate::OutputKind;
 use crate::alignment;
 use crate::alignment::Alignment;
-use crate::alignment::MACHO_PAGE_ALIGNMENT;
 use crate::args::macho::MachOArgs;
-use crate::elf::ResolutionExt;
 use crate::ensure;
 use crate::error;
 use crate::error::Result;
@@ -29,11 +26,7 @@ use crate::output_section_id::SectionOutputInfo;
 use crate::part_id;
 use crate::platform;
 use crate::platform::ObjectFile;
-use crate::platform::Symbol as _;
 use crate::symbol_db::Visibility;
-use crate::value_flags::ValueFlags;
-use gimli::LittleEndian;
-use object::Endian;
 use object::Endianness;
 use object::SymbolIndex;
 use object::macho;

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -205,6 +205,7 @@ fn write_prelude<'data, A: Arch<Platform = MachO>>(
     write_code_signature_command::<A>(layout, code_signature_command);
 
     let chained_fixup_table = buffers.get_mut(part_id::CHAINED_FIXUP_TABLE);
+    // TODO: remove in the future once we handle a dynamic number of segments
     chained_fixup_table.fill(0);
     let starts_len = size_of::<u32>() * (DEFAULT_SEGMENT_COUNT + 1);
     let min_len = size_of::<ChainedFixupsHeader>() + starts_len;
@@ -237,12 +238,12 @@ fn populate_file_header<A: Arch<Platform = MachO>>(
     let load_commands_info = get_segment_sections(layout, SegmentType::LoadCommands)
         .ok_or_else(|| error!("LoadCommands segment is mandatory"))?;
 
-    header.magic = U32::new(BigEndian, MH_CIGAM_64);
-    header.cputype = U32::new(LE, CPU_TYPE_ARM64);
-    header.cpusubtype = U32::new(LE, 0);
-    header.filetype = U32::new(LE, MH_EXECUTE);
+    header.magic.set(BigEndian, MH_CIGAM_64);
+    header.cputype.set(LE, CPU_TYPE_ARM64);
+    header.cpusubtype.set(LE, 0);
+    header.filetype.set(LE, MH_EXECUTE);
     // TODO: a cleaner way how to filter out sections being part of the final output?
-    header.ncmds = U32::new(
+    header.ncmds.set(
         LE,
         load_commands_info
             .segment_sections
@@ -250,12 +251,14 @@ fn populate_file_header<A: Arch<Platform = MachO>>(
             .filter(|s| s.0.mem_size > 0)
             .count() as u32,
     );
-    header.sizeofcmds = U32::new(LE, load_commands_info.segment_size.file_size as u32);
-    header.flags = U32::new(
+    header
+        .sizeofcmds
+        .set(LE, load_commands_info.segment_size.file_size as u32);
+    header.flags.set(
         LE,
         macho::MH_PIE | macho::MH_DYLDLINK | macho::MH_NOUNDEFS | macho::MH_TWOLEVEL,
     );
-    header.reserved = U32::new(LE, 0);
+    header.reserved.set(LE, 0);
     Ok(())
 }
 

--- a/wild/Cargo.toml
+++ b/wild/Cargo.toml
@@ -61,6 +61,8 @@ perfetto = ["libwild/perfetto"]
 
 wasm = ["libwild/wasm"]
 
+macho = ["libwild/macho"]
+
 # external tests
 external_tests = ["mold_tests"]
 mold_tests = []

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -291,6 +291,10 @@ fn collect_tests(tests: &mut Vec<Trial>, filter: &Filter) -> Result {
             continue;
         }
 
+        if platform == PlatformKind::MachO && !cfg!(feature = "macho") {
+            continue;
+        }
+
         let linkers = platform.available_linkers()?;
 
         let platform_name = platform.to_str();

--- a/wild/tests/sources/macho/trivial-multiple/lib.c
+++ b/wild/tests/sources/macho/trivial-multiple/lib.c
@@ -1,9 +1,5 @@
 int baz();
 
-int bar() {
-  return baz();
-}
+int bar() { return baz(); }
 
-int foo() {
-  return bar();
-}
+int foo() { return bar(); }

--- a/wild/tests/sources/macho/trivial-multiple/lib.c
+++ b/wild/tests/sources/macho/trivial-multiple/lib.c
@@ -1,0 +1,9 @@
+int baz();
+
+int bar() {
+  return baz();
+}
+
+int foo() {
+  return bar();
+}

--- a/wild/tests/sources/macho/trivial-multiple/trivial-multiple.c
+++ b/wild/tests/sources/macho/trivial-multiple/trivial-multiple.c
@@ -1,0 +1,17 @@
+//#Object:runtime.c
+//#Object:lib.c
+//#ExpectSym:_main
+//#TestUpdateInPlace:true
+
+#include "../common/runtime.h"
+
+int value = 42;
+
+int foo();
+long baz() {
+  return value;
+}
+
+int main() {
+  exit_syscall(foo());
+}

--- a/wild/tests/sources/macho/trivial-multiple/trivial-multiple.c
+++ b/wild/tests/sources/macho/trivial-multiple/trivial-multiple.c
@@ -8,10 +8,6 @@
 int value = 42;
 
 int foo();
-long baz() {
-  return value;
-}
+long baz() { return value; }
 
-int main() {
-  exit_syscall(foo());
-}
+int main() { exit_syscall(foo()); }


### PR DESCRIPTION
In the context of the upcoming release, it would be useful to avoid enabling Mach-O support unless the experimental feature is explicitly used. Besides that, I’ve included a number of smaller refactorings, along with a new test covering relocation handling.

Issue: #757