### PR TITLE
feat: Add `--discard-sframe` flag

### DIFF
--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -121,6 +121,7 @@ pub struct ElfArgs {
     pub(crate) trace: bool,
     pack_dyn_relocs: PackDynRelocs,
     pub(crate) use_android_relr_tags: bool,
+    pub(crate) discard_sframe: bool,
 
     pub(crate) relocation_model: RelocationModel,
     pub(crate) should_output_executable: bool,
@@ -130,7 +131,7 @@ pub struct ElfArgs {
 
     rpath_set: IndexSet<String>,
 
-    pub experimental_sframe: bool,
+    experimental_sframe: bool,
 
     pub(crate) debug_compression_kind: Option<CompressionKind>,
 }
@@ -314,6 +315,7 @@ impl Default for ElfArgs {
             trace: false,
             pack_dyn_relocs: PackDynRelocs::None,
             use_android_relr_tags: false,
+            discard_sframe: false,
 
             nmagic: false,
 
@@ -432,6 +434,10 @@ pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(
             .inputs
             .iter_mut()
             .for_each(|input| input.modifiers.allow_shared = false);
+    }
+
+    if !args.experimental_sframe {
+        args.discard_sframe = true;
     }
 
     Ok(())
@@ -1835,6 +1841,15 @@ fn setup_argument_parser() -> ArgumentParser<ElfArgs> {
         .help("Page align sections (default)")
         .execute(|args, _modifier_stack| {
             args.nmagic = false;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("discard-sframe")
+        .help("Discard SFrame section")
+        .execute(|args, _modifier_stack| {
+            args.discard_sframe = true;
             Ok(())
         });
 

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -1712,12 +1712,12 @@ impl platform::Platform for Elf {
     }
 
     fn default_layout_rules(args: &Self::Args) -> Vec<SectionRule<'static>> {
-        let sframe_outcome = if args.experimental_sframe {
+        let sframe_outcome = if args.discard_sframe {
+            SectionRuleOutcome::Discard
+        } else {
             SectionRuleOutcome::Section(crate::layout_rules::SectionOutputInfo::keep(
                 output_section_id::SFRAME,
             ))
-        } else {
-            SectionRuleOutcome::Discard
         };
         let mut rules = Vec::with_capacity(DEFAULT_SECTION_RULES.len() + 1);
         rules.extend(DEFAULT_SECTION_RULES.iter().cloned());

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -313,7 +313,7 @@ fn fill_padding(mut section_buffers: OutputSectionMap<&mut [u8]>) {
 }
 
 fn write_sframe_section(sframe_buffer: &mut [u8], layout: &ElfLayout) -> Result {
-    if !layout.args().experimental_sframe || sframe_buffer.is_empty() {
+    if layout.args().discard_sframe || sframe_buffer.is_empty() {
         return Ok(());
     }
 

--- a/wild/tests/sources/elf/backtrace/backtrace.c
+++ b/wild/tests/sources/elf/backtrace/backtrace.c
@@ -14,15 +14,30 @@
 
 //#Config:sframe:default
 //#CompArgs:-O0 -fomit-frame-pointer -Wa,--gsframe
+//#LinkArgs:-Wl,-z,now,--gc-sections
 //#WildExtraLinkArgs:-Wl,--wild-experimental-sframe
 //#RemoveSection:.eh_frame
 //#RemoveSection:.eh_frame_hdr
 //#RequiresGlibcVersion:2.42
 //#RequiresSFrameBacktrace:true
+// FIXME: This should be enabled with LD but requires LD 2.46 to retain the .sframe section with
+// `--gc-sections`.
 //#SkipLinker:ld
 
-// Without `--wild-experimental-sframe` we should discard `.sframe` section.
 //#Config:discard-sframe:default
+//#CompArgs:-O0 -fomit-frame-pointer -Wa,--gsframe
+//#LinkArgs:-Wl,-z,now,--gc-sections,--discard-sframe
+//#WildExtraLinkArgs:-Wl,--wild-experimental-sframe
+//#RequiresGlibcVersion:2.42
+//#RequiresSFrameBacktrace:true
+//#RunEnabled:false
+//#DoesNotContain:.sframe
+// FIXME: This should be enabled with LD but requires LD 2.46 to retain the .sframe section with
+// `--gc-sections`.
+//#SkipLinker:ld
+
+// Without `--wild-experimental-sframe` we should discard `.sframe` section for now.
+//#Config:discard-sframe-by-default:default
 //#CompArgs:-O0 -fomit-frame-pointer -Wa,--gsframe
 //#RequiresGlibcVersion:2.42
 //#RequiresSFrameBacktrace:true


### PR DESCRIPTION
I didn't notice it previously, but LD added this flag in 2.46: https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=blob_plain;f=ld/NEWS;hb=refs/heads/binutils-2_46-branch

I moved all SFrame handling to use that argument rather than our experimental flag. Instead, lack of the experimental flag forces the discarding.

The tests changes are made blindly as there is no way to properly run them without patching glibc.