### PR TITLE
feat(ppc64): REL24 local entry plus REL32/ADDR32/REL64

### DIFF
--- a/libwild/src/elf_ppc64.rs
+++ b/libwild/src/elf_ppc64.rs
@@ -3,6 +3,7 @@ use crate::elf::Elf;
 use crate::error;
 use crate::error::Result;
 use crate::platform::Platform;
+use linker_utils::bit_misc::BitExtraction;
 use linker_utils::elf::DynamicRelocationKind;
 use linker_utils::elf::RelocationKindInfo;
 use linker_utils::elf::ppc64_rel_type_to_string;
@@ -67,6 +68,14 @@ impl crate::platform::Arch for ElfPpc64 {
 
     fn high_part_relocations() -> &'static [u32] {
         &[]
+    }
+
+    fn local_entry_offset(st_other: u8) -> u64 {
+        // ELFv2 encodes the distance from a function's global entry point to its local entry point
+        // in st_other bits [7:5]: offset = ((1 << k) >> 2) << 2 (k=0,1 -> 0; 2 -> 4; 3 -> 8; ...).
+        let bit = u32::from(object::elf::STO_PPC64_LOCAL_BIT);
+        let k = u64::from(st_other).extract_bit_range(bit..bit + 3);
+        u64::from(((1u32 << k) >> 2) << 2)
     }
 
     #[allow(unused_variables)]

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2652,6 +2652,19 @@ fn get_resolution<'data, R: Relocation>(
     Ok((resolution, symbol_index, local_symbol_id))
 }
 
+/// Returns the `st_other` byte of the canonical definition of `symbol_id`, or 0 if it isn't
+/// defined by a regular object. Used for ppc64 local-entry-point computation.
+fn callee_st_other(layout: &ElfLayout, symbol_id: SymbolId) -> u8 {
+    let canonical = layout.symbol_db.definition(symbol_id);
+    let file_id = layout.symbol_db.file_id_for_symbol(canonical);
+    if let FileLayout::Object(obj) = layout.file_layout(file_id)
+        && let Ok(sym) = obj.object.symbol(canonical.to_input(obj.symbol_id_range))
+    {
+        return sym.st_other.0;
+    }
+    0
+}
+
 fn write_got_plt_syms(
     layout: &ElfLayout,
     symbol_writer: &mut SymbolTableWriter<'_, '_>,
@@ -2876,6 +2889,13 @@ fn apply_relocation<
 
     let mask = get_page_mask(rel_info.mask);
     let bias = rel_info.bias;
+    // For ppc64 calls, branch to the callee's local entry point (we share its TOC, so the global
+    // entry's r2 setup is unnecessary). Zero for every other architecture and relocation.
+    let branch_local_entry = if rel_info.size.is_ppc64_branch() {
+        A::local_entry_offset(callee_st_other(layout, local_symbol_id))
+    } else {
+        0
+    };
     let mut value = match rel_info.kind {
         RelocationKind::Absolute => write_absolute_relocation::<A>(
             table_writer,
@@ -2919,6 +2939,7 @@ fn apply_relocation<
                 &layout.merged_strings,
                 &layout.merged_string_start_addresses,
             )?
+            .wrapping_add(branch_local_entry)
             .wrapping_add(bias)
             .bitand(mask.symbol_plus_addend)
             .wrapping_sub(place.bitand(mask.place)),

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -145,6 +145,13 @@ pub(crate) trait Arch: Send + Sync + 'static {
         false
     }
 
+    /// For a call/branch relocation, returns the offset from a callee's global entry point to its
+    /// local entry point, derived from the callee's `st_other`. Only meaningful on ppc64 (ELFv2
+    /// dual-entry functions); defaults to 0.
+    fn local_entry_offset(_st_other: u8) -> u64 {
+        0
+    }
+
     /// Tries to create a relaxation for the relocation of the specified kind, to be applied at the
     /// specified offset in the supplied section.
     fn new_relaxation(

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -938,6 +938,21 @@ impl RelocationSize {
             bit_end,
         ))
     }
