### PR TITLE
test(ppc64): add ppc64le test infrastructure

### DIFF
--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -55,7 +55,11 @@ pub(crate) mod perf;
     not(target_os = "linux"),
     all(
         target_os = "linux",
-        any(target_arch = "riscv64", target_arch = "loongarch64")
+        any(
+            target_arch = "riscv64",
+            target_arch = "loongarch64",
+            target_arch = "powerpc64"
+        )
     )
 ))]
 #[path = "perf_unsupported.rs"]

--- a/linker-diff/src/arch.rs
+++ b/linker-diff/src/arch.rs
@@ -19,6 +19,7 @@ pub(crate) enum ArchKind {
     Aarch64,
     RISCV64,
     LoongArch64,
+    Ppc64,
 }
 
 /// Provides architecture-specific functionality needed by linker-diff.
@@ -281,6 +282,7 @@ impl ArchKind {
             object::elf::EM_AARCH64 => Ok(ArchKind::Aarch64),
             object::elf::EM_RISCV => Ok(ArchKind::RISCV64),
             object::elf::EM_LOONGARCH => Ok(ArchKind::LoongArch64),
+            object::elf::EM_PPC64 => Ok(ArchKind::Ppc64),
             other => bail!("Unsupported object architecture {other}",),
         }
     }

--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -44,6 +44,7 @@ mod gnu_hash;
 mod header_diff;
 mod init_order;
 mod loongarch64;
+mod ppc64;
 mod riscv64;
 mod riscv_attributes;
 pub(crate) mod section_map;
@@ -319,6 +320,7 @@ impl Config {
                 .map(ToOwned::to_owned),
             ),
             ArchKind::X86_64 => {}
+            ArchKind::Ppc64 => {}
             ArchKind::LoongArch64 => self.ignore.extend(
                 [
                     "section.sdata",
@@ -695,6 +697,9 @@ impl Report {
             }
             ArchKind::LoongArch64 => {
                 self.report_arch_specific_diffs::<crate::loongarch64::LoongArch64>(objects);
+            }
+            ArchKind::Ppc64 => {
+                self.report_arch_specific_diffs::<crate::ppc64::Ppc64>(objects);
             }
         }
     }

