### PR TITLE
feat: recognise ppc64 (PowerPC64, ELFv2) ELF objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ The following platforms / architectures are currently supported:
 * ARM64 on Linux
 * RISC-V (riscv64gc) on Linux
 * LoongArch64 on Linux (initial support)
+* PPC64LE on Linux (initial support)
 
 The following is working with the caveat that there may be bugs:
 

--- a/libwild/src/arch.rs
+++ b/libwild/src/arch.rs
@@ -2,6 +2,7 @@ use crate::bail;
 use crate::error::Result;
 use object::elf::EM_AARCH64;
 use object::elf::EM_LOONGARCH;
+use object::elf::EM_PPC64;
 use object::elf::EM_RISCV;
 use object::elf::EM_X86_64;
 use std::fmt::Display;
@@ -12,6 +13,7 @@ pub(crate) enum Architecture {
     AArch64,
     RISCV64,
     LoongArch64,
+    Ppc64,
     Unsupported,
 }
 
@@ -24,6 +26,7 @@ impl TryFrom<u16> for Architecture {
             EM_AARCH64 => Ok(Self::AArch64),
             EM_RISCV => Ok(Self::RISCV64),
             EM_LOONGARCH => Ok(Self::LoongArch64),
+            EM_PPC64 => Ok(Self::Ppc64),
             _ => bail!("Unsupported architecture: 0x{:x}", arch),
         }
     }
@@ -36,6 +39,7 @@ impl Display for Architecture {
             Architecture::AArch64 => "aarch64",
             Architecture::RISCV64 => "riscv64",
             Architecture::LoongArch64 => "loongarch64",
+            Architecture::Ppc64 => "ppc64",
             Architecture::Unsupported => "unsupported",
         };
         write!(f, "{arch}")

--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -355,6 +355,10 @@ const fn default_target_arch() -> Architecture {
     {
         return Architecture::LoongArch64;
     }
+    #[cfg(all(target_arch = "powerpc64", target_endian = "little"))]
+    {
+        return Architecture::Ppc64;
+    }
 
     #[allow(unreachable_code)]
     Architecture::Unsupported
@@ -547,6 +551,10 @@ fn setup_argument_parser() -> ArgumentParser<ElfArgs> {
                 Ok(())
             },
         )
+        .sub_option("elf64lppc", "PowerPC64 LE ELF target", |args, _| {
+            args.arch = Architecture::Ppc64;
+            Ok(())
+        })
         .execute(|_args, _modifier_stack, value| {
             bail!("-m {value} is not yet supported");
         });
