### PR TITLE
chore: Remove outdated cargo-nextest configuration

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,4 +1,0 @@
-[[profile.default.overrides]]
-# These tests are slow, run them first to improve parallelism.
-filter = 'test(_rust_) | test(_integration_)'
-priority = 1


### PR DESCRIPTION
The regex no longer matches since the tests rework and thanks to better granularity the tests are now fast without it.