### PR TITLE
chore: Emit cause when failing to load plugin

### DIFF
--- a/libwild/src/linker_plugins.rs
+++ b/libwild/src/linker_plugins.rs
@@ -364,7 +364,9 @@ impl LoadedPlugin {
         // Safety: Truthfully, we don't control the file we're loading. The user gave it to us and
         // there's nothing we can do to guarantee that loading and running it won't trigger UB. The
         // best we can say is that we at least try to conform to the expected plugin API.
-        let lib = unsafe { Library::new(plugin_path) }.context("Failed to open linker plugin")?;
+        let lib = unsafe { Library::new(plugin_path) }
+            .map_err(|e| error!("{}", std::error::Error::source(&e).unwrap_or(&e)))
+            .context("Failed to open linker plugin")?;
 
         timing_phase!("Initialise linker plugin");
 

--- a/wild/tests/sources/elf/linker-plugin-lto/linker-plugin-lto.c
+++ b/wild/tests/sources/elf/linker-plugin-lto/linker-plugin-lto.c
@@ -5,6 +5,7 @@
 //#RequiresLinkerPlugin:true
 
 //#AbstractConfig:error
+//#RequiresLinkerPlugin:true
 
 //#Config:gcc:default
 //#CompArgs:-flto
@@ -92,6 +93,12 @@
 //#LinkArgs:-Wl,-znow -flto -nostdlib -Wl,-plugin-opt=jobs=foo
 //#Archive:empty.c:-flto
 //#ExpectError:(Error from linker plugin: Invalid parallelism level: foo|Wild was compiled without linker-plugin support)
+
+//#Config:plugin-not-found:error
+//#Compiler:clang
+//#CompArgs:-flto
+//#LinkArgs:--plugin=/does/not/exist
+//#ExpectError:No such file or directory
 
 #include "../common/runtime.h"
 


### PR DESCRIPTION
When I originally wrote the linker plugin code I was using a version prior to 0.9.0, which reported errors differently, so the underlying error would have been shown. Version 0.9.0 [changed this](https://docs.rs/libloading/latest/libloading/changelog/r0_9_0/index.html), so that we were just reporting "dlopen failed".

Error prior to this change:

```
wild: error: Failed to initialise linker plugin `/usr/bin/../lib64/LLVMgold.so`
  Caused by:
    Failed to open linker plugin
    dlopen failed
```

Error after this change:

```
wild: error: Failed to initialise linker plugin `/usr/bin/../lib64/LLVMgold.so`
  Caused by:
    Failed to open linker plugin
    /usr/bin/../lib64/LLVMgold.so: cannot open shared object file: No such file or directory
```

We now have a test to make sure that we do actually report the underlying cause.