### PR TITLE
port(MachO): add parser for Stub Libraries (TBD)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,6 +922,8 @@ dependencies = [
  "perf-event",
  "perfetto-recorder",
  "rayon",
+ "serde",
+ "serde_yaml",
  "sha2",
  "sharded-offset-map",
  "sharded-vec-writer 0.4.0",
@@ -1646,6 +1648,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,6 +1728,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2084,6 +2105,12 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ rayon = "1.5.1"
 regex = { version = "1.12.0", features = ["std"] }
 serde = { version = "1.0.225", features = ["derive"] }
 serde-keyvalue = "0.1.0"
+serde_yaml = "0.9"
 sha2 = "0.11.0"
 sharded-offset-map = "0.2.0"
 sharded-vec-writer = "0.4.0"

--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -40,6 +40,8 @@ nix = { workspace = true, optional = true }
 object.workspace = true
 perfetto-recorder.workspace = true
 rayon.workspace = true
+serde.workspace = true
+serde_yaml.workspace = true
 sha2.workspace = true
 sharded-offset-map.workspace = true
 sharded-vec-writer.workspace = true

--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -36,6 +36,7 @@ mod linker_plugins;
 pub(crate) mod linker_script;
 pub(crate) mod macho;
 pub(crate) mod macho_aarch64;
+pub(crate) mod macho_stub_library;
 pub(crate) mod macho_writer;
 pub(crate) mod output_kind;
 pub(crate) mod output_section_id;

--- a/libwild/src/macho_stub_library.rs
+++ b/libwild/src/macho_stub_library.rs
@@ -8,7 +8,9 @@
 //! libraries reexported by the main library. This covers a practical subset of
 //! the full TBD v4 format, including the shape used by most system libraries.
 
-use anyhow::ensure;
+use crate::ensure;
+use crate::error;
+use crate::error::Result;
 use itertools::Itertools;
 use serde::Deserialize;
 use std::borrow::Cow;
@@ -88,21 +90,19 @@ pub struct DefinedStubLibrary<'a> {
 
 // TODO: remove
 #[allow(unused)]
-pub fn parse_defined_library<'data>(
-    input: &'data str,
-) -> anyhow::Result<DefinedStubLibrary<'data>> {
+pub fn parse_defined_library<'data>(input: &'data str) -> Result<DefinedStubLibrary<'data>> {
     let library_definitions = serde_yaml::Deserializer::from_str(input)
         .map(TextBasedDefinition::deserialize)
         .collect::<Result<Vec<_>, _>>()?;
 
     let main_library = library_definitions
         .first()
