### PR TITLE
feat: Add support for the DISCARD section in linker scripts

### DIFF
--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -4177,10 +4177,10 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
         for (sym_index, sym) in self.object.enumerate_symbols() {
             let symbol_id = self.symbol_id_range().input_to_id(sym_index);
 
-            if let Some(section_index) = self.object.symbol_section(sym, sym_index)? {
-                if matches!(self.sections[section_index.0], SectionSlot::Discard) {
-                    continue;
-                }
+            if let Some(section_index) = self.object.symbol_section(sym, sym_index)?
+                && matches!(self.sections[section_index.0], SectionSlot::Discard)
+            {
+                continue;
             }
 
             if !can_export_symbol(sym, symbol_id, resources, export_all_dynamic) {
@@ -4212,14 +4212,12 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
         scope: &Scope<'scope>,
     ) -> Result {
         let sym_index = self.symbol_id_range.id_to_input(symbol_id);
-        let sym = self
-            .object
-            .symbol(sym_index)?;
+        let sym = self.object.symbol(sym_index)?;
 
-        if let Some(section_index) = self.object.symbol_section(sym, sym_index)? {
-            if matches!(self.sections[section_index.0], SectionSlot::Discard) {
-                return Ok(());
-            }
+        if let Some(section_index) = self.object.symbol_section(sym, sym_index)?
+            && matches!(self.sections[section_index.0], SectionSlot::Discard)
+        {
+            return Ok(());
         }
 
         // Shared objects that we're linking against sometimes define symbols that are also defined

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -4177,6 +4177,12 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
         for (sym_index, sym) in self.object.enumerate_symbols() {
             let symbol_id = self.symbol_id_range().input_to_id(sym_index);
 
+            if let Some(section_index) = self.object.symbol_section(sym, sym_index)? {
+                if matches!(self.sections[section_index.0], SectionSlot::Discard) {
+                    continue;
+                }
+            }
+
             if !can_export_symbol(sym, symbol_id, resources, export_all_dynamic) {
                 continue;
             }
@@ -4205,9 +4211,16 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
         queue: &mut LocalWorkQueue,
         scope: &Scope<'scope>,
     ) -> Result {
+        let sym_index = self.symbol_id_range.id_to_input(symbol_id);
         let sym = self
             .object
-            .symbol(self.symbol_id_range.id_to_input(symbol_id))?;
+            .symbol(sym_index)?;
+
+        if let Some(section_index) = self.object.symbol_section(sym, sym_index)? {
+            if matches!(self.sections[section_index.0], SectionSlot::Discard) {
+                return Ok(());
+            }
+        }
 
         // Shared objects that we're linking against sometimes define symbols that are also defined
         // in regular object. When that happens, if we resolve the symbol to the definition from the

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -181,6 +181,26 @@ impl<'data> LayoutRulesBuilder<'data> {
                 for sec_cmd in &sections.commands {
                     match sec_cmd {
                         SectionCommand::Section(sec) => {
+                            if sec.output_section_name == b"/DISCARD/" {
+                                for contents_cmd in &sec.commands {
+                                    match contents_cmd {
+                                        ContentsCommand::Matcher(matcher) => {
+                                            for pattern in &matcher.input_section_name_patterns {
+                                                self.add_section_rule(SectionRule::new(
+                                                    pattern,
+                                                    matcher.input_file_pattern,
+                                                    crate::layout_rules::SectionRuleOutcome::Discard,
+                                                )?);
+                                            }
+                                        }
+                                        _ => {
+                                            return Err(crate::error!(
+                                                "Illegal use of /DISCARD/ section"
+                                            ));
+                                        }
+                                    }
+                                }
+                            }
                             let min_alignment = sec
                                 .alignment
                                 .unwrap_or(alignment::MIN)

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -193,11 +193,7 @@ impl<'data> LayoutRulesBuilder<'data> {
                                                 )?);
                                             }
                                         }
-                                        _ => {
-                                            return Err(crate::error!(
-                                                "Illegal use of /DISCARD/ section"
-                                            ));
-                                        }
+                                        _ => crate::bail!("Illegal use of /DISCARD/ section"),
                                     }
                                 }
                             }

--- a/wild/tests/sources/elf/linker-script-discard/linker-script-discard.c
+++ b/wild/tests/sources/elf/linker-script-discard/linker-script-discard.c
@@ -1,16 +1,20 @@
 //#Mode:dynamic
 //#RunEnabled:false
+//#SkipLinker:ld
 //#EnableLinker:lld
 //#LinkArgs:-shared -z now -T ./linker-script-discard.ld
 //#DiffIgnore:section.got
 //#DiffIgnore:section.riscv.attributes
 //#DiffIgnore:segment.RISCV_ATTRIBUTES.*
-// GNU ld emits `.riscv.attributes`, but Wild does not
+// lld emits `.riscv.attributes`, but Wild does not
 //#DiffIgnore:riscv_attributes.*
 //#DiffIgnore:segment.LOAD.RX.alignment
 //#DiffIgnore:segment.LOAD.RWX.alignment
+// Wild does not emit the `.eh_frame` section as all code sections are discarded, but lld still
+// emits the CIE.
+//#DiffIgnore:section.eh_frame
 //#DoesNotContain:/DISCARD/
 //#DoesNotContain:.text
 //#NoSym:foo
 
-static int foo() { return 0; }
+int foo() { return 0; }

--- a/wild/tests/sources/elf/linker-script-discard/linker-script-discard.c
+++ b/wild/tests/sources/elf/linker-script-discard/linker-script-discard.c
@@ -1,5 +1,6 @@
 //#Mode:dynamic
 //#RunEnabled:false
+//#EnableLinker:lld
 //#LinkArgs:-shared -z now -T ./linker-script-discard.ld
 //#DiffIgnore:section.got
 //#DiffIgnore:section.riscv.attributes
@@ -8,7 +9,8 @@
 //#DiffIgnore:riscv_attributes.*
 //#DiffIgnore:segment.LOAD.RX.alignment
 //#DiffIgnore:segment.LOAD.RWX.alignment
-//#DoesNotContain:DISCARD
+//#DoesNotContain:/DISCARD/
 //#DoesNotContain:.text
+//#NoSym:foo
 
-int foo() { return 0; }
+static int foo() { return 0; }

--- a/wild/tests/sources/elf/linker-script-discard/linker-script-discard.c
+++ b/wild/tests/sources/elf/linker-script-discard/linker-script-discard.c
@@ -1,0 +1,14 @@
+//#Mode:dynamic
+//#RunEnabled:false
+//#LinkArgs:-shared -z now -T ./linker-script-discard.ld
+//#DiffIgnore:section.got
+//#DiffIgnore:section.riscv.attributes
+//#DiffIgnore:segment.RISCV_ATTRIBUTES.*
+// GNU ld emits `.riscv.attributes`, but Wild does not
+//#DiffIgnore:riscv_attributes.*
+//#DiffIgnore:segment.LOAD.RX.alignment
+//#DiffIgnore:segment.LOAD.RWX.alignment
+//#DoesNotContain:DISCARD
+//#DoesNotContain:.text
+
+int foo() { return 0; }

--- a/wild/tests/sources/elf/linker-script-discard/linker-script-discard.ld
+++ b/wild/tests/sources/elf/linker-script-discard/linker-script-discard.ld
@@ -1,0 +1,5 @@
+SECTIONS {
+	/DISCARD/ : {
+		*(.text)
+    }
+}


### PR DESCRIPTION
Support discarding sections that are marked as discardable with the `/DISCARD/` command in linker scripts.

Closes: https://github.com/wild-linker/wild/issues/1829