### PR TITLE
feat: support toplevel symbol definitions within the sections command

### DIFF
--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -323,6 +323,19 @@ impl<'data> LayoutRulesBuilder<'data> {
                                     .with_hidden(provide.hidden),
                             );
                         }
+                        SectionCommand::SymbolAssignment(assignment) => {
+                            let loc = if let Some(id) = current_section_id {
+                                SymbolLoc::SectionEnd(id)
+                            } else {
+                                SymbolLoc::FirstSection
+                            };
+                            let placement = SymbolPlacement::Redirect(Redirect {
+                                kind: RedirectKind::Script,
+                                expression: assignment.expr.clone(),
+                                loc,
+                            });
+                            symbol_defs.push(InternalSymDefInfo::new(placement, assignment.name));
+                        }
                     }
                 }
             } else if let linker_script::Command::Assert(assert_cmd) = cmd {

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -89,6 +89,7 @@ pub(crate) enum SectionCommand<'a> {
     Align(Alignment),
     Assert(AssertCommand<'a>),
     Provide(ProvideSymbolDefinition<'a>),
+    SymbolAssignment(SymbolAssignment<'a>),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -957,21 +958,29 @@ fn parse_section_command<'input>(
         _ => {}
     }
 
-    if name == b"." {
-        '='.parse_next(input)?;
+    if opt("=").parse_next(input)?.is_some() {
         skip_comments_and_whitespace(input)?;
+        if name == b"." {
+            let cmd = if input.starts_with(b"ALIGN") {
+                SectionCommand::Align(parse_alignment(input)?)
+            } else {
+                SectionCommand::SetLocation(parse_location.parse_next(input)?)
+            };
 
-        let cmd = if input.starts_with(b"ALIGN") {
-            SectionCommand::Align(parse_alignment(input)?)
-        } else {
-            SectionCommand::SetLocation(parse_location.parse_next(input)?)
-        };
+            skip_comments_and_whitespace(input)?;
+            ';'.parse_next(input)?;
+            skip_comments_and_whitespace(input)?;
 
+            return Ok(cmd);
+        }
+        let expr = parse_expression.parse_next(input)?;
         skip_comments_and_whitespace(input)?;
         ';'.parse_next(input)?;
         skip_comments_and_whitespace(input)?;
-
-        return Ok(cmd);
+        return Ok(SectionCommand::SymbolAssignment(SymbolAssignment {
+            name,
+            expr,
+        }));
     }
 
     let start_address_expression = if input.starts_with(b":") {

--- a/wild/tests/sources/elf/linker-script/linker-script.c
+++ b/wild/tests/sources/elf/linker-script/linker-script.c
@@ -12,10 +12,15 @@
 //#ExpectSym:defsym_addr address=0x1234
 //#ExpectSym:defsym_decimal address=0x123e
 //#ExpectSym:defsym_hex address=0x1244
+//#ExpectSym:sections_start address=0xabcd
+//#ExpectSym:sections_end address=0xcdef
 //#DiffIgnore:section.riscv.attributes
 //#DiffIgnore:segment.RISCV_ATTRIBUTES.*
 // GNU ld emits `.riscv.attributes`, but Wild does not
 //#DiffIgnore:riscv_attributes.*
+// Different linkers emit different corresponding sections.
+//#DiffIgnore:dynsym.sections_start.section
+//#DiffIgnore:dynsym.sections_end.section
 
 static int foo1 __attribute__((used, section(".data.foo"))) = 0x01;
 

--- a/wild/tests/sources/elf/linker-script/linker-script.ld
+++ b/wild/tests/sources/elf/linker-script/linker-script.ld
@@ -1,4 +1,5 @@
 SECTIONS {
+    sections_start = 0xabcd;
     bar : ALIGN(8) {
         start_bar = .;
         KEEP(*(.data.foo .data.baz*));
@@ -6,6 +7,7 @@ SECTIONS {
         KEEP(*(.data.aaa));
         end_bar = .;
     }
+    sections_end = 0xcdef;
 }
 defsym_start_aaa = start_aaa;
 defsym_addr = 0x1234;


### PR DESCRIPTION
Adds support for defining symbols as a toplevel command under `SECTIONS`.