### PR TITLE
port(MachO): use args.output for CS identifier

### DIFF
--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -25,6 +25,7 @@ use crate::output_section_id::SectionName;
 use crate::output_section_id::SectionOutputInfo;
 use crate::part_id;
 use crate::platform;
+use crate::platform::Args;
 use crate::platform::ObjectFile;
 use crate::symbol_db::Visibility;
 use object::Endianness;
@@ -46,6 +47,7 @@ use object::read::macho::Nlist;
 use object::read::macho::Section;
 use object::read::macho::Segment;
 use std::borrow::Cow;
+use std::os::unix::ffi::OsStrExt;
 use zerocopy::BigEndian;
 use zerocopy::FromBytes;
 use zerocopy::Immutable;
@@ -223,17 +225,12 @@ pub(crate) struct CodeSignatureCodeDirectory {
 
 pub(crate) const CS_SECTION_ALIGNMENT_EXP: u8 = 4;
 pub(crate) const CS_SECTION_ALIGNMENT: u64 = 2u64.pow(CS_SECTION_ALIGNMENT_EXP as u32);
-// TODO: properly implement
-pub(crate) const CS_IDENTIFIER_STRING: &[u8] = b"a.out";
 
 pub(crate) const CS_BLOB_HEADERS_SIZE: u64 =
     (size_of::<CodeSignatureSuperBlob>() + size_of::<CodeSignatureBlobIndex>()) as u64;
 const _: () = assert!(CS_BLOB_HEADERS_SIZE.is_multiple_of(8));
 pub(crate) const CS_HEADERS_SIZE: u64 =
     CS_BLOB_HEADERS_SIZE + size_of::<CodeSignatureCodeDirectory>() as u64;
-pub(crate) const CS_PADDED_FILENAME_SIZE: u64 =
-    (CS_IDENTIFIER_STRING.len() as u64 + 1).next_multiple_of(CS_SECTION_ALIGNMENT);
-pub(crate) const CS_HEADERS_WITH_FILENAME_SIZE: u64 = CS_HEADERS_SIZE + CS_PADDED_FILENAME_SIZE;
 pub(crate) const CS_BLOCK_SIZE_EXP: u8 = 12;
 pub(crate) const CS_BLOCK_SIZE: usize = 2usize.pow(CS_BLOCK_SIZE_EXP as u32);
 // SHA-256 is being used
@@ -249,6 +246,17 @@ pub(crate) const CS_ADHOC: u32 = 0x00000002;
 pub(crate) const CS_LINKER_SIGNED: u32 = 0x00020000;
 pub(crate) const CS_HASHTYPE_SHA256: u8 = 2;
 pub(crate) const CS_EXECSEG_MAIN_BINARY: u64 = 0x1;
+
+pub(crate) fn code_signature_identifier(args: &MachOArgs) -> &[u8] {
+    args.output()
+        .file_name()
+        .expect("File name should be present at this point")
+        .as_bytes()
+}
+
+pub(crate) fn code_signature_padded_identifier_size(args: &MachOArgs) -> u64 {
+    (code_signature_identifier(args).len() as u64 + 1).next_multiple_of(CS_SECTION_ALIGNMENT)
+}
 
 #[derive(derive_more::Debug)]
 pub(crate) struct File<'data> {
@@ -1424,7 +1432,10 @@ impl platform::Platform for MachO {
         // Allocate one extra character as n_strx == 0 is treated as unnamed.
         common.allocate(part_id::STRTAB, 1);
         common.allocate(part_id::CHAINED_FIXUP_TABLE, CHAINED_FIXUP_TABLE_SIZE);
-        common.allocate(part_id::CODE_SIGNATURE, CS_HEADERS_WITH_FILENAME_SIZE);
+        common.allocate(
+            part_id::CODE_SIGNATURE,
+            CS_HEADERS_SIZE + code_signature_padded_identifier_size(symbol_db.args),
+        );
     }
 
     fn finalise_prelude_layout<'data>(

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -47,7 +47,6 @@ use object::read::macho::Nlist;
 use object::read::macho::Section;
 use object::read::macho::Segment;
 use std::borrow::Cow;
-use std::os::unix::ffi::OsStrExt;
 use zerocopy::BigEndian;
 use zerocopy::FromBytes;
 use zerocopy::Immutable;
@@ -251,7 +250,7 @@ pub(crate) fn code_signature_identifier(args: &MachOArgs) -> &[u8] {
     args.output()
         .file_name()
         .expect("File name should be present at this point")
-        .as_bytes()
+        .as_encoded_bytes()
 }
 
 pub(crate) fn code_signature_padded_identifier_size(args: &MachOArgs) -> u64 {

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -24,9 +24,7 @@ use crate::macho::CS_BLOCK_SIZE_EXP;
 use crate::macho::CS_EXECSEG_MAIN_BINARY;
 use crate::macho::CS_HASH_SIZE;
 use crate::macho::CS_HASHTYPE_SHA256;
-use crate::macho::CS_IDENTIFIER_STRING;
 use crate::macho::CS_LINKER_SIGNED;
-use crate::macho::CS_PADDED_FILENAME_SIZE;
 use crate::macho::CS_SUPPORTSEXECSEG;
 use crate::macho::CSMAGIC_CODEDIRECTORY;
 use crate::macho::CSMAGIC_EMBEDDED_SIGNATURE;
@@ -51,6 +49,8 @@ use crate::macho::SegmentCommand;
 use crate::macho::SegmentSectionsInfo;
 use crate::macho::SegmentType;
 use crate::macho::SymtabCommand;
+use crate::macho::code_signature_identifier;
+use crate::macho::code_signature_padded_identifier_size;
 use crate::macho::get_segment_sections;
 use crate::output_section_id;
 use crate::output_section_id::SectionName;
@@ -714,6 +714,8 @@ fn write_code_signature(layout: &MachOLayout, sized_output: &mut SizedOutput) ->
     let code_signature_section = layout
         .section_layouts
         .get(output_section_id::CODE_SIGNATURE);
+    let code_signature_identifier = code_signature_identifier(layout.args());
+    let padded_identifier_size = code_signature_padded_identifier_size(layout.args()) as usize;
     let calculated_hashes: Vec<_> = sized_output.out[..code_signature_section.file_offset]
         .par_chunks(CS_BLOCK_SIZE)
         .map(Sha256::digest)
@@ -733,7 +735,7 @@ fn write_code_signature(layout: &MachOLayout, sized_output: &mut SizedOutput) ->
         <[CodeSignatureCodeDirectory]>::mut_from_prefix_with_elems(rest, 1)
             .map_err(|_| error!("Invalid CODE_SIGNATURE allocation"))?;
     let code_dir = &mut code_directories[0];
-    let (identifier, hashes) = rest.split_at_mut(CS_PADDED_FILENAME_SIZE as usize);
+    let (identifier, hashes) = rest.split_at_mut(padded_identifier_size);
 
     super_blob.magic.set(CSMAGIC_EMBEDDED_SIGNATURE);
     super_blob
@@ -753,7 +755,7 @@ fn write_code_signature(layout: &MachOLayout, sized_output: &mut SizedOutput) ->
     code_dir.flags.set(CS_ADHOC | CS_LINKER_SIGNED);
     code_dir
         .hash_offset
-        .set(size_of::<CodeSignatureCodeDirectory>() as u32 + CS_PADDED_FILENAME_SIZE as u32);
+        .set(size_of::<CodeSignatureCodeDirectory>() as u32 + padded_identifier_size as u32);
     code_dir
         .ident_offset
         .set(size_of::<CodeSignatureCodeDirectory>() as u32);
@@ -786,8 +788,8 @@ fn write_code_signature(layout: &MachOLayout, sized_output: &mut SizedOutput) ->
     // TODO: change once shared libraries are supported
     code_dir.exec_seg_flags.set(CS_EXECSEG_MAIN_BINARY);
 
-    identifier[..CS_IDENTIFIER_STRING.len()].copy_from_slice(CS_IDENTIFIER_STRING);
-    identifier[CS_IDENTIFIER_STRING.len()..].fill(0);
+    identifier[..code_signature_identifier.len()].copy_from_slice(code_signature_identifier);
+    identifier[code_signature_identifier.len()..].fill(0);
     hashes.copy_from_slice(&calculated_hashes);
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
Issue: #757