+
+    /// Returns whether this relocation writes a ppc64 branch instruction, i.e. a call/branch site
+    /// that may need a local-entry-point adjustment. False for every non-ppc64 relocation.
+    #[must_use]
+    pub fn is_ppc64_branch(&self) -> bool {
+        matches!(
+            self,
+            RelocationSize::BitMasking(BitMask {
+                instruction: RelocationInstruction::Ppc64(
+                    Ppc64Instruction::Branch14 | Ppc64Instruction::Branch24
+                ),
+                ..
+            })
+        )
+    }
 }
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]

--- a/linker-utils/src/ppc64.rs
+++ b/linker-utils/src/ppc64.rs
@@ -60,6 +60,13 @@ pub const fn relocation_type_from_raw(r_type: u32) -> Option<RelocationKindInfo>
             0,
         ),
         // PC-relative data (e.g. .eh_frame pointers).
+        object::elf::R_PPC64_REL64 => (
+            RelocationKind::Relative,
+            RelocationSize::ByteSize(8),
+            AllowedRange::no_check(),
+            1,
+            0,
+        ),
         object::elf::R_PPC64_REL32 => (
             RelocationKind::Relative,
             RelocationSize::ByteSize(4),

--- a/linker-utils/src/ppc64.rs
+++ b/linker-utils/src/ppc64.rs
@@ -39,11 +39,31 @@ impl RelaxationKind {
 #[must_use]
 pub const fn relocation_type_from_raw(r_type: u32) -> Option<RelocationKindInfo> {
     let (kind, size, range, alignment, bias) = match r_type {
-        // 64-bit absolute address.
+        // Absolute addresses.
         object::elf::R_PPC64_ADDR64 => (
             RelocationKind::Absolute,
             RelocationSize::ByteSize(8),
             AllowedRange::no_check(),
+            1,
+            0,
+        ),
+        object::elf::R_PPC64_ADDR32 => (
+            RelocationKind::Absolute,
+            RelocationSize::ByteSize(4),
+            // `S + A` truncated into a 32-bit field. The overflow check mirrors binutils'
+            // `complain_overflow_bitfield` for this relocation: a value is in range if its bit
+            // pattern fits in 32 bits, whether read as signed or unsigned. That union is
+            // `[-2^31, 2^32)` -- the negative lower bound admits a sign-extended negative addend,
+            // not a negative address.
+            AllowedRange::new(-(2i64.pow(31)), 2i64.pow(32)),
+            1,
+            0,
+        ),
+        // PC-relative data (e.g. .eh_frame pointers).
+        object::elf::R_PPC64_REL32 => (
+            RelocationKind::Relative,
+            RelocationSize::ByteSize(4),
+            AllowedRange::from_bit_size(32, Sign::Signed),
             1,
             0,
         ),


### PR DESCRIPTION
Extends the ppc64le static-relocation support added in #1977 with the
  remaining pieces needed for a static link to come out correct on ELFv2:

  - **REL24 local entry.** An ELFv2 callee that sets up r2 has a separate
    local entry point. A direct call that already shares the callee's TOC
    should branch there, skipping the global-entry prologue. The offset is
    encoded in the callee's `st_other` (`STO_PPC64_LOCAL`); functions with
    no separate local entry (offset 0) are unaffected.

  - **REL32 / ADDR32.** 32-bit PC-relative and absolute. REL32 is what
    `.eh_frame` is built out of, so without it nothing with exception
    tables links cleanly.

  - **REL64.** 64-bit PC-relative — same shape as REL32 but 8 bytes.

  A small generic hook `Arch::local_entry_offset(st_other)` is added so the
  REL24 path can ask the target which entry to bias the branch by; default
  is 0 (no other architecture cares).