### PR TITLE
feat: Support GDB index

### DIFF
--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -2078,7 +2078,7 @@ impl platform::Args for ElfArgs {
     }
 
     fn should_write_gdb_index(&self) -> bool {
-        self.gdb_index
+        self.gdb_index && !self.should_strip_debug()
     }
 }
 

--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -127,6 +127,7 @@ pub struct ElfArgs {
 
     pub(crate) nmagic: bool,
     pub(crate) rosegment: bool,
+    pub(crate) gdb_index: bool,
 
     rpath_set: IndexSet<String>,
 
@@ -233,7 +234,6 @@ const SILENTLY_IGNORED_SHORT_FLAGS: &[&str] = &[
 ];
 
 const IGNORED_FLAGS: &[&str] = &[
-    "gdb-index",
     "fix-cortex-a53-835769",
     "fix-cortex-a53-843419",
     "discard-all",
@@ -332,6 +332,7 @@ impl Default for ElfArgs {
 
             experimental_sframe: false,
             debug_compression_kind: None,
+            gdb_index: false,
         }
     }
 }
@@ -1114,6 +1115,24 @@ fn setup_argument_parser() -> ArgumentParser<ElfArgs> {
                 "zstd" => args.debug_compression_kind = Some(CompressionKind::Zstd),
                 value => bail!("--compress-debug-sections={value}"),
             }
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("gdb-index")
+        .help("Generate GDB index")
+        .execute(|args, _modifier_stack| {
+            args.gdb_index = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("no-gdb-index")
+        .help("Disable GDB index generation")
+        .execute(|args, _modifier_stack| {
+            args.gdb_index = false;
             Ok(())
         });
 
@@ -2056,6 +2075,10 @@ impl platform::Args for ElfArgs {
 
     fn should_output_partial_object(&self) -> bool {
         self.should_output_partial_object
+    }
+
+    fn should_write_gdb_index(&self) -> bool {
+        self.gdb_index
     }
 }
 

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -2100,11 +2100,11 @@ impl platform::Platform for Elf {
         total_sizes.merge(&extra_sizes);
     }
 
-    type GdbIndexScanResult<'data> = crate::gdb_index::GdbIndexScanResult<'data>;
+    type GdbIndexScanResult = crate::gdb_index::GdbIndexScanResult;
 
-    fn compute_gdb_index_size<'data>(
-        groups: &[crate::layout::GroupState<'data, Self>],
-    ) -> crate::error::Result<(u64, Option<Self::GdbIndexScanResult<'data>>)> {
+    fn compute_gdb_index_size(
+        groups: &[crate::layout::GroupState<Self>],
+    ) -> crate::error::Result<(u64, Option<Self::GdbIndexScanResult>)> {
         crate::gdb_index::compute_gdb_index_size(groups)
     }
 

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -1889,6 +1889,7 @@ impl platform::Platform for Elf {
         builder.add_sections(&custom.bss);
 
         builder.add_sections(&custom.nonalloc);
+        builder.add_section(output_section_id::GDB_INDEX);
         builder.add_section(output_section_id::COMMENT);
         builder.add_section(output_section_id::RISCV_ATTRIBUTES);
         builder.add_section(output_section_id::SHSTRTAB);
@@ -2097,6 +2098,10 @@ impl platform::Platform for Elf {
 
         group_sizes.merge(&extra_sizes);
         total_sizes.merge(&extra_sizes);
+    }
+
+    fn compute_gdb_index_size(groups: &[crate::layout::GroupState<Self>]) -> u64 {
+        crate::gdb_index::compute_gdb_index_size(groups)
     }
 
     fn align_load_segment_start(
@@ -4755,6 +4760,11 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
     };
     defs[output_section_id::SYMTAB_SHNDX_GLOBAL.as_usize()] = BuiltInSectionDetails {
         kind: SectionKind::Secondary(output_section_id::SYMTAB_SHNDX_LOCAL),
+        ..DEFAULT_DEFS
+    };
+    defs[output_section_id::GDB_INDEX.as_usize()] = BuiltInSectionDetails {
+        kind: SectionKind::Primary(SectionName(GDB_INDEX_SECTION_NAME)),
+        ty: sht::PROGBITS,
         ..DEFAULT_DEFS
     };
     // Start of regular sections

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -2100,7 +2100,9 @@ impl platform::Platform for Elf {
         total_sizes.merge(&extra_sizes);
     }
 
-    fn compute_gdb_index_size(groups: &[crate::layout::GroupState<Self>]) -> u64 {
+    fn compute_gdb_index_size(
+        groups: &[crate::layout::GroupState<Self>],
+    ) -> crate::error::Result<u64> {
         crate::gdb_index::compute_gdb_index_size(groups)
     }
 

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -2100,9 +2100,11 @@ impl platform::Platform for Elf {
         total_sizes.merge(&extra_sizes);
     }
 
-    fn compute_gdb_index_size(
-        groups: &[crate::layout::GroupState<Self>],
-    ) -> crate::error::Result<u64> {
+    type GdbIndexScanResult<'data> = crate::gdb_index::GdbIndexScanResult<'data>;
+
+    fn compute_gdb_index_size<'data>(
+        groups: &[crate::layout::GroupState<'data, Self>],
+    ) -> crate::error::Result<(u64, Option<Self::GdbIndexScanResult<'data>>)> {
         crate::gdb_index::compute_gdb_index_size(groups)
     }
 

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -321,6 +321,9 @@ fn write_gdb_index_section(output: &mut [u8], layout: &ElfLayout) -> Result {
     if !layout.args().should_write_gdb_index() {
         return Ok(());
     }
+    let Some(scan) = &layout.gdb_index_data else {
+        return Ok(());
+    };
     let sl = layout.section_layouts.get(output_section_id::GDB_INDEX);
     if sl.file_size == 0 {
         return Ok(());
@@ -331,7 +334,7 @@ fn write_gdb_index_section(output: &mut [u8], layout: &ElfLayout) -> Result {
     // and our section is writable.
     let (before, rest) = output.split_at_mut(start);
     let gdb_buf = &mut rest[..sl.file_size];
-    crate::gdb_index::write_gdb_index(gdb_buf, before, layout)
+    crate::gdb_index::write_gdb_index(gdb_buf, before, layout, scan)
 }
 
 fn write_sframe_section(sframe_buffer: &mut [u8], layout: &ElfLayout) -> Result {

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -186,7 +186,7 @@ pub(crate) fn write<'data, A: Arch<Platform = Elf>>(
     }
 
     // Write .gdb_index before splitting, since it needs to read .debug_info from the output.
-    write_gdb_index_section(&mut sized_output.out, layout);
+    write_gdb_index_section(&mut sized_output.out, layout)?;
 
     let mut section_buffers = split_output_into_sections(layout, &mut sized_output.out).0;
 
@@ -316,14 +316,14 @@ fn fill_padding(mut section_buffers: OutputSectionMap<&mut [u8]>) {
     });
 }
 
-fn write_gdb_index_section(output: &mut [u8], layout: &ElfLayout) {
+fn write_gdb_index_section(output: &mut [u8], layout: &ElfLayout) -> Result {
     use crate::platform::Args as _;
     if !layout.args().should_write_gdb_index() {
-        return;
+        return Ok(());
     }
     let sl = layout.section_layouts.get(output_section_id::GDB_INDEX);
     if sl.file_size == 0 {
-        return;
+        return Ok(());
     }
     timing_phase!("Write .gdb_index");
     let start = sl.file_offset;
@@ -331,7 +331,7 @@ fn write_gdb_index_section(output: &mut [u8], layout: &ElfLayout) {
     // and our section is writable.
     let (before, rest) = output.split_at_mut(start);
     let gdb_buf = &mut rest[..sl.file_size];
-    crate::gdb_index::write_gdb_index(gdb_buf, before, layout);
+    crate::gdb_index::write_gdb_index(gdb_buf, before, layout)
 }
 
 fn write_sframe_section(sframe_buffer: &mut [u8], layout: &ElfLayout) -> Result {

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -185,6 +185,9 @@ pub(crate) fn write<'data, A: Arch<Platform = Elf>>(
         crate::validation::validate_bytes(layout, &sized_output.out)?;
     }
 
+    // Write .gdb_index before splitting, since it needs to read .debug_info from the output.
+    write_gdb_index_section(&mut sized_output.out, layout);
+
     let mut section_buffers = split_output_into_sections(layout, &mut sized_output.out).0;
 
     if layout.args().should_write_eh_frame_hdr {
@@ -311,6 +314,24 @@ fn fill_padding(mut section_buffers: OutputSectionMap<&mut [u8]>) {
     section_buffers.for_each_mut(|_, out| {
         out.fill(0);
     });
+}
+
+fn write_gdb_index_section(output: &mut [u8], layout: &ElfLayout) {
+    use crate::platform::Args as _;
+    if !layout.args().should_write_gdb_index() {
+        return;
+    }
+    let sl = layout.section_layouts.get(output_section_id::GDB_INDEX);
+    if sl.file_size == 0 {
+        return;
+    }
+    timing_phase!("Write .gdb_index");
+    let start = sl.file_offset;
+    // Split the output buffer so that the part before our section is readable (for .debug_info)
+    // and our section is writable.
+    let (before, rest) = output.split_at_mut(start);
+    let gdb_buf = &mut rest[..sl.file_size];
+    crate::gdb_index::write_gdb_index(gdb_buf, before, layout);
 }
 
 fn write_sframe_section(sframe_buffer: &mut [u8], layout: &ElfLayout) -> Result {

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -261,7 +261,9 @@ pub(crate) fn compute_gdb_index_size(groups: &[GroupState<'_, Elf>]) -> u64 {
             }
             cu_index_base += boundaries.len() as u32;
 
-            collect_pubnames_symbols(object, &offset_to_idx, base_idx, &mut symbol_map);
+            for_each_pubname_entry(object, &offset_to_idx, base_idx, |name, entry| {
+                symbol_map.entry(name).or_default().push(entry);
+            });
         }
     }
 
@@ -470,25 +472,13 @@ fn build_address_and_symbol_tables<'data>(
             }
             cu_offset += boundaries.len() as u32;
 
-            for section_name in [".debug_gnu_pubnames", ".debug_gnu_pubtypes"] {
-                let Some(data) = raw_section_by_name(object, section_name) else {
-                    continue;
-                };
-                for set in parse_pubnames_sets(data) {
-                    let cu_idx = offset_to_idx
-                        .get(&set.debug_info_offset)
-                        .copied()
-                        .unwrap_or(base);
-                    for (name, attrs) in set.entries {
-                        let entry = encode_cu_vector_entry(cu_idx, attrs);
-                        let sd = sym_map.entry(name).or_insert_with(|| SymData {
-                            cv_entries: Vec::new(),
-                            hash: gdb_hash(name),
-                        });
-                        sd.cv_entries.push(entry);
-                    }
-                }
-            }
+            for_each_pubname_entry(object, &offset_to_idx, base, |name, entry| {
+                let sd = sym_map.entry(name).or_insert_with(|| SymData {
+                    cv_entries: Vec::new(),
+                    hash: gdb_hash(name),
+                });
+                sd.cv_entries.push(entry);
+            });
         }
     }
 
@@ -507,12 +497,13 @@ fn build_address_and_symbol_tables<'data>(
     }
 }
 
-/// Collect pubnames/pubtypes symbols from an object into the global map.
-fn collect_pubnames_symbols<'data>(
+/// Iterate over `.debug_gnu_pubnames` and `.debug_gnu_pubtypes` entries in an object,
+/// calling `on_entry(name, encoded_entry)` for each symbol.
+fn for_each_pubname_entry<'data>(
     object: &crate::elf::File<'data>,
     offset_to_idx: &HashMap<u64, u32>,
     fallback_cu: u32,
-    symbol_map: &mut HashMap<&'data [u8], Vec<u32>>,
+    mut on_entry: impl FnMut(&'data [u8], u32),
 ) {
     for section_name in [".debug_gnu_pubnames", ".debug_gnu_pubtypes"] {
         let Some(data) = raw_section_by_name(object, section_name) else {
@@ -524,8 +515,7 @@ fn collect_pubnames_symbols<'data>(
                 .copied()
                 .unwrap_or(fallback_cu);
             for (name, attrs) in set.entries {
-                let entry = encode_cu_vector_entry(cu_idx, attrs);
-                symbol_map.entry(name).or_default().push(entry);
+                on_entry(name, encode_cu_vector_entry(cu_idx, attrs));
             }
         }
     }

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -228,10 +228,10 @@ pub(crate) fn compute_gdb_index_size(groups: &[GroupState<'_, Elf>]) -> u64 {
             };
             let object = obj.object;
 
-            let obj_cu_count = raw_section_by_name(object, ".debug_info")
-                .map_or(0, |data| parse_cu_boundaries(data).len());
-
-            if obj_cu_count == 0 {
+            let boundaries = raw_section_by_name(object, ".debug_info")
+                .map(parse_cu_boundaries)
+                .unwrap_or_default();
+            if boundaries.is_empty() {
                 continue;
             }
 
@@ -251,17 +251,16 @@ pub(crate) fn compute_gdb_index_size(groups: &[GroupState<'_, Elf>]) -> u64 {
                 }
             }
 
-            total_cus += obj_cu_count;
+            total_cus += boundaries.len();
             total_addr_entries += obj_addr_count;
 
             let base_idx = cu_index_base;
-            let mut offset_to_idx: HashMap<u64, u32> = HashMap::new();
-            if let Some(di_data) = raw_section_by_name(object, ".debug_info") {
-                for (i, cu) in parse_cu_boundaries(di_data).iter().enumerate() {
-                    offset_to_idx.insert(cu.offset, base_idx + i as u32);
-                }
+            let mut offset_to_idx: HashMap<u64, u32> =
+                HashMap::with_capacity(boundaries.len());
+            for (i, cu) in boundaries.iter().enumerate() {
+                offset_to_idx.insert(cu.offset, base_idx + i as u32);
             }
-            cu_index_base += obj_cu_count as u32;
+            cu_index_base += boundaries.len() as u32;
 
             collect_pubnames_symbols(object, &offset_to_idx, base_idx, &mut symbol_map);
         }

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -326,29 +326,26 @@ pub(crate) fn write_gdb_index(buf: &mut [u8], output_buf: &[u8], layout: &Layout
     let short_off = sym_off + (ht_slots * HASH_SLOT_SIZE) as u32;
     let cp_off = short_off + SHORTCUT_TABLE_SIZE as u32;
 
-    // Build constant pool: CU vectors first, then name strings.
-    let mut cv_data = Vec::new();
-    let mut str_data = Vec::new();
+    // Write constant pool: CU vectors first, then name strings.
     let mut cv_offsets = Vec::with_capacity(sorted.len());
-    let mut name_offsets = Vec::with_capacity(sorted.len());
-
+    let mut off = cp_off as usize;
     for (_, sd) in &sorted {
-        cv_offsets.push(cv_data.len() as u32);
-        cv_data.extend_from_slice(&(sd.cv_entries.len() as u32).to_le_bytes());
+        cv_offsets.push((off - cp_off as usize) as u32);
+        buf[off..off + 4].copy_from_slice(&(sd.cv_entries.len() as u32).to_le_bytes());
+        off += 4;
         for &e in &sd.cv_entries {
-            cv_data.extend_from_slice(&e.to_le_bytes());
+            buf[off..off + 4].copy_from_slice(&e.to_le_bytes());
+            off += 4;
         }
     }
+    let mut name_offsets = Vec::with_capacity(sorted.len());
     for (name, _) in &sorted {
-        name_offsets.push((cv_data.len() + str_data.len()) as u32);
-        str_data.extend_from_slice(name);
-        str_data.push(0);
+        name_offsets.push((off - cp_off as usize) as u32);
+        buf[off..off + name.len()].copy_from_slice(name);
+        off += name.len();
+        buf[off] = 0;
+        off += 1;
     }
-
-    // Emit into the output buffer.
-    let total = cp_off as usize + cv_data.len() + str_data.len();
-    let len = buf.len().min(total);
-    let buf = &mut buf[..len];
 
     let hdr = GdbIndexHeader {
         version: GDB_INDEX_VERSION,
@@ -388,10 +385,6 @@ pub(crate) fn write_gdb_index(buf: &mut [u8], output_buf: &[u8], layout: &Layout
         name_of_main_offset: 0,
     };
     buf[so..so + SHORTCUT_TABLE_SIZE].copy_from_slice(sc.as_bytes());
-
-    let cpo = cp_off as usize;
-    buf[cpo..cpo + cv_data.len()].copy_from_slice(&cv_data);
-    buf[cpo + cv_data.len()..cpo + cv_data.len() + str_data.len()].copy_from_slice(&str_data);
 }
 
 /// Build the CU list from the already-written output `.debug_info`.

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -431,13 +431,13 @@ fn scan_objects_for_gdb_index<'data>(
         }
         cu_offset += boundaries.len() as u32;
 
-        for_each_pubname_entry(object, &offset_to_idx, base, |name, entry| {
+        for (name, entry) in collect_pubname_entries(object, &offset_to_idx, base) {
             let sd = sym_map.entry(name).or_insert_with(|| SymData {
                 cv_entries: Vec::new(),
                 hash: gdb_hash(name),
             });
             sd.cv_entries.push(entry);
-        });
+        }
     }
 
     for sd in sym_map.values_mut() {
@@ -507,14 +507,14 @@ fn build_address_entries(layout: &Layout<'_, Elf>) -> Vec<GdbIndexAddressEntry> 
     entries
 }
 
-/// Iterate over `.debug_gnu_pubnames` and `.debug_gnu_pubtypes` entries in an object,
-/// calling `on_entry(name, encoded_entry)` for each symbol.
-fn for_each_pubname_entry<'data>(
+/// Collect encoded pubname/pubtype entries from an object's `.debug_gnu_pubnames`
+/// and `.debug_gnu_pubtypes` sections, returning `(name, encoded_cu_vector_entry)` pairs.
+fn collect_pubname_entries<'data>(
     object: &crate::elf::File<'data>,
     offset_to_idx: &HashMap<u64, u32>,
     fallback_cu: u32,
-    mut on_entry: impl FnMut(&'data [u8], u32),
-) {
+) -> Vec<(&'data [u8], u32)> {
+    let mut entries = Vec::new();
     for section_name in [".debug_gnu_pubnames", ".debug_gnu_pubtypes"] {
         let Some(data) = raw_section_by_name(object, section_name) else {
             continue;
@@ -525,10 +525,11 @@ fn for_each_pubname_entry<'data>(
                 .copied()
                 .unwrap_or(fallback_cu);
             for (name, attrs) in set.entries {
-                on_entry(name, encode_cu_vector_entry(cu_idx, attrs));
+                entries.push((name, encode_cu_vector_entry(cu_idx, attrs)));
             }
         }
     }
+    entries
 }
 
 /// Insert symbols into the open-addressing hash table region of `buf`.

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -116,32 +116,30 @@ struct CuBoundary {
 }
 
 /// Walk `.debug_info` bytes and return `(offset, total_length)` for each CU.
-fn parse_cu_boundaries(data: &[u8]) -> Result<Vec<CuBoundary>> {
+fn parse_cu_boundaries(data: &[u8]) -> Vec<CuBoundary> {
     let mut cus = Vec::new();
     let mut offset = 0usize;
     while offset + 4 <= data.len() {
         let init_len = u32_from_slice(&data[offset..]);
         let total = if init_len == 0xFFFF_FFFF {
-            crate::ensure!(
-                offset + 12 <= data.len(),
-                "truncated DWARF64 initial length in .debug_info at offset {offset:#x}"
-            );
+            if offset + 12 > data.len() {
+                break;
+            }
             let len = u64_from_slice(&data[offset + 4..]);
             12 + len as usize
         } else {
             4 + init_len as usize
         };
-        crate::ensure!(
-            total > 0 && offset + total <= data.len(),
-            "invalid CU length {total} in .debug_info at offset {offset:#x}"
-        );
+        if total == 0 || offset + total > data.len() {
+            break;
+        }
         cus.push(CuBoundary {
             offset: offset as u64,
             length: total as u64,
         });
         offset += total;
     }
-    Ok(cus)
+    cus
 }
 
 struct PubnamesSet<'data> {
@@ -153,7 +151,7 @@ struct PubnamesSet<'data> {
 ///
 /// Each set has a header pointing to a CU in `.debug_info`, followed by
 /// (die_offset, attrs_byte, NUL-terminated name) entries.
-fn parse_pubnames_sets(data: &[u8]) -> Result<Vec<PubnamesSet<'_>>> {
+fn parse_pubnames_sets(data: &[u8]) -> Vec<PubnamesSet<'_>> {
     let mut sets = Vec::new();
     let mut pos = 0;
     while pos + 4 <= data.len() {
@@ -161,19 +159,17 @@ fn parse_pubnames_sets(data: &[u8]) -> Result<Vec<PubnamesSet<'_>>> {
 
         let (header_size, set_end, debug_info_offset) = if init_len == 0xFFFF_FFFF {
             // DWARF64: 4 + 8(len) + 2(ver) + 8(offset) + 8(size) = 30
-            crate::ensure!(
-                pos + 30 <= data.len(),
-                "truncated DWARF64 pubnames header at offset {pos:#x}"
-            );
+            if pos + 30 > data.len() {
+                break;
+            }
             let len = u64_from_slice(&data[pos + 4..]);
             let dio = u64_from_slice(&data[pos + 14..]);
             (30, pos + 12 + len as usize, dio)
         } else {
             // DWARF32: 4(len) + 2(ver) + 4(offset) + 4(size) = 14
-            crate::ensure!(
-                pos + 14 <= data.len(),
-                "truncated DWARF32 pubnames header at offset {pos:#x}"
-            );
+            if pos + 14 > data.len() {
+                break;
+            }
             let dio = u64::from(u32_from_slice(&data[pos + 6..]));
             (14, pos + 4 + init_len as usize, dio)
         };
@@ -185,18 +181,16 @@ fn parse_pubnames_sets(data: &[u8]) -> Result<Vec<PubnamesSet<'_>>> {
 
         while ep < set_end {
             let die_offset = if is_64 {
-                crate::ensure!(
-                    ep + 8 <= set_end,
-                    "truncated DWARF64 pubnames entry at offset {ep:#x}"
-                );
+                if ep + 8 > set_end {
+                    break;
+                }
                 let v = u64_from_slice(&data[ep..]);
                 ep += 8;
                 v
             } else {
-                crate::ensure!(
-                    ep + 4 <= set_end,
-                    "truncated DWARF32 pubnames entry at offset {ep:#x}"
-                );
+                if ep + 4 > set_end {
+                    break;
+                }
                 let v = u64::from(u32_from_slice(&data[ep..]));
                 ep += 4;
                 v
@@ -204,20 +198,18 @@ fn parse_pubnames_sets(data: &[u8]) -> Result<Vec<PubnamesSet<'_>>> {
             if die_offset == 0 {
                 break;
             }
-            crate::ensure!(
-                ep < set_end,
-                "truncated pubnames entry (missing attrs/name) at offset {ep:#x}"
-            );
+            if ep >= set_end {
+                break;
+            }
             let attrs = data[ep];
             ep += 1;
             let name_start = ep;
             while ep < set_end && data[ep] != 0 {
                 ep += 1;
             }
-            crate::ensure!(
-                ep < set_end,
-                "unterminated pubnames name string at offset {name_start:#x}"
-            );
+            if ep >= set_end {
+                break;
+            }
             entries.push((&data[name_start..ep], attrs));
             ep += 1;
         }
@@ -228,7 +220,7 @@ fn parse_pubnames_sets(data: &[u8]) -> Result<Vec<PubnamesSet<'_>>> {
         });
         pos = set_end;
     }
-    Ok(sets)
+    sets
 }
 
 /// Read raw section data from an input object by name.
@@ -398,7 +390,7 @@ fn build_cu_list(output_buf: &[u8], layout: &Layout<'_, Elf>) -> Result<Vec<GdbI
         ".debug_info layout extends beyond output buffer ({end} > {})",
         output_buf.len()
     );
-    Ok(parse_cu_boundaries(&output_buf[start..end])?
+    Ok(parse_cu_boundaries(&output_buf[start..end])
         .into_iter()
         .map(|cu| GdbIndexCuEntry {
             cu_offset: cu.offset,
@@ -430,7 +422,7 @@ fn scan_objects_for_gdb_index<'data>(
 
     for (object, sections) in objects {
         let boundaries = match raw_section_by_name(object, DEBUG_INFO_SECTION_NAME_STR)? {
-            Some(data) => parse_cu_boundaries(data)?,
+            Some(data) => parse_cu_boundaries(data),
             None => continue,
         };
         if boundaries.is_empty() {
@@ -496,10 +488,8 @@ fn build_address_entries(layout: &Layout<'_, Elf>) -> Result<Vec<GdbIndexAddress
             };
             let object = obj.object;
 
-            let obj_cu_count = match raw_section_by_name(object, DEBUG_INFO_SECTION_NAME_STR)? {
-                Some(data) => parse_cu_boundaries(data)?.len() as u32,
-                None => 0,
-            };
+            let obj_cu_count = raw_section_by_name(object, DEBUG_INFO_SECTION_NAME_STR)?
+                .map_or(0, |data| parse_cu_boundaries(data).len() as u32);
             if obj_cu_count == 0 {
                 continue;
             }
@@ -544,7 +534,7 @@ fn collect_pubname_entries<'data>(
         let Some(data) = raw_section_by_name(object, section_name)? else {
             continue;
         };
-        for set in parse_pubnames_sets(data)? {
+        for set in parse_pubnames_sets(data) {
             let Some(&cu_idx) = offset_to_idx.get(&set.debug_info_offset) else {
                 continue;
             };
@@ -633,12 +623,12 @@ mod tests {
 
     #[test]
     fn test_parse_cu_boundaries() {
-        assert!(parse_cu_boundaries(&[]).unwrap().is_empty());
+        assert!(parse_cu_boundaries(&[]).is_empty());
 
         // Single DWARF32 CU: init_length=8, total = 4 + 8 = 12 bytes.
         let mut data = vec![0u8; 12];
         data[0..4].copy_from_slice(&8u32.to_le_bytes());
-        let cus = parse_cu_boundaries(&data).unwrap();
+        let cus = parse_cu_boundaries(&data);
         assert_eq!(cus.len(), 1);
         assert_eq!(cus[0].offset, 0);
         assert_eq!(cus[0].length, 12);

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -302,6 +302,12 @@ pub(crate) fn write_gdb_index(
         ht_slots,
         ..
     } = scan_objects_for_gdb_index(objects)?;
+    if !cu_entries.is_empty() && sorted_names.is_empty() {
+        layout.symbol_db.warning(
+            "Objects lack .debug_gnu_pubnames/.debug_gnu_pubtypes sections, so the symbol table in .gdb_index will be empty. \
+             Compile with -ggnu-pubnames to populate it.",
+        );
+    }
     let addr_entries = build_address_entries(layout)?;
 
     let cu_list_off = HEADER_SIZE as u32;
@@ -364,6 +370,9 @@ pub(crate) fn write_gdb_index(
         &cv_offsets,
     )?;
 
+    // The shortcut table lets GDB quickly determine the language of `main` without scanning the
+    // full index. Filling it requires looking up the DWARF language attribute of the main CU, which
+    // we don't currently do. GDB handles zeroed values here by falling back to its own lookup.
     let so = short_off as usize;
     let sc = GdbIndexShortcutTable {
         language_of_main: 0,

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -15,6 +15,9 @@ use crate::platform::ObjectFile as _;
 use crate::platform::SectionHeader as _;
 use crate::resolution::SectionSlot;
 use hashbrown::HashMap;
+use linker_utils::bit_misc::BitExtraction;
+use linker_utils::utils::u32_from_slice;
+use linker_utils::utils::u64_from_slice;
 use std::mem::size_of;
 use zerocopy::FromBytes;
 use zerocopy::Immutable;
@@ -80,8 +83,9 @@ fn gdb_hash(name: &[u8]) -> u32 {
 /// The attrs byte from `.debug_gnu_pubnames`/`.debug_gnu_pubtypes` packs kind in bits 4-6
 /// and is_static in bit 7.
 fn encode_cu_vector_entry(cu_index: u32, attrs: u8) -> u32 {
-    let kind = u32::from((attrs >> 4) & 0x7);
-    let is_static = u32::from((attrs >> 7) & 0x1);
+    let attrs = u64::from(attrs);
+    let kind = attrs.extract_bit_range(4..7) as u32;
+    let is_static = attrs.extract_bit_range(7..8) as u32;
     (cu_index & 0x00FF_FFFF) | (kind << 28) | (is_static << 31)
 }
 
@@ -103,12 +107,12 @@ fn parse_cu_boundaries(data: &[u8]) -> Vec<CuBoundary> {
     let mut cus = Vec::new();
     let mut offset = 0usize;
     while offset + 4 <= data.len() {
-        let init_len = u32::from_le_bytes(data[offset..offset + 4].try_into().unwrap());
+        let init_len = u32_from_slice(&data[offset..]);
         let total = if init_len == 0xFFFF_FFFF {
             if offset + 12 > data.len() {
                 break;
             }
-            let len = u64::from_le_bytes(data[offset + 4..offset + 12].try_into().unwrap());
+            let len = u64_from_slice(&data[offset + 4..]);
             12 + len as usize
         } else {
             4 + init_len as usize
@@ -138,24 +142,22 @@ fn parse_pubnames_sets(data: &[u8]) -> Vec<PubnamesSet<'_>> {
     let mut sets = Vec::new();
     let mut pos = 0;
     while pos + 4 <= data.len() {
-        let init_len = u32::from_le_bytes(data[pos..pos + 4].try_into().unwrap());
+        let init_len = u32_from_slice(&data[pos..]);
 
         let (header_size, set_end, debug_info_offset) = if init_len == 0xFFFF_FFFF {
             // DWARF64: 4 + 8(len) + 2(ver) + 8(offset) + 8(size) = 30
             if pos + 30 > data.len() {
                 break;
             }
-            let len = u64::from_le_bytes(data[pos + 4..pos + 12].try_into().unwrap());
-            let dio = u64::from_le_bytes(data[pos + 14..pos + 22].try_into().unwrap());
+            let len = u64_from_slice(&data[pos + 4..]);
+            let dio = u64_from_slice(&data[pos + 14..]);
             (30, pos + 12 + len as usize, dio)
         } else {
             // DWARF32: 4(len) + 2(ver) + 4(offset) + 4(size) = 14
             if pos + 14 > data.len() {
                 break;
             }
-            let dio = u64::from(u32::from_le_bytes(
-                data[pos + 6..pos + 10].try_into().unwrap(),
-            ));
+            let dio = u64::from(u32_from_slice(&data[pos + 6..]));
             (14, pos + 4 + init_len as usize, dio)
         };
 
@@ -169,14 +171,14 @@ fn parse_pubnames_sets(data: &[u8]) -> Vec<PubnamesSet<'_>> {
                 if ep + 8 > set_end {
                     break;
                 }
-                let v = u64::from_le_bytes(data[ep..ep + 8].try_into().unwrap());
+                let v = u64_from_slice(&data[ep..]);
                 ep += 8;
                 v
             } else {
                 if ep + 4 > set_end {
                     break;
                 }
-                let v = u64::from(u32::from_le_bytes(data[ep..ep + 4].try_into().unwrap()));
+                let v = u64::from(u32_from_slice(&data[ep..]));
                 ep += 4;
                 v
             };
@@ -539,12 +541,12 @@ fn write_hash_table(
     let mask = (ht_slots - 1) as u32;
     for (i, (_, sd)) in sorted.iter().enumerate() {
         let h = sd.hash;
-        let step = ((h >> 3) & mask) | 1;
+        let step = (h.wrapping_mul(17) & mask) | 1;
         let mut slot = h & mask;
         loop {
             let so = ht_start + slot as usize * HASH_SLOT_SIZE;
-            let existing_name = u32::from_le_bytes(buf[so..so + 4].try_into().unwrap());
-            let existing_vec = u32::from_le_bytes(buf[so + 4..so + 8].try_into().unwrap());
+            let existing_name = u32_from_slice(&buf[so..]);
+            let existing_vec = u32_from_slice(&buf[so + 4..]);
             if existing_name == 0 && existing_vec == 0 {
                 buf[so..so + 4].copy_from_slice(&name_offsets[i].to_le_bytes());
                 buf[so + 4..so + 8].copy_from_slice(&cv_offsets[i].to_le_bytes());

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -25,6 +25,7 @@ use linker_utils::elf::secnames::DEBUG_INFO_SECTION_NAME;
 use linker_utils::elf::secnames::DEBUG_INFO_SECTION_NAME_STR;
 use linker_utils::utils::u32_from_slice;
 use linker_utils::utils::u64_from_slice;
+use object::read::elf::SectionHeader as _;
 use rayon::iter::IntoParallelRefIterator;
 use rayon::iter::ParallelIterator;
 use std::borrow::Cow;
@@ -565,6 +566,14 @@ fn build_address_entries(
             }
             let base_cu = cu_offset;
 
+            // For objects with multiple CUs, build a section_index to local CU index map so each
+            // section is assigned to the correct CU.
+            let section_cu_map = if obj_cu_count > 1 {
+                build_section_cu_map(obj.object, obj_cu_count)?
+            } else {
+                HashMap::new()
+            };
+
             for (si, slot) in obj.sections.iter().enumerate() {
                 let SectionSlot::Loaded(section) = slot else {
                     continue;
@@ -579,10 +588,11 @@ fn build_address_entries(
                 if let Some(addr) = obj.section_resolutions[si].address()
                     && addr != 0
                 {
+                    let local_cu = section_cu_map.get(&si).copied().unwrap_or(0);
                     entries.push(GdbIndexAddressEntry {
                         low_address: addr,
                         high_address: addr + section.size,
-                        cu_index: base_cu,
+                        cu_index: base_cu + local_cu,
                     });
                 }
             }
@@ -591,6 +601,65 @@ fn build_address_entries(
         }
     }
     Ok(entries)
+}
+
+/// Build a mapping from section index to local CU index for an input object with multiple CUs.
+fn build_section_cu_map(
+    object: &crate::elf::File<'_>,
+    cu_count: u32,
+) -> Result<HashMap<usize, u32>> {
+    let boundaries = match section_by_name(object, DEBUG_INFO_SECTION_NAME_STR)? {
+        Some(data) => parse_cu_boundaries(&data)?,
+        None => return Ok(HashMap::new()),
+    };
+    if boundaries.len() != cu_count as usize {
+        return Ok(HashMap::new());
+    }
+
+    // Find the relocation section for .debug_info.
+    let rela_section = object
+        .section_by_name(".rela.debug_info")
+        .or_else(|| object.section_by_name(".rel.debug_info"));
+    let Some((_rela_idx, rela_header)) = rela_section else {
+        return Ok(HashMap::new());
+    };
+
+    let mut map: HashMap<usize, u32> = HashMap::new();
+
+    if let Some((relas, _)) = rela_header.rela(object::LittleEndian, object.data)? {
+        for rela in relas {
+            let offset = object::read::elf::Rela::r_offset(rela, object::LittleEndian);
+            let Some(sym_idx) = object::read::elf::Rela::symbol(rela, object::LittleEndian, false)
+            else {
+                continue;
+            };
+            let symbol = object.symbol(sym_idx)?;
+            let Some(sec_idx) = object.symbol_section(symbol, sym_idx)? else {
+                continue;
+            };
+            // Only record the first mapping for each section (a CU may reference the same
+            // section many times via line tables, address ranges, etc.).
+            if map.contains_key(&sec_idx.0) {
+                continue;
+            }
+            // Find which CU this relocation offset belongs to.
+            if let Some(local_cu) = cu_index_for_offset(&boundaries, offset) {
+                map.insert(sec_idx.0, local_cu);
+            }
+        }
+    }
+
+    Ok(map)
+}
+
+/// Given a relocation offset within `.debug_info`, return the 0-based CU index it falls into.
+fn cu_index_for_offset(boundaries: &[CuBoundary], offset: u64) -> Option<u32> {
+    for (i, cu) in boundaries.iter().enumerate() {
+        if offset >= cu.offset && offset < cu.offset + cu.length {
+            return Some(i as u32);
+        }
+    }
+    None
 }
 
 /// Write the constant pool (CU vectors followed by name strings) into `buf` starting at `cp_start`.

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -574,6 +574,7 @@ fn write_hash_table(
         let h = sd.hash;
         let step = (h.wrapping_mul(17) & mask) | 1;
         let mut slot = h & mask;
+        let initial_slot = slot;
         loop {
             let so = ht_start + slot as usize * HASH_SLOT_SIZE;
             let existing = GdbIndexHashSlot::read_from_bytes(&buf[so..so + HASH_SLOT_SIZE])
@@ -587,6 +588,7 @@ fn write_hash_table(
                 break;
             }
             slot = (slot + step) & mask;
+            crate::ensure!(slot != initial_slot, "gdb_index hash table is full");
         }
     }
     Ok(())

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -6,6 +6,8 @@
 //! Format reference: <https://sourceware.org/gdb/current/onlinedocs/gdb.html/Index-Section-Format.html>
 
 use crate::elf::Elf;
+use crate::error::Context as _;
+use crate::error::Result;
 use crate::layout::FileLayout;
 use crate::layout::FileLayoutState;
 use crate::layout::GroupState;
@@ -222,23 +224,28 @@ fn parse_pubnames_sets(data: &[u8]) -> Vec<PubnamesSet<'_>> {
 }
 
 /// Read raw section data from an input object by name.
-fn raw_section_by_name<'data>(object: &crate::elf::File<'data>, name: &str) -> Option<&'data [u8]> {
-    let (_index, header) = object.section_by_name(name)?;
-    object.raw_section_data(header).ok()
+fn raw_section_by_name<'data>(
+    object: &crate::elf::File<'data>,
+    name: &str,
+) -> Result<Option<&'data [u8]>> {
+    let Some((_index, header)) = object.section_by_name(name) else {
+        return Ok(None);
+    };
+    Ok(Some(object.raw_section_data(header)?))
 }
 
 /// Pre-scan all input objects to compute the `.gdb_index` section size.
-pub(crate) fn compute_gdb_index_size(groups: &[GroupState<'_, Elf>]) -> u64 {
+pub(crate) fn compute_gdb_index_size(groups: &[GroupState<'_, Elf>]) -> Result<u64> {
     let objects = groups.iter().flat_map(|g| g.files.iter()).filter_map(|f| {
         let FileLayoutState::Object(obj) = f else {
             return None;
         };
         Some((obj.object, obj.sections.as_slice()))
     });
-    let scan = scan_objects_for_gdb_index(objects);
+    let scan = scan_objects_for_gdb_index(objects)?;
 
     if scan.total_cus == 0 {
-        return 0;
+        return Ok(0);
     }
 
     let mut cv_bytes = 0usize;
@@ -249,25 +256,29 @@ pub(crate) fn compute_gdb_index_size(groups: &[GroupState<'_, Elf>]) -> u64 {
         str_bytes += name.len() + 1;
     }
 
-    (HEADER_SIZE
+    Ok((HEADER_SIZE
         + scan.total_cus * CU_ENTRY_SIZE
         + scan.total_addr_entries * ADDRESS_ENTRY_SIZE
         + scan.ht_slots * HASH_SLOT_SIZE
         + SHORTCUT_TABLE_SIZE
         + cv_bytes
-        + str_bytes) as u64
+        + str_bytes) as u64)
 }
 
 /// Write the `.gdb_index` section into `buf`.
 ///
 /// Reads the output `.debug_info` (already written into `output_buf`) for the CU list,
 /// and re-scans input objects for address ranges and pubnames/pubtypes symbols.
-pub(crate) fn write_gdb_index(buf: &mut [u8], output_buf: &[u8], layout: &Layout<'_, Elf>) {
+pub(crate) fn write_gdb_index(
+    buf: &mut [u8],
+    output_buf: &[u8],
+    layout: &Layout<'_, Elf>,
+) -> Result {
     if buf.is_empty() {
-        return;
+        return Ok(());
     }
 
-    let cu_entries = build_cu_list(output_buf, layout);
+    let cu_entries = build_cu_list(output_buf, layout)?;
     let objects = layout
         .group_layouts
         .iter()
@@ -282,8 +293,8 @@ pub(crate) fn write_gdb_index(buf: &mut [u8], output_buf: &[u8], layout: &Layout
         sorted_symbols: sorted,
         ht_slots,
         ..
-    } = scan_objects_for_gdb_index(objects);
-    let addr_entries = build_address_entries(layout);
+    } = scan_objects_for_gdb_index(objects)?;
+    let addr_entries = build_address_entries(layout)?;
 
     let cu_list_off = HEADER_SIZE as u32;
     let tu_list_off = cu_list_off + (cu_entries.len() * CU_ENTRY_SIZE) as u32;
@@ -343,7 +354,7 @@ pub(crate) fn write_gdb_index(buf: &mut [u8], output_buf: &[u8], layout: &Layout
         &sorted,
         &name_offsets,
         &cv_offsets,
-    );
+    )?;
 
     let so = short_off as usize;
     let sc = GdbIndexShortcutTable {
@@ -351,29 +362,32 @@ pub(crate) fn write_gdb_index(buf: &mut [u8], output_buf: &[u8], layout: &Layout
         name_of_main_offset: 0,
     };
     buf[so..so + SHORTCUT_TABLE_SIZE].copy_from_slice(sc.as_bytes());
+    Ok(())
 }
 
 /// Build the CU list from the already-written output `.debug_info`.
-fn build_cu_list(output_buf: &[u8], layout: &Layout<'_, Elf>) -> Vec<GdbIndexCuEntry> {
+fn build_cu_list(output_buf: &[u8], layout: &Layout<'_, Elf>) -> Result<Vec<GdbIndexCuEntry>> {
     let Some(id) = layout
         .output_sections
         .section_id_by_name(SectionName(DEBUG_INFO_SECTION_NAME))
     else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
     let sl = layout.section_layouts.get(id);
     let start = sl.file_offset;
     let end = start + sl.file_size;
-    if end > output_buf.len() {
-        return Vec::new();
-    }
-    parse_cu_boundaries(&output_buf[start..end])
+    crate::ensure!(
+        end <= output_buf.len(),
+        ".debug_info layout extends beyond output buffer ({end} > {})",
+        output_buf.len()
+    );
+    Ok(parse_cu_boundaries(&output_buf[start..end])
         .into_iter()
         .map(|cu| GdbIndexCuEntry {
             cu_offset: cu.offset,
             cu_length: cu.length,
         })
-        .collect()
+        .collect())
 }
 
 struct SymData {
@@ -391,16 +405,17 @@ struct GdbIndexScanResult<'data> {
 /// Scan input objects to build the symbol table and count CUs / address entries.
 fn scan_objects_for_gdb_index<'data>(
     objects: impl Iterator<Item = (&'data crate::elf::File<'data>, &'data [SectionSlot])>,
-) -> GdbIndexScanResult<'data> {
+) -> Result<GdbIndexScanResult<'data>> {
     let mut total_cus = 0usize;
     let mut total_addr_entries = 0usize;
     let mut sym_map: HashMap<&'data [u8], SymData> = HashMap::new();
     let mut cu_offset = 0u32;
 
     for (object, sections) in objects {
-        let boundaries = raw_section_by_name(object, DEBUG_INFO_SECTION_NAME_STR)
-            .map(parse_cu_boundaries)
-            .unwrap_or_default();
+        let boundaries = match raw_section_by_name(object, DEBUG_INFO_SECTION_NAME_STR)? {
+            Some(data) => parse_cu_boundaries(data),
+            None => continue,
+        };
         if boundaries.is_empty() {
             continue;
         }
@@ -415,9 +430,7 @@ fn scan_objects_for_gdb_index<'data>(
             if section.size == 0 {
                 continue;
             }
-            let Ok(header) = object.section(object::SectionIndex(si)) else {
-                continue;
-            };
+            let header = object.section(object::SectionIndex(si))?;
             if header.is_alloc() && header.is_executable() {
                 obj_addr_count += 1;
             }
@@ -432,7 +445,7 @@ fn scan_objects_for_gdb_index<'data>(
         }
         cu_offset += boundaries.len() as u32;
 
-        for (name, entry) in collect_pubname_entries(object, &offset_to_idx, base) {
+        for (name, entry) in collect_pubname_entries(object, &offset_to_idx)? {
             let sd = sym_map.entry(name).or_insert_with(|| SymData {
                 cv_entries: BTreeSet::new(),
                 hash: gdb_hash(name),
@@ -446,16 +459,16 @@ fn scan_objects_for_gdb_index<'data>(
         .sorted_unstable_by_key(|(name, _)| *name)
         .collect();
     let ht_slots = compute_hash_table_slots(sorted.len());
-    GdbIndexScanResult {
+    Ok(GdbIndexScanResult {
         total_cus,
         total_addr_entries,
         sorted_symbols: sorted,
         ht_slots,
-    }
+    })
 }
 
 /// Build address entries using resolved addresses from the final layout.
-fn build_address_entries(layout: &Layout<'_, Elf>) -> Vec<GdbIndexAddressEntry> {
+fn build_address_entries(layout: &Layout<'_, Elf>) -> Result<Vec<GdbIndexAddressEntry>> {
     let mut entries = Vec::new();
     let mut cu_offset = 0u32;
 
@@ -466,7 +479,7 @@ fn build_address_entries(layout: &Layout<'_, Elf>) -> Vec<GdbIndexAddressEntry> 
             };
             let object = obj.object;
 
-            let obj_cu_count = raw_section_by_name(object, DEBUG_INFO_SECTION_NAME_STR)
+            let obj_cu_count = raw_section_by_name(object, DEBUG_INFO_SECTION_NAME_STR)?
                 .map_or(0, |data| parse_cu_boundaries(data).len() as u32);
             if obj_cu_count == 0 {
                 continue;
@@ -480,9 +493,7 @@ fn build_address_entries(layout: &Layout<'_, Elf>) -> Vec<GdbIndexAddressEntry> 
                 if section.size == 0 {
                     continue;
                 }
-                let Ok(header) = object.section(object::SectionIndex(si)) else {
-                    continue;
-                };
+                let header = object.section(object::SectionIndex(si))?;
                 if !header.is_alloc() || !header.is_executable() {
                     continue;
                 }
@@ -500,7 +511,7 @@ fn build_address_entries(layout: &Layout<'_, Elf>) -> Vec<GdbIndexAddressEntry> 
             cu_offset += obj_cu_count;
         }
     }
-    entries
+    Ok(entries)
 }
 
 /// Collect encoded pubname/pubtype entries from an object's `.debug_gnu_pubnames`
@@ -508,24 +519,22 @@ fn build_address_entries(layout: &Layout<'_, Elf>) -> Vec<GdbIndexAddressEntry> 
 fn collect_pubname_entries<'data>(
     object: &crate::elf::File<'data>,
     offset_to_idx: &HashMap<u64, u32>,
-    fallback_cu: u32,
-) -> Vec<(&'data [u8], u32)> {
+) -> Result<Vec<(&'data [u8], u32)>> {
     let mut entries = Vec::new();
     for section_name in [".debug_gnu_pubnames", ".debug_gnu_pubtypes"] {
-        let Some(data) = raw_section_by_name(object, section_name) else {
+        let Some(data) = raw_section_by_name(object, section_name)? else {
             continue;
         };
         for set in parse_pubnames_sets(data) {
-            let cu_idx = offset_to_idx
-                .get(&set.debug_info_offset)
-                .copied()
-                .unwrap_or(fallback_cu);
+            let Some(&cu_idx) = offset_to_idx.get(&set.debug_info_offset) else {
+                continue;
+            };
             for (name, attrs) in set.entries {
                 entries.push((name, encode_cu_vector_entry(cu_idx, attrs)));
             }
         }
     }
-    entries
+    Ok(entries)
 }
 
 /// Insert symbols into the open-addressing hash table region of `buf`.
@@ -536,12 +545,12 @@ fn write_hash_table(
     sorted: &[(&[u8], SymData)],
     name_offsets: &[u32],
     cv_offsets: &[u32],
-) {
+) -> Result {
     let ht_end = ht_start + ht_slots * HASH_SLOT_SIZE;
     buf[ht_start..ht_end].fill(0);
 
     if ht_slots == 0 {
-        return;
+        return Ok(());
     }
     let mask = (ht_slots - 1) as u32;
     for (i, (_, sd)) in sorted.iter().enumerate() {
@@ -550,8 +559,8 @@ fn write_hash_table(
         let mut slot = h & mask;
         loop {
             let so = ht_start + slot as usize * HASH_SLOT_SIZE;
-            let existing =
-                GdbIndexHashSlot::read_from_bytes(&buf[so..so + HASH_SLOT_SIZE]).unwrap();
+            let existing = GdbIndexHashSlot::read_from_bytes(&buf[so..so + HASH_SLOT_SIZE])
+                .context("Failed to read .gdb_index hash table slot")?;
             if existing.name_offset == 0 && existing.cu_vector_offset == 0 {
                 let new_slot = GdbIndexHashSlot {
                     name_offset: name_offsets[i],
@@ -563,6 +572,7 @@ fn write_hash_table(
             slot = (slot + step) & mask;
         }
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -116,30 +116,32 @@ struct CuBoundary {
 }
 
 /// Walk `.debug_info` bytes and return `(offset, total_length)` for each CU.
-fn parse_cu_boundaries(data: &[u8]) -> Vec<CuBoundary> {
+fn parse_cu_boundaries(data: &[u8]) -> Result<Vec<CuBoundary>> {
     let mut cus = Vec::new();
     let mut offset = 0usize;
     while offset + 4 <= data.len() {
         let init_len = u32_from_slice(&data[offset..]);
         let total = if init_len == 0xFFFF_FFFF {
-            if offset + 12 > data.len() {
-                break;
-            }
+            crate::ensure!(
+                offset + 12 <= data.len(),
+                "truncated DWARF64 initial length in .debug_info at offset {offset:#x}"
+            );
             let len = u64_from_slice(&data[offset + 4..]);
             12 + len as usize
         } else {
             4 + init_len as usize
         };
-        if total == 0 || offset + total > data.len() {
-            break;
-        }
+        crate::ensure!(
+            total > 0 && offset + total <= data.len(),
+            "invalid CU length {total} in .debug_info at offset {offset:#x}"
+        );
         cus.push(CuBoundary {
             offset: offset as u64,
             length: total as u64,
         });
         offset += total;
     }
-    cus
+    Ok(cus)
 }
 
 struct PubnamesSet<'data> {
@@ -151,7 +153,7 @@ struct PubnamesSet<'data> {
 ///
 /// Each set has a header pointing to a CU in `.debug_info`, followed by
 /// (die_offset, attrs_byte, NUL-terminated name) entries.
-fn parse_pubnames_sets(data: &[u8]) -> Vec<PubnamesSet<'_>> {
+fn parse_pubnames_sets(data: &[u8]) -> Result<Vec<PubnamesSet<'_>>> {
     let mut sets = Vec::new();
     let mut pos = 0;
     while pos + 4 <= data.len() {
@@ -159,17 +161,19 @@ fn parse_pubnames_sets(data: &[u8]) -> Vec<PubnamesSet<'_>> {
 
         let (header_size, set_end, debug_info_offset) = if init_len == 0xFFFF_FFFF {
             // DWARF64: 4 + 8(len) + 2(ver) + 8(offset) + 8(size) = 30
-            if pos + 30 > data.len() {
-                break;
-            }
+            crate::ensure!(
+                pos + 30 <= data.len(),
+                "truncated DWARF64 pubnames header at offset {pos:#x}"
+            );
             let len = u64_from_slice(&data[pos + 4..]);
             let dio = u64_from_slice(&data[pos + 14..]);
             (30, pos + 12 + len as usize, dio)
         } else {
             // DWARF32: 4(len) + 2(ver) + 4(offset) + 4(size) = 14
-            if pos + 14 > data.len() {
-                break;
-            }
+            crate::ensure!(
+                pos + 14 <= data.len(),
+                "truncated DWARF32 pubnames header at offset {pos:#x}"
+            );
             let dio = u64::from(u32_from_slice(&data[pos + 6..]));
             (14, pos + 4 + init_len as usize, dio)
         };
@@ -181,16 +185,18 @@ fn parse_pubnames_sets(data: &[u8]) -> Vec<PubnamesSet<'_>> {
 
         while ep < set_end {
             let die_offset = if is_64 {
-                if ep + 8 > set_end {
-                    break;
-                }
+                crate::ensure!(
+                    ep + 8 <= set_end,
+                    "truncated DWARF64 pubnames entry at offset {ep:#x}"
+                );
                 let v = u64_from_slice(&data[ep..]);
                 ep += 8;
                 v
             } else {
-                if ep + 4 > set_end {
-                    break;
-                }
+                crate::ensure!(
+                    ep + 4 <= set_end,
+                    "truncated DWARF32 pubnames entry at offset {ep:#x}"
+                );
                 let v = u64::from(u32_from_slice(&data[ep..]));
                 ep += 4;
                 v
@@ -198,18 +204,20 @@ fn parse_pubnames_sets(data: &[u8]) -> Vec<PubnamesSet<'_>> {
             if die_offset == 0 {
                 break;
             }
-            if ep >= set_end {
-                break;
-            }
+            crate::ensure!(
+                ep < set_end,
+                "truncated pubnames entry (missing attrs/name) at offset {ep:#x}"
+            );
             let attrs = data[ep];
             ep += 1;
             let name_start = ep;
             while ep < set_end && data[ep] != 0 {
                 ep += 1;
             }
-            if ep >= set_end {
-                break;
-            }
+            crate::ensure!(
+                ep < set_end,
+                "unterminated pubnames name string at offset {name_start:#x}"
+            );
             entries.push((&data[name_start..ep], attrs));
             ep += 1;
         }
@@ -220,7 +228,7 @@ fn parse_pubnames_sets(data: &[u8]) -> Vec<PubnamesSet<'_>> {
         });
         pos = set_end;
     }
-    sets
+    Ok(sets)
 }
 
 /// Read raw section data from an input object by name.
@@ -381,7 +389,7 @@ fn build_cu_list(output_buf: &[u8], layout: &Layout<'_, Elf>) -> Result<Vec<GdbI
         ".debug_info layout extends beyond output buffer ({end} > {})",
         output_buf.len()
     );
-    Ok(parse_cu_boundaries(&output_buf[start..end])
+    Ok(parse_cu_boundaries(&output_buf[start..end])?
         .into_iter()
         .map(|cu| GdbIndexCuEntry {
             cu_offset: cu.offset,
@@ -413,7 +421,7 @@ fn scan_objects_for_gdb_index<'data>(
 
     for (object, sections) in objects {
         let boundaries = match raw_section_by_name(object, DEBUG_INFO_SECTION_NAME_STR)? {
-            Some(data) => parse_cu_boundaries(data),
+            Some(data) => parse_cu_boundaries(data)?,
             None => continue,
         };
         if boundaries.is_empty() {
@@ -479,8 +487,10 @@ fn build_address_entries(layout: &Layout<'_, Elf>) -> Result<Vec<GdbIndexAddress
             };
             let object = obj.object;
 
-            let obj_cu_count = raw_section_by_name(object, DEBUG_INFO_SECTION_NAME_STR)?
-                .map_or(0, |data| parse_cu_boundaries(data).len() as u32);
+            let obj_cu_count = match raw_section_by_name(object, DEBUG_INFO_SECTION_NAME_STR)? {
+                Some(data) => parse_cu_boundaries(data)?.len() as u32,
+                None => 0,
+            };
             if obj_cu_count == 0 {
                 continue;
             }
@@ -525,7 +535,7 @@ fn collect_pubname_entries<'data>(
         let Some(data) = raw_section_by_name(object, section_name)? else {
             continue;
         };
-        for set in parse_pubnames_sets(data) {
+        for set in parse_pubnames_sets(data)? {
             let Some(&cu_idx) = offset_to_idx.get(&set.debug_info_offset) else {
                 continue;
             };
@@ -614,12 +624,12 @@ mod tests {
 
     #[test]
     fn test_parse_cu_boundaries() {
-        assert!(parse_cu_boundaries(&[]).is_empty());
+        assert!(parse_cu_boundaries(&[]).unwrap().is_empty());
 
         // Single DWARF32 CU: init_length=8, total = 4 + 8 = 12 bytes.
         let mut data = vec![0u8; 12];
         data[0..4].copy_from_slice(&8u32.to_le_bytes());
-        let cus = parse_cu_boundaries(&data);
+        let cus = parse_cu_boundaries(&data).unwrap();
         assert_eq!(cus.len(), 1);
         assert_eq!(cus[0].offset, 0);
         assert_eq!(cus[0].length, 12);

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -64,7 +64,14 @@ const HEADER_SIZE: usize = size_of::<GdbIndexHeader>();
 const CU_ENTRY_SIZE: usize = size_of::<GdbIndexCuEntry>();
 const ADDRESS_ENTRY_SIZE: usize = size_of::<GdbIndexAddressEntry>();
 const SHORTCUT_TABLE_SIZE: usize = size_of::<GdbIndexShortcutTable>();
-const HASH_SLOT_SIZE: usize = 8; // (name_offset, cu_vector_offset) pair
+#[derive(Debug, Clone, Copy, FromBytes, Immutable, IntoBytes, KnownLayout)]
+#[repr(C, packed)]
+struct GdbIndexHashSlot {
+    name_offset: u32,
+    cu_vector_offset: u32,
+}
+
+const HASH_SLOT_SIZE: usize = size_of::<GdbIndexHashSlot>();
 
 /// The GDB index hash function.
 fn gdb_hash(name: &[u8]) -> u32 {
@@ -545,11 +552,14 @@ fn write_hash_table(
         let mut slot = h & mask;
         loop {
             let so = ht_start + slot as usize * HASH_SLOT_SIZE;
-            let existing_name = u32_from_slice(&buf[so..]);
-            let existing_vec = u32_from_slice(&buf[so + 4..]);
-            if existing_name == 0 && existing_vec == 0 {
-                buf[so..so + 4].copy_from_slice(&name_offsets[i].to_le_bytes());
-                buf[so + 4..so + 8].copy_from_slice(&cv_offsets[i].to_le_bytes());
+            let existing =
+                GdbIndexHashSlot::read_from_bytes(&buf[so..so + HASH_SLOT_SIZE]).unwrap();
+            if existing.name_offset == 0 && existing.cu_vector_offset == 0 {
+                let new_slot = GdbIndexHashSlot {
+                    name_offset: name_offsets[i],
+                    cu_vector_offset: cv_offsets[i],
+                };
+                buf[so..so + HASH_SLOT_SIZE].copy_from_slice(new_slot.as_bytes());
                 break;
             }
             slot = (slot + step) & mask;

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -27,6 +27,7 @@ use linker_utils::utils::u32_from_slice;
 use linker_utils::utils::u64_from_slice;
 use rayon::iter::IntoParallelRefIterator;
 use rayon::iter::ParallelIterator;
+use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::mem::size_of;
 use zerocopy::FromBytes;
@@ -230,19 +231,19 @@ fn parse_pubnames_sets(data: &[u8]) -> Vec<PubnamesSet<'_>> {
     sets
 }
 
-/// Read raw section data from an input object by name.
-fn raw_section_by_name<'data>(
+/// Read section data from an input object by name.
+fn section_by_name<'data>(
     object: &crate::elf::File<'data>,
     name: &str,
-) -> Result<Option<&'data [u8]>> {
+) -> Result<Option<Cow<'data, [u8]>>> {
     let Some((_index, header)) = object.section_by_name(name) else {
         return Ok(None);
     };
-    Ok(Some(object.raw_section_data(header)?))
+    Ok(Some(object.section_data_cow(header)?))
 }
 
 /// Compute the size from a scan result.
-fn gdb_index_size_from_scan(scan: &GdbIndexScanResult<'_>) -> u64 {
+fn gdb_index_size_from_scan(scan: &GdbIndexScanResult) -> u64 {
     if scan.total_cus == 0 {
         return 0;
     }
@@ -266,9 +267,9 @@ fn gdb_index_size_from_scan(scan: &GdbIndexScanResult<'_>) -> u64 {
 
 /// Pre-scan all input objects to compute the `.gdb_index` section size and return the scan result
 /// for later use during the write phase.
-pub(crate) fn compute_gdb_index_size<'data>(
-    groups: &[GroupState<'data, Elf>],
-) -> Result<(u64, Option<GdbIndexScanResult<'data>>)> {
+pub(crate) fn compute_gdb_index_size(
+    groups: &[GroupState<'_, Elf>],
+) -> Result<(u64, Option<GdbIndexScanResult>)> {
     timing_phase!("Compute GDB index size");
 
     let objects: Vec<_> = groups
@@ -299,7 +300,7 @@ pub(crate) fn write_gdb_index(
     buf: &mut [u8],
     output_buf: &[u8],
     layout: &Layout<'_, Elf>,
-    scan: &GdbIndexScanResult<'_>,
+    scan: &GdbIndexScanResult,
 ) -> Result {
     if buf.is_empty() {
         return Ok(());
@@ -399,10 +400,10 @@ struct SymData {
     hash: u32,
 }
 
-pub(crate) struct GdbIndexScanResult<'data> {
+pub(crate) struct GdbIndexScanResult {
     total_cus: usize,
     total_addr_entries: usize,
-    sorted_symbols: Vec<(&'data [u8], SymData)>,
+    sorted_symbols: Vec<(Vec<u8>, SymData)>,
     ht_slots: usize,
     /// CU count for each object that has debug info, in input order. Used by
     /// `build_address_entries` to assign global CU indices.
@@ -410,20 +411,21 @@ pub(crate) struct GdbIndexScanResult<'data> {
 }
 
 /// Result of scanning a single input object for GDB index data.
-struct PerObjectGdbScan<'data> {
+struct PerObjectGdbScan {
     num_cus: usize,
     num_addr_entries: usize,
     /// `(name, local_cu_index, attrs)`. CU index is 0-based within this object.
-    symbol_entries: Vec<(&'data [u8], u32, u8)>,
+    /// Names are owned because section data may have been decompressed.
+    symbol_entries: Vec<(Vec<u8>, u32, u8)>,
 }
 
 /// Scan a single input object, returning per-object GDB index data with 0-based CU indices.
-fn scan_one_object<'data>(
-    object: &crate::elf::File<'data>,
+fn scan_one_object(
+    object: &crate::elf::File<'_>,
     sections: &[SectionSlot],
-) -> Result<Option<PerObjectGdbScan<'data>>> {
-    let boundaries = match raw_section_by_name(object, DEBUG_INFO_SECTION_NAME_STR)? {
-        Some(data) => parse_cu_boundaries(data),
+) -> Result<Option<PerObjectGdbScan>> {
+    let boundaries = match section_by_name(object, DEBUG_INFO_SECTION_NAME_STR)? {
+        Some(data) => parse_cu_boundaries(&data),
         None => return Ok(None),
     };
     if boundaries.is_empty() {
@@ -453,15 +455,15 @@ fn scan_one_object<'data>(
     // Collect raw pubname entries with local CU indices and raw attrs.
     let mut symbol_entries = Vec::new();
     for section_name in [".debug_gnu_pubnames", ".debug_gnu_pubtypes"] {
-        let Some(data) = raw_section_by_name(object, section_name)? else {
+        let Some(data) = section_by_name(object, section_name)? else {
             continue;
         };
-        for set in parse_pubnames_sets(data) {
+        for set in parse_pubnames_sets(&data) {
             let Some(&local_cu_idx) = offset_to_idx.get(&set.debug_info_offset) else {
                 continue;
             };
             for (name, attrs) in set.entries {
-                symbol_entries.push((name, local_cu_idx, attrs));
+                symbol_entries.push((name.to_vec(), local_cu_idx, attrs));
             }
         }
     }
@@ -474,14 +476,12 @@ fn scan_one_object<'data>(
 }
 
 /// Merge per-object scan results into a single `GdbIndexScanResult`, assigning global CU indices.
-fn merge_gdb_index_scans<'data>(
-    per_object: Vec<Option<PerObjectGdbScan<'data>>>,
-) -> GdbIndexScanResult<'data> {
+fn merge_gdb_index_scans(per_object: Vec<Option<PerObjectGdbScan>>) -> GdbIndexScanResult {
     timing_phase!("Merge GDB index scans");
 
     let mut total_cus = 0usize;
     let mut total_addr_entries = 0usize;
-    let mut sym_map: HashMap<&'data [u8], SymData> = HashMap::new();
+    let mut sym_map: HashMap<Vec<u8>, SymData> = HashMap::new();
     let mut per_object_cu_counts = Vec::new();
 
     for scan in per_object {
@@ -496,7 +496,7 @@ fn merge_gdb_index_scans<'data>(
 
         for (name, local_cu_idx, attrs) in scan.symbol_entries {
             let entry = encode_cu_vector_entry(base + local_cu_idx, attrs);
-            let sd = sym_map.entry(name).or_insert_with(|| SymData {
+            let sd = sym_map.entry(name).or_insert_with_key(|name| SymData {
                 cv_entries: BTreeSet::new(),
                 hash: gdb_hash(name),
             });
@@ -504,9 +504,9 @@ fn merge_gdb_index_scans<'data>(
         }
     }
 
-    let sorted: Vec<(&[u8], SymData)> = sym_map
+    let sorted: Vec<(Vec<u8>, SymData)> = sym_map
         .into_iter()
-        .sorted_unstable_by_key(|(name, _)| *name)
+        .sorted_unstable_by(|(a, _), (b, _)| a.cmp(b))
         .collect();
     let ht_slots = compute_hash_table_slots(sorted.len());
 
@@ -520,9 +520,9 @@ fn merge_gdb_index_scans<'data>(
 }
 
 /// Scan all input objects in parallel to build the GDB index symbol table.
-fn scan_objects_for_gdb_index<'data>(
-    objects: &[(&'data crate::elf::File<'data>, &[SectionSlot])],
-) -> Result<GdbIndexScanResult<'data>> {
+fn scan_objects_for_gdb_index(
+    objects: &[(&crate::elf::File<'_>, &[SectionSlot])],
+) -> Result<GdbIndexScanResult> {
     timing_phase!("Scan objects for GDB index");
 
     let per_object: Result<Vec<_>> = objects
@@ -586,7 +586,7 @@ fn build_address_entries(
 fn write_constant_pool(
     buf: &mut [u8],
     cp_start: usize,
-    sorted: &[(&[u8], SymData)],
+    sorted: &[(Vec<u8>, SymData)],
 ) -> (Vec<u32>, Vec<u32>) {
     let mut cv_offsets = Vec::with_capacity(sorted.len());
     let mut off = cp_start;
@@ -615,7 +615,7 @@ fn write_hash_table(
     buf: &mut [u8],
     ht_slots: usize,
     ht_start: usize,
-    sorted: &[(&[u8], SymData)],
+    sorted: &[(Vec<u8>, SymData)],
     name_offsets: &[u32],
     cv_offsets: &[u32],
 ) -> Result {

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -228,77 +228,30 @@ fn raw_section_by_name<'data>(object: &crate::elf::File<'data>, name: &str) -> O
 
 /// Pre-scan all input objects to compute the `.gdb_index` section size.
 pub(crate) fn compute_gdb_index_size(groups: &[GroupState<'_, Elf>]) -> u64 {
-    let mut total_cus = 0usize;
-    let mut total_addr_entries = 0usize;
-    let mut symbol_map: HashMap<&[u8], Vec<u32>> = HashMap::new();
-    let mut cu_index_base = 0u32;
+    let objects = groups.iter().flat_map(|g| g.files.iter()).filter_map(|f| {
+        let FileLayoutState::Object(obj) = f else {
+            return None;
+        };
+        Some((obj.object, obj.sections.as_slice()))
+    });
+    let scan = scan_objects_for_gdb_index(objects);
 
-    for group in groups {
-        for file in &group.files {
-            let FileLayoutState::Object(obj) = file else {
-                continue;
-            };
-            let object = obj.object;
-
-            let boundaries = raw_section_by_name(object, DEBUG_INFO_SECTION_NAME_STR)
-                .map(parse_cu_boundaries)
-                .unwrap_or_default();
-            if boundaries.is_empty() {
-                continue;
-            }
-
-            let mut obj_addr_count = 0usize;
-            for (si, slot) in obj.sections.iter().enumerate() {
-                let SectionSlot::Loaded(section) = slot else {
-                    continue;
-                };
-                if section.size == 0 {
-                    continue;
-                }
-                let Ok(header) = object.section(object::SectionIndex(si)) else {
-                    continue;
-                };
-                if header.is_alloc() && header.is_executable() {
-                    obj_addr_count += 1;
-                }
-            }
-
-            total_cus += boundaries.len();
-            total_addr_entries += obj_addr_count;
-
-            let base_idx = cu_index_base;
-            let mut offset_to_idx: HashMap<u64, u32> = HashMap::with_capacity(boundaries.len());
-            for (i, cu) in boundaries.iter().enumerate() {
-                offset_to_idx.insert(cu.offset, base_idx + i as u32);
-            }
-            cu_index_base += boundaries.len() as u32;
-
-            for_each_pubname_entry(object, &offset_to_idx, base_idx, |name, entry| {
-                symbol_map.entry(name).or_default().push(entry);
-            });
-        }
-    }
-
-    if total_cus == 0 {
+    if scan.total_cus == 0 {
         return 0;
     }
 
     let mut cv_bytes = 0usize;
     let mut str_bytes = 0usize;
-    for (name, entries) in &mut symbol_map {
-        entries.sort_unstable();
-        entries.dedup();
+    for (name, sd) in &scan.sorted_symbols {
         // 4 bytes for the entry count, then 4 bytes per entry.
-        cv_bytes += 4 + entries.len() * 4;
+        cv_bytes += 4 + sd.cv_entries.len() * 4;
         str_bytes += name.len() + 1;
     }
 
-    let ht_slots = compute_hash_table_slots(symbol_map.len());
-
     (HEADER_SIZE
-        + total_cus * CU_ENTRY_SIZE
-        + total_addr_entries * ADDRESS_ENTRY_SIZE
-        + ht_slots * HASH_SLOT_SIZE
+        + scan.total_cus * CU_ENTRY_SIZE
+        + scan.total_addr_entries * ADDRESS_ENTRY_SIZE
+        + scan.ht_slots * HASH_SLOT_SIZE
         + SHORTCUT_TABLE_SIZE
         + cv_bytes
         + str_bytes) as u64
@@ -314,11 +267,22 @@ pub(crate) fn write_gdb_index(buf: &mut [u8], output_buf: &[u8], layout: &Layout
     }
 
     let cu_entries = build_cu_list(output_buf, layout);
-    let AddressAndSymbolData {
-        addr_entries,
+    let objects = layout
+        .group_layouts
+        .iter()
+        .flat_map(|g| g.files.iter())
+        .filter_map(|f| {
+            let FileLayout::Object(obj) = f else {
+                return None;
+            };
+            Some((obj.object, obj.sections.as_slice()))
+        });
+    let GdbIndexScanResult {
         sorted_symbols: sorted,
         ht_slots,
-    } = build_address_and_symbol_tables(layout);
+        ..
+    } = scan_objects_for_gdb_index(objects);
+    let addr_entries = build_address_entries(layout);
 
     let cu_list_off = HEADER_SIZE as u32;
     let tu_list_off = cu_list_off + (cu_entries.len() * CU_ENTRY_SIZE) as u32;
@@ -416,18 +380,87 @@ struct SymData {
     hash: u32,
 }
 
-struct AddressAndSymbolData<'data> {
-    addr_entries: Vec<GdbIndexAddressEntry>,
+struct GdbIndexScanResult<'data> {
+    total_cus: usize,
+    total_addr_entries: usize,
     sorted_symbols: Vec<(&'data [u8], SymData)>,
     ht_slots: usize,
 }
 
-/// Build address entries and symbol table in a single pass over input objects.
-fn build_address_and_symbol_tables<'data>(
-    layout: &'data Layout<'_, Elf>,
-) -> AddressAndSymbolData<'data> {
-    let mut addr_entries = Vec::new();
+/// Scan input objects to build the symbol table and count CUs / address entries.
+fn scan_objects_for_gdb_index<'data>(
+    objects: impl Iterator<Item = (&'data crate::elf::File<'data>, &'data [SectionSlot])>,
+) -> GdbIndexScanResult<'data> {
+    let mut total_cus = 0usize;
+    let mut total_addr_entries = 0usize;
     let mut sym_map: HashMap<&'data [u8], SymData> = HashMap::new();
+    let mut cu_offset = 0u32;
+
+    for (object, sections) in objects {
+        let boundaries = raw_section_by_name(object, DEBUG_INFO_SECTION_NAME_STR)
+            .map(parse_cu_boundaries)
+            .unwrap_or_default();
+        if boundaries.is_empty() {
+            continue;
+        }
+
+        let base = cu_offset;
+
+        let mut obj_addr_count = 0usize;
+        for (si, slot) in sections.iter().enumerate() {
+            let SectionSlot::Loaded(section) = slot else {
+                continue;
+            };
+            if section.size == 0 {
+                continue;
+            }
+            let Ok(header) = object.section(object::SectionIndex(si)) else {
+                continue;
+            };
+            if header.is_alloc() && header.is_executable() {
+                obj_addr_count += 1;
+            }
+        }
+
+        total_cus += boundaries.len();
+        total_addr_entries += obj_addr_count;
+
+        let mut offset_to_idx: HashMap<u64, u32> = HashMap::with_capacity(boundaries.len());
+        for (i, cu) in boundaries.iter().enumerate() {
+            offset_to_idx.insert(cu.offset, base + i as u32);
+        }
+        cu_offset += boundaries.len() as u32;
+
+        for_each_pubname_entry(object, &offset_to_idx, base, |name, entry| {
+            let sd = sym_map.entry(name).or_insert_with(|| SymData {
+                cv_entries: Vec::new(),
+                hash: gdb_hash(name),
+            });
+            sd.cv_entries.push(entry);
+        });
+    }
+
+    for sd in sym_map.values_mut() {
+        sd.cv_entries.sort_unstable();
+        sd.cv_entries.dedup();
+    }
+
+    let sorted: Vec<(&[u8], SymData)> = sym_map
+        .into_iter()
+        .sorted_unstable_by_key(|(name, _)| *name)
+        .collect();
+    let ht_slots = compute_hash_table_slots(sorted.len());
+    GdbIndexScanResult {
+        total_cus,
+        total_addr_entries,
+        sorted_symbols: sorted,
+        ht_slots,
+    }
+}
+
+/// Build address entries using resolved addresses from the final layout.
+fn build_address_entries(layout: &Layout<'_, Elf>) -> Vec<GdbIndexAddressEntry> {
+    let mut entries = Vec::new();
     let mut cu_offset = 0u32;
 
     for group in &layout.group_layouts {
@@ -437,16 +470,13 @@ fn build_address_and_symbol_tables<'data>(
             };
             let object = obj.object;
 
-            let boundaries = raw_section_by_name(object, DEBUG_INFO_SECTION_NAME_STR)
-                .map(parse_cu_boundaries)
-                .unwrap_or_default();
-            if boundaries.is_empty() {
+            let obj_cu_count = raw_section_by_name(object, DEBUG_INFO_SECTION_NAME_STR)
+                .map_or(0, |data| parse_cu_boundaries(data).len() as u32);
+            if obj_cu_count == 0 {
                 continue;
             }
+            let base_cu = cu_offset;
 
-            let base = cu_offset;
-
-            // Address entries: map each executable section to its resolved address.
             for (si, slot) in obj.sections.iter().enumerate() {
                 let SectionSlot::Loaded(section) = slot else {
                     continue;
@@ -463,46 +493,18 @@ fn build_address_and_symbol_tables<'data>(
                 if let Some(addr) = obj.section_resolutions[si].address()
                     && addr != 0
                 {
-                    addr_entries.push(GdbIndexAddressEntry {
+                    entries.push(GdbIndexAddressEntry {
                         low_address: addr,
                         high_address: addr + section.size,
-                        cu_index: base,
+                        cu_index: base_cu,
                     });
                 }
             }
 
-            // Symbol table: collect from pubnames/pubtypes.
-            let mut offset_to_idx: HashMap<u64, u32> = HashMap::with_capacity(boundaries.len());
-            for (i, cu) in boundaries.iter().enumerate() {
-                offset_to_idx.insert(cu.offset, base + i as u32);
-            }
-            cu_offset += boundaries.len() as u32;
-
-            for_each_pubname_entry(object, &offset_to_idx, base, |name, entry| {
-                let sd = sym_map.entry(name).or_insert_with(|| SymData {
-                    cv_entries: Vec::new(),
-                    hash: gdb_hash(name),
-                });
-                sd.cv_entries.push(entry);
-            });
+            cu_offset += obj_cu_count;
         }
     }
-
-    for sd in sym_map.values_mut() {
-        sd.cv_entries.sort_unstable();
-        sd.cv_entries.dedup();
-    }
-
-    let sorted: Vec<(&[u8], SymData)> = sym_map
-        .into_iter()
-        .sorted_unstable_by_key(|(name, _)| *name)
-        .collect();
-    let ht_slots = compute_hash_table_slots(sorted.len());
-    AddressAndSymbolData {
-        addr_entries,
-        sorted_symbols: sorted,
-        ht_slots,
-    }
+    entries
 }
 
 /// Iterate over `.debug_gnu_pubnames` and `.debug_gnu_pubtypes` entries in an object,

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -124,30 +124,32 @@ struct CuBoundary {
 ///
 /// Each CU starts with an initial length field (§7.5.1.1) encoded per §7.4: a 4-byte value, or
 /// `0xFFFF_FFFF` followed by an 8-byte length for DWARF-64.
-fn parse_cu_boundaries(data: &[u8]) -> Vec<CuBoundary> {
+fn parse_cu_boundaries(data: &[u8]) -> Result<Vec<CuBoundary>> {
     let mut cus = Vec::new();
     let mut offset = 0usize;
     while offset + 4 <= data.len() {
         let init_len = u32_from_slice(&data[offset..]);
         let total = if init_len == 0xFFFF_FFFF {
-            if offset + 12 > data.len() {
-                break;
-            }
+            crate::ensure!(
+                offset + 12 <= data.len(),
+                "Truncated DWARF64 initial length in .debug_info at offset {offset}"
+            );
             let len = u64_from_slice(&data[offset + 4..]);
             12 + len as usize
         } else {
             4 + init_len as usize
         };
-        if total == 0 || offset + total > data.len() {
-            break;
-        }
+        crate::ensure!(
+            total > 0 && offset + total <= data.len(),
+            "Invalid CU length {total} in .debug_info at offset {offset}"
+        );
         cus.push(CuBoundary {
             offset: offset as u64,
             length: total as u64,
         });
         offset += total;
     }
-    cus
+    Ok(cus)
 }
 
 struct PubnamesSet<'data> {
@@ -158,8 +160,11 @@ struct PubnamesSet<'data> {
 /// Parse `.debug_gnu_pubnames` / `.debug_gnu_pubtypes` section data.
 ///
 /// Each set has a header pointing to a CU in `.debug_info`, followed by
-/// (die_offset, attrs_byte, NUL-terminated name) entries.
-fn parse_pubnames_sets(data: &[u8]) -> Vec<PubnamesSet<'_>> {
+/// (die_offset, attrs_byte, NUL-terminated name) entries terminated by a zero die_offset.
+fn parse_pubnames_sets<'data>(
+    data: &'data [u8],
+    section_name: &str,
+) -> Result<Vec<PubnamesSet<'data>>> {
     let mut sets = Vec::new();
     let mut pos = 0;
     while pos + 4 <= data.len() {
@@ -167,17 +172,19 @@ fn parse_pubnames_sets(data: &[u8]) -> Vec<PubnamesSet<'_>> {
 
         let (header_size, set_end, debug_info_offset) = if init_len == 0xFFFF_FFFF {
             // DWARF64: 4 + 8(len) + 2(ver) + 8(offset) + 8(size) = 30
-            if pos + 30 > data.len() {
-                break;
-            }
+            crate::ensure!(
+                pos + 30 <= data.len(),
+                "Truncated DWARF64 header in {section_name} at offset {pos}"
+            );
             let len = u64_from_slice(&data[pos + 4..]);
             let dio = u64_from_slice(&data[pos + 14..]);
             (30, pos + 12 + len as usize, dio)
         } else {
             // DWARF32: 4(len) + 2(ver) + 4(offset) + 4(size) = 14
-            if pos + 14 > data.len() {
-                break;
-            }
+            crate::ensure!(
+                pos + 14 <= data.len(),
+                "Truncated DWARF32 header in {section_name} at offset {pos}"
+            );
             let dio = u64::from(u32_from_slice(&data[pos + 6..]));
             (14, pos + 4 + init_len as usize, dio)
         };
@@ -189,16 +196,18 @@ fn parse_pubnames_sets(data: &[u8]) -> Vec<PubnamesSet<'_>> {
 
         while ep < set_end {
             let die_offset = if is_64 {
-                if ep + 8 > set_end {
-                    break;
-                }
+                crate::ensure!(
+                    ep + 8 <= set_end,
+                    "Truncated die offset in {section_name} at offset {ep}"
+                );
                 let v = u64_from_slice(&data[ep..]);
                 ep += 8;
                 v
             } else {
-                if ep + 4 > set_end {
-                    break;
-                }
+                crate::ensure!(
+                    ep + 4 <= set_end,
+                    "Truncated die offset in {section_name} at offset {ep}"
+                );
                 let v = u64::from(u32_from_slice(&data[ep..]));
                 ep += 4;
                 v
@@ -206,18 +215,20 @@ fn parse_pubnames_sets(data: &[u8]) -> Vec<PubnamesSet<'_>> {
             if die_offset == 0 {
                 break;
             }
-            if ep >= set_end {
-                break;
-            }
+            crate::ensure!(
+                ep < set_end,
+                "Missing attrs byte in {section_name} at offset {ep}"
+            );
             let attrs = data[ep];
             ep += 1;
             let name_start = ep;
             while ep < set_end && data[ep] != 0 {
                 ep += 1;
             }
-            if ep >= set_end {
-                break;
-            }
+            crate::ensure!(
+                ep < set_end,
+                "Unterminated name in {section_name} at offset {name_start}"
+            );
             entries.push((&data[name_start..ep], attrs));
             ep += 1;
         }
@@ -228,7 +239,7 @@ fn parse_pubnames_sets(data: &[u8]) -> Vec<PubnamesSet<'_>> {
         });
         pos = set_end;
     }
-    sets
+    Ok(sets)
 }
 
 /// Read section data from an input object by name.
@@ -386,7 +397,7 @@ fn build_cu_list(output_buf: &[u8], layout: &Layout<'_, Elf>) -> Result<Vec<GdbI
         ".debug_info layout extends beyond output buffer ({end} > {})",
         output_buf.len()
     );
-    Ok(parse_cu_boundaries(&output_buf[start..end])
+    Ok(parse_cu_boundaries(&output_buf[start..end])?
         .into_iter()
         .map(|cu| GdbIndexCuEntry {
             cu_offset: cu.offset,
@@ -425,7 +436,7 @@ fn scan_one_object(
     sections: &[SectionSlot],
 ) -> Result<Option<PerObjectGdbScan>> {
     let boundaries = match section_by_name(object, DEBUG_INFO_SECTION_NAME_STR)? {
-        Some(data) => parse_cu_boundaries(&data),
+        Some(data) => parse_cu_boundaries(&data)?,
         None => return Ok(None),
     };
     if boundaries.is_empty() {
@@ -458,7 +469,7 @@ fn scan_one_object(
         let Some(data) = section_by_name(object, section_name)? else {
             continue;
         };
-        for set in parse_pubnames_sets(&data) {
+        for set in parse_pubnames_sets(&data, section_name)? {
             let Some(&local_cu_idx) = offset_to_idx.get(&set.debug_info_offset) else {
                 continue;
             };
@@ -690,12 +701,12 @@ mod tests {
 
     #[test]
     fn test_parse_cu_boundaries() {
-        assert!(parse_cu_boundaries(&[]).is_empty());
+        assert!(parse_cu_boundaries(&[]).unwrap().is_empty());
 
         // Single DWARF32 CU: init_length=8, total = 4 + 8 = 12 bytes.
         let mut data = vec![0u8; 12];
         data[0..4].copy_from_slice(&8u32.to_le_bytes());
-        let cus = parse_cu_boundaries(&data);
+        let cus = parse_cu_boundaries(&data).unwrap();
         assert_eq!(cus.len(), 1);
         assert_eq!(cus[0].offset, 0);
         assert_eq!(cus[0].length, 12);

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -290,7 +290,7 @@ pub(crate) fn write_gdb_index(
             Some((obj.object, obj.sections.as_slice()))
         });
     let GdbIndexScanResult {
-        sorted_symbols: sorted,
+        sorted_symbols: sorted_names,
         ht_slots,
         ..
     } = scan_objects_for_gdb_index(objects)?;
@@ -304,9 +304,9 @@ pub(crate) fn write_gdb_index(
     let cp_off = short_off + SHORTCUT_TABLE_SIZE as u32;
 
     // Write constant pool: CU vectors first, then name strings.
-    let mut cv_offsets = Vec::with_capacity(sorted.len());
+    let mut cv_offsets = Vec::with_capacity(sorted_names.len());
     let mut off = cp_off as usize;
-    for (_, sd) in &sorted {
+    for (_, sd) in &sorted_names {
         cv_offsets.push((off - cp_off as usize) as u32);
         buf[off..off + 4].copy_from_slice(&(sd.cv_entries.len() as u32).to_le_bytes());
         off += 4;
@@ -315,8 +315,8 @@ pub(crate) fn write_gdb_index(
             off += 4;
         }
     }
-    let mut name_offsets = Vec::with_capacity(sorted.len());
-    for (name, _) in &sorted {
+    let mut name_offsets = Vec::with_capacity(sorted_names.len());
+    for (name, _) in &sorted_names {
         name_offsets.push((off - cp_off as usize) as u32);
         buf[off..off + name.len()].copy_from_slice(name);
         off += name.len();
@@ -351,7 +351,7 @@ pub(crate) fn write_gdb_index(
         buf,
         ht_slots,
         sym_off as usize,
-        &sorted,
+        &sorted_names,
         &name_offsets,
         &cv_offsets,
     )?;

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -16,6 +16,7 @@ use crate::output_section_id::SectionName;
 use crate::platform::ObjectFile as _;
 use crate::platform::SectionHeader as _;
 use crate::resolution::SectionSlot;
+use crate::timing_phase;
 use hashbrown::HashMap;
 use itertools::Itertools as _;
 use linker_utils::bit_misc::BitExtraction;
@@ -239,6 +240,8 @@ fn raw_section_by_name<'data>(
 
 /// Pre-scan all input objects to compute the `.gdb_index` section size.
 pub(crate) fn compute_gdb_index_size(groups: &[GroupState<'_, Elf>]) -> Result<u64> {
+    timing_phase!("Compute GDB index size");
+
     let objects = groups.iter().flat_map(|g| g.files.iter()).filter_map(|f| {
         let FileLayoutState::Object(obj) = f else {
             return None;
@@ -418,6 +421,8 @@ struct GdbIndexScanResult<'data> {
 fn scan_objects_for_gdb_index<'data>(
     objects: impl Iterator<Item = (&'data crate::elf::File<'data>, &'data [SectionSlot])>,
 ) -> Result<GdbIndexScanResult<'data>> {
+    timing_phase!("Scan objects for GDB index");
+
     let mut total_cus = 0usize;
     let mut total_addr_entries = 0usize;
     let mut sym_map: HashMap<&'data [u8], SymData> = HashMap::new();

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -17,6 +17,7 @@ use crate::platform::ObjectFile as _;
 use crate::platform::SectionHeader as _;
 use crate::resolution::SectionSlot;
 use crate::timing_phase;
+use crate::verbose_timing_phase;
 use hashbrown::HashMap;
 use itertools::Itertools as _;
 use linker_utils::bit_misc::BitExtraction;
@@ -304,8 +305,6 @@ pub(crate) fn write_gdb_index(
         return Ok(());
     }
 
-    timing_phase!("Write GDB index");
-
     let cu_entries = build_cu_list(output_buf, layout)?;
     let sorted_names = &scan.sorted_symbols;
     let ht_slots = scan.ht_slots;
@@ -315,7 +314,7 @@ pub(crate) fn write_gdb_index(
              Compile with -ggnu-pubnames to populate it.",
         );
     }
-    let addr_entries = build_address_entries(layout)?;
+    let addr_entries = build_address_entries(layout, &scan.per_object_cu_counts)?;
 
     let cu_list_off = HEADER_SIZE as u32;
     let tu_list_off = cu_list_off + (cu_entries.len() * CU_ENTRY_SIZE) as u32;
@@ -324,26 +323,7 @@ pub(crate) fn write_gdb_index(
     let short_off = sym_off + (ht_slots * HASH_SLOT_SIZE) as u32;
     let cp_off = short_off + SHORTCUT_TABLE_SIZE as u32;
 
-    // Write constant pool: CU vectors first, then name strings.
-    let mut cv_offsets = Vec::with_capacity(sorted_names.len());
-    let mut off = cp_off as usize;
-    for (_, sd) in sorted_names {
-        cv_offsets.push((off - cp_off as usize) as u32);
-        buf[off..off + 4].copy_from_slice(&(sd.cv_entries.len() as u32).to_le_bytes());
-        off += 4;
-        for &e in &sd.cv_entries {
-            buf[off..off + 4].copy_from_slice(&e.to_le_bytes());
-            off += 4;
-        }
-    }
-    let mut name_offsets = Vec::with_capacity(sorted_names.len());
-    for (name, _) in sorted_names {
-        name_offsets.push((off - cp_off as usize) as u32);
-        buf[off..off + name.len()].copy_from_slice(name);
-        off += name.len();
-        buf[off] = 0;
-        off += 1;
-    }
+    let (cv_offsets, name_offsets) = write_constant_pool(buf, cp_off as usize, sorted_names);
 
     let hdr = GdbIndexHeader {
         version: GDB_INDEX_VERSION,
@@ -424,6 +404,9 @@ pub(crate) struct GdbIndexScanResult<'data> {
     total_addr_entries: usize,
     sorted_symbols: Vec<(&'data [u8], SymData)>,
     ht_slots: usize,
+    /// CU count for each object that has debug info, in input order. Used by
+    /// `build_address_entries` to assign global CU indices.
+    per_object_cu_counts: Vec<u32>,
 }
 
 /// Result of scanning a single input object for GDB index data.
@@ -499,11 +482,17 @@ fn merge_gdb_index_scans<'data>(
     let mut total_cus = 0usize;
     let mut total_addr_entries = 0usize;
     let mut sym_map: HashMap<&'data [u8], SymData> = HashMap::new();
+    let mut per_object_cu_counts = Vec::new();
 
-    for scan in per_object.into_iter().flatten() {
+    for scan in per_object {
+        let Some(scan) = scan else {
+            per_object_cu_counts.push(0);
+            continue;
+        };
         let base = total_cus as u32;
         total_cus += scan.num_cus;
         total_addr_entries += scan.num_addr_entries;
+        per_object_cu_counts.push(scan.num_cus as u32);
 
         for (name, local_cu_idx, attrs) in scan.symbol_entries {
             let entry = encode_cu_vector_entry(base + local_cu_idx, attrs);
@@ -526,6 +515,7 @@ fn merge_gdb_index_scans<'data>(
         total_addr_entries,
         sorted_symbols: sorted,
         ht_slots,
+        per_object_cu_counts,
     }
 }
 
@@ -544,19 +534,21 @@ fn scan_objects_for_gdb_index<'data>(
 }
 
 /// Build address entries using resolved addresses from the final layout.
-fn build_address_entries(layout: &Layout<'_, Elf>) -> Result<Vec<GdbIndexAddressEntry>> {
+fn build_address_entries(
+    layout: &Layout<'_, Elf>,
+    per_object_cu_counts: &[u32],
+) -> Result<Vec<GdbIndexAddressEntry>> {
+    verbose_timing_phase!("Build GDB address entries");
     let mut entries = Vec::new();
     let mut cu_offset = 0u32;
+    let mut cu_count_iter = per_object_cu_counts.iter();
 
     for group in &layout.group_layouts {
         for file in &group.files {
             let FileLayout::Object(obj) = file else {
                 continue;
             };
-            let object = obj.object;
-
-            let obj_cu_count = raw_section_by_name(object, DEBUG_INFO_SECTION_NAME_STR)?
-                .map_or(0, |data| parse_cu_boundaries(data).len() as u32);
+            let &obj_cu_count = cu_count_iter.next().unwrap_or(&0);
             if obj_cu_count == 0 {
                 continue;
             }
@@ -569,7 +561,7 @@ fn build_address_entries(layout: &Layout<'_, Elf>) -> Result<Vec<GdbIndexAddress
                 if section.size == 0 {
                     continue;
                 }
-                let header = object.section(object::SectionIndex(si))?;
+                let header = obj.object.section(object::SectionIndex(si))?;
                 if !header.is_alloc() || !header.is_executable() {
                     continue;
                 }
@@ -590,6 +582,34 @@ fn build_address_entries(layout: &Layout<'_, Elf>) -> Result<Vec<GdbIndexAddress
     Ok(entries)
 }
 
+/// Write the constant pool (CU vectors followed by name strings) into `buf` starting at `cp_start`.
+fn write_constant_pool(
+    buf: &mut [u8],
+    cp_start: usize,
+    sorted: &[(&[u8], SymData)],
+) -> (Vec<u32>, Vec<u32>) {
+    let mut cv_offsets = Vec::with_capacity(sorted.len());
+    let mut off = cp_start;
+    for (_, sd) in sorted {
+        cv_offsets.push((off - cp_start) as u32);
+        buf[off..off + 4].copy_from_slice(&(sd.cv_entries.len() as u32).to_le_bytes());
+        off += 4;
+        for &e in &sd.cv_entries {
+            buf[off..off + 4].copy_from_slice(&e.to_le_bytes());
+            off += 4;
+        }
+    }
+    let mut name_offsets = Vec::with_capacity(sorted.len());
+    for (name, _) in sorted {
+        name_offsets.push((off - cp_start) as u32);
+        buf[off..off + name.len()].copy_from_slice(name);
+        off += name.len();
+        buf[off] = 0;
+        off += 1;
+    }
+    (cv_offsets, name_offsets)
+}
+
 /// Insert symbols into the open-addressing hash table region of `buf`.
 fn write_hash_table(
     buf: &mut [u8],
@@ -599,6 +619,7 @@ fn write_hash_table(
     name_offsets: &[u32],
     cv_offsets: &[u32],
 ) -> Result {
+    verbose_timing_phase!("Write GDB hash table");
     let ht_end = ht_start + ht_slots * HASH_SLOT_SIZE;
     buf[ht_start..ht_end].fill(0);
 

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -16,6 +16,8 @@ use crate::platform::SectionHeader as _;
 use crate::resolution::SectionSlot;
 use hashbrown::HashMap;
 use linker_utils::bit_misc::BitExtraction;
+use linker_utils::elf::secnames::DEBUG_INFO_SECTION_NAME;
+use linker_utils::elf::secnames::DEBUG_INFO_SECTION_NAME_STR;
 use linker_utils::utils::u32_from_slice;
 use linker_utils::utils::u64_from_slice;
 use std::mem::size_of;
@@ -237,7 +239,7 @@ pub(crate) fn compute_gdb_index_size(groups: &[GroupState<'_, Elf>]) -> u64 {
             };
             let object = obj.object;
 
-            let boundaries = raw_section_by_name(object, ".debug_info")
+            let boundaries = raw_section_by_name(object, DEBUG_INFO_SECTION_NAME_STR)
                 .map(parse_cu_boundaries)
                 .unwrap_or_default();
             if boundaries.is_empty() {
@@ -396,7 +398,7 @@ pub(crate) fn write_gdb_index(buf: &mut [u8], output_buf: &[u8], layout: &Layout
 fn build_cu_list(output_buf: &[u8], layout: &Layout<'_, Elf>) -> Vec<GdbIndexCuEntry> {
     let Some(id) = layout
         .output_sections
-        .section_id_by_name(SectionName(b".debug_info"))
+        .section_id_by_name(SectionName(DEBUG_INFO_SECTION_NAME))
     else {
         return Vec::new();
     };
@@ -441,7 +443,7 @@ fn build_address_and_symbol_tables<'data>(
             };
             let object = obj.object;
 
-            let boundaries = raw_section_by_name(object, ".debug_info")
+            let boundaries = raw_section_by_name(object, DEBUG_INFO_SECTION_NAME_STR)
                 .map(parse_cu_boundaries)
                 .unwrap_or_default();
             if boundaries.is_empty() {

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -116,6 +116,9 @@ struct CuBoundary {
 }
 
 /// Walk `.debug_info` bytes and return `(offset, total_length)` for each CU.
+///
+/// Each CU starts with an initial length field (§7.5.1.1) encoded per §7.4: a 4-byte value, or
+/// `0xFFFF_FFFF` followed by an 8-byte length for DWARF-64.
 fn parse_cu_boundaries(data: &[u8]) -> Vec<CuBoundary> {
     let mut cus = Vec::new();
     let mut offset = 0usize;

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -15,6 +15,7 @@ use crate::platform::ObjectFile as _;
 use crate::platform::SectionHeader as _;
 use crate::resolution::SectionSlot;
 use hashbrown::HashMap;
+use itertools::Itertools as _;
 use linker_utils::bit_misc::BitExtraction;
 use linker_utils::elf::secnames::DEBUG_INFO_SECTION_NAME;
 use linker_utils::elf::secnames::DEBUG_INFO_SECTION_NAME_STR;
@@ -492,8 +493,10 @@ fn build_address_and_symbol_tables<'data>(
         sd.cv_entries.dedup();
     }
 
-    let mut sorted: Vec<(&[u8], SymData)> = sym_map.into_iter().collect();
-    sorted.sort_unstable_by_key(|(name, _)| *name);
+    let sorted: Vec<(&[u8], SymData)> = sym_map
+        .into_iter()
+        .sorted_unstable_by_key(|(name, _)| *name)
+        .collect();
     let ht_slots = compute_hash_table_slots(sorted.len());
     AddressAndSymbolData {
         addr_entries,

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -1,0 +1,633 @@
+//! Generates a `.gdb_index` section.
+//!
+//! The `.gdb_index` section is an accelerator structure that lets GDB skip parsing all
+//! `.debug_info` at startup. We emit version 9, which includes a shortcut table.
+//!
+//! Format reference: <https://sourceware.org/gdb/current/onlinedocs/gdb.html/Index-Section-Format.html>
+
+use crate::elf::Elf;
+use crate::layout::FileLayout;
+use crate::layout::FileLayoutState;
+use crate::layout::GroupState;
+use crate::layout::Layout;
+use crate::output_section_id::SectionName;
+use crate::platform::ObjectFile as _;
+use crate::platform::SectionHeader as _;
+use crate::resolution::SectionSlot;
+use hashbrown::HashMap;
+use std::mem::size_of;
+use zerocopy::FromBytes;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
+use zerocopy::KnownLayout;
+
+const GDB_INDEX_VERSION: u32 = 9;
+
+#[derive(Debug, Clone, Copy, FromBytes, Immutable, IntoBytes, KnownLayout)]
+#[repr(C, packed)]
+struct GdbIndexHeader {
+    version: u32,
+    cu_list_offset: u32,
+    tu_list_offset: u32,
+    address_area_offset: u32,
+    symbol_table_offset: u32,
+    shortcut_table_offset: u32,
+    constant_pool_offset: u32,
+}
+
+#[derive(Debug, Clone, Copy, FromBytes, Immutable, IntoBytes, KnownLayout)]
+#[repr(C, packed)]
+struct GdbIndexCuEntry {
+    cu_offset: u64,
+    cu_length: u64,
+}
+
+#[derive(Debug, Clone, Copy, FromBytes, Immutable, IntoBytes, KnownLayout)]
+#[repr(C, packed)]
+struct GdbIndexAddressEntry {
+    low_address: u64,
+    high_address: u64,
+    cu_index: u32,
+}
+
+#[derive(Debug, Clone, Copy, FromBytes, Immutable, IntoBytes, KnownLayout)]
+#[repr(C, packed)]
+struct GdbIndexShortcutTable {
+    language_of_main: u32,
+    name_of_main_offset: u32,
+}
+
+const HEADER_SIZE: usize = size_of::<GdbIndexHeader>();
+const CU_ENTRY_SIZE: usize = size_of::<GdbIndexCuEntry>();
+const ADDRESS_ENTRY_SIZE: usize = size_of::<GdbIndexAddressEntry>();
+const SHORTCUT_TABLE_SIZE: usize = size_of::<GdbIndexShortcutTable>();
+const HASH_SLOT_SIZE: usize = 8; // (name_offset, cu_vector_offset) pair
+
+/// The GDB index hash function.
+fn gdb_hash(name: &[u8]) -> u32 {
+    let mut r: u32 = 0;
+    for &c in name {
+        r = r
+            .wrapping_mul(67)
+            .wrapping_add(u32::from(c.to_ascii_lowercase()))
+            .wrapping_sub(113);
+    }
+    r
+}
+
+/// Encode a CU vector entry: bits 0-23 = CU index, bits 28-30 = kind, bit 31 = is_static.
+///
+/// The attrs byte from `.debug_gnu_pubnames`/`.debug_gnu_pubtypes` packs kind in bits 4-6
+/// and is_static in bit 7.
+fn encode_cu_vector_entry(cu_index: u32, attrs: u8) -> u32 {
+    let kind = u32::from((attrs >> 4) & 0x7);
+    let is_static = u32::from((attrs >> 7) & 0x1);
+    (cu_index & 0x00FF_FFFF) | (kind << 28) | (is_static << 31)
+}
+
+/// Number of hash table slots: next power of two >= 4/3 * n.
+fn compute_hash_table_slots(num_symbols: usize) -> usize {
+    if num_symbols == 0 {
+        return 0;
+    }
+    (num_symbols * 4 / 3 + 1).next_power_of_two()
+}
+
+struct CuBoundary {
+    offset: u64,
+    length: u64,
+}
+
+/// Walk `.debug_info` bytes and return `(offset, total_length)` for each CU.
+fn parse_cu_boundaries(data: &[u8]) -> Vec<CuBoundary> {
+    let mut cus = Vec::new();
+    let mut offset = 0usize;
+    while offset + 4 <= data.len() {
+        let init_len = u32::from_le_bytes(data[offset..offset + 4].try_into().unwrap());
+        let total = if init_len == 0xFFFF_FFFF {
+            if offset + 12 > data.len() {
+                break;
+            }
+            let len = u64::from_le_bytes(data[offset + 4..offset + 12].try_into().unwrap());
+            12 + len as usize
+        } else {
+            4 + init_len as usize
+        };
+        if total == 0 || offset + total > data.len() {
+            break;
+        }
+        cus.push(CuBoundary {
+            offset: offset as u64,
+            length: total as u64,
+        });
+        offset += total;
+    }
+    cus
+}
+
+struct PubnamesSet<'data> {
+    debug_info_offset: u64,
+    entries: Vec<(&'data [u8], u8)>,
+}
+
+/// Parse `.debug_gnu_pubnames` / `.debug_gnu_pubtypes` section data.
+///
+/// Each set has a header pointing to a CU in `.debug_info`, followed by
+/// (die_offset, attrs_byte, NUL-terminated name) entries.
+fn parse_pubnames_sets(data: &[u8]) -> Vec<PubnamesSet<'_>> {
+    let mut sets = Vec::new();
+    let mut pos = 0;
+    while pos + 4 <= data.len() {
+        let init_len = u32::from_le_bytes(data[pos..pos + 4].try_into().unwrap());
+
+        let (header_size, set_end, debug_info_offset) = if init_len == 0xFFFF_FFFF {
+            // DWARF64: 4 + 8(len) + 2(ver) + 8(offset) + 8(size) = 30
+            if pos + 30 > data.len() {
+                break;
+            }
+            let len = u64::from_le_bytes(data[pos + 4..pos + 12].try_into().unwrap());
+            let dio = u64::from_le_bytes(data[pos + 14..pos + 22].try_into().unwrap());
+            (30, pos + 12 + len as usize, dio)
+        } else {
+            // DWARF32: 4(len) + 2(ver) + 4(offset) + 4(size) = 14
+            if pos + 14 > data.len() {
+                break;
+            }
+            let dio = u64::from(u32::from_le_bytes(
+                data[pos + 6..pos + 10].try_into().unwrap(),
+            ));
+            (14, pos + 4 + init_len as usize, dio)
+        };
+
+        let set_end = set_end.min(data.len());
+        let mut ep = pos + header_size;
+        let mut entries = Vec::new();
+        let is_64 = init_len == 0xFFFF_FFFF;
+
+        while ep < set_end {
+            let die_offset = if is_64 {
+                if ep + 8 > set_end {
+                    break;
+                }
+                let v = u64::from_le_bytes(data[ep..ep + 8].try_into().unwrap());
+                ep += 8;
+                v
+            } else {
+                if ep + 4 > set_end {
+                    break;
+                }
+                let v = u64::from(u32::from_le_bytes(data[ep..ep + 4].try_into().unwrap()));
+                ep += 4;
+                v
+            };
+            if die_offset == 0 {
+                break;
+            }
+            if ep >= set_end {
+                break;
+            }
+            let attrs = data[ep];
+            ep += 1;
+            let name_start = ep;
+            while ep < set_end && data[ep] != 0 {
+                ep += 1;
+            }
+            if ep >= set_end {
+                break;
+            }
+            entries.push((&data[name_start..ep], attrs));
+            ep += 1;
+        }
+
+        sets.push(PubnamesSet {
+            debug_info_offset,
+            entries,
+        });
+        pos = set_end;
+    }
+    sets
+}
+
+/// Read raw section data from an input object by name.
+fn raw_section_by_name<'data>(object: &crate::elf::File<'data>, name: &str) -> Option<&'data [u8]> {
+    let (_index, header) = object.section_by_name(name)?;
+    object.raw_section_data(header).ok()
+}
+
+/// Pre-scan all input objects to compute the `.gdb_index` section size.
+pub(crate) fn compute_gdb_index_size(groups: &[GroupState<'_, Elf>]) -> u64 {
+    let mut total_cus = 0usize;
+    let mut total_addr_entries = 0usize;
+    let mut symbol_map: HashMap<&[u8], Vec<u32>> = HashMap::new();
+    let mut cu_index_base = 0u32;
+
+    for group in groups {
+        for file in &group.files {
+            let FileLayoutState::Object(obj) = file else {
+                continue;
+            };
+            let object = obj.object;
+
+            let obj_cu_count = raw_section_by_name(object, ".debug_info")
+                .map_or(0, |data| parse_cu_boundaries(data).len());
+
+            if obj_cu_count == 0 {
+                continue;
+            }
+
+            let mut obj_addr_count = 0usize;
+            for (si, slot) in obj.sections.iter().enumerate() {
+                let SectionSlot::Loaded(section) = slot else {
+                    continue;
+                };
+                if section.size == 0 {
+                    continue;
+                }
+                let Ok(header) = object.section(object::SectionIndex(si)) else {
+                    continue;
+                };
+                if header.is_alloc() && header.is_executable() {
+                    obj_addr_count += 1;
+                }
+            }
+
+            total_cus += obj_cu_count;
+            total_addr_entries += obj_addr_count;
+
+            let base_idx = cu_index_base;
+            let mut offset_to_idx: HashMap<u64, u32> = HashMap::new();
+            if let Some(di_data) = raw_section_by_name(object, ".debug_info") {
+                for (i, cu) in parse_cu_boundaries(di_data).iter().enumerate() {
+                    offset_to_idx.insert(cu.offset, base_idx + i as u32);
+                }
+            }
+            cu_index_base += obj_cu_count as u32;
+
+            collect_pubnames_symbols(object, &offset_to_idx, base_idx, &mut symbol_map);
+        }
+    }
+
+    if total_cus == 0 {
+        return 0;
+    }
+
+    let mut cv_bytes = 0usize;
+    let mut str_bytes = 0usize;
+    for (name, entries) in &mut symbol_map {
+        entries.sort_unstable();
+        entries.dedup();
+        cv_bytes += 4 + entries.len() * 4;
+        str_bytes += name.len() + 1;
+    }
+
+    let ht_slots = compute_hash_table_slots(symbol_map.len());
+
+    (HEADER_SIZE
+        + total_cus * CU_ENTRY_SIZE
+        + total_addr_entries * ADDRESS_ENTRY_SIZE
+        + ht_slots * HASH_SLOT_SIZE
+        + SHORTCUT_TABLE_SIZE
+        + cv_bytes
+        + str_bytes) as u64
+}
+
+/// Write the `.gdb_index` section into `buf`.
+///
+/// Reads the output `.debug_info` (already written into `output_buf`) for the CU list,
+/// and re-scans input objects for address ranges and pubnames/pubtypes symbols.
+pub(crate) fn write_gdb_index(buf: &mut [u8], output_buf: &[u8], layout: &Layout<'_, Elf>) {
+    if buf.is_empty() {
+        return;
+    }
+
+    let cu_entries = build_cu_list(output_buf, layout);
+    let addr_entries = build_address_entries(layout);
+    let (sorted, ht_slots) = build_symbol_table(layout);
+
+    let cu_list_off = HEADER_SIZE as u32;
+    let tu_list_off = cu_list_off + (cu_entries.len() * CU_ENTRY_SIZE) as u32;
+    let addr_off = tu_list_off;
+    let sym_off = addr_off + (addr_entries.len() * ADDRESS_ENTRY_SIZE) as u32;
+    let short_off = sym_off + (ht_slots * HASH_SLOT_SIZE) as u32;
+    let cp_off = short_off + SHORTCUT_TABLE_SIZE as u32;
+
+    // Build constant pool: CU vectors first, then name strings.
+    let mut cv_data = Vec::new();
+    let mut str_data = Vec::new();
+    let mut cv_offsets = Vec::with_capacity(sorted.len());
+    let mut name_offsets = Vec::with_capacity(sorted.len());
+
+    for (_, sd) in &sorted {
+        cv_offsets.push(cv_data.len() as u32);
+        cv_data.extend_from_slice(&(sd.cv_entries.len() as u32).to_le_bytes());
+        for &e in &sd.cv_entries {
+            cv_data.extend_from_slice(&e.to_le_bytes());
+        }
+    }
+    for (name, _) in &sorted {
+        name_offsets.push((cv_data.len() + str_data.len()) as u32);
+        str_data.extend_from_slice(name);
+        str_data.push(0);
+    }
+
+    // Emit into the output buffer.
+    let total = cp_off as usize + cv_data.len() + str_data.len();
+    let len = buf.len().min(total);
+    let buf = &mut buf[..len];
+
+    let hdr = GdbIndexHeader {
+        version: GDB_INDEX_VERSION,
+        cu_list_offset: cu_list_off,
+        tu_list_offset: tu_list_off,
+        address_area_offset: addr_off,
+        symbol_table_offset: sym_off,
+        shortcut_table_offset: short_off,
+        constant_pool_offset: cp_off,
+    };
+    buf[..HEADER_SIZE].copy_from_slice(hdr.as_bytes());
+
+    let mut off = cu_list_off as usize;
+    for cu in &cu_entries {
+        buf[off..off + CU_ENTRY_SIZE].copy_from_slice(cu.as_bytes());
+        off += CU_ENTRY_SIZE;
+    }
+
+    off = addr_off as usize;
+    for a in &addr_entries {
+        buf[off..off + ADDRESS_ENTRY_SIZE].copy_from_slice(a.as_bytes());
+        off += ADDRESS_ENTRY_SIZE;
+    }
+
+    write_hash_table(
+        buf,
+        ht_slots,
+        sym_off as usize,
+        &sorted,
+        &name_offsets,
+        &cv_offsets,
+    );
+
+    let so = short_off as usize;
+    let sc = GdbIndexShortcutTable {
+        language_of_main: 0,
+        name_of_main_offset: 0,
+    };
+    buf[so..so + SHORTCUT_TABLE_SIZE].copy_from_slice(sc.as_bytes());
+
+    let cpo = cp_off as usize;
+    buf[cpo..cpo + cv_data.len()].copy_from_slice(&cv_data);
+    buf[cpo + cv_data.len()..cpo + cv_data.len() + str_data.len()].copy_from_slice(&str_data);
+}
+
+/// Build the CU list from the already-written output `.debug_info`.
+fn build_cu_list(output_buf: &[u8], layout: &Layout<'_, Elf>) -> Vec<GdbIndexCuEntry> {
+    let Some(id) = layout
+        .output_sections
+        .section_id_by_name(SectionName(b".debug_info"))
+    else {
+        return Vec::new();
+    };
+    let sl = layout.section_layouts.get(id);
+    let start = sl.file_offset;
+    let end = start + sl.file_size;
+    if end > output_buf.len() {
+        return Vec::new();
+    }
+    parse_cu_boundaries(&output_buf[start..end])
+        .into_iter()
+        .map(|cu| GdbIndexCuEntry {
+            cu_offset: cu.offset,
+            cu_length: cu.length,
+        })
+        .collect()
+}
+
+/// Build address entries by mapping each executable section to its resolved address.
+fn build_address_entries(layout: &Layout<'_, Elf>) -> Vec<GdbIndexAddressEntry> {
+    let mut entries = Vec::new();
+    let mut cu_offset = 0u32;
+
+    for group in &layout.group_layouts {
+        for file in &group.files {
+            let FileLayout::Object(obj) = file else {
+                continue;
+            };
+            let object = obj.object;
+
+            let obj_cu_count = raw_section_by_name(object, ".debug_info")
+                .map_or(0, |data| parse_cu_boundaries(data).len() as u32);
+            if obj_cu_count == 0 {
+                continue;
+            }
+            let base_cu = cu_offset;
+
+            for (si, slot) in obj.sections.iter().enumerate() {
+                let SectionSlot::Loaded(section) = slot else {
+                    continue;
+                };
+                if section.size == 0 {
+                    continue;
+                }
+                let Ok(header) = object.section(object::SectionIndex(si)) else {
+                    continue;
+                };
+                if !header.is_alloc() || !header.is_executable() {
+                    continue;
+                }
+                if let Some(addr) = obj.section_resolutions[si].address()
+                    && addr != 0
+                {
+                    entries.push(GdbIndexAddressEntry {
+                        low_address: addr,
+                        high_address: addr + section.size,
+                        cu_index: base_cu,
+                    });
+                }
+            }
+
+            cu_offset += obj_cu_count;
+        }
+    }
+    entries
+}
+
+struct SymData {
+    cv_entries: Vec<u32>,
+    hash: u32,
+}
+
+/// Build the symbol table from `.debug_gnu_pubnames`/`.debug_gnu_pubtypes`, returning
+/// the symbols sorted by name and the computed hash table slot count.
+fn build_symbol_table<'data>(
+    layout: &'data Layout<'_, Elf>,
+) -> (Vec<(&'data [u8], SymData)>, usize) {
+    let mut sym_map: HashMap<&'data [u8], SymData> = HashMap::new();
+    let mut cu_offset = 0u32;
+
+    for group in &layout.group_layouts {
+        for file in &group.files {
+            let FileLayout::Object(obj) = file else {
+                continue;
+            };
+            let object = obj.object;
+
+            let boundaries = raw_section_by_name(object, ".debug_info")
+                .map(parse_cu_boundaries)
+                .unwrap_or_default();
+            if boundaries.is_empty() {
+                continue;
+            }
+
+            let base = cu_offset;
+            let mut offset_to_idx: HashMap<u64, u32> = HashMap::with_capacity(boundaries.len());
+            for (i, cu) in boundaries.iter().enumerate() {
+                offset_to_idx.insert(cu.offset, base + i as u32);
+            }
+            cu_offset += boundaries.len() as u32;
+
+            for section_name in [".debug_gnu_pubnames", ".debug_gnu_pubtypes"] {
+                let Some(data) = raw_section_by_name(object, section_name) else {
+                    continue;
+                };
+                for set in parse_pubnames_sets(data) {
+                    let cu_idx = offset_to_idx
+                        .get(&set.debug_info_offset)
+                        .copied()
+                        .unwrap_or(base);
+                    for (name, attrs) in set.entries {
+                        let entry = encode_cu_vector_entry(cu_idx, attrs);
+                        let sd = sym_map.entry(name).or_insert_with(|| SymData {
+                            cv_entries: Vec::new(),
+                            hash: gdb_hash(name),
+                        });
+                        sd.cv_entries.push(entry);
+                    }
+                }
+            }
+        }
+    }
+
+    for sd in sym_map.values_mut() {
+        sd.cv_entries.sort_unstable();
+        sd.cv_entries.dedup();
+    }
+
+    let mut sorted: Vec<(&[u8], SymData)> = sym_map.into_iter().collect();
+    sorted.sort_unstable_by_key(|(name, _)| *name);
+    let ht_slots = compute_hash_table_slots(sorted.len());
+    (sorted, ht_slots)
+}
+
+/// Collect pubnames/pubtypes symbols from an object into the global map.
+fn collect_pubnames_symbols<'data>(
+    object: &crate::elf::File<'data>,
+    offset_to_idx: &HashMap<u64, u32>,
+    fallback_cu: u32,
+    symbol_map: &mut HashMap<&'data [u8], Vec<u32>>,
+) {
+    for section_name in [".debug_gnu_pubnames", ".debug_gnu_pubtypes"] {
+        let Some(data) = raw_section_by_name(object, section_name) else {
+            continue;
+        };
+        for set in parse_pubnames_sets(data) {
+            let cu_idx = offset_to_idx
+                .get(&set.debug_info_offset)
+                .copied()
+                .unwrap_or(fallback_cu);
+            for (name, attrs) in set.entries {
+                let entry = encode_cu_vector_entry(cu_idx, attrs);
+                symbol_map.entry(name).or_default().push(entry);
+            }
+        }
+    }
+}
+
+/// Insert symbols into the open-addressing hash table region of `buf`.
+fn write_hash_table(
+    buf: &mut [u8],
+    ht_slots: usize,
+    ht_start: usize,
+    sorted: &[(&[u8], SymData)],
+    name_offsets: &[u32],
+    cv_offsets: &[u32],
+) {
+    let ht_end = ht_start + ht_slots * HASH_SLOT_SIZE;
+    buf[ht_start..ht_end].fill(0);
+
+    if ht_slots == 0 {
+        return;
+    }
+    let mask = (ht_slots - 1) as u32;
+    for (i, (_, sd)) in sorted.iter().enumerate() {
+        let h = sd.hash;
+        let step = ((h >> 3) & mask) | 1;
+        let mut slot = h & mask;
+        loop {
+            let so = ht_start + slot as usize * HASH_SLOT_SIZE;
+            let existing_name = u32::from_le_bytes(buf[so..so + 4].try_into().unwrap());
+            let existing_vec = u32::from_le_bytes(buf[so + 4..so + 8].try_into().unwrap());
+            if existing_name == 0 && existing_vec == 0 {
+                buf[so..so + 4].copy_from_slice(&name_offsets[i].to_le_bytes());
+                buf[so + 4..so + 8].copy_from_slice(&cv_offsets[i].to_le_bytes());
+                break;
+            }
+            slot = (slot + step) & mask;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gdb_hash_case_insensitive() {
+        assert_eq!(gdb_hash(b"main"), gdb_hash(b"MAIN"));
+        assert_eq!(gdb_hash(b"main"), gdb_hash(b"Main"));
+        assert_ne!(gdb_hash(b"main"), gdb_hash(b"foo"));
+    }
+
+    #[test]
+    fn test_hash_table_slots_power_of_two() {
+        assert_eq!(compute_hash_table_slots(0), 0);
+        assert_eq!(compute_hash_table_slots(1), 2);
+        for n in 1..100 {
+            let s = compute_hash_table_slots(n);
+            assert!(s.is_power_of_two());
+            assert!(s >= n);
+        }
+    }
+
+    #[test]
+    fn test_encode_cu_vector_entry() {
+        // Global function: kind=3 in bits 4-6, is_static=0 in bit 7
+        let e = encode_cu_vector_entry(5, 0b0011_0000);
+        assert_eq!(e & 0x00FF_FFFF, 5);
+        assert_eq!((e >> 28) & 0x7, 3);
+        assert_eq!((e >> 31) & 0x1, 0);
+
+        // Static function: kind=3, is_static=1
+        let e2 = encode_cu_vector_entry(42, 0b1011_0000);
+        assert_eq!(e2 & 0x00FF_FFFF, 42);
+        assert_eq!((e2 >> 28) & 0x7, 3);
+        assert_eq!((e2 >> 31) & 0x1, 1);
+    }
+
+    #[test]
+    fn test_parse_cu_boundaries() {
+        assert!(parse_cu_boundaries(&[]).is_empty());
+
+        // Single DWARF32 CU: init_length=8, total = 4 + 8 = 12 bytes.
+        let mut data = vec![0u8; 12];
+        data[0..4].copy_from_slice(&8u32.to_le_bytes());
+        let cus = parse_cu_boundaries(&data);
+        assert_eq!(cus.len(), 1);
+        assert_eq!(cus[0].offset, 0);
+        assert_eq!(cus[0].length, 12);
+    }
+
+    #[test]
+    fn test_header_size() {
+        assert_eq!(HEADER_SIZE, 7 * 4);
+    }
+}

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -255,8 +255,7 @@ pub(crate) fn compute_gdb_index_size(groups: &[GroupState<'_, Elf>]) -> u64 {
             total_addr_entries += obj_addr_count;
 
             let base_idx = cu_index_base;
-            let mut offset_to_idx: HashMap<u64, u32> =
-                HashMap::with_capacity(boundaries.len());
+            let mut offset_to_idx: HashMap<u64, u32> = HashMap::with_capacity(boundaries.len());
             for (i, cu) in boundaries.iter().enumerate() {
                 offset_to_idx.insert(cu.offset, base_idx + i as u32);
             }
@@ -300,8 +299,11 @@ pub(crate) fn write_gdb_index(buf: &mut [u8], output_buf: &[u8], layout: &Layout
     }
 
     let cu_entries = build_cu_list(output_buf, layout);
-    let addr_entries = build_address_entries(layout);
-    let (sorted, ht_slots) = build_symbol_table(layout);
+    let AddressAndSymbolData {
+        addr_entries,
+        sorted_symbols: sorted,
+        ht_slots,
+    } = build_address_and_symbol_tables(layout);
 
     let cu_list_off = HEADER_SIZE as u32;
     let tu_list_off = cu_list_off + (cu_entries.len() * CU_ENTRY_SIZE) as u32;
@@ -401,65 +403,22 @@ fn build_cu_list(output_buf: &[u8], layout: &Layout<'_, Elf>) -> Vec<GdbIndexCuE
         .collect()
 }
 
-/// Build address entries by mapping each executable section to its resolved address.
-fn build_address_entries(layout: &Layout<'_, Elf>) -> Vec<GdbIndexAddressEntry> {
-    let mut entries = Vec::new();
-    let mut cu_offset = 0u32;
-
-    for group in &layout.group_layouts {
-        for file in &group.files {
-            let FileLayout::Object(obj) = file else {
-                continue;
-            };
-            let object = obj.object;
-
-            let obj_cu_count = raw_section_by_name(object, ".debug_info")
-                .map_or(0, |data| parse_cu_boundaries(data).len() as u32);
-            if obj_cu_count == 0 {
-                continue;
-            }
-            let base_cu = cu_offset;
-
-            for (si, slot) in obj.sections.iter().enumerate() {
-                let SectionSlot::Loaded(section) = slot else {
-                    continue;
-                };
-                if section.size == 0 {
-                    continue;
-                }
-                let Ok(header) = object.section(object::SectionIndex(si)) else {
-                    continue;
-                };
-                if !header.is_alloc() || !header.is_executable() {
-                    continue;
-                }
-                if let Some(addr) = obj.section_resolutions[si].address()
-                    && addr != 0
-                {
-                    entries.push(GdbIndexAddressEntry {
-                        low_address: addr,
-                        high_address: addr + section.size,
-                        cu_index: base_cu,
-                    });
-                }
-            }
-
-            cu_offset += obj_cu_count;
-        }
-    }
-    entries
-}
-
 struct SymData {
     cv_entries: Vec<u32>,
     hash: u32,
 }
 
-/// Build the symbol table from `.debug_gnu_pubnames`/`.debug_gnu_pubtypes`, returning
-/// the symbols sorted by name and the computed hash table slot count.
-fn build_symbol_table<'data>(
+struct AddressAndSymbolData<'data> {
+    addr_entries: Vec<GdbIndexAddressEntry>,
+    sorted_symbols: Vec<(&'data [u8], SymData)>,
+    ht_slots: usize,
+}
+
+/// Build address entries and symbol table in a single pass over input objects.
+fn build_address_and_symbol_tables<'data>(
     layout: &'data Layout<'_, Elf>,
-) -> (Vec<(&'data [u8], SymData)>, usize) {
+) -> AddressAndSymbolData<'data> {
+    let mut addr_entries = Vec::new();
     let mut sym_map: HashMap<&'data [u8], SymData> = HashMap::new();
     let mut cu_offset = 0u32;
 
@@ -478,6 +437,33 @@ fn build_symbol_table<'data>(
             }
 
             let base = cu_offset;
+
+            // Address entries: map each executable section to its resolved address.
+            for (si, slot) in obj.sections.iter().enumerate() {
+                let SectionSlot::Loaded(section) = slot else {
+                    continue;
+                };
+                if section.size == 0 {
+                    continue;
+                }
+                let Ok(header) = object.section(object::SectionIndex(si)) else {
+                    continue;
+                };
+                if !header.is_alloc() || !header.is_executable() {
+                    continue;
+                }
+                if let Some(addr) = obj.section_resolutions[si].address()
+                    && addr != 0
+                {
+                    addr_entries.push(GdbIndexAddressEntry {
+                        low_address: addr,
+                        high_address: addr + section.size,
+                        cu_index: base,
+                    });
+                }
+            }
+
+            // Symbol table: collect from pubnames/pubtypes.
             let mut offset_to_idx: HashMap<u64, u32> = HashMap::with_capacity(boundaries.len());
             for (i, cu) in boundaries.iter().enumerate() {
                 offset_to_idx.insert(cu.offset, base + i as u32);
@@ -514,7 +500,11 @@ fn build_symbol_table<'data>(
     let mut sorted: Vec<(&[u8], SymData)> = sym_map.into_iter().collect();
     sorted.sort_unstable_by_key(|(name, _)| *name);
     let ht_slots = compute_hash_table_slots(sorted.len());
-    (sorted, ht_slots)
+    AddressAndSymbolData {
+        addr_entries,
+        sorted_symbols: sorted,
+        ht_slots,
+    }
 }
 
 /// Collect pubnames/pubtypes symbols from an object into the global map.

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -24,6 +24,8 @@ use linker_utils::elf::secnames::DEBUG_INFO_SECTION_NAME;
 use linker_utils::elf::secnames::DEBUG_INFO_SECTION_NAME_STR;
 use linker_utils::utils::u32_from_slice;
 use linker_utils::utils::u64_from_slice;
+use rayon::iter::IntoParallelRefIterator;
+use rayon::iter::ParallelIterator;
 use std::collections::BTreeSet;
 use std::mem::size_of;
 use zerocopy::FromBytes;
@@ -238,20 +240,10 @@ fn raw_section_by_name<'data>(
     Ok(Some(object.raw_section_data(header)?))
 }
 
-/// Pre-scan all input objects to compute the `.gdb_index` section size.
-pub(crate) fn compute_gdb_index_size(groups: &[GroupState<'_, Elf>]) -> Result<u64> {
-    timing_phase!("Compute GDB index size");
-
-    let objects = groups.iter().flat_map(|g| g.files.iter()).filter_map(|f| {
-        let FileLayoutState::Object(obj) = f else {
-            return None;
-        };
-        Some((obj.object, obj.sections.as_slice()))
-    });
-    let scan = scan_objects_for_gdb_index(objects)?;
-
+/// Compute the size from a scan result.
+fn gdb_index_size_from_scan(scan: &GdbIndexScanResult<'_>) -> u64 {
     if scan.total_cus == 0 {
-        return Ok(0);
+        return 0;
     }
 
     let mut cv_bytes = 0usize;
@@ -262,44 +254,61 @@ pub(crate) fn compute_gdb_index_size(groups: &[GroupState<'_, Elf>]) -> Result<u
         str_bytes += name.len() + 1;
     }
 
-    Ok((HEADER_SIZE
+    (HEADER_SIZE
         + scan.total_cus * CU_ENTRY_SIZE
         + scan.total_addr_entries * ADDRESS_ENTRY_SIZE
         + scan.ht_slots * HASH_SLOT_SIZE
         + SHORTCUT_TABLE_SIZE
         + cv_bytes
-        + str_bytes) as u64)
+        + str_bytes) as u64
+}
+
+/// Pre-scan all input objects to compute the `.gdb_index` section size and return the scan result
+/// for later use during the write phase.
+pub(crate) fn compute_gdb_index_size<'data>(
+    groups: &[GroupState<'data, Elf>],
+) -> Result<(u64, Option<GdbIndexScanResult<'data>>)> {
+    timing_phase!("Compute GDB index size");
+
+    let objects: Vec<_> = groups
+        .iter()
+        .flat_map(|g| g.files.iter())
+        .filter_map(|f| {
+            let FileLayoutState::Object(obj) = f else {
+                return None;
+            };
+            Some((obj.object, obj.sections.as_slice()))
+        })
+        .collect();
+    let scan = scan_objects_for_gdb_index(&objects)?;
+
+    let size = gdb_index_size_from_scan(&scan);
+    if size == 0 {
+        Ok((0, None))
+    } else {
+        Ok((size, Some(scan)))
+    }
 }
 
 /// Write the `.gdb_index` section into `buf`.
 ///
 /// Reads the output `.debug_info` (already written into `output_buf`) for the CU list,
-/// and re-scans input objects for address ranges and pubnames/pubtypes symbols.
+/// and uses the pre-computed scan result for symbol data.
 pub(crate) fn write_gdb_index(
     buf: &mut [u8],
     output_buf: &[u8],
     layout: &Layout<'_, Elf>,
+    scan: &GdbIndexScanResult<'_>,
 ) -> Result {
     if buf.is_empty() {
         return Ok(());
     }
 
+    timing_phase!("Write GDB index");
+
     let cu_entries = build_cu_list(output_buf, layout)?;
-    let objects = layout
-        .group_layouts
-        .iter()
-        .flat_map(|g| g.files.iter())
-        .filter_map(|f| {
-            let FileLayout::Object(obj) = f else {
-                return None;
-            };
-            Some((obj.object, obj.sections.as_slice()))
-        });
-    let GdbIndexScanResult {
-        sorted_symbols: sorted_names,
-        ht_slots,
-        ..
-    } = scan_objects_for_gdb_index(objects)?;
+    let sorted_names = &scan.sorted_symbols;
+    let ht_slots = scan.ht_slots;
     if !cu_entries.is_empty() && sorted_names.is_empty() {
         layout.symbol_db.warning(
             "Objects lack .debug_gnu_pubnames/.debug_gnu_pubtypes sections, so the symbol table in .gdb_index will be empty. \
@@ -318,7 +327,7 @@ pub(crate) fn write_gdb_index(
     // Write constant pool: CU vectors first, then name strings.
     let mut cv_offsets = Vec::with_capacity(sorted_names.len());
     let mut off = cp_off as usize;
-    for (_, sd) in &sorted_names {
+    for (_, sd) in sorted_names {
         cv_offsets.push((off - cp_off as usize) as u32);
         buf[off..off + 4].copy_from_slice(&(sd.cv_entries.len() as u32).to_le_bytes());
         off += 4;
@@ -328,7 +337,7 @@ pub(crate) fn write_gdb_index(
         }
     }
     let mut name_offsets = Vec::with_capacity(sorted_names.len());
-    for (name, _) in &sorted_names {
+    for (name, _) in sorted_names {
         name_offsets.push((off - cp_off as usize) as u32);
         buf[off..off + name.len()].copy_from_slice(name);
         off += name.len();
@@ -363,7 +372,7 @@ pub(crate) fn write_gdb_index(
         buf,
         ht_slots,
         sym_off as usize,
-        &sorted_names,
+        sorted_names,
         &name_offsets,
         &cv_offsets,
     )?;
@@ -410,59 +419,94 @@ struct SymData {
     hash: u32,
 }
 
-struct GdbIndexScanResult<'data> {
+pub(crate) struct GdbIndexScanResult<'data> {
     total_cus: usize,
     total_addr_entries: usize,
     sorted_symbols: Vec<(&'data [u8], SymData)>,
     ht_slots: usize,
 }
 
-/// Scan input objects to build the symbol table and count CUs / address entries.
-fn scan_objects_for_gdb_index<'data>(
-    objects: impl Iterator<Item = (&'data crate::elf::File<'data>, &'data [SectionSlot])>,
-) -> Result<GdbIndexScanResult<'data>> {
-    timing_phase!("Scan objects for GDB index");
+/// Result of scanning a single input object for GDB index data.
+struct PerObjectGdbScan<'data> {
+    num_cus: usize,
+    num_addr_entries: usize,
+    /// `(name, local_cu_index, attrs)`. CU index is 0-based within this object.
+    symbol_entries: Vec<(&'data [u8], u32, u8)>,
+}
+
+/// Scan a single input object, returning per-object GDB index data with 0-based CU indices.
+fn scan_one_object<'data>(
+    object: &crate::elf::File<'data>,
+    sections: &[SectionSlot],
+) -> Result<Option<PerObjectGdbScan<'data>>> {
+    let boundaries = match raw_section_by_name(object, DEBUG_INFO_SECTION_NAME_STR)? {
+        Some(data) => parse_cu_boundaries(data),
+        None => return Ok(None),
+    };
+    if boundaries.is_empty() {
+        return Ok(None);
+    }
+
+    let mut num_addr_entries = 0usize;
+    for (si, slot) in sections.iter().enumerate() {
+        let SectionSlot::Loaded(section) = slot else {
+            continue;
+        };
+        if section.size == 0 {
+            continue;
+        }
+        let header = object.section(object::SectionIndex(si))?;
+        if header.is_alloc() && header.is_executable() {
+            num_addr_entries += 1;
+        }
+    }
+
+    // Build offset-to-local-index map for this object's CUs.
+    let mut offset_to_idx: HashMap<u64, u32> = HashMap::with_capacity(boundaries.len());
+    for (i, cu) in boundaries.iter().enumerate() {
+        offset_to_idx.insert(cu.offset, i as u32);
+    }
+
+    // Collect raw pubname entries with local CU indices and raw attrs.
+    let mut symbol_entries = Vec::new();
+    for section_name in [".debug_gnu_pubnames", ".debug_gnu_pubtypes"] {
+        let Some(data) = raw_section_by_name(object, section_name)? else {
+            continue;
+        };
+        for set in parse_pubnames_sets(data) {
+            let Some(&local_cu_idx) = offset_to_idx.get(&set.debug_info_offset) else {
+                continue;
+            };
+            for (name, attrs) in set.entries {
+                symbol_entries.push((name, local_cu_idx, attrs));
+            }
+        }
+    }
+
+    Ok(Some(PerObjectGdbScan {
+        num_cus: boundaries.len(),
+        num_addr_entries,
+        symbol_entries,
+    }))
+}
+
+/// Merge per-object scan results into a single `GdbIndexScanResult`, assigning global CU indices.
+fn merge_gdb_index_scans<'data>(
+    per_object: Vec<Option<PerObjectGdbScan<'data>>>,
+) -> GdbIndexScanResult<'data> {
+    timing_phase!("Merge GDB index scans");
 
     let mut total_cus = 0usize;
     let mut total_addr_entries = 0usize;
     let mut sym_map: HashMap<&'data [u8], SymData> = HashMap::new();
-    let mut cu_offset = 0u32;
 
-    for (object, sections) in objects {
-        let boundaries = match raw_section_by_name(object, DEBUG_INFO_SECTION_NAME_STR)? {
-            Some(data) => parse_cu_boundaries(data),
-            None => continue,
-        };
-        if boundaries.is_empty() {
-            continue;
-        }
+    for scan in per_object.into_iter().flatten() {
+        let base = total_cus as u32;
+        total_cus += scan.num_cus;
+        total_addr_entries += scan.num_addr_entries;
 
-        let base = cu_offset;
-
-        let mut obj_addr_count = 0usize;
-        for (si, slot) in sections.iter().enumerate() {
-            let SectionSlot::Loaded(section) = slot else {
-                continue;
-            };
-            if section.size == 0 {
-                continue;
-            }
-            let header = object.section(object::SectionIndex(si))?;
-            if header.is_alloc() && header.is_executable() {
-                obj_addr_count += 1;
-            }
-        }
-
-        total_cus += boundaries.len();
-        total_addr_entries += obj_addr_count;
-
-        let mut offset_to_idx: HashMap<u64, u32> = HashMap::with_capacity(boundaries.len());
-        for (i, cu) in boundaries.iter().enumerate() {
-            offset_to_idx.insert(cu.offset, base + i as u32);
-        }
-        cu_offset += boundaries.len() as u32;
-
-        for (name, entry) in collect_pubname_entries(object, &offset_to_idx)? {
+        for (name, local_cu_idx, attrs) in scan.symbol_entries {
+            let entry = encode_cu_vector_entry(base + local_cu_idx, attrs);
             let sd = sym_map.entry(name).or_insert_with(|| SymData {
                 cv_entries: BTreeSet::new(),
                 hash: gdb_hash(name),
@@ -476,12 +520,27 @@ fn scan_objects_for_gdb_index<'data>(
         .sorted_unstable_by_key(|(name, _)| *name)
         .collect();
     let ht_slots = compute_hash_table_slots(sorted.len());
-    Ok(GdbIndexScanResult {
+
+    GdbIndexScanResult {
         total_cus,
         total_addr_entries,
         sorted_symbols: sorted,
         ht_slots,
-    })
+    }
+}
+
+/// Scan all input objects in parallel to build the GDB index symbol table.
+fn scan_objects_for_gdb_index<'data>(
+    objects: &[(&'data crate::elf::File<'data>, &[SectionSlot])],
+) -> Result<GdbIndexScanResult<'data>> {
+    timing_phase!("Scan objects for GDB index");
+
+    let per_object: Result<Vec<_>> = objects
+        .par_iter()
+        .map(|(object, sections)| scan_one_object(object, sections))
+        .collect();
+
+    Ok(merge_gdb_index_scans(per_object?))
 }
 
 /// Build address entries using resolved addresses from the final layout.
@@ -526,29 +585,6 @@ fn build_address_entries(layout: &Layout<'_, Elf>) -> Result<Vec<GdbIndexAddress
             }
 
             cu_offset += obj_cu_count;
-        }
-    }
-    Ok(entries)
-}
-
-/// Collect encoded pubname/pubtype entries from an object's `.debug_gnu_pubnames`
-/// and `.debug_gnu_pubtypes` sections, returning `(name, encoded_cu_vector_entry)` pairs.
-fn collect_pubname_entries<'data>(
-    object: &crate::elf::File<'data>,
-    offset_to_idx: &HashMap<u64, u32>,
-) -> Result<Vec<(&'data [u8], u32)>> {
-    let mut entries = Vec::new();
-    for section_name in [".debug_gnu_pubnames", ".debug_gnu_pubtypes"] {
-        let Some(data) = raw_section_by_name(object, section_name)? else {
-            continue;
-        };
-        for set in parse_pubnames_sets(data) {
-            let Some(&cu_idx) = offset_to_idx.get(&set.debug_info_offset) else {
-                continue;
-            };
-            for (name, attrs) in set.entries {
-                entries.push((name, encode_cu_vector_entry(cu_idx, attrs)));
-            }
         }
     }
     Ok(entries)

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -285,6 +285,7 @@ pub(crate) fn compute_gdb_index_size(groups: &[GroupState<'_, Elf>]) -> u64 {
     for (name, entries) in &mut symbol_map {
         entries.sort_unstable();
         entries.dedup();
+        // 4 bytes for the entry count, then 4 bytes per entry.
         cv_bytes += 4 + entries.len() * 4;
         str_bytes += name.len() + 1;
     }

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -21,6 +21,7 @@ use linker_utils::elf::secnames::DEBUG_INFO_SECTION_NAME;
 use linker_utils::elf::secnames::DEBUG_INFO_SECTION_NAME_STR;
 use linker_utils::utils::u32_from_slice;
 use linker_utils::utils::u64_from_slice;
+use std::collections::BTreeSet;
 use std::mem::size_of;
 use zerocopy::FromBytes;
 use zerocopy::Immutable;
@@ -376,7 +377,7 @@ fn build_cu_list(output_buf: &[u8], layout: &Layout<'_, Elf>) -> Vec<GdbIndexCuE
 }
 
 struct SymData {
-    cv_entries: Vec<u32>,
+    cv_entries: BTreeSet<u32>,
     hash: u32,
 }
 
@@ -433,16 +434,11 @@ fn scan_objects_for_gdb_index<'data>(
 
         for (name, entry) in collect_pubname_entries(object, &offset_to_idx, base) {
             let sd = sym_map.entry(name).or_insert_with(|| SymData {
-                cv_entries: Vec::new(),
+                cv_entries: BTreeSet::new(),
                 hash: gdb_hash(name),
             });
-            sd.cv_entries.push(entry);
+            sd.cv_entries.insert(entry);
         }
-    }
-
-    for sd in sym_map.values_mut() {
-        sd.cv_entries.sort_unstable();
-        sd.cv_entries.dedup();
     }
 
     let sorted: Vec<(&[u8], SymData)> = sym_map

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -705,7 +705,7 @@ pub struct Layout<'data, P: Platform> {
     pub(crate) thunk_block_addresses: Vec<BTreeMap<SymbolId, u64>>,
 
     pub(crate) compressed_debug_sections: OutputSectionMap<Option<CompressedSection>>,
-    pub(crate) gdb_index_data: Option<P::GdbIndexScanResult<'data>>,
+    pub(crate) gdb_index_data: Option<P::GdbIndexScanResult>,
 }
 
 #[derive(Debug, Default)]
@@ -1955,10 +1955,7 @@ fn compute_total_section_part_sizes<'data, P: Platform>(
     per_symbol_flags: &mut PerSymbolFlags,
     must_keep_sections: OutputSectionMap<bool>,
     resources: &FinaliseSizesResources<'data, '_, P>,
-) -> Result<(
-    OutputSectionPartMap<u64>,
-    Option<P::GdbIndexScanResult<'data>>,
-)> {
+) -> Result<(OutputSectionPartMap<u64>, Option<P::GdbIndexScanResult>)> {
     timing_phase!("Compute total section sizes");
 
     let mut total_sizes: OutputSectionPartMap<u64> = output_sections.new_part_map();

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -220,7 +220,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         output_order.display::<A::Platform>(&output_sections, &program_segments)
     );
 
-    let mut section_part_sizes = compute_total_section_part_sizes(
+    let (mut section_part_sizes, gdb_index_data) = compute_total_section_part_sizes(
         &mut group_states,
         &mut output_sections,
         &output_order,
@@ -435,6 +435,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         properties_and_attributes,
         thunk_block_addresses,
         compressed_debug_sections: OutputSectionMap::with_size(num_sections),
+        gdb_index_data,
     };
 
     P::maybe_compress_debug_sections::<A>(&mut layout)?;
@@ -704,6 +705,7 @@ pub struct Layout<'data, P: Platform> {
     pub(crate) thunk_block_addresses: Vec<BTreeMap<SymbolId, u64>>,
 
     pub(crate) compressed_debug_sections: OutputSectionMap<Option<CompressedSection>>,
+    pub(crate) gdb_index_data: Option<P::GdbIndexScanResult<'data>>,
 }
 
 #[derive(Debug, Default)]
@@ -1953,7 +1955,10 @@ fn compute_total_section_part_sizes<'data, P: Platform>(
     per_symbol_flags: &mut PerSymbolFlags,
     must_keep_sections: OutputSectionMap<bool>,
     resources: &FinaliseSizesResources<'data, '_, P>,
-) -> Result<OutputSectionPartMap<u64>> {
+) -> Result<(
+    OutputSectionPartMap<u64>,
+    Option<P::GdbIndexScanResult<'data>>,
+)> {
     timing_phase!("Compute total section sizes");
 
     let mut total_sizes: OutputSectionPartMap<u64> = output_sections.new_part_map();
@@ -1962,10 +1967,10 @@ fn compute_total_section_part_sizes<'data, P: Platform>(
     }
 
     // Compute and allocate the .gdb_index section size if --gdb-index is enabled.
-    let gdb_index_size = if resources.symbol_db.args.should_write_gdb_index() {
+    let (gdb_index_size, gdb_index_data) = if resources.symbol_db.args.should_write_gdb_index() {
         P::compute_gdb_index_size(group_states)?
     } else {
-        0
+        (0, None)
     };
     if gdb_index_size > 0 {
         let first_group = group_states.first_mut().unwrap();
@@ -2014,7 +2019,7 @@ fn compute_total_section_part_sizes<'data, P: Platform>(
         }
     }
 
-    Ok(total_sizes)
+    Ok((total_sizes, gdb_index_data))
 }
 
 /// Allocates space for thunk blocks in each object that owns one.

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -1238,6 +1238,8 @@ impl<'data, P: Platform> CommonGroupState<'data, P> {
             *self.mem_sizes.get(part_id::SYMTAB_SHNDX_GLOBAL),
         );
 
+        memory_offsets.increment(part_id::GDB_INDEX, *self.mem_sizes.get(part_id::GDB_INDEX));
+
         strtab_offset_start
     }
 
@@ -1957,6 +1959,21 @@ fn compute_total_section_part_sizes<'data, P: Platform>(
     let mut total_sizes: OutputSectionPartMap<u64> = output_sections.new_part_map();
     for group_state in group_states.iter() {
         total_sizes.merge(&group_state.common.mem_sizes);
+    }
+
+    // Compute and allocate the .gdb_index section size if --gdb-index is enabled.
+    let gdb_index_size = if resources.symbol_db.args.should_write_gdb_index() {
+        P::compute_gdb_index_size(group_states)
+    } else {
+        0
+    };
+    if gdb_index_size > 0 {
+        let first_group = group_states.first_mut().unwrap();
+        first_group
+            .common
+            .mem_sizes
+            .increment(part_id::GDB_INDEX, gdb_index_size);
+        total_sizes.increment(part_id::GDB_INDEX, gdb_index_size);
     }
 
     // We need to apply late-stage adjustments for the epilogue before we do so for the prelude,

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -1963,7 +1963,7 @@ fn compute_total_section_part_sizes<'data, P: Platform>(
 
     // Compute and allocate the .gdb_index section size if --gdb-index is enabled.
     let gdb_index_size = if resources.symbol_db.args.should_write_gdb_index() {
-        P::compute_gdb_index_size(group_states)
+        P::compute_gdb_index_size(group_states)?
     } else {
         0
     };

--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -22,6 +22,7 @@ pub(crate) mod file_kind;
 pub(crate) mod file_writer;
 pub(crate) mod fs;
 pub(crate) mod gc_stats;
+pub(crate) mod gdb_index;
 pub(crate) mod glob_match;
 pub(crate) mod grouping;
 pub(crate) mod hash;

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -899,7 +899,7 @@ impl platform::Platform for MachO {
     type SymtabShndxEntry = ();
     type SymbolVersionIndex = ();
     type LayoutExt<'data> = LayoutExt<'data>;
-    type GdbIndexScanResult<'data> = ();
+    type GdbIndexScanResult = ();
     type SectionIterator<'a> = core::slice::Iter<'a, SectionHeader>;
     type DynamicTagValues<'data> = DynamicTagValues<'data>;
     type RelocationList<'data> = RelocationList<'data>;

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -899,6 +899,7 @@ impl platform::Platform for MachO {
     type SymtabShndxEntry = ();
     type SymbolVersionIndex = ();
     type LayoutExt<'data> = LayoutExt<'data>;
+    type GdbIndexScanResult<'data> = ();
     type SectionIterator<'a> = core::slice::Iter<'a, SectionHeader>;
     type DynamicTagValues<'data> = DynamicTagValues<'data>;
     type RelocationList<'data> = RelocationList<'data>;

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -101,6 +101,7 @@ pub(crate) const SYMTAB_SHNDX_LOCAL: OutputSectionId =
     part_id::SYMTAB_SHNDX_LOCAL.output_section_id();
 pub(crate) const SYMTAB_SHNDX_GLOBAL: OutputSectionId =
     part_id::SYMTAB_SHNDX_GLOBAL.output_section_id();
+pub(crate) const GDB_INDEX: OutputSectionId = part_id::GDB_INDEX.output_section_id();
 
 // Mach-O specific sections
 pub(crate) const PAGEZERO_SEGMENT: OutputSectionId = part_id::PAGEZERO_SEGMENT.output_section_id();

--- a/libwild/src/part_id.rs
+++ b/libwild/src/part_id.rs
@@ -51,36 +51,37 @@ pub(crate) const RELRO_PADDING: PartId = PartId(28);
 pub(crate) const RELR_DYN: PartId = PartId(29);
 pub(crate) const SYMTAB_SHNDX_LOCAL: PartId = PartId(30);
 pub(crate) const SYMTAB_SHNDX_GLOBAL: PartId = PartId(31);
+pub(crate) const GDB_INDEX: PartId = PartId(32);
 
 // Mach-O specific sections
-pub(crate) const PAGEZERO_SEGMENT: PartId = PartId(32);
-pub(crate) const TEXT_SEGMENT: PartId = PartId(33);
-pub(crate) const DATA_SEGMENT: PartId = PartId(34);
-pub(crate) const DATA_CONST_SEGMENT: PartId = PartId(35);
-pub(crate) const LINK_EDIT_SEGMENT: PartId = PartId(36);
-pub(crate) const ENTRY_POINT: PartId = PartId(37);
-pub(crate) const DYLD_CHAINED_FIXUPS: PartId = PartId(38);
-pub(crate) const LOAD_DYLIB: PartId = PartId(39);
-pub(crate) const SYMTAB_COMMAND: PartId = PartId(40);
-pub(crate) const CODE_SIGNATURE_COMMAND: PartId = PartId(41);
-pub(crate) const CODE_SIGNATURE: PartId = PartId(42);
-pub(crate) const CHAINED_FIXUP_TABLE: PartId = PartId(43);
+pub(crate) const PAGEZERO_SEGMENT: PartId = PartId(33);
+pub(crate) const TEXT_SEGMENT: PartId = PartId(34);
+pub(crate) const DATA_SEGMENT: PartId = PartId(35);
+pub(crate) const DATA_CONST_SEGMENT: PartId = PartId(36);
+pub(crate) const LINK_EDIT_SEGMENT: PartId = PartId(37);
+pub(crate) const ENTRY_POINT: PartId = PartId(38);
+pub(crate) const DYLD_CHAINED_FIXUPS: PartId = PartId(39);
+pub(crate) const LOAD_DYLIB: PartId = PartId(40);
+pub(crate) const SYMTAB_COMMAND: PartId = PartId(41);
+pub(crate) const CODE_SIGNATURE_COMMAND: PartId = PartId(42);
+pub(crate) const CODE_SIGNATURE: PartId = PartId(43);
+pub(crate) const CHAINED_FIXUP_TABLE: PartId = PartId(44);
 
 // Wasm specific sections. Each one corresponds to a single standard Wasm section.
-pub(crate) const WASM_TYPE: PartId = PartId(44);
-pub(crate) const WASM_IMPORT: PartId = PartId(45);
-pub(crate) const WASM_FUNCTION: PartId = PartId(46);
-pub(crate) const WASM_TABLE: PartId = PartId(47);
-pub(crate) const WASM_MEMORY: PartId = PartId(48);
-pub(crate) const WASM_GLOBAL: PartId = PartId(49);
-pub(crate) const WASM_EXPORT: PartId = PartId(50);
-pub(crate) const WASM_START: PartId = PartId(51);
-pub(crate) const WASM_ELEMENT: PartId = PartId(52);
-pub(crate) const WASM_DATA_COUNT: PartId = PartId(53);
-pub(crate) const WASM_CODE: PartId = PartId(54);
-pub(crate) const WASM_DATA: PartId = PartId(55);
+pub(crate) const WASM_TYPE: PartId = PartId(45);
+pub(crate) const WASM_IMPORT: PartId = PartId(46);
+pub(crate) const WASM_FUNCTION: PartId = PartId(47);
+pub(crate) const WASM_TABLE: PartId = PartId(48);
+pub(crate) const WASM_MEMORY: PartId = PartId(49);
+pub(crate) const WASM_GLOBAL: PartId = PartId(50);
+pub(crate) const WASM_EXPORT: PartId = PartId(51);
+pub(crate) const WASM_START: PartId = PartId(52);
+pub(crate) const WASM_ELEMENT: PartId = PartId(53);
+pub(crate) const WASM_DATA_COUNT: PartId = PartId(54);
+pub(crate) const WASM_CODE: PartId = PartId(55);
+pub(crate) const WASM_DATA: PartId = PartId(56);
 
-pub(crate) const NUM_SINGLE_PART_SECTIONS: u32 = 56;
+pub(crate) const NUM_SINGLE_PART_SECTIONS: u32 = 57;
 
 #[cfg(test)]
 pub(crate) const NUM_BUILT_IN_PARTS: usize = NUM_SINGLE_PART_SECTIONS as usize

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -765,11 +765,14 @@ pub(crate) trait Platform:
         0
     }
 
-    /// Compute the size of the `.gdb_index` section, if applicable.
-    fn compute_gdb_index_size(
-        _groups: &[crate::layout::GroupState<Self>],
-    ) -> crate::error::Result<u64> {
-        Ok(0)
+    /// Scan result for the `.gdb_index` section, if applicable.
+    type GdbIndexScanResult<'data>;
+
+    /// Compute the size of the `.gdb_index` section and return the scan result for the write phase.
+    fn compute_gdb_index_size<'data>(
+        _groups: &[crate::layout::GroupState<'data, Self>],
+    ) -> crate::error::Result<(u64, Option<Self::GdbIndexScanResult<'data>>)> {
+        Ok((0, None))
     }
 }
 

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -764,6 +764,11 @@ pub(crate) trait Platform:
     fn get_sizeof_headers(_header_info: &layout::HeaderInfo) -> u64 {
         0
     }
+
+    /// Compute the size of the `.gdb_index` section, if applicable.
+    fn compute_gdb_index_size(_groups: &[crate::layout::GroupState<Self>]) -> u64 {
+        0
+    }
 }
 
 /// Abstracts over the different object file formats that we support (or may support). e.g. ELF.
@@ -1342,6 +1347,10 @@ pub(crate) trait Args: std::fmt::Debug + Send + Sync + 'static {
 
     fn relocation_model(&self) -> crate::args::RelocationModel {
         self.common().relocation_model
+    }
+
+    fn should_write_gdb_index(&self) -> bool {
+        false
     }
 
     fn should_output_executable(&self) -> bool;

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -766,12 +766,12 @@ pub(crate) trait Platform:
     }
 
     /// Scan result for the `.gdb_index` section, if applicable.
-    type GdbIndexScanResult<'data>;
+    type GdbIndexScanResult: Send + Sync;
 
     /// Compute the size of the `.gdb_index` section and return the scan result for the write phase.
-    fn compute_gdb_index_size<'data>(
-        _groups: &[crate::layout::GroupState<'data, Self>],
-    ) -> crate::error::Result<(u64, Option<Self::GdbIndexScanResult<'data>>)> {
+    fn compute_gdb_index_size(
+        _groups: &[crate::layout::GroupState<Self>],
+    ) -> crate::error::Result<(u64, Option<Self::GdbIndexScanResult>)> {
         Ok((0, None))
     }
 }

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -766,8 +766,10 @@ pub(crate) trait Platform:
     }
 
     /// Compute the size of the `.gdb_index` section, if applicable.
-    fn compute_gdb_index_size(_groups: &[crate::layout::GroupState<Self>]) -> u64 {
-        0
+    fn compute_gdb_index_size(
+        _groups: &[crate::layout::GroupState<Self>],
+    ) -> crate::error::Result<u64> {
+        Ok(0)
     }
 }
 

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -1801,6 +1801,7 @@ impl platform::Platform for Wasm {
     type SymtabShndxEntry = ();
     type SymbolVersionIndex = ();
     type LayoutExt<'data> = WasmLayout<'data>;
+    type GdbIndexScanResult<'data> = ();
     type SectionIterator<'a> = core::slice::Iter<'a, SectionHeader>;
     type DynamicTagValues<'data> = DynamicTagValues<'data>;
     type RelocationList<'data> = RelocationList<'data>;

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -1801,7 +1801,7 @@ impl platform::Platform for Wasm {
     type SymtabShndxEntry = ();
     type SymbolVersionIndex = ();
     type LayoutExt<'data> = WasmLayout<'data>;
-    type GdbIndexScanResult<'data> = ();
+    type GdbIndexScanResult = ();
     type SectionIterator<'a> = core::slice::Iter<'a, SectionHeader>;
     type DynamicTagValues<'data> = DynamicTagValues<'data>;
     type RelocationList<'data> = RelocationList<'data>;

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -326,6 +326,8 @@ pub mod secnames {
     pub const RELRO_PADDING_SECTION_NAME: &[u8] = RELRO_PADDING_SECTION_NAME_STR.as_bytes();
     pub const SYMTAB_SHNDX_SECTION_NAME_STR: &str = ".symtab_shndx";
     pub const SYMTAB_SHNDX_SECTION_NAME: &[u8] = SYMTAB_SHNDX_SECTION_NAME_STR.as_bytes();
+    pub const DEBUG_INFO_SECTION_NAME_STR: &str = ".debug_info";
+    pub const DEBUG_INFO_SECTION_NAME: &[u8] = DEBUG_INFO_SECTION_NAME_STR.as_bytes();
     pub const GDB_INDEX_SECTION_NAME_STR: &str = ".gdb_index";
     pub const GDB_INDEX_SECTION_NAME: &[u8] = GDB_INDEX_SECTION_NAME_STR.as_bytes();
 

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -326,6 +326,8 @@ pub mod secnames {
     pub const RELRO_PADDING_SECTION_NAME: &[u8] = RELRO_PADDING_SECTION_NAME_STR.as_bytes();
     pub const SYMTAB_SHNDX_SECTION_NAME_STR: &str = ".symtab_shndx";
     pub const SYMTAB_SHNDX_SECTION_NAME: &[u8] = SYMTAB_SHNDX_SECTION_NAME_STR.as_bytes();
+    pub const GDB_INDEX_SECTION_NAME_STR: &str = ".gdb_index";
+    pub const GDB_INDEX_SECTION_NAME: &[u8] = GDB_INDEX_SECTION_NAME_STR.as_bytes();
 
     pub const GNU_LTO_SYMTAB_PREFIX: &str = ".gnu.lto_.symtab";
 }

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -16,6 +16,7 @@ tests = [
   "execute-only.sh",
   "fatal-warnings.sh",                     # `-warn-common` and `-fatal-warnings`
   "filter.sh",
+  "gdb-index-compress-output.sh",          # --compress-debug-sections=zlib-gabi
   "global-offset-table.sh",                # `-defsym=foo=_GLOBAL_OFFSET_TABLE_`
   "icf-gcc-except-table.sh",               # `--icf`
   "icf.sh",                                # `--icf`
@@ -48,20 +49,6 @@ tests = [
   "undefined-glob.sh",
   "warn-common.sh",
   "warn-once.sh",
-]
-
-[skipped_groups.gdb_index]
-reason = "GDB index support"
-tracking_issue = "https://github.com/wild-linker/wild/issues/811"
-tests = [
-  "gdb-index-compress-output.sh",
-  "gdb-index-dwarf2.sh",
-  "gdb-index-dwarf3.sh",
-  "gdb-index-dwarf4.sh",
-  "gdb-index-dwarf5.sh",
-  "gdb-index-dwarf64.sh",
-  "gdb-index-split-dwarf.sh",
-  "gdb-index-rnglistx.sh",
 ]
 
 [skipped_groups.version_script]

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -80,6 +80,9 @@
 //! ExpectGdbIndexSymbol:{name} Checks that the `.gdb_index` symbol table contains an entry for the
 //! specified symbol name.
 //!
+//! ExpectGdbIndexDistinctAddrCus:{count} Checks that the `.gdb_index` address area references at
+//! least {count} distinct CU indices.
+//!
 //! Mode:{mode} Set linking mode to static (default), dynamic or unspecified. Cannot be used
 //! together with LinkerDriver.
 //!
@@ -1276,6 +1279,7 @@ struct Assertions {
     expected_section_bytes: Vec<ExpectedSectionBytes>,
     expected_gdb_index_cu_count: Option<usize>,
     expected_gdb_index_symbols: Vec<String>,
+    expected_gdb_index_distinct_addr_cus: Option<usize>,
     output_file_matches: Vec<OutputFileMatch>,
     max_thunks: u64,
     expected_program_headers: Vec<ExpectedProgramHeaders>,
@@ -1646,6 +1650,13 @@ fn process_directive(
             .assertions
             .expected_gdb_index_symbols
             .push(arg.trim().to_owned()),
+        "ExpectGdbIndexDistinctAddrCus" => {
+            config.assertions.expected_gdb_index_distinct_addr_cus = Some(
+                arg.trim()
+                    .parse::<usize>()
+                    .with_context(|| format!("Invalid distinct addr CU count: {arg}"))?,
+            );
+        }
         "ExpectSectionBytes" => {
             let (section_name, hex_str) = arg.split_once('=').with_context(|| {
                 format!("ExpectSectionBytes requires section_name=0xhex_bytes, got `{arg}`")
@@ -3643,6 +3654,7 @@ impl Assertions {
         self.verify_section_bytes(&obj)?;
         self.verify_gdb_index_cu_count(&obj)?;
         self.verify_gdb_index_symbols(&obj)?;
+        self.verify_gdb_index_distinct_addr_cus(&obj)?;
         self.verify_strings(&bytes)?;
         verify_no_overlapping_sections(&obj)?;
         verify_no_overlapping_segments(&obj)?;
@@ -3767,6 +3779,34 @@ impl Assertions {
                 }
             );
         }
+        Ok(())
+    }
+
+    fn verify_gdb_index_distinct_addr_cus(&self, obj: &object::File) -> Result {
+        let Some(expected) = self.expected_gdb_index_distinct_addr_cus else {
+            return Ok(());
+        };
+        let data = gdb_index_section_data(obj, "ExpectGdbIndexDistinctAddrCus")?;
+        let hdr = GdbIndexOffsets::parse(&data)?;
+        // Each address entry is 20 bytes: low_address(u64) + high_address(u64) + cu_index(u32).
+        let entry_size = 20;
+        let area = &data[hdr.address_area..hdr.symbol_table];
+        let mut distinct_cus: HashSet<u32> = HashSet::new();
+        for chunk in area.chunks_exact(entry_size) {
+            let cu_index = u32::from_le_bytes(chunk[16..20].try_into().unwrap());
+            distinct_cus.insert(cu_index);
+        }
+        ensure!(
+            distinct_cus.len() >= expected,
+            "ExpectGdbIndexDistinctAddrCus: expected at least {expected} distinct CU indices \
+             in address area, got {} (indices: {:?})",
+            distinct_cus.len(),
+            {
+                let mut v: Vec<_> = distinct_cus.iter().copied().collect();
+                v.sort();
+                v
+            }
+        );
         Ok(())
     }
 
@@ -4139,6 +4179,7 @@ impl Assertions {
 struct GdbIndexOffsets {
     cu_list: usize,
     tu_list: usize,
+    address_area: usize,
     symbol_table: usize,
     constant_pool: usize,
 }
@@ -4151,6 +4192,7 @@ impl GdbIndexOffsets {
         let version = u32::from_le_bytes(data[0..4].try_into().unwrap());
         let cu_list = u32::from_le_bytes(data[4..8].try_into().unwrap()) as usize;
         let tu_list = u32::from_le_bytes(data[8..12].try_into().unwrap()) as usize;
+        let address_area = u32::from_le_bytes(data[12..16].try_into().unwrap()) as usize;
         let symbol_table = u32::from_le_bytes(data[16..20].try_into().unwrap()) as usize;
         let constant_pool = if version >= 8 {
             ensure!(
@@ -4168,6 +4210,7 @@ impl GdbIndexOffsets {
         Ok(Self {
             cu_list,
             tu_list,
+            address_area,
             symbol_table,
             constant_pool,
         })

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -67,8 +67,18 @@
 //!
 //! Contains:{string} Checks that the output binary does contain the specified string.
 //!
+//! ExpectSection:{section_name} Checks that the specified section exists in the output binary.
+//!
+//! NoSection:{section_name} Checks that the specified section does not exist in the output binary.
+//!
 //! ExpectSectionBytes:{section_name}=0x{hex_bytes} Checks that the specified section contains
 //! exactly the given bytes.
+//!
+//! ExpectGdbIndexCuCount:{count} Checks that the `.gdb_index` section contains exactly the
+//! specified number of CU entries.
+//!
+//! ExpectGdbIndexSymbol:{name} Checks that the `.gdb_index` symbol table contains an entry for the
+//! specified symbol name.
 //!
 //! Mode:{mode} Set linking mode to static (default), dynamic or unspecified. Cannot be used
 //! together with LinkerDriver.
@@ -1261,7 +1271,11 @@ struct Assertions {
     expected_load_alignments: Vec<u64>,
     expected_dynamic_entries: Vec<String>,
     absent_dynamic_entries: Vec<String>,
+    expected_sections: Vec<String>,
+    absent_sections: Vec<String>,
     expected_section_bytes: Vec<ExpectedSectionBytes>,
+    expected_gdb_index_cu_count: Option<usize>,
+    expected_gdb_index_symbols: Vec<String>,
     output_file_matches: Vec<OutputFileMatch>,
     max_thunks: u64,
     expected_program_headers: Vec<ExpectedProgramHeaders>,
@@ -1613,6 +1627,25 @@ fn process_directive(
         }
         "DoesNotContain" => config.assertions.does_not_contain.push(arg.to_owned()),
         "Contains" => config.assertions.contains_strings.push(arg.to_owned()),
+        "ExpectSection" => config
+            .assertions
+            .expected_sections
+            .push(arg.trim().to_owned()),
+        "NoSection" => config
+            .assertions
+            .absent_sections
+            .push(arg.trim().to_owned()),
+        "ExpectGdbIndexCuCount" => {
+            config.assertions.expected_gdb_index_cu_count = Some(
+                arg.trim()
+                    .parse::<usize>()
+                    .with_context(|| format!("Invalid CU count: {arg}"))?,
+            );
+        }
+        "ExpectGdbIndexSymbol" => config
+            .assertions
+            .expected_gdb_index_symbols
+            .push(arg.trim().to_owned()),
         "ExpectSectionBytes" => {
             let (section_name, hex_str) = arg.split_once('=').with_context(|| {
                 format!("ExpectSectionBytes requires section_name=0xhex_bytes, got `{arg}`")
@@ -3605,7 +3638,11 @@ impl Assertions {
             "dynsym",
         )?;
         self.verify_symbols_absent(&self.no_sym, obj.symbols(), "symtab")?;
+        self.verify_expected_sections(&obj)?;
+        self.verify_absent_sections(&obj)?;
         self.verify_section_bytes(&obj)?;
+        self.verify_gdb_index_cu_count(&obj)?;
+        self.verify_gdb_index_symbols(&obj)?;
         self.verify_strings(&bytes)?;
         verify_no_overlapping_sections(&obj)?;
         verify_no_overlapping_segments(&obj)?;
@@ -3647,6 +3684,88 @@ impl Assertions {
 
         if linker_used.is_wild() {
             self.verify_max_thunks(path)?;
+        }
+        Ok(())
+    }
+
+    fn verify_expected_sections(&self, obj: &object::File) -> Result {
+        for name in &self.expected_sections {
+            ensure!(
+                obj.section_by_name(name).is_some(),
+                "Expected section `{name}` not found"
+            );
+        }
+        Ok(())
+    }
+
+    fn verify_absent_sections(&self, obj: &object::File) -> Result {
+        for name in &self.absent_sections {
+            ensure!(
+                obj.section_by_name(name).is_none(),
+                "Section `{name}` should not exist but was found"
+            );
+        }
+        Ok(())
+    }
+
+    fn verify_gdb_index_cu_count(&self, obj: &object::File) -> Result {
+        let Some(expected) = self.expected_gdb_index_cu_count else {
+            return Ok(());
+        };
+        let data = gdb_index_section_data(obj, "ExpectGdbIndexCuCount")?;
+        let hdr = GdbIndexOffsets::parse(&data)?;
+        let cu_count = (hdr.tu_list - hdr.cu_list) / 16;
+        ensure!(
+            cu_count == expected,
+            "ExpectGdbIndexCuCount: expected {expected} CUs, got {cu_count}"
+        );
+        Ok(())
+    }
+
+    fn verify_gdb_index_symbols(&self, obj: &object::File) -> Result {
+        if self.expected_gdb_index_symbols.is_empty() {
+            return Ok(());
+        }
+        let data = gdb_index_section_data(obj, "ExpectGdbIndexSymbol")?;
+        let hdr = GdbIndexOffsets::parse(&data)?;
+        let num_slots = (hdr.constant_pool - hdr.symbol_table) / 8;
+
+        // Walk the hash table to collect all indexed symbol names.
+        let mut found: HashSet<&str> = HashSet::new();
+        for i in 0..num_slots {
+            let so = hdr.symbol_table + i * 8;
+            if so + 8 > data.len() {
+                break;
+            }
+            let name_rel = u32::from_le_bytes(data[so..so + 4].try_into().unwrap()) as usize;
+            let cv_rel = u32::from_le_bytes(data[so + 4..so + 8].try_into().unwrap()) as usize;
+            if name_rel == 0 && cv_rel == 0 {
+                continue;
+            }
+            let abs = hdr.constant_pool + name_rel;
+            if abs >= data.len() {
+                continue;
+            }
+            let end = data[abs..]
+                .iter()
+                .position(|&b| b == 0)
+                .map_or(data.len(), |p| abs + p);
+            if let Ok(name) = std::str::from_utf8(&data[abs..end]) {
+                found.insert(name);
+            }
+        }
+
+        for expected in &self.expected_gdb_index_symbols {
+            ensure!(
+                found.contains(expected.as_str()),
+                "ExpectGdbIndexSymbol: `{expected}` not found in .gdb_index.\n\
+                 Found symbols: {:?}",
+                {
+                    let mut v: Vec<_> = found.iter().collect();
+                    v.sort();
+                    v
+                }
+            );
         }
         Ok(())
     }
@@ -4014,6 +4133,52 @@ impl Assertions {
         // won't be checked for the test that writes the output to /dev/null.
         self.max_thunks > 0
     }
+}
+
+/// Parsed offsets from a `.gdb_index` header, version-agnostic.
+struct GdbIndexOffsets {
+    cu_list: usize,
+    tu_list: usize,
+    symbol_table: usize,
+    constant_pool: usize,
+}
+
+impl GdbIndexOffsets {
+    /// Parse from section data. Handles both the 6-field header (versions <= 7)
+    /// and the 7-field header (versions 8+, which adds a shortcut table offset).
+    fn parse(data: &[u8]) -> Result<Self> {
+        ensure!(data.len() >= 24, ".gdb_index too small for header");
+        let version = u32::from_le_bytes(data[0..4].try_into().unwrap());
+        let cu_list = u32::from_le_bytes(data[4..8].try_into().unwrap()) as usize;
+        let tu_list = u32::from_le_bytes(data[8..12].try_into().unwrap()) as usize;
+        let symbol_table = u32::from_le_bytes(data[16..20].try_into().unwrap()) as usize;
+        let constant_pool = if version >= 8 {
+            ensure!(
+                data.len() >= 28,
+                ".gdb_index v{version} too small for header"
+            );
+            // Version 8+: header has a shortcut_table_offset between symbol_table and
+            // constant_pool.
+            u32::from_le_bytes(data[24..28].try_into().unwrap()) as usize
+        } else {
+            // Version <= 7: no shortcut table; constant_pool immediately follows
+            // symbol_table_offset.
+            u32::from_le_bytes(data[20..24].try_into().unwrap()) as usize
+        };
+        Ok(Self {
+            cu_list,
+            tu_list,
+            symbol_table,
+            constant_pool,
+        })
+    }
+}
+
+fn gdb_index_section_data<'a>(obj: &'a object::File, directive: &str) -> Result<Vec<u8>> {
+    let section = obj
+        .section_by_name(".gdb_index")
+        .with_context(|| format!("{directive}: .gdb_index section not found"))?;
+    Ok(section.data()?.to_vec())
 }
 
 fn verify_no_overlapping_sections(obj: &object::File) -> Result {

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -4174,7 +4174,7 @@ impl GdbIndexOffsets {
     }
 }
 
-fn gdb_index_section_data<'a>(obj: &'a object::File, directive: &str) -> Result<Vec<u8>> {
+fn gdb_index_section_data(obj: &object::File, directive: &str) -> Result<Vec<u8>> {
     let section = obj
         .section_by_name(".gdb_index")
         .with_context(|| format!("{directive}: .gdb_index section not found"))?;

--- a/wild/tests/sources/elf/gdb-index-multi-cu/gdb-index-multi-cu.c
+++ b/wild/tests/sources/elf/gdb-index-multi-cu/gdb-index-multi-cu.c
@@ -1,0 +1,28 @@
+// Tests that .gdb_index address entries are assigned to the correct CU when a single input object
+// contains multiple CUs. -ffunction-sections ensures each function gets a separate section so the
+// per-CU assignment is observable in the address table.
+
+//#CompArgs:-g -ggnu-pubnames -ffunction-sections
+//#Object:runtime.c
+//#Relocatable:multi-cu-a.c,multi-cu-b.c
+//#SkipLinker:ld
+//#LinkArgs:--gdb-index
+//#ExpectSection:.gdb_index
+// 4 CU indices expected: this file, runtime.c, multi-cu-a.c, and multi-cu-b.c.
+//#ExpectGdbIndexDistinctAddrCus:4
+
+#include "../common/runtime.h"
+
+int multi_cu_a(int x);
+int multi_cu_b(int x);
+
+void _start(void) {
+  runtime_init();
+  if (multi_cu_a(21) != 42) {
+    exit_syscall(10);
+  }
+  if (multi_cu_b(39) != 42) {
+    exit_syscall(11);
+  }
+  exit_syscall(42);
+}

--- a/wild/tests/sources/elf/gdb-index-multi-cu/multi-cu-a.c
+++ b/wild/tests/sources/elf/gdb-index-multi-cu/multi-cu-a.c
@@ -1,0 +1,1 @@
+int multi_cu_a(int x) { return x * 2; }

--- a/wild/tests/sources/elf/gdb-index-multi-cu/multi-cu-b.c
+++ b/wild/tests/sources/elf/gdb-index-multi-cu/multi-cu-b.c
@@ -1,0 +1,1 @@
+int multi_cu_b(int x) { return x + 3; }

--- a/wild/tests/sources/elf/gdb-index/gdb-index.c
+++ b/wild/tests/sources/elf/gdb-index/gdb-index.c
@@ -18,6 +18,15 @@
 //#LinkArgs:--gdb-index --no-gdb-index
 //#NoSection:.gdb_index
 
+//#Config:with-strip-debug:default
+//#LinkArgs:--gdb-index --strip-debug
+//#NoSection:.gdb_index
+
+//#Config:with-strip-all:default
+//#LinkArgs:--gdb-index --strip-all
+//#DiffIgnore:file-header.entry
+//#NoSection:.gdb_index
+
 #include "../common/runtime.h"
 
 int foo(int a, int b);

--- a/wild/tests/sources/elf/gdb-index/gdb-index.c
+++ b/wild/tests/sources/elf/gdb-index/gdb-index.c
@@ -1,0 +1,37 @@
+//#AbstractConfig:default
+//#CompArgs:-g -ggnu-pubnames
+//#Object:runtime.c
+//#Object:gdb-index2.c
+//#SkipLinker:ld
+//#EnableLinker:lld
+
+//#Config:enabled:default
+//#LinkArgs:--gdb-index
+//#DiffIgnore:section.gdb_index
+//#ExpectSection:.gdb_index
+//#ExpectGdbIndexCuCount:3
+//#ExpectGdbIndexSymbol:compute
+//#ExpectGdbIndexSymbol:_start
+//#ExpectGdbIndexSymbol:foo
+
+//#Config:disabled:default
+//#LinkArgs:--gdb-index --no-gdb-index
+//#NoSection:.gdb_index
+
+#include "../common/runtime.h"
+
+int foo(int a, int b);
+
+int compute(int x) { return x + 1; }
+
+void _start(void) {
+  runtime_init();
+  if (compute(41) != 42) {
+    exit_syscall(10);
+  }
+  if (foo(20, 22) != 42) {
+    exit_syscall(11);
+  }
+
+  exit_syscall(42);
+}

--- a/wild/tests/sources/elf/gdb-index/gdb-index2.c
+++ b/wild/tests/sources/elf/gdb-index/gdb-index2.c
@@ -1,0 +1,1 @@
+int foo(int a, int b) { return a + b; }


### PR DESCRIPTION
This patch adds support for `--gdb-index` and `--no-gdb-index`. Although we support version 9 here, the test environment may produce a version 7 GDB index when using lld. This patch also adds a test that checks whether specific symbols are included in the symbol table of the `.gdb_index` section. Because of this requirement, the integration test includes logic to support versions earlier than version 9 as well.

Closes #811 