--- a/linker-diff/src/ppc64.rs
+++ b/linker-diff/src/ppc64.rs
@@ -1,0 +1,150 @@
+use crate::ArchKind;
+use crate::arch::Arch;
+use crate::arch::Instruction;
+use crate::arch::Relaxation;
+use crate::arch::RelaxationByteRange;
+use crate::asm_diff::BasicValueKind;
+use crate::utils::decode_insn_with_objdump;
+use linker_utils::elf::DynamicRelocationKind;
+use linker_utils::elf::RelocationKindInfo;
+use linker_utils::elf::ppc64_rel_type_to_string;
+use linker_utils::ppc64::RelaxationKind;
+use linker_utils::relaxation::RelocationModifier;
+use std::fmt::Display;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) struct Ppc64;
+
+impl Arch for Ppc64 {
+    type RType = RType;
+    type RelaxationKind = RelaxationKind;
+    type RawInstruction = Option<String>;
+
+    const MAX_RELAX_MODIFY_BEFORE: u64 = 0;
+    const MAX_RELAX_MODIFY_AFTER: u64 = 0;
+
+    fn possible_relaxations_do(
+        _r_type: Self::RType,
+        _section_kind: object::SectionKind,
+        _cb: impl FnMut(Relaxation<Self>),
+    ) {
+        // No relaxations are implemented for ppc64 yet.
+    }
+
+    fn relaxation_byte_range(_relaxation: Relaxation<Self>) -> RelaxationByteRange {
+        RelaxationByteRange {
+            offset_shift: 0,
+            num_bytes: 4,
+        }
+    }
+
+    fn apply_relaxation(
+        relaxation_kind: Self::RelaxationKind,
+        section_bytes: &mut [u8],
+        offset_in_section: &mut u64,
+        addend: &mut i64,
+    ) {
+        relaxation_kind.apply(section_bytes, offset_in_section, addend);
+    }
+
+    fn next_relocation_modifier(relaxation_kind: Self::RelaxationKind) -> RelocationModifier {
+        relaxation_kind.next_modifier()
+    }
+
+    fn instruction_to_string(instruction: &Instruction<Self>) -> String {
+        instruction.raw_instruction.clone().unwrap_or_default()
+    }
+
+    fn decode_instructions_in_range(
+        section_bytes: &[u8],
+        section_address: u64,
+        _function_offset_in_section: u64,
+        range: std::ops::Range<u64>,
+    ) -> Vec<Instruction<'_, Self>> {
+        // ppc64 instructions are a fixed 4 bytes, so we can start decoding at the (aligned) start
+        // of the range.
+        let mut offset = range.start & !3;
+        let mut instructions = Vec::new();
+        while offset < range.end {
+            if offset as usize + 4 > section_bytes.len() {
+                break;
+            }
+            let bytes = &section_bytes[offset as usize..offset as usize + 4];
+            let address = section_address + offset;
+            let raw_instruction = decode_insn_with_objdump(bytes, address, ArchKind::Ppc64).ok();
+            instructions.push(Instruction {
+                raw_instruction,
+                address,
+                bytes,
+            });
+            offset += 4;
+        }
+        instructions
+    }
+
+    fn decode_plt_entry(
+        _plt_entry: &[u8],
+        _plt_base: u64,
+        _plt_offset: u64,
+    ) -> Option<crate::arch::PltEntry> {
+        // PLT generation isn't implemented for ppc64 yet.
+        None
+    }
+
+    fn should_chain_relocations(_chain_prefix: &[Self::RType]) -> bool {
+        false
+    }
+
+    fn get_relocation_base_mask(_relocation_info: &RelocationKindInfo) -> u64 {
+        u64::MAX
+    }
+
+    fn relocation_to_pc_offset(_relocation_info: &RelocationKindInfo) -> u64 {
+        0
+    }
+
+    fn is_complete_chain(_chain: impl Iterator<Item = Self::RType>) -> bool {
+        true
+    }
+
+    fn get_basic_value_for_tp_offset() -> BasicValueKind {
+        BasicValueKind::TlsOffset
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RType(u32);
+
+impl crate::arch::RType for RType {
+    fn from_raw(raw: u32) -> Self {
+        RType(raw)
+    }
+
+    fn from_dynamic_relocation_kind(kind: DynamicRelocationKind) -> Self {
+        Self::from_raw(kind.ppc64_r_type())
+    }
+
+    fn opt_relocation_info(self) -> Option<RelocationKindInfo> {
+        linker_utils::ppc64::relocation_type_from_raw(self.0)
+    }
+
+    fn dynamic_relocation_kind(self) -> Option<DynamicRelocationKind> {
+        DynamicRelocationKind::from_ppc64_r_type(self.0)
+    }
+}
+
+impl Display for RType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&ppc64_rel_type_to_string(self.0), f)
+    }
+}
+
+impl crate::arch::RelaxationKind for RelaxationKind {
+    fn is_no_op(self) -> bool {
+        matches!(self, RelaxationKind::NoOp)
+    }
+
+    fn is_replace_with_no_op(self) -> bool {
+        false
+    }
+}

--- a/linker-diff/src/utils.rs
+++ b/linker-diff/src/utils.rs
@@ -18,6 +18,7 @@ pub fn decode_insn_with_objdump(insn: &[u8], address: u64, arch: ArchKind) -> Re
         ArchKind::RISCV64 => ("riscv:rv64", ["riscv64-linux-gnu-objdump", "objdump"]),
         ArchKind::X86_64 => todo!(), // x86_64 objdump is not used in linker-diff currently
         ArchKind::LoongArch64 => ("Loongarch64", ["loongarch64-linux-gnu-objdump", "objdump"]),
+        ArchKind::Ppc64 => ("powerpc:common64", ["powerpc64le-linux-gnu-objdump", "objdump"]),
     };
 
     let objdump = objdump_bin_candidates
