### PR TITLE
linker-diff: Use dynamic endianness

### DIFF
--- a/linker-diff/src/arch.rs
+++ b/linker-diff/src/arch.rs
@@ -7,7 +7,6 @@ use linker_utils::elf::BitMask;
 use linker_utils::elf::DynamicRelocationKind;
 use linker_utils::elf::RelocationKindInfo;
 use linker_utils::relaxation::RelocationModifier;
-use object::LittleEndian;
 use object::read::elf::FileHeader as _;
 use std::fmt::Debug;
 use std::fmt::Display;
@@ -276,7 +275,9 @@ pub(crate) enum PltEntry {
 
 impl ArchKind {
     pub(crate) fn from_objects(bins: &[Binary]) -> Result<ArchKind> {
-        match bins[0].elf_file.elf_header().e_machine(LittleEndian) {
+        let binary = &bins[0];
+        let e = binary.elf_file.endian();
+        match binary.elf_file.elf_header().e_machine(e) {
             object::elf::EM_X86_64 => Ok(ArchKind::X86_64),
             object::elf::EM_AARCH64 => Ok(ArchKind::Aarch64),
             object::elf::EM_RISCV => Ok(ArchKind::RiscV64),

--- a/linker-diff/src/asm_diff.rs
+++ b/linker-diff/src/asm_diff.rs
@@ -74,7 +74,7 @@ use linker_utils::elf::RelocationSize;
 use linker_utils::elf::secnames::*;
 use linker_utils::relaxation::RelocationModifier;
 use linker_utils::utils::u32_from_slice;
-use object::LittleEndian;
+use object::Endianness;
 use object::Object as _;
 use object::ObjectKind;
 use object::ObjectSection as _;
@@ -754,13 +754,14 @@ fn get_original_referent<'data, R: RType>(
     rel: &object::Relocation,
     input_file: &crate::section_map::InputFile<'data>,
 ) -> Result<Referent<'data, R>> {
+    let e = input_file.elf_file.endian();
     if let RelocationTarget::Symbol(symbol_index) = rel.target() {
         let symbol = input_file.elf_file.symbol_by_index(symbol_index)?;
 
         if let Some(section_index) = symbol.section_index() {
             let section = input_file.elf_file.section_by_index(section_index)?;
 
-            let flags = section.elf_section_header().sh_flags(LittleEndian);
+            let flags = section.elf_section_header().sh_flags(e);
 
             if flags.contains(object::elf::SHF_MERGE | object::elf::SHF_STRINGS) {
                 let section_data = section.data()?;
@@ -1793,7 +1794,7 @@ struct RelaxationTester<'data> {
 
 impl<'data> RelaxationTester<'data> {
     fn new(
-        original_section: &ElfSection64<'data, '_, LittleEndian>,
+        original_section: &ElfSection64<'data, '_, Endianness>,
         bin: &'data Binary<'data>,
         section_address: u64,
         input_file: &section_map::InputFile,
@@ -2755,6 +2756,8 @@ fn symbol_versions_by_name<'data>(
     binaries: &'data [Binary<'data>],
     layout: &IndexedLayout<'data>,
 ) -> HashMap<&'data [u8], SymbolVersions> {
+    let e = binaries[0].elf_file.endian();
+
     // Populate our map with eligible unique symbols from the input files.
     let mut by_name: HashMap<&[u8], SymbolVersions> = layout
         .symbol_name_to_section_id
@@ -2764,7 +2767,7 @@ fn symbol_versions_by_name<'data>(
 
             // Merge sections are ignored, since they're split before copying, so can't be compared
             // 1:1 between output files.
-            if is_merge_section(&section)
+            if is_merge_section(&section, e)
                 || section.size() == 0
                 || !SUPPORTED_SECTION_KINDS.contains(&section.kind())
             {
@@ -2810,10 +2813,10 @@ fn symbol_versions_by_name<'data>(
 
 /// Returns whether the supplied section has the merge flag set. Merge sections aren't copied in
 /// their entirety, so need special handling.
-fn is_merge_section(section: &ElfSection64<LittleEndian>) -> bool {
+fn is_merge_section(section: &ElfSection64<Endianness>, e: Endianness) -> bool {
     section
         .elf_section_header()
-        .sh_flags(LittleEndian)
+        .sh_flags(e)
         .contains(object::elf::SHF_MERGE)
 }
 
@@ -2922,7 +2925,7 @@ impl<'data> SectionVersions<'data> {
     fn original_section<'layout>(
         &self,
         layout: &'layout IndexedLayout<'data>,
-    ) -> Result<ElfSection64<'data, 'layout, LittleEndian>> {
+    ) -> Result<ElfSection64<'data, 'layout, Endianness>> {
         layout.get_elf_section(self.input_section_id)
     }
 
@@ -3170,7 +3173,7 @@ impl<'data> AddressIndex<'data> {
     }
 
     fn index_verdef(elf_file: &ElfFile64<'data>) -> Result<Vec<Option<&'data [u8]>>> {
-        let e = LittleEndian;
+        let e = elf_file.endian();
         let mut versions = Vec::new();
 
         let maybe_verdef = elf_file
@@ -3203,7 +3206,7 @@ impl<'data> AddressIndex<'data> {
     }
 
     fn index_verneed(elf_file: &ElfFile64<'data>) -> Result<Vec<Option<&'data [u8]>>> {
-        let e = LittleEndian;
+        let e = elf_file.endian();
         let mut versions = Vec::new();
 
         let maybe_verneed = elf_file
@@ -3242,7 +3245,8 @@ impl<'data> AddressIndex<'data> {
         &self,
         elf_file: &ElfFile64<'data>,
     ) -> Result<Vec<SymtabEntryInfo<'data>>> {
-        let symbol_version_indexes: Option<&[object::elf::Versym<LittleEndian>]> = self
+        let e = elf_file.endian();
+        let symbol_version_indexes: Option<&[object::elf::Versym<Endianness>]> = self
             .versym_address
             .and_then(|address| {
                 elf_file
@@ -3260,7 +3264,7 @@ impl<'data> AddressIndex<'data> {
             max_index = max_index.max(sym_index);
             let version_index = symbol_version_indexes
                 .and_then(|indexes| indexes.get(sym_index))
-                .map(|versym| versym.0.get(LittleEndian).index());
+                .map(|versym| versym.0.get(e).index());
 
             let version: Option<&[u8]> = match version_index {
                 Some(object::elf::VER_NDX_LOCAL) | Some(object::elf::VER_NDX_GLOBAL)
@@ -3367,7 +3371,9 @@ impl<'data> AddressIndex<'data> {
             return Ok(());
         };
 
-        let entry_length = section.elf_section_header().sh_entsize(LittleEndian) as usize;
+        let e = elf_file.endian();
+
+        let entry_length = section.elf_section_header().sh_entsize(e) as usize;
 
         if ![0, 8, 0x10].contains(&entry_length) {
             bail!("{section_name} has unrecognised entry length {entry_length}");
@@ -3422,16 +3428,16 @@ impl<'data> AddressIndex<'data> {
     }
 
     fn index_dynamic(&mut self, elf_file: &ElfFile64) {
-        let e = LittleEndian;
+        let e = elf_file.endian();
 
         let dynamic_segment = elf_file
             .elf_program_headers()
             .iter()
-            .find(|seg| seg.p_type(LittleEndian) == object::elf::PT_DYNAMIC);
+            .find(|seg| seg.p_type(e) == object::elf::PT_DYNAMIC);
 
         self.dynamic_segment_address = dynamic_segment.map(|seg| seg.p_vaddr(e));
 
-        if elf_file.elf_header().e_type(LittleEndian) == object::elf::ET_DYN {
+        if elf_file.elf_header().e_type(e) == object::elf::ET_DYN {
             self.bin_attributes.relocatability = Relocatability::Relocatable;
         }
 
@@ -3440,9 +3446,9 @@ impl<'data> AddressIndex<'data> {
         };
 
         dynamic_segment
-            .and_then(|seg| seg.data(LittleEndian, elf_file.data()).ok())
+            .and_then(|seg| seg.data(e, elf_file.data()).ok())
             .and_then(|dynamic_table_data| {
-                object::slice_from_all_bytes::<object::elf::Dyn64<LittleEndian>>(dynamic_table_data)
+                object::slice_from_all_bytes::<object::elf::Dyn64<Endianness>>(dynamic_table_data)
                     .ok()
             })
             .unwrap_or_default()
@@ -3512,13 +3518,12 @@ impl<'data> AddressIndex<'data> {
 }
 
 fn get_tls_segment_size(elf_file: &ElfFile64) -> u64 {
+    let e = elf_file.endian();
+
     elf_file
         .elf_program_headers()
         .iter()
-        .find_map(|header| {
-            (header.p_type(LittleEndian) == object::elf::PT_TLS)
-                .then(|| header.p_memsz(LittleEndian))
-        })
+        .find_map(|header| (header.p_type(e) == object::elf::PT_TLS).then(|| header.p_memsz(e)))
         .unwrap_or(0)
 }
 
@@ -3721,8 +3726,8 @@ struct DynamicRelocation<'data, R: RType> {
 /// Attempts to read some data starting at `address` up to the end of the segment.
 fn read_segment<'data>(elf_file: &ElfFile64<'data>, address: u64) -> Option<Data<'data>> {
     // This could well end up needing to be optimised if we end up caring about performance.
+    let e = elf_file.endian();
     for raw_seg in elf_file.elf_program_headers() {
-        let e = LittleEndian;
         if raw_seg.p_type(e) != object::elf::PT_LOAD {
             continue;
         }
@@ -3952,7 +3957,7 @@ impl Display for OutputKind {
 }
 
 impl Visibility {
-    fn from_sym(elf_symbol: &object::elf::Sym64<LittleEndian>) -> Visibility {
+    fn from_sym(elf_symbol: &object::elf::Sym64<Endianness>) -> Visibility {
         match elf_symbol.st_visibility() {
             object::elf::STV_DEFAULT => Visibility::Default,
             object::elf::STV_PROTECTED => Visibility::Protected,

--- a/linker-diff/src/debug_info_diff.rs
+++ b/linker-diff/src/debug_info_diff.rs
@@ -4,7 +4,6 @@ use crate::DiffValues;
 use crate::Report;
 use crate::header_diff::DiffMode;
 use anyhow::Result;
-use gimli::LittleEndian;
 use hashbrown::HashMap;
 use itertools::Itertools;
 use object::ObjectSection;
@@ -26,7 +25,7 @@ impl Display for CompilationUnitIdentifier {
 const DEBUG_INFO_ERROR_KEY: &str = "debug_info";
 
 fn parse_unit_info(
-    unit: gimli::UnitRef<'_, gimli::EndianSlice<'_, LittleEndian>>,
+    unit: gimli::UnitRef<'_, gimli::EndianSlice<'_, gimli::LittleEndian>>,
     size: usize,
 ) -> Result<(CompilationUnitIdentifier, usize)> {
     let mut name = None;
@@ -75,7 +74,8 @@ fn read_file_debug_info(obj: &Binary) -> Result<HashMap<CompilationUnitIdentifie
         })
     };
 
-    let borrow_section = |section| gimli::EndianSlice::new(Cow::as_ref(section), LittleEndian);
+    let borrow_section =
+        |section| gimli::EndianSlice::new(Cow::as_ref(section), gimli::LittleEndian);
     let dwarf_sections = gimli::DwarfSections::load(&load_section)?;
     let dwarf = dwarf_sections.borrow(borrow_section);
 

--- a/linker-diff/src/eh_frame_diff.rs
+++ b/linker-diff/src/eh_frame_diff.rs
@@ -9,7 +9,7 @@ use gimli::UnwindSection;
 use hashbrown::HashMap;
 use linker_utils::elf::secnames::EH_FRAME_HDR_SECTION_NAME_STR;
 use linker_utils::elf::secnames::EH_FRAME_SECTION_NAME_STR;
-use object::LittleEndian;
+use object::Endianness;
 use object::Object;
 use object::ObjectSection;
 use object::ObjectSymbol;
@@ -31,9 +31,10 @@ pub(crate) fn report_diffs(report: &mut crate::Report, objects: &[crate::Binary]
 }
 
 fn read_eh_frame_hdr_fields(object: &crate::Binary) -> Result<FieldValues> {
+    let e = object.elf_file.endian();
     let mut values = FieldValues::default();
 
-    let Some(segment_hdr) = eh_frame_segment(object) else {
+    let Some(segment_hdr) = eh_frame_segment(object, e) else {
         values.insert_string_owned("GNU_EH_FRAME".to_owned(), "Missing".to_owned());
         return Ok(values);
     };
@@ -46,7 +47,7 @@ fn read_eh_frame_hdr_fields(object: &crate::Binary) -> Result<FieldValues> {
         return Ok(values);
     };
 
-    let address1 = segment_hdr.p_vaddr(LittleEndian);
+    let address1 = segment_hdr.p_vaddr(e);
     let address2 = section.address();
     if address1 != address2 {
         bail!(".eh_frame_hdr address doesn't match GNU_EN_FRAME segment");
@@ -186,9 +187,9 @@ fn verify_frames(
     Ok(())
 }
 
-fn eh_frame_segment(object: &crate::Binary) -> Option<ProgramHeader64<LittleEndian>> {
+fn eh_frame_segment(object: &crate::Binary, e: Endianness) -> Option<ProgramHeader64<Endianness>> {
     for hdr in object.elf_file.elf_program_headers() {
-        if hdr.p_type.get(LittleEndian) == object::elf::PT_GNU_EH_FRAME {
+        if hdr.p_type.get(e) == object::elf::PT_GNU_EH_FRAME {
             return Some(*hdr);
         }
     }

--- a/linker-diff/src/gnu_hash.rs
+++ b/linker-diff/src/gnu_hash.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use anyhow::anyhow;
 use anyhow::bail;
 use linker_utils::elf::secnames::GNU_HASH_SECTION_NAME_STR;
-use object::LittleEndian;
+use object::Endianness;
 use object::Object as _;
 use object::ObjectSection as _;
 use object::ObjectSymbol as _;
@@ -13,7 +13,7 @@ use object::SymbolIndex;
 use object::elf::FileHeader64;
 use object::read::elf::ElfSymbolTable;
 
-type GnuHashHeader = object::elf::GnuHashHeader<LittleEndian>;
+type GnuHashHeader = object::elf::GnuHashHeader<Endianness>;
 
 pub(crate) fn check_object(obj: &Binary) -> Result {
     let num_symbols = obj
@@ -36,7 +36,7 @@ pub(crate) fn check_object(obj: &Binary) -> Result {
     }
 
     let gnu_hash_bytes = gnu_hash.data()?;
-    let e = LittleEndian;
+    let e = obj.elf_file.endian();
 
     let (header, rest) = object::from_bytes::<GnuHashHeader>(gnu_hash_bytes)
         .map_err(|_| anyhow!("Insufficient .gnu.hash bytes"))?;
@@ -90,17 +90,18 @@ pub(crate) fn check_object(obj: &Binary) -> Result {
         }
         let name = sym.name()?;
         let name_bytes = sym.name_bytes()?;
-        let symbol_index = lookup_symbol(name_bytes, header, bloom_values, buckets, chains, dynsym)
-            .with_context(|| {
-                let hash = object::elf::gnu_hash(name_bytes);
-                format!(
-                    "Hash lookup of symbol `{name}` failed. \
+        let symbol_index =
+            lookup_symbol(name_bytes, header, bloom_values, buckets, chains, dynsym, e)
+                .with_context(|| {
+                    let hash = object::elf::gnu_hash(name_bytes);
+                    format!(
+                        "Hash lookup of symbol `{name}` failed. \
                         hash=0x{hash:x} \
                         buckets={buckets:?} \
                         symbol_base={symbol_base} \
                         chains={chains:x?}"
-                )
-            })?;
+                    )
+                })?;
         if symbol_index != sym.index().0 {
             bail!(
                 "Dynamic symbol `{}` hash lookup found {symbol_index}, expected {}",
@@ -115,13 +116,13 @@ pub(crate) fn check_object(obj: &Binary) -> Result {
 
 fn lookup_symbol(
     sym_name: &[u8],
-    header: &object::elf::GnuHashHeader<LittleEndian>,
+    header: &object::elf::GnuHashHeader<Endianness>,
     bloom_values: &[u64],
     buckets: &[u32],
     chains: &[u32],
-    dynsym: ElfSymbolTable<FileHeader64<LittleEndian>>,
+    dynsym: ElfSymbolTable<FileHeader64<Endianness>>,
+    e: Endianness,
 ) -> Result<usize> {
-    let e = LittleEndian;
     let symbol_base = header.symbol_base.get(e) as usize;
     let hash = object::elf::gnu_hash(sym_name);
     let elf_class_bits = size_of::<u64>() as u32 * 8;

--- a/linker-diff/src/header_diff.rs
+++ b/linker-diff/src/header_diff.rs
@@ -15,7 +15,7 @@ use linker_utils::elf::SectionFlags;
 #[allow(clippy::wildcard_imports)]
 use linker_utils::elf::secnames::*;
 use linker_utils::elf::shf;
-use object::LittleEndian;
+use object::Endianness;
 use object::Object as _;
 use object::ObjectSection as _;
 use object::ObjectSymbol as _;
@@ -227,30 +227,31 @@ pub(crate) fn report_section_diffs(report: &mut Report, objects: &[Binary]) {
             |object| {
                 let section = section_or_equiv(object, name, &report.config)
                     .ok_or_else(|| anyhow!("Section missing"))?;
+                let e = object.elf_file.endian();
                 let mut values = FieldValues::default();
                 values.insert("alignment", section.align(), Converter::None, object);
                 let section_header = section.elf_section_header();
                 values.insert(
                     "link",
-                    section_header.sh_link.get(LittleEndian),
+                    section_header.sh_link.get(e),
                     Converter::SectionIndex,
                     object,
                 );
                 values.insert(
                     "flags",
-                    section_header.sh_flags.get(LittleEndian).0,
+                    section_header.sh_flags.get(e).0,
                     Converter::SectionFlags,
                     object,
                 );
                 values.insert(
                     "type",
-                    section_header.sh_type.get(LittleEndian).0,
+                    section_header.sh_type.get(e).0,
                     Converter::None,
                     object,
                 );
                 values.insert(
                     "entsize",
-                    section_header.sh_entsize.get(LittleEndian),
+                    section_header.sh_entsize.get(e),
                     Converter::None,
                     object,
                 );
@@ -266,7 +267,7 @@ fn section_or_equiv<'data, 'file: 'data>(
     object: &'file Binary<'data>,
     name: &[u8],
     config: &Config,
-) -> Option<ElfSection64<'data, 'file, LittleEndian>> {
+) -> Option<ElfSection64<'data, 'file, Endianness>> {
     if let Some(section) = object.section_by_name_bytes(name) {
         return Some(section);
     }
@@ -474,7 +475,7 @@ impl FieldValues {
 fn read_file_header_fields(obj: &Binary) -> Result<FieldValues> {
     let mut values = FieldValues::default();
     let header = obj.elf_file.elf_header();
-    let e = LittleEndian;
+    let e = obj.elf_file.endian();
     values.insert_string("ident", format!("{:?}", header.e_ident.magic));
     values.insert("type", header.e_type.get(e).0, Converter::None, obj);
     values.insert("machine", header.e_machine.get(e).0, Converter::None, obj);
@@ -503,9 +504,9 @@ fn read_dynamic_fields(obj: &Binary) -> Result<FieldValues> {
         .with_context(|| format!("`{obj}` is missing .dynamic"))?;
 
     let mut values = FieldValues::default();
-    let e = LittleEndian;
+    let e = obj.elf_file.endian();
 
-    let entries: &[object::elf::Dyn64<LittleEndian>] = slice_from_all_bytes(dynamic.data()?);
+    let entries: &[object::elf::Dyn64<Endianness>] = slice_from_all_bytes(dynamic.data()?);
     let mut got_null = false;
 
     // The following relies on the BFD order of the tags, but seems the easiest way how to catch

--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -23,7 +23,7 @@ use itertools::Itertools as _;
 #[allow(clippy::wildcard_imports)]
 use linker_utils::elf::secnames::*;
 use linker_utils::utils::slice_from_all_bytes;
-use object::LittleEndian;
+use object::Endianness;
 use object::Object as _;
 use object::ObjectSection;
 use object::ObjectSymbol as _;
@@ -57,8 +57,8 @@ mod version_diff;
 mod x86_64;
 
 type Result<T = (), E = anyhow::Error> = core::result::Result<T, E>;
-type ElfFile64<'data> = object::read::elf::ElfFile64<'data, LittleEndian>;
-type ElfSymbol64<'data, 'file> = object::read::elf::ElfSymbol64<'data, 'file, LittleEndian>;
+type ElfFile64<'data> = object::read::elf::ElfFile64<'data, Endianness>;
+type ElfSymbol64<'data, 'file> = object::read::elf::ElfSymbol64<'data, 'file, Endianness>;
 
 use arch::Arch;
 use arch::ArchKind;
@@ -494,14 +494,14 @@ impl<'data> Binary<'data> {
     fn section_by_name<'file: 'data>(
         &'file self,
         name: &str,
-    ) -> Option<ElfSection64<'data, 'file, LittleEndian>> {
+    ) -> Option<ElfSection64<'data, 'file, Endianness>> {
         self.section_by_name_bytes(name.as_bytes())
     }
 
     fn section_by_name_bytes<'file: 'data>(
         &'file self,
         name: &[u8],
-    ) -> Option<ElfSection64<'data, 'file, LittleEndian>> {
+    ) -> Option<ElfSection64<'data, 'file, Endianness>> {
         let index = self.sections_by_name.get(name)?.index;
         self.elf_file.section_by_index(index).ok()
     }
@@ -509,7 +509,7 @@ impl<'data> Binary<'data> {
     fn section_containing_address<'file: 'data>(
         &'file self,
         address: u64,
-    ) -> Option<ElfSection64<'file, 'data, LittleEndian>> {
+    ) -> Option<ElfSection64<'file, 'data, Endianness>> {
         self.elf_file
             .sections()
             .find(|sec| (sec.address()..sec.address() + sec.size()).contains(&address))

--- a/linker-diff/src/section_map.rs
+++ b/linker-diff/src/section_map.rs
@@ -5,7 +5,7 @@ use anyhow::bail;
 use hashbrown::HashMap;
 use itertools::Itertools;
 use linker_layout::ArchiveEntryInfo;
-use object::LittleEndian;
+use object::Endianness;
 use object::Object;
 use object::ObjectSection;
 use object::ObjectSymbol;
@@ -254,7 +254,7 @@ impl<'data> IndexedLayout<'data> {
     pub(crate) fn get_elf_section(
         &self,
         section_id: InputSectionId,
-    ) -> Result<ElfSection64<'data, '_, LittleEndian>> {
+    ) -> Result<ElfSection64<'data, '_, Endianness>> {
         Ok(self.files[section_id.file_index]
             .elf_file
             .section_by_index(section_id.section_index)?)

--- a/linker-diff/src/segment.rs
+++ b/linker-diff/src/segment.rs
@@ -4,7 +4,6 @@ use crate::header_diff::FieldValues;
 use anyhow::Ok;
 use anyhow::Result;
 use linker_utils::elf::pt;
-use object::LittleEndian;
 use object::elf::PT_LOAD;
 use object::read::elf::ProgramHeader as _;
 
@@ -18,7 +17,7 @@ pub(crate) fn report_diffs(report: &mut crate::Report, objects: &[crate::Binary]
 }
 
 fn read_program_segment_fields(object: &crate::Binary) -> Result<FieldValues> {
-    let e = LittleEndian;
+    let e = object.elf_file.endian();
     let mut values = FieldValues::default();
 
     for segment in object.elf_file.elf_program_headers() {

--- a/linker-diff/src/symtab.rs
+++ b/linker-diff/src/symtab.rs
@@ -2,7 +2,6 @@ use crate::Binary;
 use crate::Result;
 use anyhow::bail;
 use linker_utils::elf::sht;
-use object::LittleEndian;
 use object::Object as _;
 use object::ObjectSymbol;
 use object::read::elf::SectionHeader as _;
@@ -17,6 +16,7 @@ pub(crate) fn validate_dynamic(object: &Binary) -> Result {
 }
 
 fn validate(object: &Binary, dynamic: bool) -> Result {
+    let e = object.elf_file.endian();
     let mut symtab_info = 0;
     let (symtab_section_type, mut symbols) = if dynamic {
         (sht::DYNSYM, object.elf_file.dynamic_symbols())
@@ -24,8 +24,8 @@ fn validate(object: &Binary, dynamic: bool) -> Result {
         (sht::SYMTAB, object.elf_file.symbols())
     };
     for section in object.elf_file.elf_section_table().iter() {
-        if section.sh_type(LittleEndian) == symtab_section_type {
-            symtab_info = section.sh_info(LittleEndian);
+        if section.sh_type(e) == symtab_section_type {
+            symtab_info = section.sh_info(e);
         }
     }
     let first_non_local = symbols.find_map(|sym| sym.is_local().not().then(|| sym.index()));

--- a/linker-diff/src/sysv_hash.rs
+++ b/linker-diff/src/sysv_hash.rs
@@ -5,7 +5,7 @@ use anyhow::bail;
 use anyhow::ensure;
 use itertools::Itertools;
 use linker_utils::elf::secnames::HASH_SECTION_NAME_STR;
-use object::LittleEndian;
+use object::Endianness;
 use object::Object as _;
 use object::ObjectSection as _;
 use object::ObjectSymbol as _;
@@ -101,7 +101,7 @@ fn lookup_symbol(
     sym_name: &[u8],
     buckets: &[u32],
     chains: &[u32],
-    dynsym: ElfSymbolTable<FileHeader64<LittleEndian>>,
+    dynsym: ElfSymbolTable<FileHeader64<Endianness>>,
 ) -> Result<usize> {
     if buckets.is_empty() {
         bail!("Empty .hash bucket table");

--- a/linker-diff/src/version_diff.rs
+++ b/linker-diff/src/version_diff.rs
@@ -3,7 +3,6 @@ use crate::header_diff::FieldValues;
 use anyhow::Result;
 use linker_utils::elf::secnames::GNU_VERSION_D_SECTION_NAME_STR;
 use linker_utils::elf::secnames::GNU_VERSION_SECTION_NAME_STR;
-use object::LittleEndian;
 use object::Object;
 use object::ObjectSymbol;
 use object::elf;
@@ -28,7 +27,7 @@ pub(crate) fn report_diffs(report: &mut crate::Report, objects: &[crate::Binary]
 // Reads version names defined in the binary's version_d section and their parent name to find
 // whether all the versions are present.
 fn read_gnu_version_d(bin: &crate::Binary) -> Result<FieldValues> {
-    let e = LittleEndian;
+    let e = bin.elf_file.endian();
     let mut values = FieldValues::default();
 
     let Some((mut verdef_iterator, strings_index)) = bin
@@ -84,7 +83,7 @@ fn read_gnu_version_d(bin: &crate::Binary) -> Result<FieldValues> {
 // Reads dynamic symbol names and their corresponding version names to find whether all dynamic
 // symbols have the correct version.
 fn read_gnu_version(bin: &crate::Binary) -> Result<FieldValues> {
-    let e = LittleEndian;
+    let e = bin.elf_file.endian();
     let mut values = FieldValues::default();
 
     let Some((versyms, _)) = bin


### PR DESCRIPTION
This is a step towards making linker-diff work with more than just ELF files. I don't actually intend to support big endian - the gimli stuff still hard-codes little endian - but `object::File::parse` gives you file where the endianness is a runtime not a compile-time property.