### PR TITLE
port(ppc64): decode the static relocation subset

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -142,6 +142,9 @@ pub const NON_PIE_START_MEM_ADDRESS: u64 = 0x400_000;
 
 pub(crate) const GLOBAL_POINTER_SYMBOL_NAME: &str = "__global_pointer$";
 
+/// The ppc64 TOC base symbol. Defined to point at the start of the GOT.
+pub(crate) const TOC_SYMBOL_NAME: &str = ".TOC.";
+
 pub(crate) const THUNK_SYMBOL_PREFIX: &str = "__thunk_";
 
 pub(crate) type FileHeader = object::elf::FileHeader64<LittleEndian>;
@@ -909,6 +912,10 @@ impl platform::Platform for Elf {
                 output_section_id::DATA,
                 crate::elf::GLOBAL_POINTER_SYMBOL_NAME,
             );
+        }
+
+        if args.arch == Architecture::Ppc64 {
+            symbols.section_start(output_section_id::GOT, crate::elf::TOC_SYMBOL_NAME);
         }
 
         symbols

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -1381,10 +1381,24 @@ pub enum LoongArch64Instruction {
 }
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]
+pub enum Ppc64Instruction {
+    /// D-form: 16-bit field in instruction bits [15:0] (e.g. `addi`, `addis`, `lwz`).
+    D,
+    /// DS-form: 14-bit field in instruction bits [15:2]; the low two bits are part of the opcode
+    /// and are preserved (e.g. `ld`, `std`).
+    Ds,
+    /// B-form conditional branch (`bc`): 14-bit displacement field in instruction bits [15:2].
+    Branch14,
+    /// I-form branch (`b`/`bl`): 24-bit displacement field in instruction bits [25:2].
+    Branch24,
+}
+
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub enum RelocationInstruction {
     AArch64(AArch64Instruction),
     RiscV(RiscVInstruction),
     LoongArch64(LoongArch64Instruction),
+    Ppc64(Ppc64Instruction),
 }
 
 impl RelocationInstruction {
@@ -1410,6 +1424,7 @@ impl RelocationInstruction {
             Self::AArch64(insn) => insn.write_to_value(extracted_value, negative, dest),
             Self::RiscV(insn) => insn.write_to_value(extracted_value, negative, dest),
             Self::LoongArch64(insn) => insn.write_to_value(extracted_value, negative, dest),
+            Self::Ppc64(insn) => insn.write_to_value(extracted_value, negative, dest),
         }
     }
 
@@ -1421,6 +1436,7 @@ impl RelocationInstruction {
             Self::AArch64(insn) => insn.read_value(bytes),
             Self::RiscV(insn) => insn.read_value(bytes),
             Self::LoongArch64(insn) => insn.read_value(bytes),
+            Self::Ppc64(insn) => insn.read_value(bytes),
         }
     }
 
@@ -1431,6 +1447,7 @@ impl RelocationInstruction {
             Self::AArch64(..) => 4,
             Self::RiscV(..) => 4,
             Self::LoongArch64(..) => 4,
+            Self::Ppc64(..) => 4,
         }
     }
 }
