### PR TITLE
fix(LoongArch64/RV64): allow empty sequence for merge_eflags

### DIFF
--- a/libwild/src/elf_loongarch64.rs
+++ b/libwild/src/elf_loongarch64.rs
@@ -88,9 +88,13 @@ impl crate::platform::Arch for ElfLoongArch64 {
     fn merge_eflags(
         mut eflags: impl Iterator<Item = object::elf::FileFlags>,
     ) -> Result<object::elf::FileFlags> {
-        eflags
-            .all_equal_value()
-            .map_err(|_e| error!("non-unique e_flags"))
+        let res = eflags.all_equal_value();
+        match res {
+            Ok(flags) => Ok(flags),
+            // no items, return blank flags
+            Err(None) => Ok(object::elf::FileFlags(0)),
+            Err(Some((a, b))) => Err(error!("non-unique e_flags: {a}, {b}")),
+        }
     }
 
     fn high_part_relocations() -> &'static [u32] {

--- a/libwild/src/elf_loongarch64.rs
+++ b/libwild/src/elf_loongarch64.rs
@@ -88,8 +88,7 @@ impl crate::platform::Arch for ElfLoongArch64 {
     fn merge_eflags(
         mut eflags: impl Iterator<Item = object::elf::FileFlags>,
     ) -> Result<object::elf::FileFlags> {
-        let res = eflags.all_equal_value();
-        match res {
+        match eflags.all_equal_value() {
             Ok(flags) => Ok(flags),
             // no items, return blank flags
             Err(None) => Ok(object::elf::FileFlags(0)),

--- a/libwild/src/elf_riscv64.rs
+++ b/libwild/src/elf_riscv64.rs
@@ -109,6 +109,10 @@ impl crate::platform::Arch for ElfRiscV64 {
         eflags: impl Iterator<Item = object::elf::FileFlags>,
     ) -> Result<object::elf::FileFlags> {
         let eflags = eflags.collect_vec();
+        if eflags.is_empty() {
+            return Ok(object::elf::FileFlags(0));
+        }
+
         let or_eflags = eflags
             .iter()
             .fold(object::elf::FileFlags(0), |acc, x| acc | *x);
@@ -116,8 +120,7 @@ impl crate::platform::Arch for ElfRiscV64 {
             eflags
                 .iter()
                 .map(|flag| flag.riscv_float_abi())
-                .unique()
-                .exactly_one()
+                .all_equal_value()
                 .is_ok(),
             "Float ABI flag mismatch"
         );
@@ -125,8 +128,7 @@ impl crate::platform::Arch for ElfRiscV64 {
             eflags
                 .iter()
                 .map(|flag| flag.contains(EF_RISCV_RVE))
-                .unique()
-                .exactly_one()
+                .all_equal_value()
                 .is_ok(),
             "RVE flag mismatch"
         );
@@ -134,8 +136,7 @@ impl crate::platform::Arch for ElfRiscV64 {
             eflags
                 .iter()
                 .map(|flag| flag.contains(EF_RISCV_RV64ILP32))
-                .unique()
-                .exactly_one()
+                .all_equal_value()
                 .is_ok(),
             "RV64ILP32 flag mismatch"
         );


### PR DESCRIPTION
Noticed that while debugging the Mold external tests on LoongArch64 (and RV64) - for an empty shared library, we can have none eflags to be merged and so we should allow empty sequence and build `object::elf::FileFlags::(0)`.