### PR TITLE
port(Macho): plug stub symbols into symbol DB

### DIFF
--- a/libwild/src/diagnostics.rs
+++ b/libwild/src/diagnostics.rs
@@ -56,6 +56,7 @@ impl SymbolInfoPrinter {
                     ResolvedFile::Prelude(_) => Some(PRELUDE_FILE_ID),
                     ResolvedFile::Object(obj) => Some(obj.common.file_id),
                     ResolvedFile::Dynamic(obj) => Some(obj.common.file_id),
+                    ResolvedFile::StubLibrary(obj) => Some(obj.file_id),
                     ResolvedFile::LinkerScript(obj) => Some(obj.file_id),
                     ResolvedFile::SyntheticSymbols(obj) => Some(obj.file_id),
                     #[cfg(all(feature = "plugins", unix))]
@@ -163,6 +164,10 @@ impl SymbolInfoPrinter {
                             continue;
                         }
                     },
+                    SequencedInput::StubLibrary(s) => {
+                        sym_debug = "Mach-O stub library symbol".to_owned();
+                        input = s.to_string();
+                    }
                     SequencedInput::LinkerScript(s) => {
                         sym_debug = "Linker script symbol".to_owned();
                         input = s.parsed.input.to_string();

--- a/libwild/src/grouping.rs
+++ b/libwild/src/grouping.rs
@@ -3,6 +3,7 @@ use crate::input_data::FileId;
 use crate::input_data::MAX_FILES_PER_GROUP;
 use crate::input_section_id::InputSectionId;
 use crate::input_section_id::SectionIdRange;
+use crate::macho_stub_library::DefinedStubLibrary;
 use crate::parsing::ParsedInputObject;
 use crate::parsing::Prelude;
 use crate::parsing::ProcessedLinkerScript;
@@ -24,6 +25,7 @@ use std::fmt::Display;
 pub(crate) enum Group<'data, P: Platform> {
     Prelude(Prelude<'data, P>),
     Objects(&'data [SequencedInputObject<'data, P>]),
+    StubLibraries(Vec<SequencedStubLibrary<'data>>),
     LinkerScripts(Vec<SequencedLinkerScript<'data, P>>),
     SyntheticSymbols(SyntheticSymbols),
     #[cfg(all(feature = "plugins", unix))]
@@ -46,9 +48,18 @@ pub(crate) struct SequencedLinkerScript<'data, P: Platform> {
 }
 
 #[derive(Debug)]
+pub(crate) struct SequencedStubLibrary<'data> {
+    pub(crate) defined: DefinedStubLibrary<'data>,
+    pub(crate) symbols: Vec<&'data [u8]>,
+    pub(crate) symbol_id_range: SymbolIdRange,
+    pub(crate) file_id: FileId,
+}
+
+#[derive(Debug)]
 pub(crate) enum SequencedInput<'db, 'data, P: Platform> {
     Prelude(&'db Prelude<'data, P>),
     Object(&'data SequencedInputObject<'data, P>),
+    StubLibrary(&'db SequencedStubLibrary<'data>),
     LinkerScript(&'db SequencedLinkerScript<'data, P>),
     SyntheticSymbols(&'db SyntheticSymbols),
     #[cfg(all(feature = "plugins", unix))]
@@ -61,6 +72,7 @@ impl<'data, P: Platform> Group<'data, P> {
         match self {
             Group::Prelude(_) => 0,
             Group::Objects(objects) => objects[0].file_id.group(),
+            Group::StubLibraries(stubs) => stubs[0].file_id.group(),
             Group::LinkerScripts(scripts) => scripts[0].file_id.group(),
             Group::SyntheticSymbols(s) => s.file_id.group(),
             #[cfg(all(feature = "plugins", unix))]
@@ -78,6 +90,10 @@ impl<'data, P: Platform> Group<'data, P> {
             Group::Objects(objects) => SymbolIdRange::covering(
                 objects[0].symbol_id_range,
                 objects[objects.len() - 1].symbol_id_range,
+            ),
+            Group::StubLibraries(stubs) => SymbolIdRange::covering(
+                stubs[0].symbol_id_range,
+                stubs[stubs.len() - 1].symbol_id_range,
             ),
             Group::LinkerScripts(scripts) => {
                 if scripts.is_empty() {
@@ -106,6 +122,7 @@ impl<'data, P: Platform> Group<'data, P> {
 pub(crate) fn create_groups<'data, P: Platform>(
     symbol_db: &mut SymbolDb<'data, P>,
     parsed_objects: Vec<Box<ParsedInputObject<'data, P>>>,
+    stub_libraries: Vec<DefinedStubLibrary<'data>>,
     linker_scripts: Vec<ProcessedLinkerScript<'data, P>>,
 ) {
     timing_phase!("Group files");
@@ -190,6 +207,37 @@ pub(crate) fn create_groups<'data, P: Platform>(
 
     if !linker_scripts.is_empty() {
         symbol_db.add_group(Group::LinkerScripts(linker_scripts));
+    }
+
+    let stub_libraries: Vec<SequencedStubLibrary<'data>> = stub_libraries
+        .into_iter()
+        .enumerate()
+        .map(|(i, defined)| {
+            let mut symbols = defined
+                .symbols
+                .iter()
+                .map(|s| allocator.alloc_slice_copy(s.as_bytes()) as &'data [u8])
+                .collect::<Vec<_>>();
+            symbols.extend(
+                defined
+                    .weak_symbols
+                    .iter()
+                    .map(|s| allocator.alloc_slice_copy(s.as_bytes()) as &'data [u8]),
+            );
+            let symbol_id_range = SymbolIdRange::input(next_symbol_id, symbols.len());
+            next_symbol_id = next_symbol_id.add_usize(symbol_id_range.len());
+
+            SequencedStubLibrary {
+                defined,
+                symbols,
+                symbol_id_range,
+                file_id: FileId::new(symbol_db.next_group_index(), i as u32),
+            }
+        })
+        .collect();
+
+    if !stub_libraries.is_empty() {
+        symbol_db.add_group(Group::StubLibraries(stub_libraries));
     }
 
     symbol_db.next_input_section_id = next_input_section_id;
@@ -314,11 +362,33 @@ impl<'data, P: Platform> SequencedLinkerScript<'data, P> {
     }
 }
 
+impl<'data> SequencedStubLibrary<'data> {
+    pub(crate) fn symbol_name(&self, symbol_id: SymbolId) -> UnversionedSymbolName<'data> {
+        let local_index = self.symbol_id_range.id_to_offset(symbol_id);
+        UnversionedSymbolName::new(self.symbols[local_index])
+    }
+
+    pub(crate) fn symbol_strength(&self, symbol_id: SymbolId) -> SymbolStrength {
+        let local_index = self.symbol_id_range.id_to_offset(symbol_id);
+        if self
+            .defined
+            .weak_symbols
+            .iter()
+            .any(|weak| weak.as_bytes() == self.symbols[local_index])
+        {
+            SymbolStrength::Weak
+        } else {
+            SymbolStrength::Strong
+        }
+    }
+}
+
 impl<'db, 'data, P: Platform> SequencedInput<'db, 'data, P> {
     pub(crate) fn symbol_id_range(&self) -> SymbolIdRange {
         match self {
             SequencedInput::Prelude(o) => SymbolIdRange::prelude(o.symbol_definitions.len()),
             SequencedInput::Object(o) => o.symbol_id_range,
+            SequencedInput::StubLibrary(o) => o.symbol_id_range,
             SequencedInput::LinkerScript(o) => o.symbol_id_range,
             SequencedInput::SyntheticSymbols(o) => o.symbol_id_range,
             #[cfg(all(feature = "plugins", unix))]
@@ -327,18 +397,18 @@ impl<'db, 'data, P: Platform> SequencedInput<'db, 'data, P> {
     }
 
     pub(crate) fn is_dynamic(&self) -> bool {
-        if let SequencedInput::Object(o) = self {
-            o.is_dynamic()
-        } else {
-            false
+        match self {
+            SequencedInput::StubLibrary(_) => true,
+            SequencedInput::Object(o) if o.is_dynamic() => true,
+            _ => false,
         }
     }
 
     pub(crate) fn symbol_strength(&self, symbol_id: SymbolId) -> SymbolStrength {
-        if let SequencedInput::Object(o) = self {
-            o.symbol_strength(symbol_id)
-        } else {
-            SymbolStrength::Undefined
+        match self {
+            SequencedInput::Object(o) => o.symbol_strength(symbol_id),
+            SequencedInput::StubLibrary(o) => o.symbol_strength(symbol_id),
+            _ => SymbolStrength::Undefined,
         }
     }
 
@@ -362,6 +432,12 @@ impl<'data, P: Platform> std::fmt::Display for SequencedInputObject<'data, P> {
     }
 }
 
+impl std::fmt::Display for SequencedStubLibrary<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.defined.install_name, f)
+    }
+}
+
 impl<'data, P: Platform> Display for Group<'data, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -378,6 +454,7 @@ impl<'data, P: Platform> Display for Group<'data, P> {
                     num_objects = parsed_input_objects.len(),
                 )
             }
+            Group::StubLibraries(stubs) => write!(f, "{} Mach-O stub library(s)", stubs.len()),
             Group::LinkerScripts(scripts) => write!(f, "{} linker script(s)", scripts.len()),
             Group::SyntheticSymbols(_) => write!(f, "<epilogue>"),
             #[cfg(all(feature = "plugins", unix))]
@@ -391,6 +468,7 @@ impl<'db, 'data, P: Platform> std::fmt::Display for SequencedInput<'db, 'data, P
         match self {
             SequencedInput::Prelude(_) => std::fmt::Display::fmt("<prelude>", f),
             SequencedInput::Object(o) => std::fmt::Display::fmt(o, f),
+            SequencedInput::StubLibrary(o) => std::fmt::Display::fmt(o, f),
             SequencedInput::LinkerScript(o) => std::fmt::Display::fmt(&o.parsed, f),
             SequencedInput::SyntheticSymbols(_) => std::fmt::Display::fmt("<epilogue>", f),
             #[cfg(all(feature = "plugins", unix))]

--- a/libwild/src/grouping.rs
+++ b/libwild/src/grouping.rs
@@ -19,8 +19,6 @@ use crate::symbol_db::SymbolIdRange;
 use crate::symbol_db::SymbolStrength;
 use crate::timing_phase;
 use crate::verbose_timing_phase;
-use itertools::Itertools;
-use std::borrow::Cow;
 use std::fmt::Display;
 
 #[derive(Debug)]
@@ -51,9 +49,7 @@ pub(crate) struct SequencedLinkerScript<'data, P: Platform> {
 
 #[derive(Debug)]
 pub(crate) struct SequencedStubLibrary<'data> {
-    pub(crate) install_name: String,
-    pub(crate) symbols: Vec<&'data [u8]>,
-    pub(crate) weak_symbols: Vec<&'data [u8]>,
+    pub(crate) defined_symbols: DefinedStubLibrary<'data>,
     pub(crate) symbol_id_range: SymbolIdRange,
     pub(crate) file_id: FileId,
 }
@@ -212,29 +208,16 @@ pub(crate) fn create_groups<'data, P: Platform>(
         symbol_db.add_group(Group::LinkerScripts(linker_scripts));
     }
 
-    let symbol_name_bytes = |symbol_name: &Cow<'data, str>| match symbol_name {
-        Cow::Borrowed(name) => name.as_bytes(),
-        Cow::Owned(name) => allocator.alloc_slice_copy(name.as_bytes()),
-    };
-
     let stub_libraries: Vec<SequencedStubLibrary<'data>> = stub_libraries
         .into_iter()
         .enumerate()
-        .map(|(i, defined)| {
-            let symbols = defined.symbols.iter().map(&symbol_name_bytes).collect_vec();
-            let weak_symbols = defined
-                .weak_symbols
-                .iter()
-                .map(&symbol_name_bytes)
-                .collect_vec();
+        .map(|(i, defined_symbols)| {
             let symbol_id_range =
-                SymbolIdRange::input(next_symbol_id, symbols.len() + weak_symbols.len());
+                SymbolIdRange::input(next_symbol_id, defined_symbols.total_symbols());
             next_symbol_id = next_symbol_id.add_usize(symbol_id_range.len());
 
             SequencedStubLibrary {
-                install_name: defined.install_name,
-                symbols,
-                weak_symbols,
+                defined_symbols,
                 symbol_id_range,
                 file_id: FileId::new(symbol_db.next_group_index(), i as u32),
             }
@@ -371,15 +354,20 @@ impl<'data> SequencedStubLibrary<'data> {
     pub(crate) fn symbol_name(&self, symbol_id: SymbolId) -> UnversionedSymbolName<'data> {
         let local_index = self.symbol_id_range.id_to_offset(symbol_id);
         UnversionedSymbolName::new(
-            self.symbols
+            self.defined_symbols
+                .symbols
                 .get(local_index)
-                .unwrap_or(&self.weak_symbols[local_index - self.symbols.len()]),
+                .unwrap_or(
+                    &self.defined_symbols.weak_symbols
+                        [local_index - self.defined_symbols.symbols.len()],
+                )
+                .as_bytes(),
         )
     }
 
     pub(crate) fn symbol_strength(&self, symbol_id: SymbolId) -> SymbolStrength {
         let local_index = self.symbol_id_range.id_to_offset(symbol_id);
-        if local_index <= self.symbols.len() {
+        if local_index <= self.defined_symbols.symbols.len() {
             SymbolStrength::Strong
         } else {
             SymbolStrength::Weak
@@ -438,7 +426,7 @@ impl<'data, P: Platform> std::fmt::Display for SequencedInputObject<'data, P> {
 
 impl std::fmt::Display for SequencedStubLibrary<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(&self.install_name, f)
+        std::fmt::Display::fmt(&self.defined_symbols.install_name, f)
     }
 }
 

--- a/libwild/src/grouping.rs
+++ b/libwild/src/grouping.rs
@@ -1,5 +1,7 @@
 use crate::error::Result;
 use crate::input_data::FileId;
+use crate::input_data::InputRef;
+use crate::input_data::LoadedStubLibrary;
 use crate::input_data::MAX_FILES_PER_GROUP;
 use crate::input_section_id::InputSectionId;
 use crate::input_section_id::SectionIdRange;
@@ -49,6 +51,7 @@ pub(crate) struct SequencedLinkerScript<'data, P: Platform> {
 
 #[derive(Debug)]
 pub(crate) struct SequencedStubLibrary<'data> {
+    pub(crate) input: InputRef<'data>,
     pub(crate) defined_symbols: DefinedStubLibrary<'data>,
     pub(crate) symbol_id_range: SymbolIdRange,
     pub(crate) file_id: FileId,
@@ -121,7 +124,7 @@ impl<'data, P: Platform> Group<'data, P> {
 pub(crate) fn create_groups<'data, P: Platform>(
     symbol_db: &mut SymbolDb<'data, P>,
     parsed_objects: Vec<Box<ParsedInputObject<'data, P>>>,
-    stub_libraries: Vec<DefinedStubLibrary<'data>>,
+    stub_libraries: Vec<LoadedStubLibrary<'data>>,
     linker_scripts: Vec<ProcessedLinkerScript<'data, P>>,
 ) {
     timing_phase!("Group files");
@@ -211,13 +214,14 @@ pub(crate) fn create_groups<'data, P: Platform>(
     let stub_libraries: Vec<SequencedStubLibrary<'data>> = stub_libraries
         .into_iter()
         .enumerate()
-        .map(|(i, defined_symbols)| {
+        .map(|(i, stub)| {
             let symbol_id_range =
-                SymbolIdRange::input(next_symbol_id, defined_symbols.total_symbols());
+                SymbolIdRange::input(next_symbol_id, stub.defined_symbols.total_symbols());
             next_symbol_id = next_symbol_id.add_usize(symbol_id_range.len());
 
             SequencedStubLibrary {
-                defined_symbols,
+                input: stub.input,
+                defined_symbols: stub.defined_symbols,
                 symbol_id_range,
                 file_id: FileId::new(symbol_db.next_group_index(), i as u32),
             }
@@ -390,8 +394,8 @@ impl<'db, 'data, P: Platform> SequencedInput<'db, 'data, P> {
 
     pub(crate) fn is_dynamic(&self) -> bool {
         match self {
-            SequencedInput::StubLibrary(_) => true,
             SequencedInput::Object(o) if o.is_dynamic() => true,
+            SequencedInput::StubLibrary(_) => true,
             _ => false,
         }
     }
@@ -426,7 +430,7 @@ impl<'data, P: Platform> std::fmt::Display for SequencedInputObject<'data, P> {
 
 impl std::fmt::Display for SequencedStubLibrary<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(&self.defined_symbols.install_name, f)
+        std::fmt::Display::fmt(&self.input, f)
     }
 }
 

--- a/libwild/src/grouping.rs
+++ b/libwild/src/grouping.rs
@@ -361,17 +361,17 @@ impl<'data> SequencedStubLibrary<'data> {
             self.defined_symbols
                 .symbols
                 .get(local_index)
-                .unwrap_or(
+                .unwrap_or_else(|| {
                     &self.defined_symbols.weak_symbols
-                        [local_index - self.defined_symbols.symbols.len()],
-                )
+                        [local_index - self.defined_symbols.symbols.len()]
+                })
                 .as_bytes(),
         )
     }
 
     pub(crate) fn symbol_strength(&self, symbol_id: SymbolId) -> SymbolStrength {
         let local_index = self.symbol_id_range.id_to_offset(symbol_id);
-        if local_index <= self.defined_symbols.symbols.len() {
+        if local_index < self.defined_symbols.symbols.len() {
             SymbolStrength::Strong
         } else {
             SymbolStrength::Weak

--- a/libwild/src/grouping.rs
+++ b/libwild/src/grouping.rs
@@ -19,6 +19,8 @@ use crate::symbol_db::SymbolIdRange;
 use crate::symbol_db::SymbolStrength;
 use crate::timing_phase;
 use crate::verbose_timing_phase;
+use itertools::Itertools;
+use std::borrow::Cow;
 use std::fmt::Display;
 
 #[derive(Debug)]
@@ -49,8 +51,9 @@ pub(crate) struct SequencedLinkerScript<'data, P: Platform> {
 
 #[derive(Debug)]
 pub(crate) struct SequencedStubLibrary<'data> {
-    pub(crate) defined: DefinedStubLibrary<'data>,
+    pub(crate) install_name: String,
     pub(crate) symbols: Vec<&'data [u8]>,
+    pub(crate) weak_symbols: Vec<&'data [u8]>,
     pub(crate) symbol_id_range: SymbolIdRange,
     pub(crate) file_id: FileId,
 }
@@ -209,27 +212,29 @@ pub(crate) fn create_groups<'data, P: Platform>(
         symbol_db.add_group(Group::LinkerScripts(linker_scripts));
     }
 
+    let symbol_name_bytes = |symbol_name: &Cow<'data, str>| match symbol_name {
+        Cow::Borrowed(name) => name.as_bytes(),
+        Cow::Owned(name) => allocator.alloc_slice_copy(name.as_bytes()),
+    };
+
     let stub_libraries: Vec<SequencedStubLibrary<'data>> = stub_libraries
         .into_iter()
         .enumerate()
         .map(|(i, defined)| {
-            let mut symbols = defined
-                .symbols
+            let symbols = defined.symbols.iter().map(&symbol_name_bytes).collect_vec();
+            let weak_symbols = defined
+                .weak_symbols
                 .iter()
-                .map(|s| allocator.alloc_slice_copy(s.as_bytes()) as &'data [u8])
-                .collect::<Vec<_>>();
-            symbols.extend(
-                defined
-                    .weak_symbols
-                    .iter()
-                    .map(|s| allocator.alloc_slice_copy(s.as_bytes()) as &'data [u8]),
-            );
-            let symbol_id_range = SymbolIdRange::input(next_symbol_id, symbols.len());
+                .map(&symbol_name_bytes)
+                .collect_vec();
+            let symbol_id_range =
+                SymbolIdRange::input(next_symbol_id, symbols.len() + weak_symbols.len());
             next_symbol_id = next_symbol_id.add_usize(symbol_id_range.len());
 
             SequencedStubLibrary {
-                defined,
+                install_name: defined.install_name,
                 symbols,
+                weak_symbols,
                 symbol_id_range,
                 file_id: FileId::new(symbol_db.next_group_index(), i as u32),
             }
@@ -365,20 +370,19 @@ impl<'data, P: Platform> SequencedLinkerScript<'data, P> {
 impl<'data> SequencedStubLibrary<'data> {
     pub(crate) fn symbol_name(&self, symbol_id: SymbolId) -> UnversionedSymbolName<'data> {
         let local_index = self.symbol_id_range.id_to_offset(symbol_id);
-        UnversionedSymbolName::new(self.symbols[local_index])
+        UnversionedSymbolName::new(
+            self.symbols
+                .get(local_index)
+                .unwrap_or(&self.weak_symbols[local_index - self.symbols.len()]),
+        )
     }
 
     pub(crate) fn symbol_strength(&self, symbol_id: SymbolId) -> SymbolStrength {
         let local_index = self.symbol_id_range.id_to_offset(symbol_id);
-        if self
-            .defined
-            .weak_symbols
-            .iter()
-            .any(|weak| weak.as_bytes() == self.symbols[local_index])
-        {
-            SymbolStrength::Weak
-        } else {
+        if local_index <= self.symbols.len() {
             SymbolStrength::Strong
+        } else {
+            SymbolStrength::Weak
         }
     }
 }
@@ -434,7 +438,7 @@ impl<'data, P: Platform> std::fmt::Display for SequencedInputObject<'data, P> {
 
 impl std::fmt::Display for SequencedStubLibrary<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(&self.defined.install_name, f)
+        std::fmt::Display::fmt(&self.install_name, f)
     }
 }
 

--- a/libwild/src/input_data.rs
+++ b/libwild/src/input_data.rs
@@ -62,9 +62,14 @@ pub(crate) struct LoadedInputs<'data, P: Platform> {
 
     pub(crate) linker_scripts: Vec<InputLinkerScript<'data>>,
 
-    pub(crate) stub_libraries: Vec<DefinedStubLibrary<'data>>,
+    pub(crate) stub_libraries: Vec<LoadedStubLibrary<'data>>,
 
     pub(crate) lto_objects: Vec<Result<Box<LtoInputInfo<'data>>>>,
+}
+
+pub(crate) struct LoadedStubLibrary<'data> {
+    pub(crate) input: InputRef<'data>,
+    pub(crate) defined_symbols: DefinedStubLibrary<'data>,
 }
 
 pub(crate) struct InputBytes<'data> {
@@ -443,7 +448,13 @@ impl<'data> FileLoader<'data> {
             }
             Some(LoadedFileState::StubLibrary(input_file, defined_stub_library)) => {
                 self.has_dynamic = true;
-                loaded.stub_libraries.push(defined_stub_library);
+                loaded.stub_libraries.push(LoadedStubLibrary {
+                    input: InputRef {
+                        file: input_file,
+                        entry: None,
+                    },
+                    defined_symbols: defined_stub_library,
+                });
                 self.loaded_files.push(input_file);
             }
             Some(LoadedFileState::Error(error)) => {

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -453,7 +453,7 @@ fn update_redirect_resolutions<'data, P: Platform>(
                     }
                 }
             }
-            Group::Objects(_) | Group::SyntheticSymbols(_) => {}
+            Group::Objects(_) | Group::StubLibraries(_) | Group::SyntheticSymbols(_) => {}
             #[cfg(all(feature = "plugins", unix))]
             Group::LtoInputs(_) => {}
         }
@@ -4364,6 +4364,13 @@ impl<'data, P: Platform> resolution::ResolvedFile<'data, P> {
         match self {
             resolution::ResolvedFile::Object(s) => new_object_layout_state(s),
             resolution::ResolvedFile::Dynamic(s) => new_dynamic_object_layout_state(&s),
+            resolution::ResolvedFile::StubLibrary(s) => FileLayoutState::NotLoaded(NotLoaded {
+                symbol_id_range: s.symbol_id_range,
+                section_id_range: crate::input_section_id::SectionIdRange::input(
+                    crate::input_section_id::InputSectionId::from_usize(0),
+                    0,
+                ),
+            }),
             resolution::ResolvedFile::Prelude(s) => {
                 FileLayoutState::Prelude(PreludeLayoutState::new(s, args))
             }

--- a/libwild/src/macho_stub_library.rs
+++ b/libwild/src/macho_stub_library.rs
@@ -13,7 +13,6 @@ use crate::error;
 use crate::error::Result;
 use itertools::Itertools;
 use serde::Deserialize;
-use std::borrow::Cow;
 use std::collections::HashSet;
 
 const ARM64_LIB_ARCH: &str = "arm64-macos";
@@ -23,11 +22,11 @@ const ARM64_LIB_ARCH: &str = "arm64-macos";
 struct TextBasedDefinition<'a> {
     tbd_version: u32,
     #[serde(borrow)]
-    targets: Vec<Cow<'a, str>>,
+    targets: Vec<&'a str>,
     #[serde(borrow)]
-    install_name: Cow<'a, str>,
+    install_name: &'a str,
     #[serde(default)]
-    current_version: Cow<'a, str>,
+    current_version: &'a str,
     #[serde(default)]
     parent_umbrella: Vec<ParentUmbrella<'a>>,
     #[serde(default)]
@@ -48,44 +47,50 @@ impl<'a> TextBasedDefinition<'a> {
 #[serde(rename_all = "kebab-case")]
 struct ParentUmbrella<'a> {
     #[serde(borrow)]
-    targets: Vec<Cow<'a, str>>,
+    targets: Vec<&'a str>,
     #[serde(borrow)]
-    umbrella: Cow<'a, str>,
+    umbrella: &'a str,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 struct ReexportedLibraries<'a> {
     #[serde(borrow)]
-    targets: Vec<Cow<'a, str>>,
+    targets: Vec<&'a str>,
     #[serde(borrow)]
-    libraries: Vec<Cow<'a, str>>,
+    libraries: Vec<&'a str>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 struct Exports<'a> {
     #[serde(borrow)]
-    targets: Vec<Cow<'a, str>>,
+    targets: Vec<&'a str>,
     #[serde(default)]
     #[serde(borrow)]
-    symbols: Vec<Cow<'a, str>>,
+    symbols: Vec<&'a str>,
     #[serde(default)]
     #[serde(borrow)]
-    weak_symbols: Vec<Cow<'a, str>>,
+    weak_symbols: Vec<&'a str>,
 }
 // TODO: remove
 #[allow(unused)]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct DefinedStubLibrary<'a> {
     /// Install name of the dynamic library, including its `.dylib` suffix.    
     pub(crate) install_name: String,
     /// Current version recorded for the library, if present.
     pub(crate) current_version: String,
     /// Global symbols defined by the library or by any reexported child library.
-    pub(crate) symbols: Vec<Cow<'a, str>>,
+    pub(crate) symbols: Vec<&'a str>,
     /// Weak symbols defined by the library or by any reexported child library.
-    pub(crate) weak_symbols: Vec<Cow<'a, str>>,
+    pub(crate) weak_symbols: Vec<&'a str>,
+}
+
+impl DefinedStubLibrary<'_> {
+    pub(crate) fn total_symbols(&self) -> usize {
+        self.symbols.len() + self.weak_symbols.len()
+    }
 }
 
 pub fn parse_defined_library<'data>(input: &'data str) -> Result<DefinedStubLibrary<'data>> {
@@ -97,9 +102,7 @@ pub fn parse_defined_library<'data>(input: &'data str) -> Result<DefinedStubLibr
         .first()
         .ok_or_else(|| error!("root library must be defined"))?;
     ensure!(
-        main_library
-            .targets
-            .contains(&Cow::Borrowed(ARM64_LIB_ARCH)),
+        main_library.targets.contains(&ARM64_LIB_ARCH),
         "'{ARM64_LIB_ARCH}' architecture not implemented by the library"
     );
 
@@ -135,12 +138,10 @@ pub fn parse_defined_library<'data>(input: &'data str) -> Result<DefinedStubLibr
         .map_err(|_| error!("expected just a single exported library"))?
     {
         ensure!(
-            exported_libraries
-                .targets
-                .contains(&Cow::Borrowed(ARM64_LIB_ARCH)),
+            exported_libraries.targets.contains(&ARM64_LIB_ARCH),
             "'{ARM64_LIB_ARCH}' architecture not covered in the exported library"
         );
-        let exported_libraries: HashSet<_> = exported_libraries.libraries.iter().clone().collect();
+        let exported_libraries: HashSet<_> = exported_libraries.libraries.iter().copied().collect();
         exported_libraries
     } else {
         HashSet::new()
@@ -154,20 +155,18 @@ pub fn parse_defined_library<'data>(input: &'data str) -> Result<DefinedStubLibr
         );
         if lib != main_library {
             ensure!(
-                exported_libraries.contains(&lib.install_name),
+                exported_libraries.contains(lib.install_name),
                 "child library '{}' not listed as reexported by the main library",
                 lib.install_name
             );
         }
 
         for export in lib.all_exports() {
-            if export.targets.contains(&Cow::Borrowed(ARM64_LIB_ARCH)) {
-                defined_library
-                    .symbols
-                    .extend(export.symbols.iter().cloned());
+            if export.targets.contains(&ARM64_LIB_ARCH) {
+                defined_library.symbols.extend(export.symbols.iter());
                 defined_library
                     .weak_symbols
-                    .extend(export.weak_symbols.iter().cloned());
+                    .extend(export.weak_symbols.iter());
             }
         }
     }

--- a/libwild/src/macho_stub_library.rs
+++ b/libwild/src/macho_stub_library.rs
@@ -74,23 +74,20 @@ struct Exports<'a> {
     #[serde(borrow)]
     weak_symbols: Vec<Cow<'a, str>>,
 }
-
 // TODO: remove
 #[allow(unused)]
 #[derive(Debug)]
-pub struct DefinedStubLibrary<'a> {
+pub(crate) struct DefinedStubLibrary<'a> {
     /// Install name of the dynamic library, including its `.dylib` suffix.    
-    pub install_name: String,
+    pub(crate) install_name: String,
     /// Current version recorded for the library, if present.
-    pub current_version: String,
+    pub(crate) current_version: String,
     /// Global symbols defined by the library or by any reexported child library.
-    pub symbols: HashSet<Cow<'a, str>>,
+    pub(crate) symbols: Vec<Cow<'a, str>>,
     /// Weak symbols defined by the library or by any reexported child library.
-    pub weak_symbols: HashSet<Cow<'a, str>>,
+    pub(crate) weak_symbols: Vec<Cow<'a, str>>,
 }
 
-// TODO: remove
-#[allow(unused)]
 pub fn parse_defined_library<'data>(input: &'data str) -> Result<DefinedStubLibrary<'data>> {
     let library_definitions = serde_yaml::Deserializer::from_str(input)
         .map(TextBasedDefinition::deserialize)
@@ -113,14 +110,14 @@ pub fn parse_defined_library<'data>(input: &'data str) -> Result<DefinedStubLibr
     let mut defined_library = DefinedStubLibrary {
         install_name: main_library.install_name.to_string(),
         current_version: main_library.current_version.to_string(),
-        symbols: HashSet::with_capacity(
+        symbols: Vec::with_capacity(
             library_definitions
                 .iter()
                 .flat_map(TextBasedDefinition::all_exports)
                 .map(|exp| exp.symbols.len())
                 .sum(),
         ),
-        weak_symbols: HashSet::with_capacity(
+        weak_symbols: Vec::with_capacity(
             library_definitions
                 .iter()
                 .flat_map(TextBasedDefinition::all_exports)
@@ -238,9 +235,6 @@ reexports:
         assert_eq!(
             stub_library.symbols,
             ["_main_arm64", "_a_arm64", "_b_arm64", "_b_exported_arm64"]
-                .into_iter()
-                .map(Cow::Borrowed)
-                .collect()
         );
         assert_eq!(
             stub_library.weak_symbols,
@@ -249,9 +243,6 @@ reexports:
                 "_a_weak_arm64",
                 "_b_weak_exported_arm64"
             ]
-            .into_iter()
-            .map(Cow::Borrowed)
-            .collect()
         );
     }
 }

--- a/libwild/src/macho_stub_library.rs
+++ b/libwild/src/macho_stub_library.rs
@@ -1,7 +1,9 @@
 //! Parser for the Text-Based Stub (`.tbd`) library definitions used by Mach-O.
 //!
 //! This crate currently targets TBD format version 4 and extracts the
-//! linker-visible symbol definitions (and weak symbols).
+//! linker-visible symbol definitions (and weak symbols). To keep parsing
+//! simple and efficient, the parser rejects escape sequences and returns
+//! `&'data str` slices directly from the input.
 //!
 //! The parser accepts multi-document YAML TBD files. The first document is
 //! treated as the main library. Additional documents are treated as child

--- a/libwild/src/macho_stub_library.rs
+++ b/libwild/src/macho_stub_library.rs
@@ -77,6 +77,7 @@ struct Exports<'a> {
 
 // TODO: remove
 #[allow(unused)]
+#[derive(Debug)]
 pub struct DefinedStubLibrary<'a> {
     /// Install name of the dynamic library, including its `.dylib` suffix.    
     pub install_name: String,

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -60,6 +60,7 @@ use rayon::iter::IndexedParallelIterator;
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::IntoParallelRefMutIterator;
 use rayon::iter::ParallelIterator;
+use std::collections::HashSet;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
@@ -311,6 +312,36 @@ fn resolve_group<'data, 'definitions, P: Platform>(
                     ResolvedFile::NotLoaded(NotLoaded {
                         symbol_id_range: s.symbol_id_range,
                         section_id_range: s.section_id_range,
+                    })
+                })
+                .collect();
+
+            ResolvedGroup { files }
+        }
+        Group::StubLibraries(stubs) => {
+            let files = stubs
+                .iter()
+                .map(|stub| {
+                    symbol_definitions_slice
+                        .split_off_mut(..stub.symbol_id_range.len())
+                        .unwrap();
+                    definitions_out_per_file.push(AtomicTake::empty());
+                    ResolvedFile::StubLibrary(ResolvedStubLibrary {
+                        file_id: stub.file_id,
+                        symbol_id_range: stub.symbol_id_range,
+                        weak_symbols: stub
+                            .defined
+                            .weak_symbols
+                            .iter()
+                            .map(|s| {
+                                stub.symbols
+                                    .iter()
+                                    .copied()
+                                    .find(|symbol| *symbol == s.as_bytes())
+                                    .expect("weak stub symbol should be in the symbol list")
+                            })
+                            .collect(),
+                        symbols: stub.symbols.clone(),
                     })
                 })
                 .collect();
@@ -590,6 +621,7 @@ fn work_items_do<'definitions, 'data, P: Platform>(
             // Push won't fail because we allocated enough space for all the objects.
             outputs.loaded.push(resolved_object).unwrap();
         }
+        Group::StubLibraries(_) => {}
         #[cfg(all(feature = "plugins", unix))]
         Group::LtoInputs(lto_objects) => {
             let obj = &lto_objects[file_id.file()];
@@ -648,6 +680,7 @@ pub(crate) enum ResolvedFile<'data, P: Platform> {
     Prelude(ResolvedPrelude<'data, P>),
     Object(ResolvedObject<'data, P>),
     Dynamic(ResolvedDynamic<'data, P>),
+    StubLibrary(ResolvedStubLibrary<'data>),
     LinkerScript(ResolvedLinkerScript<'data, P>),
     SyntheticSymbols(ResolvedSyntheticSymbols<'data, P>),
     #[cfg(all(feature = "plugins", unix))]
@@ -753,6 +786,14 @@ pub(crate) struct ResolvedDynamic<'data, P: Platform> {
     dynamic_tag_values: P::DynamicTagValues<'data>,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedStubLibrary<'data> {
+    pub(crate) file_id: FileId,
+    pub(crate) symbol_id_range: SymbolIdRange,
+    weak_symbols: HashSet<&'data [u8]>,
+    symbols: Vec<&'data [u8]>,
+}
+
 #[derive(Debug)]
 pub(crate) struct ResolvedLinkerScript<'data, P: Platform> {
     pub(crate) input: InputRef<'data>,
@@ -856,6 +897,7 @@ fn process_object<'scope, 'data: 'scope, 'definitions, P: Platform>(
                 .with_context(|| format!("Failed to resolve symbols in {obj}")),
             );
         }
+        Group::StubLibraries(_) => {}
         Group::LinkerScripts(scripts) => {
             for script in scripts {
                 for sym in &script.parsed.symbol_defs {
@@ -1569,6 +1611,23 @@ impl<'data, P: Platform> std::fmt::Display for ResolvedDynamic<'data, P> {
     }
 }
 
+impl ResolvedStubLibrary<'_> {
+    pub(crate) fn symbol_strength(&self, symbol_id: SymbolId) -> SymbolStrength {
+        let local_index = self.symbol_id_range.id_to_offset(symbol_id);
+        if self.weak_symbols.contains(&self.symbols[local_index]) {
+            SymbolStrength::Weak
+        } else {
+            SymbolStrength::Strong
+        }
+    }
+}
+
+impl std::fmt::Display for ResolvedStubLibrary<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt("<Mach-O stub library>", f)
+    }
+}
+
 impl<'data, P: Platform> std::fmt::Display for ResolvedLinkerScript<'data, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(&self.input, f)
@@ -1582,6 +1641,7 @@ impl<'data, P: Platform> std::fmt::Display for ResolvedFile<'data, P> {
             ResolvedFile::Prelude(_) => std::fmt::Display::fmt("<prelude>", f),
             ResolvedFile::Object(o) => std::fmt::Display::fmt(o, f),
             ResolvedFile::Dynamic(o) => std::fmt::Display::fmt(o, f),
+            ResolvedFile::StubLibrary(o) => std::fmt::Display::fmt(o, f),
             ResolvedFile::LinkerScript(o) => std::fmt::Display::fmt(o, f),
             ResolvedFile::SyntheticSymbols(_) => std::fmt::Display::fmt("<synthetic>", f),
             #[cfg(all(feature = "plugins", unix))]
@@ -1610,6 +1670,7 @@ impl<'data, P: Platform> ResolvedFile<'data, P> {
             ResolvedFile::Prelude(s) => s.symbol_id_range(),
             ResolvedFile::Object(s) => s.common.symbol_id_range,
             ResolvedFile::Dynamic(s) => s.common.symbol_id_range,
+            ResolvedFile::StubLibrary(s) => s.symbol_id_range,
             ResolvedFile::LinkerScript(s) => s.symbol_id_range,
             ResolvedFile::SyntheticSymbols(s) => s.symbol_id_range(),
             #[cfg(all(feature = "plugins", unix))]

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -20,6 +20,7 @@ use crate::input_section_id::SectionIdRange;
 use crate::layout_rules::SectionRuleOutcome;
 use crate::layout_rules::SectionRules;
 use crate::linker_script::Expression;
+use crate::macho_stub_library::DefinedStubLibrary;
 use crate::output_section_id::CustomSectionDetails;
 use crate::output_section_id::InitFiniSectionDetail;
 use crate::output_section_id::OutputSections;
@@ -328,8 +329,8 @@ fn resolve_group<'data, 'definitions, P: Platform>(
                     ResolvedFile::StubLibrary(ResolvedStubLibrary {
                         file_id: stub.file_id,
                         symbol_id_range: stub.symbol_id_range,
-                        weak_symbols: stub.weak_symbols.clone(),
-                        symbols: stub.symbols.clone(),
+                        // TODO: do we need to clone it?
+                        defined_symbols: stub.defined_symbols.clone(),
                     })
                 })
                 .collect();
@@ -778,8 +779,7 @@ pub(crate) struct ResolvedDynamic<'data, P: Platform> {
 pub(crate) struct ResolvedStubLibrary<'data> {
     pub(crate) file_id: FileId,
     pub(crate) symbol_id_range: SymbolIdRange,
-    pub(crate) symbols: Vec<&'data [u8]>,
-    pub(crate) weak_symbols: Vec<&'data [u8]>,
+    pub(crate) defined_symbols: DefinedStubLibrary<'data>,
 }
 
 #[derive(Debug)]
@@ -1602,10 +1602,10 @@ impl<'data, P: Platform> std::fmt::Display for ResolvedDynamic<'data, P> {
 impl ResolvedStubLibrary<'_> {
     pub(crate) fn symbol_strength(&self, symbol_id: SymbolId) -> SymbolStrength {
         let local_index = self.symbol_id_range.id_to_offset(symbol_id);
-        if self.weak_symbols.contains(&self.symbols[local_index]) {
-            SymbolStrength::Weak
-        } else {
+        if local_index <= self.defined_symbols.symbols.len() {
             SymbolStrength::Strong
+        } else {
+            SymbolStrength::Weak
         }
     }
 }

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -327,6 +327,7 @@ fn resolve_group<'data, 'definitions, P: Platform>(
                         .unwrap();
                     definitions_out_per_file.push(AtomicTake::empty());
                     ResolvedFile::StubLibrary(ResolvedStubLibrary {
+                        input: stub.input,
                         file_id: stub.file_id,
                         symbol_id_range: stub.symbol_id_range,
                         // TODO: do we need to clone it?
@@ -777,6 +778,7 @@ pub(crate) struct ResolvedDynamic<'data, P: Platform> {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ResolvedStubLibrary<'data> {
+    pub(crate) input: InputRef<'data>,
     pub(crate) file_id: FileId,
     pub(crate) symbol_id_range: SymbolIdRange,
     pub(crate) defined_symbols: DefinedStubLibrary<'data>,
@@ -1612,7 +1614,7 @@ impl ResolvedStubLibrary<'_> {
 
 impl std::fmt::Display for ResolvedStubLibrary<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt("<Mach-O stub library>", f)
+        std::fmt::Display::fmt(&self.input, f)
     }
 }
 

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -60,7 +60,6 @@ use rayon::iter::IndexedParallelIterator;
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::IntoParallelRefMutIterator;
 use rayon::iter::ParallelIterator;
-use std::collections::HashSet;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
@@ -329,18 +328,7 @@ fn resolve_group<'data, 'definitions, P: Platform>(
                     ResolvedFile::StubLibrary(ResolvedStubLibrary {
                         file_id: stub.file_id,
                         symbol_id_range: stub.symbol_id_range,
-                        weak_symbols: stub
-                            .defined
-                            .weak_symbols
-                            .iter()
-                            .map(|s| {
-                                stub.symbols
-                                    .iter()
-                                    .copied()
-                                    .find(|symbol| *symbol == s.as_bytes())
-                                    .expect("weak stub symbol should be in the symbol list")
-                            })
-                            .collect(),
+                        weak_symbols: stub.weak_symbols.clone(),
                         symbols: stub.symbols.clone(),
                     })
                 })
@@ -790,8 +778,8 @@ pub(crate) struct ResolvedDynamic<'data, P: Platform> {
 pub(crate) struct ResolvedStubLibrary<'data> {
     pub(crate) file_id: FileId,
     pub(crate) symbol_id_range: SymbolIdRange,
-    weak_symbols: HashSet<&'data [u8]>,
-    symbols: Vec<&'data [u8]>,
+    pub(crate) symbols: Vec<&'data [u8]>,
+    pub(crate) weak_symbols: Vec<&'data [u8]>,
 }
 
 #[derive(Debug)]

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -1604,7 +1604,7 @@ impl<'data, P: Platform> std::fmt::Display for ResolvedDynamic<'data, P> {
 impl ResolvedStubLibrary<'_> {
     pub(crate) fn symbol_strength(&self, symbol_id: SymbolId) -> SymbolStrength {
         let local_index = self.symbol_id_range.id_to_offset(symbol_id);
-        if local_index <= self.defined_symbols.symbols.len() {
+        if local_index < self.defined_symbols.symbols.len() {
             SymbolStrength::Strong
         } else {
             SymbolStrength::Weak

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -330,7 +330,7 @@ fn resolve_group<'data, 'definitions, P: Platform>(
                         input: stub.input,
                         file_id: stub.file_id,
                         symbol_id_range: stub.symbol_id_range,
-                        // TODO: do we need to clone it?
+                        // TODO: Consider alternative to cloning this.
                         defined_symbols: stub.defined_symbols.clone(),
                     })
                 })

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -1534,7 +1534,13 @@ fn load_stub_library_symbols<'data, P: Platform>(
     symbols_out: &mut SymbolWriterShard<'_, '_, 'data, P>,
     outputs: &mut SymbolLoadOutputs<'data>,
 ) {
-    for (offset, symbol_name) in stub.defined_symbols.symbols.iter().enumerate() {
+    for (offset, symbol_name) in stub
+        .defined_symbols
+        .symbols
+        .iter()
+        .chain(stub.defined_symbols.weak_symbols.iter())
+        .enumerate()
+    {
         let symbol_id = stub.symbol_id_range.offset_to_id(offset);
         outputs.add_non_versioned(PendingSymbol::new(symbol_id, symbol_name.as_bytes()));
         symbols_out.set_next(ValueFlags::DYNAMIC, symbol_id, stub.file_id);

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -1534,9 +1534,9 @@ fn load_stub_library_symbols<'data, P: Platform>(
     symbols_out: &mut SymbolWriterShard<'_, '_, 'data, P>,
     outputs: &mut SymbolLoadOutputs<'data>,
 ) {
-    for (offset, symbol_name) in stub.symbols.iter().enumerate() {
+    for (offset, symbol_name) in stub.defined_symbols.symbols.iter().enumerate() {
         let symbol_id = stub.symbol_id_range.offset_to_id(offset);
-        outputs.add_non_versioned(PendingSymbol::new(symbol_id, symbol_name));
+        outputs.add_non_versioned(PendingSymbol::new(symbol_id, symbol_name.as_bytes()));
         symbols_out.set_next(ValueFlags::DYNAMIC, symbol_id, stub.file_id);
     }
 }

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -413,7 +413,12 @@ impl<'data, P: Platform> SymbolDb<'data, P> {
                 )?));
         }
 
-        grouping::create_groups(self, parsed_objects, processed_linker_scripts);
+        grouping::create_groups(
+            self,
+            parsed_objects,
+            loaded.stub_libraries,
+            processed_linker_scripts,
+        );
 
         self.create_lto_input_groups(loaded.lto_objects)?;
 
@@ -625,6 +630,7 @@ impl<'data, P: Platform> SymbolDb<'data, P> {
 
                 obj_symbol.visibility()
             }
+            Group::StubLibraries(_) => Visibility::Default,
             Group::LinkerScripts(_) => Visibility::Default,
             Group::SyntheticSymbols(_) => Visibility::Default,
             #[cfg(all(feature = "plugins", unix))]
@@ -661,6 +667,7 @@ impl<'data, P: Platform> SymbolDb<'data, P> {
             Group::Objects(parsed_input_objects) => {
                 parsed_input_objects[file_id.file()].symbol_name(symbol_id)
             }
+            Group::StubLibraries(stubs) => Ok(stubs[file_id.file()].symbol_name(symbol_id)),
             Group::LinkerScripts(scripts) => Ok(scripts[file_id.file()].symbol_name(symbol_id)),
             Group::SyntheticSymbols(syn) => {
                 Ok(self.start_stop_symbol_names[syn.symbol_id_range.id_to_offset(symbol_id)])
@@ -793,6 +800,7 @@ impl<'data, P: Platform> SymbolDb<'data, P> {
             Group::Objects(parsed_input_objects) => {
                 SequencedInput::Object(&parsed_input_objects[file_id.file()])
             }
+            Group::StubLibraries(stubs) => SequencedInput::StubLibrary(&stubs[file_id.file()]),
             Group::LinkerScripts(scripts) => SequencedInput::LinkerScript(&scripts[file_id.file()]),
             Group::SyntheticSymbols(syn) => SequencedInput::SyntheticSymbols(syn),
             #[cfg(all(feature = "plugins", unix))]
@@ -864,6 +872,7 @@ impl<'data, P: Platform> SymbolDb<'data, P> {
         match &resolved[file_id.group()].files[file_id.file()] {
             ResolvedFile::Object(obj) => obj.common.symbol_strength(symbol_id),
             ResolvedFile::Dynamic(obj) => obj.common.symbol_strength(symbol_id),
+            ResolvedFile::StubLibrary(stub) => stub.symbol_strength(symbol_id),
             #[cfg(all(feature = "plugins", unix))]
             ResolvedFile::LtoInput(obj) => {
                 use crate::linker_plugins::SymbolKind;
@@ -1496,6 +1505,11 @@ fn read_symbols_for_group<'data, P: Platform>(
                 .with_context(|| format!("Failed to load symbols from `{}`", obj.parsed.input))?;
             }
         }
+        Group::StubLibraries(stubs) => {
+            for stub in stubs {
+                load_stub_library_symbols(stub, shard, &mut outputs);
+            }
+        }
         Group::LinkerScripts(scripts) => {
             for script in scripts {
                 load_linker_script_symbols(script, shard, &mut outputs);
@@ -1513,6 +1527,18 @@ fn read_symbols_for_group<'data, P: Platform>(
     }
 
     Ok(outputs)
+}
+
+fn load_stub_library_symbols<'data, P: Platform>(
+    stub: &crate::grouping::SequencedStubLibrary<'data>,
+    symbols_out: &mut SymbolWriterShard<'_, '_, 'data, P>,
+    outputs: &mut SymbolLoadOutputs<'data>,
+) {
+    for (offset, symbol_name) in stub.symbols.iter().enumerate() {
+        let symbol_id = stub.symbol_id_range.offset_to_id(offset);
+        outputs.add_non_versioned(PendingSymbol::new(symbol_id, symbol_name));
+        symbols_out.set_next(ValueFlags::DYNAMIC, symbol_id, stub.file_id);
+    }
 }
 
 #[cfg(all(feature = "plugins", unix))]
@@ -1904,6 +1930,10 @@ impl<'a, 'data, P: Platform> std::fmt::Display for SymbolDebug<'a, 'data, P> {
                     } else {
                         write!(f, "<unnamed symbol>")?;
                     }
+                }
+                SequencedInput::StubLibrary(_) => {
+                    // TODO: add file name to error message
+                    write!(f, "<unnamed Mach-O stub library symbol>")?;
                 }
                 SequencedInput::LinkerScript(s) => {
                     write!(f, "Symbol from linker script `{}`", s.parsed.input)?;

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -1937,9 +1937,8 @@ impl<'a, 'data, P: Platform> std::fmt::Display for SymbolDebug<'a, 'data, P> {
                         write!(f, "<unnamed symbol>")?;
                     }
                 }
-                SequencedInput::StubLibrary(_) => {
-                    // TODO: add file name to error message
-                    write!(f, "<unnamed Mach-O stub library symbol>")?;
+                SequencedInput::StubLibrary(s) => {
+                    write!(f, "<unnamed Mach-O stub library symbol from `{}`>", s.input)?;
                 }
                 SequencedInput::LinkerScript(s) => {
                     write!(f, "Symbol from linker script `{}`", s.parsed.input)?;


### PR DESCRIPTION
The change correctly wires in symbols loaded from the stub libraries. Given the issues around `Cow::Owned` and the `&'data` lifetime requirements in the symbols DB, I chose not to support escape sequences in `.tbd` files. Based on my testing, all system stub libraries can be parsed successfully with our implementation.

Issue: #757