-        .ok_or_else(|| anyhow::anyhow!("root library must be defined"))?;
+        .ok_or_else(|| error!("root library must be defined"))?;
     ensure!(
         main_library
             .targets
             .contains(&Cow::Borrowed(ARM64_LIB_ARCH)),
-        format!("'{ARM64_LIB_ARCH}' architecture not implemented by the library",)
+        "'{ARM64_LIB_ARCH}' architecture not implemented by the library"
     );
 
     ensure!(
@@ -134,13 +134,13 @@ pub fn parse_defined_library<'data>(
         .reexported_libraries
         .iter()
         .at_most_one()
-        .map_err(|_| anyhow::anyhow!("expected just a single exported library"))?
+        .map_err(|_| error!("expected just a single exported library"))?
     {
         ensure!(
             exported_libraries
                 .targets
                 .contains(&Cow::Borrowed(ARM64_LIB_ARCH)),
-            format!("'{ARM64_LIB_ARCH}' architecture not covered in the exported library",)
+            "'{ARM64_LIB_ARCH}' architecture not covered in the exported library"
         );
         let exported_libraries: HashSet<_> = exported_libraries.libraries.iter().clone().collect();
         exported_libraries
@@ -151,15 +151,14 @@ pub fn parse_defined_library<'data>(
     for lib in &library_definitions {
         ensure!(
             lib.tbd_version == 4,
-            format!("TBD version 4 expected, got {}", lib.tbd_version)
+            "TBD version 4 expected, got {}",
+            lib.tbd_version
         );
         if lib != main_library {
             ensure!(
                 exported_libraries.contains(&lib.install_name),
-                format!(
-                    "child library '{}' not listed as reexported by the main library",
-                    lib.install_name
-                )
+                "child library '{}' not listed as reexported by the main library",
+                lib.install_name
             );
         }
 

--- a/libwild/src/macho_stub_library.rs
+++ b/libwild/src/macho_stub_library.rs
@@ -88,7 +88,9 @@ pub struct DefinedStubLibrary<'a> {
 
 // TODO: remove
 #[allow(unused)]
-pub fn parse_defined_library(input: &str) -> anyhow::Result<DefinedStubLibrary<'_>> {
+pub fn parse_defined_library<'data>(
+    input: &'data str,
+) -> anyhow::Result<DefinedStubLibrary<'data>> {
     let library_definitions = serde_yaml::Deserializer::from_str(input)
         .map(TextBasedDefinition::deserialize)
         .collect::<Result<Vec<_>, _>>()?;

--- a/libwild/src/macho_stub_library.rs
+++ b/libwild/src/macho_stub_library.rs
@@ -1,0 +1,255 @@
+//! Parser for the Text-Based Stub (`.tbd`) library definitions used by Mach-O.
+//!
+//! This crate currently targets TBD format version 4 and extracts the
+//! linker-visible symbol definitions (and weak symbols).
+//!
+//! The parser accepts multi-document YAML TBD files. The first document is
+//! treated as the main library. Additional documents are treated as child
+//! libraries reexported by the main library. This covers a practical subset of
+//! the full TBD v4 format, including the shape used by most system libraries.
+
+use anyhow::ensure;
+use itertools::Itertools;
+use serde::Deserialize;
+use std::borrow::Cow;
+use std::collections::HashSet;
+
+const ARM64_LIB_ARCH: &str = "arm64-macos";
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct TextBasedDefinition<'a> {
+    tbd_version: u32,
+    #[serde(borrow)]
+    targets: Vec<Cow<'a, str>>,
+    #[serde(borrow)]
+    install_name: Cow<'a, str>,
+    #[serde(default)]
+    current_version: Cow<'a, str>,
+    #[serde(default)]
+    parent_umbrella: Vec<ParentUmbrella<'a>>,
+    #[serde(default)]
+    reexported_libraries: Vec<ReexportedLibraries<'a>>,
+    #[serde(default)]
+    exports: Vec<Exports<'a>>,
+    #[serde(default)]
+    reexports: Vec<Exports<'a>>,
+}
+
+impl<'a> TextBasedDefinition<'a> {
+    fn all_exports(&self) -> impl Iterator<Item = &Exports<'a>> {
+        self.exports.iter().chain(&self.reexports)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct ParentUmbrella<'a> {
+    #[serde(borrow)]
+    targets: Vec<Cow<'a, str>>,
+    #[serde(borrow)]
+    umbrella: Cow<'a, str>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct ReexportedLibraries<'a> {
+    #[serde(borrow)]
+    targets: Vec<Cow<'a, str>>,
+    #[serde(borrow)]
+    libraries: Vec<Cow<'a, str>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct Exports<'a> {
+    #[serde(borrow)]
+    targets: Vec<Cow<'a, str>>,
+    #[serde(default)]
+    #[serde(borrow)]
+    symbols: Vec<Cow<'a, str>>,
+    #[serde(default)]
+    #[serde(borrow)]
+    weak_symbols: Vec<Cow<'a, str>>,
+}
+
+// TODO: remove
+#[allow(unused)]
+pub struct DefinedStubLibrary<'a> {
+    /// Install name of the dynamic library, including its `.dylib` suffix.    
+    pub install_name: String,
+    /// Current version recorded for the library, if present.
+    pub current_version: String,
+    /// Global symbols defined by the library or by any reexported child library.
+    pub symbols: HashSet<Cow<'a, str>>,
+    /// Weak symbols defined by the library or by any reexported child library.
+    pub weak_symbols: HashSet<Cow<'a, str>>,
+}
+
+// TODO: remove
+#[allow(unused)]
+pub fn parse_defined_library(input: &str) -> anyhow::Result<DefinedStubLibrary<'_>> {
+    let library_definitions = serde_yaml::Deserializer::from_str(input)
+        .map(TextBasedDefinition::deserialize)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let main_library = library_definitions
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("root library must be defined"))?;
+    ensure!(
+        main_library
+            .targets
+            .contains(&Cow::Borrowed(ARM64_LIB_ARCH)),
+        format!("'{ARM64_LIB_ARCH}' architecture not implemented by the library",)
+    );
+
+    ensure!(
+        !main_library.current_version.is_empty(),
+        "Missing library version of the main library"
+    );
+    let mut defined_library = DefinedStubLibrary {
+        install_name: main_library.install_name.to_string(),
+        current_version: main_library.current_version.to_string(),
+        symbols: HashSet::with_capacity(
+            library_definitions
+                .iter()
+                .flat_map(TextBasedDefinition::all_exports)
+                .map(|exp| exp.symbols.len())
+                .sum(),
+        ),
+        weak_symbols: HashSet::with_capacity(
+            library_definitions
+                .iter()
+                .flat_map(TextBasedDefinition::all_exports)
+                .map(|exp| exp.weak_symbols.len())
+                .sum(),
+        ),
+    };
+
+    // Main libraries commonly reexport symbols from child libraries. This parser
+    // currently supports only a flat tree: one main library with leaf children.
+    let exported_libraries = if let Some(exported_libraries) = main_library
+        .reexported_libraries
+        .iter()
+        .at_most_one()
+        .map_err(|_| anyhow::anyhow!("expected just a single exported library"))?
+    {
+        ensure!(
+            exported_libraries
+                .targets
+                .contains(&Cow::Borrowed(ARM64_LIB_ARCH)),
+            format!("'{ARM64_LIB_ARCH}' architecture not covered in the exported library",)
+        );
+        let exported_libraries: HashSet<_> = exported_libraries.libraries.iter().clone().collect();
+        exported_libraries
+    } else {
+        HashSet::new()
+    };
+
+    for lib in &library_definitions {
+        ensure!(
+            lib.tbd_version == 4,
+            format!("TBD version 4 expected, got {}", lib.tbd_version)
+        );
+        if lib != main_library {
+            ensure!(
+                exported_libraries.contains(&lib.install_name),
+                format!(
+                    "child library '{}' not listed as reexported by the main library",
+                    lib.install_name
+                )
+            );
+        }
+
+        for export in lib.all_exports() {
+            if export.targets.contains(&Cow::Borrowed(ARM64_LIB_ARCH)) {
+                defined_library
+                    .symbols
+                    .extend(export.symbols.iter().cloned());
+                defined_library
+                    .weak_symbols
+                    .extend(export.weak_symbols.iter().cloned());
+            }
+        }
+    }
+
+    Ok(defined_library)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_library_with_reexports() {
+        let stub_library = parse_defined_library(
+            r#"--- !tapi-tbd
+tbd-version:     4
+targets:         [ x86_64-macos, arm64-macos ]
+install-name:    '/usr/lib/libMain.dylib'
+current-version: 1.2.3
+reexported-libraries:
+  - targets:         [ x86_64-macos, arm64-macos ]
+    libraries:       [ '/usr/lib/libA.dylib', '/usr/lib/libB.dylib' ]
+exports:
+  - targets:         [ arm64-macos ]
+    symbols:         [ _main_arm64 ]
+    weak-symbols:    [ _main_weak_arm64 ]
+  - targets:         [ x86_64-macos ]
+    symbols:         [ _main_x86_64 ]
+    weak-symbols:    [ _main_weak_x86_64 ]
+--- !tapi-tbd
+tbd-version:     4
+targets:         [ x86_64-macos, arm64-macos ]
+install-name:    '/usr/lib/libA.dylib'
+current-version: 10
+parent-umbrella:
+  - targets:         [ x86_64-macos, arm64-macos ]
+    umbrella:        Main
+exports:
+  - targets:         [ arm64-macos ]
+    symbols:         [ _a_arm64 ]
+    weak-symbols:    [ _a_weak_arm64 ]
+  - targets:         [ x86_64-macos ]
+    symbols:         [ _a_x86_64 ]
+--- !tapi-tbd
+tbd-version:     4
+targets:         [ x86_64-macos, arm64-macos ]
+install-name:    '/usr/lib/libB.dylib'
+current-version: 11
+parent-umbrella:
+  - targets:         [ x86_64-macos, arm64-macos ]
+    umbrella:        Main
+exports:
+  - targets:         [ arm64-macos ]
+    symbols:         [ _b_arm64 ]
+reexports:
+  - targets:         [ arm64-macos ]
+    symbols:         [ _b_exported_arm64 ]
+    weak-symbols:    [ _b_weak_exported_arm64 ]
+"#,
+        )
+        .expect("definition should parse");
+
+        assert_eq!(stub_library.install_name, "/usr/lib/libMain.dylib");
+        assert_eq!(stub_library.current_version, "1.2.3");
+        assert_eq!(
+            stub_library.symbols,
+            ["_main_arm64", "_a_arm64", "_b_arm64", "_b_exported_arm64"]
+                .into_iter()
+                .map(Cow::Borrowed)
+                .collect()
+        );
+        assert_eq!(
+            stub_library.weak_symbols,
+            [
+                "_main_weak_arm64",
+                "_a_weak_arm64",
+                "_b_weak_exported_arm64"
+            ]
+            .into_iter()
+            .map(Cow::Borrowed)
+            .collect()
+        );
+    }
+}


### PR DESCRIPTION
When linking against a library (such as `libSystem` or `libc++`), the linker does not operate on the actual `.dylib` binaries directly. Instead, it uses stub library definition files. This PR introduces a parser that extracts the list of strong and weak symbols defined by a given library.

The parser performs well when it comes to commonly used system libraries:
```
[src/main.rs:11:9] defined_library.install_name = "/usr/lib/libc++.1.dylib"
[src/main.rs:13:9] defined_library.symbols.len() = 2303
[src/main.rs:14:9] defined_library.weak_symbols.len() = 48
[src/main.rs:15:9] Instant::now() - start = 1.772994ms

[src/main.rs:8:9] library_name = "libSystem.tbd"
[src/main.rs:11:9] defined_library.install_name = "/usr/lib/libSystem.B.dylib"
[src/main.rs:13:9] defined_library.symbols.len() = 9184
[src/main.rs:14:9] defined_library.weak_symbols.len() = 1
[src/main.rs:15:9] Instant::now() - start = 4.447121ms
```

Issue: #757