@@ -28,6 +29,10 @@ pub fn decode_insn_with_objdump(insn: &[u8], address: u64, arch: ArchKind) -> Re
     let command = Command::new(objdump)
         .arg("-b")
         .arg("binary")
+        // Every target we support is little-endian. Be explicit, since some machines (e.g. the
+        // generic `powerpc:common64`) default to big-endian and would otherwise disassemble the
+        // raw bytes as garbage on a big-endian-defaulting host.
+        .arg("--endian=little")
         .arg(format!("--adjust-vma=0x{address:x}"))
         .arg("-m")
         .arg(objdump_arch)

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -1313,6 +1313,23 @@ impl DynamicRelocationKind {
             DynamicRelocationKind::JumpSlot => object::elf::R_PPC64_JMP_SLOT,
         }
     }
+
+    #[must_use]
+    pub fn from_ppc64_r_type(r_type: u32) -> Option<Self> {
+        let kind = match r_type {
+            object::elf::R_PPC64_COPY => DynamicRelocationKind::Copy,
+            object::elf::R_PPC64_IRELATIVE => DynamicRelocationKind::Irelative,
+            object::elf::R_PPC64_DTPMOD64 => DynamicRelocationKind::DtpMod,
+            object::elf::R_PPC64_DTPREL64 => DynamicRelocationKind::DtpOff,
+            object::elf::R_PPC64_TPREL64 => DynamicRelocationKind::TpOff,
+            object::elf::R_PPC64_RELATIVE => DynamicRelocationKind::Relative,
+            object::elf::R_PPC64_ADDR64 => DynamicRelocationKind::Absolute,
+            object::elf::R_PPC64_GLOB_DAT => DynamicRelocationKind::GotEntry,
+            object::elf::R_PPC64_JMP_SLOT => DynamicRelocationKind::JumpSlot,
+            _ => return None,
+        };
+        Some(kind)
+    }
 }
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -549,6 +549,8 @@ enum Architecture {
     RISCV64,
     #[strum(serialize = "loongarch64")]
     LoongArch64,
+    #[strum(serialize = "ppc64le")]
+    Ppc64,
 }
 
 const ALL_ARCHITECTURES: &[Architecture] = &[
@@ -556,6 +558,7 @@ const ALL_ARCHITECTURES: &[Architecture] = &[
     Architecture::AArch64,
     Architecture::RISCV64,
     Architecture::LoongArch64,
+    Architecture::Ppc64,
 ];
 
 impl Architecture {
@@ -565,6 +568,16 @@ impl Architecture {
             Architecture::AArch64 => "aarch64elf",
             Architecture::RISCV64 => "elf64lriscv",
             Architecture::LoongArch64 => "elf64loongarch",
+            Architecture::Ppc64 => "elf64lppc",
+        }
+    }
+
+    /// The architecture prefix used in target triples / cross-toolchain names. This differs from
+    /// the short name (`Display`) for ppc64le, whose triple prefix is `powerpc64le`.
+    fn triple_arch(&self) -> String {
+        match self {
+            Architecture::Ppc64 => "powerpc64le".to_owned(),
+            _ => self.to_string(),
         }
     }
 
@@ -577,7 +590,7 @@ impl Architecture {
 
     fn default_target_triple(&self, platform: PlatformKind) -> String {
         match platform {
-            PlatformKind::Elf => format!("{self}-unknown-linux-gnu"),
+            PlatformKind::Elf => format!("{}-unknown-linux-gnu", self.triple_arch()),
             PlatformKind::MachO => format!("{}-apple-darwin", self.darwin_arch_name()),
         }
     }
@@ -590,11 +603,12 @@ impl Architecture {
     }
 
     fn cross_triplet(&self) -> String {
-        let suse_triplet = format!("{self}-suse-linux");
+        let arch = self.triple_arch();
+        let suse_triplet = format!("{arch}-suse-linux");
         if std::path::Path::new(&format!("/usr/{suse_triplet}/sys-root")).exists() {
             return suse_triplet;
         }
-        format!("{self}-linux-gnu")
+        format!("{arch}-linux-gnu")
     }
 
     fn get_cross_sysroot_path(&self) -> String {
@@ -640,6 +654,7 @@ fn dynamic_linker_path(cross_arch: Option<Architecture>) -> &'static str {
         Some(Architecture::AArch64) => "/lib/ld-linux-aarch64.so.1",
         Some(Architecture::RISCV64) => "/lib/ld-linux-riscv64-lp64d.so.1",
         Some(Architecture::LoongArch64) => "/lib/ld-linux-loongarch-lp64d.so.1",
+        Some(Architecture::Ppc64) => "/lib64/ld64.so.2",
     }
 }
 
@@ -701,6 +716,10 @@ fn get_host_architecture() -> Architecture {
     #[cfg(target_arch = "loongarch64")]
     {
         Architecture::LoongArch64
+    }
+    #[cfg(all(target_arch = "powerpc64", target_endian = "little"))]
+    {
+        Architecture::Ppc64
     }
 }
 
@@ -2296,14 +2315,20 @@ fn get_c_compiler(
         (_, "clang", CLanguage::Cpp) => Ok("clang++".to_string()),
         (
             Some(
-                arch @ (Architecture::AArch64 | Architecture::RISCV64 | Architecture::LoongArch64),
+                arch @ (Architecture::AArch64
+                | Architecture::RISCV64
+                | Architecture::LoongArch64
+                | Architecture::Ppc64),
             ),
             "gcc" | "g++",
             CLanguage::C,
         ) => Ok(format!("{}-gcc", arch.cross_triplet())),
         (
             Some(
-                arch @ (Architecture::AArch64 | Architecture::RISCV64 | Architecture::LoongArch64),
+                arch @ (Architecture::AArch64
+                | Architecture::RISCV64
+                | Architecture::LoongArch64
+                | Architecture::Ppc64),
             ),
             "gcc" | "g++",
             CLanguage::Cpp,

--- a/wild/tests/sources/elf/common/runtime.c
+++ b/wild/tests/sources/elf/common/runtime.c
@@ -53,4 +53,25 @@ void exit_syscall(int exit_code) {
                        : "r"(a7), "r"(a0)
                        : "memory");
 }
+#elif defined(__powerpc64__)
+void exit_syscall(int exit_code) {
+  register long r0 __asm__("r0") = 1;  // __NR_exit
+  register long r3 __asm__("r3") = exit_code;
+  __asm__ __volatile__("sc" : "+r"(r3) : "r"(r0) : "memory");
+}
+#endif
+
+#if defined(__powerpc64__)
+// Unlike the other targets, gcc on ppc64le lowers large aggregate initialisers to a call to
+// memcpy even at -O0, and these freestanding tests don't link libc. Provide a minimal
+// implementation. At -O0 gcc doesn't run loop-idiom recognition, so this byte loop is not turned
+// back into a memcpy call (verified by disassembly).
+void* memcpy(void* dest, const void* src, __SIZE_TYPE__ n) {
+  char* d = dest;
+  const char* s = src;
+  for (__SIZE_TYPE__ i = 0; i < n; i++) {
+    d[i] = s[i];
+  }
+  return dest;
+}
 #endif


### PR DESCRIPTION
  Wires ppc64le into the test framework so we can exercise the ppc64
  backend — no linker capability here, the relocation work lands
  separately.

  - register ppc64le in the integration test harness (target triple,
    `-m elf64lppc`, the `ld64.so.2` dynamic linker, native-host detection)
  - a ppc64 linker-diff module (objdump-based decoding via
    `-m powerpc:common64`, forced little-endian)
  - let libwild build natively on ppc64le (powerpc64 was missing from the
    `perf_unsupported` cfg list)
  - `exit_syscall` + `memcpy` for the test runtime on ppc64le. ppc64le gcc
    lowers large aggregate initialisers to a memcpy call even at `-O0`, where
    the other targets inline it, so the test programs don't link without one.