@@ -2050,6 +2058,7 @@ impl platform::Args for ElfArgs {
             Architecture::AArch64 => Alignment { exponent: 16 },
             Architecture::RISCV64 => Alignment { exponent: 12 },
             Architecture::LoongArch64 => Alignment { exponent: 16 },
+            Architecture::Ppc64 => Alignment { exponent: 16 },
             Architecture::Unsupported => unreachable!(),
         }
     }

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -350,6 +350,9 @@ impl platform::Platform for Elf {
             crate::arch::Architecture::LoongArch64 => {
                 linker.link_for_arch::<Elf, crate::elf_loongarch64::ElfLoongArch64>(args)
             }
+            crate::arch::Architecture::Ppc64 => {
+                linker.link_for_arch::<Elf, crate::elf_ppc64::ElfPpc64>(args)
+            }
             crate::arch::Architecture::Unsupported => {
                 bail!(
                     "No default target architecture known for host platform. \

--- a/libwild/src/elf_ppc64.rs
+++ b/libwild/src/elf_ppc64.rs
@@ -1,0 +1,133 @@
+use crate::bail;
+use crate::elf::Elf;
+use crate::error;
+use crate::error::Result;
+use crate::platform::Platform;
+use linker_utils::elf::DynamicRelocationKind;
+use linker_utils::elf::RelocationKindInfo;
+use linker_utils::elf::ppc64_rel_type_to_string;
+use linker_utils::ppc64::RelaxationKind;
+use linker_utils::relaxation::RelocationModifier;
+
+pub(crate) struct ElfPpc64;
+
+impl crate::platform::Arch for ElfPpc64 {
+    type Relaxation = Relaxation;
+    type Platform = Elf;
+
+    fn arch_identifier() -> <Self::Platform as Platform>::ArchIdentifier {
+        object::elf::EM_PPC64
+    }
+
+    #[inline(always)]
+    fn relocation_from_raw(r_type: u32) -> Result<RelocationKindInfo> {
+        linker_utils::ppc64::relocation_type_from_raw(r_type).ok_or_else(|| {
+            error!(
+                "Unsupported relocation type {}",
+                Self::rel_type_to_string(r_type)
+            )
+        })
+    }
+
+    fn get_dynamic_relocation_type(relocation: DynamicRelocationKind) -> u32 {
+        relocation.ppc64_r_type()
+    }
+
+    fn rel_type_to_string(r_type: u32) -> std::borrow::Cow<'static, str> {
+        ppc64_rel_type_to_string(r_type)
+    }
+
+    fn write_plt_entry(
+        _plt_entry: &mut [u8],
+        _got_address: u64,
+        _plt_address: u64,
+    ) -> crate::error::Result {
+        bail!("PLT generation for ppc64 is not yet implemented");
+    }
+
+    /// The thread pointer (`r13`) points 0x7000 bytes past the start of the static TLS block.
+    fn tp_offset_start(layout: &crate::layout::Layout<Elf>) -> u64 {
+        layout.tls_start_address() + 0x7000
+    }
+
+    /// DTV entries point 0x8000 bytes past the start of each module's TLS block.
+    fn get_dtv_offset() -> u64 {
+        0x8000
+    }
+
+    fn get_property_class(_property_type: u32) -> Option<crate::elf::PropertyClass> {
+        None
+    }
+
+    fn merge_eflags(eflags: impl Iterator<Item = u32>) -> Result<u32> {
+        Ok(eflags.fold(0, |merged, flags| merged | flags))
+    }
+
+    fn high_part_relocations() -> &'static [u32] {
+        &[]
+    }
+
+    #[allow(unused_variables)]
+    #[inline(always)]
+    fn new_relaxation(
+        relocation_kind: u32,
+        section_bytes: &[u8],
+        offset_in_section: u64,
+        flags: crate::value_flags::ValueFlags,
+        output_kind: crate::output_kind::OutputKind,
+        section_flags: linker_utils::elf::SectionFlags,
+        non_zero_address: bool,
+        relax_deltas: Option<&linker_utils::relaxation::SectionRelaxDeltas>,
+    ) -> Option<Self::Relaxation>
+    where
+        Self: std::marker::Sized,
+    {
+        None
+    }
+
+    fn get_source_info<'data>(
+        object: &<Self::Platform as Platform>::File<'data>,
+        relocations: &<Self::Platform as Platform>::RelocationSections,
+        section: &<Self::Platform as Platform>::SectionHeader,
+        offset_in_section: u64,
+    ) -> Result<crate::platform::SourceInfo> {
+        crate::dwarf_address_info::get_source_info::<Self>(
+            object,
+            relocations,
+            section,
+            offset_in_section,
+        )
+    }
+}
+
+// Relaxations are not yet implemented for ppc64, so `new_relaxation` always returns `None` and
+// this type is never constructed.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub(crate) struct Relaxation {
+    kind: RelaxationKind,
+    rel_info: RelocationKindInfo,
+    mandatory: bool,
+}
+
+impl crate::platform::Relaxation for Relaxation {
+    fn apply(&self, section_bytes: &mut [u8], offset_in_section: &mut u64, addend: &mut i64) {
+        self.kind.apply(section_bytes, offset_in_section, addend);
+    }
+
+    fn rel_info(&self) -> RelocationKindInfo {
+        self.rel_info
+    }
+
+    fn debug_kind(&self) -> impl std::fmt::Debug {
+        &self.kind
+    }
+
+    fn next_modifier(&self) -> RelocationModifier {
+        self.kind.next_modifier()
+    }
+
+    fn is_mandatory(&self) -> bool {
+        self.mandatory
+    }
+}

--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -11,6 +11,7 @@ pub(crate) mod dwarf_address_info;
 pub(crate) mod elf;
 pub(crate) mod elf_aarch64;
 pub(crate) mod elf_loongarch64;
+pub(crate) mod elf_ppc64;
 pub(crate) mod elf_riscv64;
 pub(crate) mod elf_writer;
 pub(crate) mod elf_x86_64;

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -579,6 +579,48 @@ pub fn loongarch64_rel_type_to_string(r_type: u32) -> Cow<'static, str> {
     }
 }
 