@@ -1487,6 +1504,19 @@ impl RelocationSize {
     ) -> RelocationSize {
         Self::BitMasking(BitMask::new(
             RelocationInstruction::LoongArch64(instruction),
+            bit_start,
+            bit_end,
+        ))
+    }
+
+    #[must_use]
+    pub const fn bit_mask_ppc64(
+        bit_start: u32,
+        bit_end: u32,
+        instruction: Ppc64Instruction,
+    ) -> RelocationSize {
+        Self::BitMasking(BitMask::new(
+            RelocationInstruction::Ppc64(instruction),
             bit_start,
             bit_end,
         ))

--- a/linker-utils/src/ppc64.rs
+++ b/linker-utils/src/ppc64.rs
@@ -1,10 +1,20 @@
 //! Relocation utilities for the ppc64 (PowerPC64 LE, ELFv2) target.
 //!
-//! Relocation decoding is not yet implemented; `relocation_type_from_raw` returns `None` for every
-//! relocation type, which causes the linker to emit a clean "unsupported relocation" error rather
-//! than producing incorrect output.
+//! Only a static relocation subset is currently decoded (absolute data, PC-relative branches and
+//! `@ha`/`@lo` halves, and TOC-relative data access). Unsupported relocation types return `None`,
+//! which causes the linker to emit a clean "unsupported relocation" error rather than producing
+//! incorrect output.
+//!
+//! The TOC base (the value of `r2` / the `.TOC.` symbol) is the start of the GOT. The conventional
+//! 0x8000 bias used to centre the addressable TOC window is folded into the `@ha` relocation's
+//! `bias`, so `@ha`/`@lo` pairs stay correct across the full signed 32-bit TOC range.
 
+use crate::elf::AllowedRange;
+use crate::elf::Ppc64Instruction;
+use crate::elf::RelocationKind;
 use crate::elf::RelocationKindInfo;
+use crate::elf::RelocationSize;
+use crate::elf::Sign;
 use crate::relaxation::RelocationModifier;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -27,6 +37,106 @@ impl RelaxationKind {
 }
 
 #[must_use]
-pub const fn relocation_type_from_raw(_r_type: u32) -> Option<RelocationKindInfo> {
-    None
+pub const fn relocation_type_from_raw(r_type: u32) -> Option<RelocationKindInfo> {
+    let (kind, size, range, alignment, bias) = match r_type {
+        // 64-bit absolute address.
+        object::elf::R_PPC64_ADDR64 => (
+            RelocationKind::Absolute,
+            RelocationSize::ByteSize(8),
+            AllowedRange::no_check(),
+            1,
+            0,
+        ),
+        // PC-relative branches.
+        object::elf::R_PPC64_REL24 => (
+            RelocationKind::Relative,
+            RelocationSize::bit_mask_ppc64(0, 26, Ppc64Instruction::Branch24),
+            AllowedRange::from_bit_size(26, Sign::Signed),
+            4,
+            0,
+        ),
+        object::elf::R_PPC64_REL14 => (
+            RelocationKind::Relative,
+            RelocationSize::bit_mask_ppc64(0, 16, Ppc64Instruction::Branch14),
+            AllowedRange::from_bit_size(16, Sign::Signed),
+            4,
+            0,
+        ),
+        // PC-relative `@ha`/`@lo` halves (used by the TOC-pointer prologue, referencing `.TOC.`).
+        object::elf::R_PPC64_REL16_HA => (
+            RelocationKind::Relative,
+            RelocationSize::bit_mask_ppc64(16, 32, Ppc64Instruction::D),
+            AllowedRange::no_check(),
+            1,
+            0x8000,
+        ),
+        object::elf::R_PPC64_REL16_LO => (
+            RelocationKind::Relative,
+            RelocationSize::bit_mask_ppc64(0, 16, Ppc64Instruction::D),
+            AllowedRange::no_check(),
+            1,
+            0,
+        ),
+        // TOC-relative data access. The value is relative to the TOC base (start of the GOT); the
+        // 0x8000 centring bias lives on the `@ha` half.
+        object::elf::R_PPC64_TOC16_HA => (
+            RelocationKind::SymRelGotBase,
+            RelocationSize::bit_mask_ppc64(16, 32, Ppc64Instruction::D),
+            AllowedRange::no_check(),
+            1,
+            0x8000,
+        ),
+        object::elf::R_PPC64_TOC16_LO => (
+            RelocationKind::SymRelGotBase,
+            RelocationSize::bit_mask_ppc64(0, 16, Ppc64Instruction::D),
+            AllowedRange::no_check(),
+            1,
+            0,
+        ),
+        object::elf::R_PPC64_TOC16_LO_DS => (
+            RelocationKind::SymRelGotBase,
+            RelocationSize::bit_mask_ppc64(0, 16, Ppc64Instruction::Ds),
+            AllowedRange::no_check(),
+            4,
+            0,
+        ),
+        _ => return None,
+    };
+
+    Some(RelocationKindInfo {
+        kind,
+        size,
+        mask: None,
+        range,
+        alignment,
+        bias,
+        thunkable: false,
+    })
+}
+
+impl Ppc64Instruction {
+    /// Writes `extracted_value` (the relevant bit range of the relocation value) into the
+    /// instruction field. ppc64 displacement bits map 1:1 onto instruction bit positions, so this
+    /// is a masked OR with no shifting; the low bits that belong to the opcode are preserved.
+    pub fn write_to_value(self, extracted_value: u64, _negative: bool, dest: &mut [u8]) {
+        let field_mask: u32 = match self {
+            Ppc64Instruction::D => 0x0000_ffff,
+            Ppc64Instruction::Ds | Ppc64Instruction::Branch14 => 0x0000_fffc,
+            Ppc64Instruction::Branch24 => 0x03ff_fffc,
+        };
+        let mut insn = u32::from_le_bytes([dest[0], dest[1], dest[2], dest[3]]);
+        insn = (insn & !field_mask) | (extracted_value as u32 & field_mask);
+        dest[0..4].copy_from_slice(&insn.to_le_bytes());
+    }
+
+    #[must_use]
+    pub fn read_value(self, bytes: &[u8]) -> (u64, bool) {
+        let field_mask: u32 = match self {
+            Ppc64Instruction::D => 0x0000_ffff,
+            Ppc64Instruction::Ds | Ppc64Instruction::Branch14 => 0x0000_fffc,
+            Ppc64Instruction::Branch24 => 0x03ff_fffc,
+        };
+        let insn = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+        (u64::from(insn & field_mask), false)
+    }
 }


### PR DESCRIPTION
Next step after the ppc64 recognition scaffold. We can spot ppc64 objects now, so this makes the linker actually resolve the relocs you need for a freestanding exe: ADDR64, REL24, REL14, REL16_HA/LO and TOC16_HA/LO/LO_DS.

Added a little `Ppc64Instruction` encoder for the D/DS/branch forms, and a `.TOC.` symbol at the start of the GOT. I'm just using the GOT base as the TOC base and shoving the usual 0x8000 bias into the `@ha` relocs, so `@ha/@lo` still cover the full 32-bit range and I don't have to offset the symbol itself.

Not done yet: REL24 local-entry + the post-call r2 restore, so calls into functions that have a global-entry prologue are still wrong. That's next. GOT/PLT, dynamic linking, thunks, TLS all still TODO.