### PR TITLE
fix: Keep `--defsym`/linker-script redirect targets alive through LTO

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -4413,7 +4413,8 @@ fn get_defsym_attributes(
                 ));
 
         if let Some(target_id) = target_symbol_id {
-            get_symbol_attributes(layout, target_id)
+            let canonical_id = layout.symbol_db.definition(target_id);
+            get_symbol_attributes(layout, canonical_id)
         } else {
             Err(redirect.missing_target(target_name))
         }

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -320,7 +320,7 @@ impl Redirect<'_> {
 
     pub(crate) fn missing_resolution(&self, target_name: &[u8]) -> crate::error::Error {
         crate::error!(
-            "Symbol '{name}' referenced by {kind} has no resolution. Might be issue #1960",
+            "Symbol '{name}' referenced by {kind} has no resolution.",
             name = String::from_utf8_lossy(target_name),
             kind = self.kind.message_text(),
         )

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -937,6 +937,15 @@ fn load_symbols_in_redirect<'data, 'scope, P: Platform>(
         {
             let file_id = resources.symbol_db.file_id_for_symbol(target_symbol_id);
             resources.try_request_file_id(file_id, scope);
+
+            // Mark the target as having a non-IR reference. Without this, when the target is
+            // defined in an LTO/IR input, the linker plugin would report the symbol as
+            // `PrevailingDefIronly` and the LTO compiler would be free to DCE or internalize the
+            // symbol, leaving the --defsym/script redirect with no resolution.
+            resources
+                .per_symbol_flags
+                .get_atomic(target_symbol_id)
+                .or_assign(ValueFlags::HAS_NON_IR_REF);
         }
         true
     });

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -194,7 +194,6 @@ tests = [
   "duplicate-error-lto.sh",        # Wild deduplicates inputs
   "lto-comdat.sh",                 # We don't support COMDAT
   "wrap-lto.sh",                   # We don't yet support --wrap with LTO
-  "defsym-lto.sh",
   "lto-archive4.sh",
   "lto-mixed-gcc-fat.sh",
   "lto-mixed-gcc-slim-archive.sh",

--- a/wild/tests/sources/elf/defsym/defsym.c
+++ b/wild/tests/sources/elf/defsym/defsym.c
@@ -5,6 +5,13 @@
 //#LinkArgs:--defsym=bar=foo
 //#ExpectSym:bar section=".text"
 
+//#Config:symbol_alias_lto:symbol_alias
+//#RequiresLinkerPlugin:true
+//#SkipLinker:ld
+//#LinkerDriver:gcc
+//#CompArgs:-flto
+//#LinkArgs:-flto -nostdlib -Wl,--defsym=bar=foo
+
 //#Config:address_alias:default
 //#LinkArgs:--defsym=bar=0x12345678
 //#ExpectSym:bar address=0x12345678

--- a/wild/tests/sources/elf/linker-script-symbols/linker-script-symbols.c
+++ b/wild/tests/sources/elf/linker-script-symbols/linker-script-symbols.c
@@ -2,7 +2,6 @@
 //#AugmentLinkerScript:script.ld
 //#Object:runtime.c
 
-// TODO: Make this test not error and enable for GNU ld. Issue #1960.
 //#Config:lto:default
 //#RequiresLinkerPlugin:true
 //#SkipLinker:ld
@@ -10,7 +9,6 @@
 //#CompArgs:-flto
 //#LinkArgs:-flto -nostdlib -znow
 //#DiffIgnore:section.got
-//#ExpectError:Symbol '.+' referenced by linker script has no resolution
 
 #include "../common/runtime.h"
 


### PR DESCRIPTION
When `--defsym=alias=target` (or an equivalent linker-script symbol assignment) referenced a symbol defined in an LTO input, the linker plugin reported the target as `PrevailingDefIronly` because nothing inside the IR referenced it. GCC's LTO was then free to DCE or internalize the symbol.

Mark redirect targets with `HAS_NON_IR_REF` during symbol resolution so that the plugin sees them as `PrevailingDef` and the LTO compiler keeps them in the post-LTO output.

Fix #1960 