### PR TITLE
feat: implement symbol resolution within the ASSERT command

### DIFF
--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -1,4 +1,3 @@
-use crate::args::WarningCallback;
 /// Evaluation of linker script ASSERT commands after layout is complete.
 ///
 /// NOTE: ASSERT expression evaluation currently supports a subset of GNU ld expression
@@ -7,9 +6,9 @@ use crate::args::WarningCallback;
 use crate::bail;
 use crate::error::Context;
 use crate::error::Result;
-use crate::error::Warning;
 use crate::grouping::Group;
 use crate::layout::OutputRecordLayout;
+use crate::layout::Resolution;
 use crate::linker_script::Expression;
 use crate::linker_script::MemoryRegion;
 use crate::output_section_id::OutputSections;
@@ -17,6 +16,8 @@ use crate::output_section_id::SectionName;
 use crate::output_section_map::OutputSectionMap;
 use crate::parsing::SymbolLoc;
 use crate::platform::Platform;
+use crate::symbol::UnversionedSymbolName;
+use crate::symbol_db::SymbolDb;
 
 /// Compute 1-based line number by counting newlines before `remainder` in `file_bytes`.
 fn line_number(file_bytes: &[u8], remainder: &[u8]) -> u32 {
@@ -53,12 +54,12 @@ pub(crate) fn eval_constant_expr(expr: &Expression<'_>) -> crate::error::Result<
 /// Evaluate all ASSERT commands from all processed linker scripts.
 /// Must be called after layout is complete so section sizes/addresses are known.
 pub(crate) fn evaluate_assertions<'data, P: Platform>(
-    groups: &[Group<'data, P>],
+    symbol_db: &SymbolDb<'data, P>,
     section_layouts: &OutputSectionMap<OutputRecordLayout>,
     output_sections: &OutputSections<'data, P>,
-    warning_callback: &WarningCallback,
+    resolutions: &[Option<Resolution<P>>],
 ) -> Result {
-    for group in groups {
+    for group in &symbol_db.groups {
         let Group::LinkerScripts(scripts) = group else {
             continue;
         };
@@ -73,14 +74,19 @@ pub(crate) fn evaluate_assertions<'data, P: Platform>(
                     output_sections,
                     &parsed.memory_regions,
                     &|name| {
-                        // Symbol resolution in ASSERT is not yet implemented. Rather than failing the
-                        // link (which would be our fault, not the user's), emit a warning and skip the
-                        // assertion by returning 1 (true).
-                        warning_callback(Warning::new(format!(
-                            "ASSERT: symbol references not yet supported ('{}'), skipping assertion",
-                            String::from_utf8_lossy(name)
-                        )));
-                        Ok(1)
+                        let Some(target_symbol_id) =
+                            symbol_db.get_unversioned(&UnversionedSymbolName::prehashed(name))
+                        else {
+                            bail!(
+                                "Undefined symbol '{}' referenced in expression",
+                                String::from_utf8_lossy(name)
+                            );
+                        };
+
+                        let canonical_target_id = symbol_db.definition(target_symbol_id);
+                        Ok(resolutions[canonical_target_id.as_usize()]
+                            .as_ref()
+                            .map_or(0, |r| r.raw_value))
                     },
                 )
                 .with_context(|| format!("{}:{}: Failed to evaluate ASSERT", parsed.input, line))?;
@@ -265,20 +271,32 @@ mod tests {
     use crate::input_data::FileId;
     use crate::linker_script::AssertCommand;
     use crate::parsing::ProcessedLinkerScript;
+    use crate::symbol_db::SymbolDb;
     use crate::symbol_db::SymbolIdRange;
+    use colosseum::sync::Arena;
 
-    fn dummy_context() -> (
-        OutputSectionMap<OutputRecordLayout>,
-        OutputSections<'static, Elf>,
-    ) {
+    fn with_dummy_context<R>(
+        f: impl for<'test> FnOnce(
+            &OutputSectionMap<OutputRecordLayout>,
+            &OutputSections<'test, Elf>,
+            &mut SymbolDb<'test, Elf>,
+        ) -> R,
+    ) -> R {
         let sections = OutputSections::<Elf>::for_testing();
         let layouts = sections.new_section_map::<OutputRecordLayout>();
-        (layouts, sections)
+        let args = crate::args::elf::ElfArgs::new().unwrap();
+        let output_kind = crate::output_kind::OutputKind::Relocatable;
+        let arena = Arena::new();
+        let auxiliary = crate::input_data::AuxiliaryFiles::new(&args, &arena).unwrap();
+        let herd = Default::default();
+        let mut symbol_db = SymbolDb::<Elf>::new(&args, output_kind, &auxiliary, &herd).unwrap();
+        f(&layouts, &sections, &mut symbol_db)
     }
 
     fn eval_const(expr: &Expression<'static>) -> Result<u64> {
-        let (layouts, sections) = dummy_context();
-        evaluate_expression::<Elf>(expr, SymbolLoc::None, &layouts, &sections, &[], &|_| Ok(1))
+        with_dummy_context(|layouts, sections, _| {
+            evaluate_expression::<Elf>(expr, SymbolLoc::None, layouts, sections, &[], &|_| Ok(1))
+        })
     }
 
     #[test]
@@ -581,7 +599,7 @@ mod tests {
         );
     }
 
-    fn make_group(assertions: Vec<AssertCommand<'static>>) -> Group<'static, Elf> {
+    fn make_group<'data>(assertions: Vec<AssertCommand<'static>>) -> Group<'data, Elf> {
         static DUMMY_FILE: std::sync::OnceLock<crate::input_data::InputFile> =
             std::sync::OnceLock::new();
         let file = DUMMY_FILE.get_or_init(crate::input_data::InputFile::for_testing);
@@ -601,65 +619,70 @@ mod tests {
 
     #[test]
     fn test_evaluate_assertions_passes() {
-        let (layouts, sections) = dummy_context();
-        let group = make_group(vec![AssertCommand {
-            expression: Expression::Equal(
-                Box::new(Expression::Number(1)),
-                Box::new(Expression::Number(1)),
-            ),
-            message: b"should pass",
-            remainder: b"",
-        }]);
-        assert!(evaluate_assertions::<Elf>(&[group], &layouts, &sections, &|_| {}).is_ok());
+        with_dummy_context(|layouts, sections, symbol_db| {
+            let group = make_group(vec![AssertCommand {
+                expression: Expression::Equal(
+                    Box::new(Expression::Number(1)),
+                    Box::new(Expression::Number(1)),
+                ),
+                message: b"should pass",
+                remainder: b"",
+            }]);
+            symbol_db.add_group(group);
+            assert!(evaluate_assertions::<Elf>(symbol_db, layouts, sections, &[]).is_ok());
+        });
     }
 
     #[test]
     fn test_evaluate_assertions_fails() {
-        let (layouts, sections) = dummy_context();
-        let group = make_group(vec![AssertCommand {
-            expression: Expression::Number(0),
-            message: b"intentional failure",
-            remainder: b"",
-        }]);
-        let err = evaluate_assertions::<Elf>(&[group], &layouts, &sections, &|_| {}).unwrap_err();
-        assert!(err.to_string().contains("intentional failure"));
+        with_dummy_context(|layouts, sections, symbol_db| {
+            let group = make_group(vec![AssertCommand {
+                expression: Expression::Number(0),
+                message: b"intentional failure",
+                remainder: b"",
+            }]);
+            symbol_db.add_group(group);
+            let err = evaluate_assertions::<Elf>(symbol_db, layouts, sections, &[]).unwrap_err();
+            assert!(err.to_string().contains("intentional failure"));
+        });
     }
 
     #[test]
     fn test_memory_functions_evaluation() {
-        let (layouts, sections) = dummy_context();
-        let regions = [
-            MemoryRegion {
-                name: b"rom",
-                origin: Expression::Number(0x08000000),
-                length: Expression::Number(0x100000),
-            },
-            MemoryRegion {
-                name: b"ram",
-                origin: Expression::Number(0x20000000),
-                length: Expression::Number(0x40000),
-            },
-        ];
-        let eval = |expr: &Expression| {
-            evaluate_expression::<Elf>(
-                expr,
-                SymbolLoc::None,
-                &layouts,
-                &sections,
-                &regions,
-                &|_| Ok(0),
-            )
-        };
-        assert_eq!(eval(&Expression::Origin(b"rom")).unwrap(), 0x08000000);
-        assert_eq!(eval(&Expression::Length(b"rom")).unwrap(), 0x100000);
-        assert_eq!(eval(&Expression::Origin(b"ram")).unwrap(), 0x20000000);
-        assert_eq!(eval(&Expression::Length(b"ram")).unwrap(), 0x40000);
-        // end of rom = origin + length
-        let end = Expression::Add(
-            Box::new(Expression::Origin(b"rom")),
-            Box::new(Expression::Length(b"rom")),
-        );
-        assert_eq!(eval(&end).unwrap(), 0x08100000);
-        assert!(eval(&Expression::Origin(b"flash")).is_err());
+        with_dummy_context(|layouts, sections, _| {
+            let regions = [
+                MemoryRegion {
+                    name: b"rom",
+                    origin: Expression::Number(0x08000000),
+                    length: Expression::Number(0x100000),
+                },
+                MemoryRegion {
+                    name: b"ram",
+                    origin: Expression::Number(0x20000000),
+                    length: Expression::Number(0x40000),
+                },
+            ];
+            let eval = |expr: &Expression| {
+                evaluate_expression::<Elf>(
+                    expr,
+                    SymbolLoc::None,
+                    &layouts,
+                    &sections,
+                    &regions,
+                    &|_| Ok(0),
+                )
+            };
+            assert_eq!(eval(&Expression::Origin(b"rom")).unwrap(), 0x08000000);
+            assert_eq!(eval(&Expression::Length(b"rom")).unwrap(), 0x100000);
+            assert_eq!(eval(&Expression::Origin(b"ram")).unwrap(), 0x20000000);
+            assert_eq!(eval(&Expression::Length(b"ram")).unwrap(), 0x40000);
+            // end of rom = origin + length
+            let end = Expression::Add(
+                Box::new(Expression::Origin(b"rom")),
+                Box::new(Expression::Length(b"rom")),
+            );
+            assert_eq!(eval(&end).unwrap(), 0x08100000);
+            assert!(eval(&Expression::Origin(b"flash")).is_err());
+        });
     }
 }

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -357,10 +357,10 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
 
     // Evaluate ASSERT commands from all linker scripts now that layout is complete.
     crate::expression_eval::evaluate_assertions(
-        &symbol_db.groups,
+        &symbol_db,
         &section_layouts,
         &output_sections,
-        &resources.symbol_db.args.common().warning_callback,
+        &symbol_resolutions.resolutions,
     )?;
 
     let thunk_block_addresses = thunk_block_addresses_out

--- a/wild/tests/sources/elf/linker-script-assert-fail/linker-script-assert-fail.c
+++ b/wild/tests/sources/elf/linker-script-assert-fail/linker-script-assert-fail.c
@@ -1,3 +1,9 @@
+//#Config:linker-script-assert-fail
 //#LinkArgs:-T ./linker-script-assert-fail.ld
 //#ExpectError:assertion failed: text section cannot be empty
+
+//#Config:linker-script-assert-symbol-fail
+//#LinkArgs:-T ./linker-script-assert-symbol-fail.ld
+//#ExpectError:symbol1 must be 0x2000
+
 void _start() {}

--- a/wild/tests/sources/elf/linker-script-assert-fail/linker-script-assert-symbol-fail.ld
+++ b/wild/tests/sources/elf/linker-script-assert-fail/linker-script-assert-symbol-fail.ld
@@ -1,0 +1,9 @@
+SECTIONS {
+    .text : { *(.text*) }
+    .data : { *(.data*) }
+    .bss  : { *(.bss*)  }
+}
+
+
+symbol1 = 0x1000;
+ASSERT(symbol1 == 0x2000, "symbol1 must be 0x2000");

--- a/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
+++ b/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
@@ -17,3 +17,11 @@ ASSERT(SIZEOF(.text) > 0, "text section must be non-empty");
 
 /* Realistic check: full evaluator path - function -> arithmetic -> comparison */
 ASSERT(SIZEOF(.text) + SIZEOF(.data) < 0x100000, "image too big");
+
+symbol1 = 0x1000;
+symbol2 = 0x2000;
+
+ASSERT(symbol1 == 0x1000, "symbol1 must be 0x1000");
+ASSERT(symbol1 + symbol2 == 0x3000, "symbol1 + symbol2 must be 0x3000");
+ASSERT(symbol1 + symbol2 != symbol1 - symbol2, "symbol1 + symbol2 must not be symbol1 - symbol2");
+ASSERT(0xffffffff81000000 == (0xffffffff80000000 + (((symbol1 * 0x1000) + (symbol2 * 0x100 - 1)) & ~(0x200000 - 1))), "Incorrect Value");


### PR DESCRIPTION
Adds support for evaluating ASSERT statements that reference symbols.