### PR TITLE
tools: Use WILD_LOG environment variable rather than RUST_LOG

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -295,6 +295,11 @@ So in summary, if you think something shouldn't happen, it's fine to panic. Call
 fine. But if you're less sure that it can't happen, or you've observed it happen and need to debug
 why it happened, then switching to returning an error is recommended.
 
+### Logging
+
+Wild uses tracing for logging. To see trace output, run with `WILD_LOG=trace`. You can also filter
+by module. e.g. `WILD_LOG=libwild::grouping`.
+
 ## Building wild with wild
 
 You can add or modify a `.cargo/config.toml` file to change the linker used to build `wild` to be `wild`!

--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -135,7 +135,7 @@ pub fn setup_tracing(args: &Args) -> Result<(), AlreadyInitialised> {
     } else {
         tracing_subscriber::registry()
             .with(fmt::layer())
-            .with(EnvFilter::from_default_env())
+            .with(EnvFilter::from_env("WILD_LOG"))
             .try_init()
             .map_err(|_| AlreadyInitialised)
     }


### PR DESCRIPTION
Using RUST_LOG didn't work so well with cargo run because any change to RUST_LOG causes a rebuild.