### PR TITLE
tests: include missing -Wl,-z,now

### DIFF
--- a/wild/tests/sources/elf/lto-dead-code-undef/lto-dead-code-undef.c
+++ b/wild/tests/sources/elf/lto-dead-code-undef/lto-dead-code-undef.c
@@ -9,7 +9,7 @@
 //#Config:gcc:default
 //#LinkerDriver:gcc
 //#Object:lto-dead-code-undef-1.c
-//#LinkArgs:-flto -O1 -nostdlib
+//#LinkArgs:-flto -O1 -nostdlib -Wl,-z,now
 //#DiffIgnore:section.rodata
 //#DiffIgnore:section.got
 

--- a/wild/tests/sources/elf/trivial-lto/trivial-lto.c
+++ b/wild/tests/sources/elf/trivial-lto/trivial-lto.c
@@ -3,7 +3,7 @@
 //#Object:runtime.c
 //#LinkerDriver:gcc
 //#CompArgs:-flto -O1
-//#LinkArgs:-flto -O1 -nostdlib
+//#LinkArgs:-flto -O1 -nostdlib -Wl,-z,now
 //#DiffIgnore:section.got
 
 #include "../common/runtime.h"


### PR DESCRIPTION
Not sure what exactly has changed on my Arch system, but these tests started to fail a couple days ago:
```
running 1 test
    test elf/x86_64/lto-dead-code-undef/gcc ... FAILED

    failures:

    ---- elf/x86_64/lto-dead-code-undef/gcc ----
    Validation failed.
    wild: /home/marxin/Programming/wild/wild/tests/build/elf/x86_64/lto-dead-code-undef/gcc/lto-dead-code-undef.c.wild
    ld: /home/marxin/Programming/wild/wild/tests/build/elf/x86_64/lto-dead-code-undef/gcc/lto-dead-code-undef.c.ld
    .dynamic.DT_FLAGS_1.NOW
      wild 1
      ld
```