+#[must_use]
+pub fn ppc64_rel_type_to_string(r_type: u32) -> Cow<'static, str> {
+    if let Some(name) = const_name_by_value![
+        r_type,
+        R_PPC64_ADDR64,
+        R_PPC64_ADDR16_HA,
+        R_PPC64_ADDR16_LO,
+        R_PPC64_ADDR16_LO_DS,
+        R_PPC64_REL16_HA,
+        R_PPC64_REL16_LO,
+        R_PPC64_REL24,
+        R_PPC64_REL14,
+        R_PPC64_TOC16_HA,
+        R_PPC64_TOC16_LO,
+        R_PPC64_TOC16_LO_DS,
+        R_PPC64_TOC,
+        R_PPC64_GOT16_HA,
+        R_PPC64_JMP_SLOT,
+        R_PPC64_GLOB_DAT,
+        R_PPC64_RELATIVE,
+        R_PPC64_COPY,
+        R_PPC64_IRELATIVE,
+        R_PPC64_DTPMOD64,
+        R_PPC64_DTPREL64,
+        R_PPC64_TPREL64,
+        R_PPC64_TPREL16_HA,
+        R_PPC64_TPREL16_LO,
+        R_PPC64_DTPREL16_HA,
+        R_PPC64_GOT_TLSGD16_HA,
+        R_PPC64_GOT_TLSLD16_HA,
+        R_PPC64_GOT_TPREL16_HA,
+        R_PPC64_GOT_TPREL16_LO_DS,
+        R_PPC64_TLS,
+        R_PPC64_TLSGD,
+        R_PPC64_TLSLD,
+    ] {
+        Cow::Borrowed(name)
+    } else {
+        Cow::Owned(format!("Unknown ppc64 relocation type 0x{r_type:x}"))
+    }
+}
+
 /// Section flag bit values.
 pub mod shf {
     use super::SectionFlags;
@@ -1252,6 +1294,23 @@ impl DynamicRelocationKind {
             DynamicRelocationKind::GotEntry => object::elf::R_LARCH_64,
             DynamicRelocationKind::TlsDesc => object::elf::R_LARCH_TLS_DESC64,
             DynamicRelocationKind::JumpSlot => object::elf::R_LARCH_JUMP_SLOT,
+        }
+    }
+
+    #[must_use]
+    pub fn ppc64_r_type(&self) -> u32 {
+        match self {
+            DynamicRelocationKind::Copy => object::elf::R_PPC64_COPY,
+            DynamicRelocationKind::Irelative => object::elf::R_PPC64_IRELATIVE,
+            DynamicRelocationKind::DtpMod => object::elf::R_PPC64_DTPMOD64,
+            DynamicRelocationKind::DtpOff => object::elf::R_PPC64_DTPREL64,
+            DynamicRelocationKind::TpOff => object::elf::R_PPC64_TPREL64,
+            DynamicRelocationKind::Relative => object::elf::R_PPC64_RELATIVE,
+            DynamicRelocationKind::Absolute => object::elf::R_PPC64_ADDR64,
+            DynamicRelocationKind::GotEntry => object::elf::R_PPC64_GLOB_DAT,
+            // ppc64 uses the __tls_get_addr (GD/LD) model, not TLS descriptors.
+            DynamicRelocationKind::TlsDesc => unreachable!("ppc64 does not use TLS descriptors"),
+            DynamicRelocationKind::JumpSlot => object::elf::R_PPC64_JMP_SLOT,
         }
     }
 }

--- a/linker-utils/src/lib.rs
+++ b/linker-utils/src/lib.rs
@@ -2,6 +2,7 @@ pub mod aarch64;
 pub mod bit_misc;
 pub mod elf;
 pub mod loongarch64;
+pub mod ppc64;
 pub mod relaxation;
 pub mod riscv64;
 pub mod utils;

--- a/linker-utils/src/ppc64.rs
+++ b/linker-utils/src/ppc64.rs
@@ -1,0 +1,32 @@
+//! Relocation utilities for the ppc64 (PowerPC64 LE, ELFv2) target.
+//!
+//! Relocation decoding is not yet implemented; `relocation_type_from_raw` returns `None` for every
+//! relocation type, which causes the linker to emit a clean "unsupported relocation" error rather
+//! than producing incorrect output.
+
+use crate::elf::RelocationKindInfo;
+use crate::relaxation::RelocationModifier;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelaxationKind {
+    /// Leave the instruction alone. Used when we only want to change the kind of relocation used.
+    NoOp,
+}
+
+impl RelaxationKind {
+    pub fn apply(self, _section_bytes: &mut [u8], _offset_in_section: &mut u64, _addend: &mut i64) {
+        match self {
+            RelaxationKind::NoOp => {}
+        }
+    }
+
+    #[must_use]
+    pub fn next_modifier(&self) -> RelocationModifier {
+        RelocationModifier::Normal
+    }
+}
+
+#[must_use]
+pub const fn relocation_type_from_raw(_r_type: u32) -> Option<RelocationKindInfo> {
+    None
+}


### PR DESCRIPTION
Initial scaffold for PowerPC64 little-endian (ELFv2). It wires the target in but doesn't process relocations yet, so it can't link — wild just recognises ppc64 inputs and fails cleanly.

NOTES: IBM does offer free ppc64le GitHub Runner, please check https://github.com/IBM/actionspz which would come in handy for CI build/release process. Alternatively cross-compilation could be an option (though slower than native silicon).