### PR TITLE
feat: support defining custom phdrs in linker scripts

### DIFF
--- a/LINKER_SCRIPT_SUPPORT.md
+++ b/LINKER_SCRIPT_SUPPORT.md
@@ -57,6 +57,7 @@ end lists the features required to link the Linux kernel.
 | `BYTE(expr)`, `SHORT(expr)`, `LONG(expr)`, `QUAD(expr)` output data | ❌ | |
 | `SUBALIGN(n)` forced input alignment | ❌ | |
 | `ONLY_IF_RO` / `ONLY_IF_RW` output section constraints | ❌ | |
+| `:phdr` output section phdrs | 🧪 | Only a single `:phdr` specifier is supported per output section. |
 
 ## Expressions and Functions
 
@@ -119,7 +120,7 @@ see at a glance what remains before Wild can link the kernel.
 | `SORT_BY_NAME(...)`, `SORT_BY_ALIGNMENT(...)`, `SORT_BY_INIT_PRIORITY(...)` | 📅 | |
 | `EXCLUDE_FILE(...)` inside input section matchers | 📅 | |
 | `CONSTRUCTORS` command | 📅 | |
-| `PHDRS` command for explicit program header definition | 📅 | |
+| `PHDRS` command for explicit program header definition | 🧪 | The FILEHDR and PHDRS keywords aren't yet supported. |
 | Ternary operator (`condition ? a : b`) | 📅 | |
 | `DEFINED(sym)` function | 📅 | |
 | `SIZEOF_HEADERS` built-in symbol | 📅 | |

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -1897,7 +1897,7 @@ impl platform::Platform for Elf {
         output_kind: OutputKind,
         output_sections: &OutputSections<'data, Self>,
         secondary: &OutputSectionMap<Vec<OutputSectionId>>,
-        linker_script: &[&SequencedLinkerScript<'data, Self>],
+        linker_scripts: &[&SequencedLinkerScript<'data, Self>],
         phdr_map: &mut hashbrown::HashMap<&[u8], Vec<OutputSectionId>>,
     ) -> Result<(OutputOrder<'data>, ProgramSegments<Self::ProgramSegmentDef>)> {
         let mut builder =
@@ -1908,7 +1908,7 @@ impl platform::Platform for Elf {
         let mut insert_r = false;
         let mut first_load = false;
 
-        for script in linker_script {
+        for script in linker_scripts {
             for phdr in &script.parsed.program_headers {
                 let ptype = expression_eval::evaluate_const(&phdr.ptype)?;
                 let flags = phdr

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -13,9 +13,11 @@ use crate::ensure;
 use crate::error;
 use crate::error::Context as _;
 use crate::error::Result;
+use crate::expression_eval;
 use crate::file_kind::FileKind;
 use crate::file_writer::copy_section_data;
 use crate::grouping::Group;
+use crate::grouping::SequencedLinkerScript;
 use crate::input_data::InputBytes;
 use crate::input_data::InputRef;
 use crate::layout;
@@ -967,6 +969,7 @@ impl platform::Platform for Elf {
                 min_alignment: d.min_alignment,
                 location: None,
                 secondary_order: None,
+                phdr_name: None,
             })
             .collect()
     }
@@ -1827,7 +1830,8 @@ impl platform::Platform for Elf {
         output_sections: &OutputSections<'data, Self>,
         secondary: &OutputSectionMap<Vec<OutputSectionId>>,
     ) -> (OutputOrder<'data>, ProgramSegments<Self::ProgramSegmentDef>) {
-        let mut builder = OutputOrderBuilder::<Self>::new(output_kind, output_sections, secondary);
+        let mut builder =
+            OutputOrderBuilder::<Self>::new(output_kind, output_sections, secondary, false);
 
         builder.add_section(output_section_id::FILE_HEADER);
         builder.add_section(output_section_id::PROGRAM_HEADERS);
@@ -1886,6 +1890,98 @@ impl platform::Platform for Elf {
         builder.add_section(output_section_id::STRTAB);
 
         builder.build()
+    }
+
+    fn build_custom_output_order_and_program_segments<'data>(
+        custom: &CustomSectionIds,
+        output_kind: OutputKind,
+        output_sections: &OutputSections<'data, Self>,
+        secondary: &OutputSectionMap<Vec<OutputSectionId>>,
+        linker_script: &[&SequencedLinkerScript<'data, Self>],
+        phdr_map: &mut hashbrown::HashMap<&[u8], Vec<OutputSectionId>>,
+    ) -> Result<(OutputOrder<'data>, ProgramSegments<Self::ProgramSegmentDef>)> {
+        let mut builder =
+            OutputOrderBuilder::<Self>::new(output_kind, output_sections, secondary, true);
+
+        let mut insert_re = false;
+        let mut insert_rw = false;
+        let mut insert_r = false;
+        let mut first_load = false;
+
+        for script in linker_script {
+            for phdr in &script.parsed.program_headers {
+                let ptype = expression_eval::evaluate_const(&phdr.ptype)?;
+                let flags = phdr
+                    .flags
+                    .as_ref()
+                    .map(|f| expression_eval::evaluate_const(f).map(|c| c as u32))
+                    .transpose()?;
+                if let Some(sections) = phdr_map.get_mut(phdr.name) {
+                    let flags = flags
+                        .or_else(|| {
+                            let section_info =
+                                output_sections.section_infos.get(*sections.first()?);
+                            let flags = section_info.section_attributes.flags();
+                            let mut pflags = SegmentFlags(0);
+                            if flags.contains(shf::ALLOC) {
+                                pflags |= pf::READABLE;
+                            }
+                            if flags.contains(shf::WRITE) {
+                                pflags |= pf::WRITABLE;
+                            }
+                            if flags.contains(shf::EXECINSTR) {
+                                pflags |= pf::EXECUTABLE;
+                            }
+                            Some(pflags.0)
+                        })
+                        .unwrap_or(0);
+                    if ptype == 1 && !first_load {
+                        sections.splice(
+                            0..0,
+                            [
+                                output_section_id::FILE_HEADER,
+                                output_section_id::PROGRAM_HEADERS,
+                                output_section_id::SECTION_HEADERS,
+                            ],
+                        );
+                        first_load = true;
+                    };
+                    if ptype == 1 {
+                        let is_write = (flags & 2) != 0;
+                        let is_exec = (flags & 1) != 0;
+
+                        if is_exec && !is_write && !insert_re {
+                            sections.extend(&custom.exec);
+                            insert_re = true;
+                        }
+                        if is_write && !insert_rw {
+                            sections.extend(&custom.tdata);
+                            sections.extend(&custom.tbss);
+                            sections.extend(&custom.data);
+                            sections.extend(&custom.bss);
+                            insert_rw = true;
+                        }
+                        if !is_write && !is_exec && !insert_r {
+                            sections.extend(&custom.ro);
+                            insert_r = true;
+                        }
+                    }
+
+                    builder.add_segment_with_sections(
+                        ptype as u32,
+                        flags,
+                        sections,
+                        output_sections,
+                    );
+                }
+            }
+        }
+
+        for &id in &custom.nonalloc {
+            builder.add_section(id);
+        }
+
+        Ok(builder.build())
     }
 
     fn will_emit_section_symbol_for_partial_objects(
@@ -4365,6 +4461,13 @@ impl platform::ProgramSegmentDef for ProgramSegmentDef {
 
     fn should_cut_rw_segment_when_ending(self) -> bool {
         self.segment_type == pt::GNU_RELRO
+    }
+
+    fn from_linker_script(ptype: u32, flags: u32) -> Self {
+        Self {
+            segment_type: SegmentType(ptype),
+            segment_flags: SegmentFlags(flags),
+        }
     }
 }
 

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -240,7 +240,7 @@ pub(crate) fn evaluate_const<'data>(expr: &Expression<'data>) -> Result<u64> {
         Expression::LogicalOr(l, r) => Ok(u64::from(
             evaluate_const(l)? != 0 || evaluate_const(r)? != 0,
         )),
-        Expression::LogicalNot(expression) => Ok(u64::from(!evaluate_const(expression)? != 0)),
+        Expression::LogicalNot(expression) => Ok(u64::from(evaluate_const(expression)? != 0)),
         Expression::BitwiseNot(expression) => Ok(!evaluate_const(expression)?),
         Expression::Negate(expression) => Ok(evaluate_const(expression)?.wrapping_neg()),
 

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -240,7 +240,7 @@ pub(crate) fn evaluate_const<'data>(expr: &Expression<'data>) -> Result<u64> {
         Expression::LogicalOr(l, r) => Ok(u64::from(
             evaluate_const(l)? != 0 || evaluate_const(r)? != 0,
         )),
-        Expression::LogicalNot(expression) => Ok(u64::from(evaluate_const(expression)? != 0)),
+        Expression::LogicalNot(expression) => Ok(u64::from(evaluate_const(expression)? == 0)),
         Expression::BitwiseNot(expression) => Ok(!evaluate_const(expression)?),
         Expression::Negate(expression) => Ok(evaluate_const(expression)?.wrapping_neg()),
 

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -204,6 +204,50 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
     }
 }
 
+pub(crate) fn evaluate_const<'data>(expr: &Expression<'data>) -> Result<u64> {
+    match expr {
+        Expression::Number(n) => Ok(*n),
+        Expression::Add(l, r) => Ok(evaluate_const(l)?.wrapping_add(evaluate_const(r)?)),
+        Expression::Subtract(l, r) => Ok(evaluate_const(l)?.wrapping_sub(evaluate_const(r)?)),
+        Expression::Multiply(l, r) => Ok(evaluate_const(l)?.wrapping_mul(evaluate_const(r)?)),
+        Expression::Divide(l, r) => {
+            let divisor = evaluate_const(r)?;
+            if divisor == 0 {
+                bail!("Division by zero in linker script expression");
+            }
+            Ok(evaluate_const(l)?.wrapping_div(divisor))
+        }
+        Expression::LessThan(l, r) => Ok(u64::from(evaluate_const(l)? < evaluate_const(r)?)),
+        Expression::GreaterThan(l, r) => Ok(u64::from(evaluate_const(l)? > evaluate_const(r)?)),
+        Expression::LessEqual(l, r) => Ok(u64::from(evaluate_const(l)? <= evaluate_const(r)?)),
+        Expression::GreaterEqual(l, r) => Ok(u64::from(evaluate_const(l)? >= evaluate_const(r)?)),
+        Expression::Equal(l, r) => Ok(u64::from(evaluate_const(l)? == evaluate_const(r)?)),
+        Expression::NotEqual(l, r) => Ok(u64::from(evaluate_const(l)? != evaluate_const(r)?)),
+        Expression::Min(l, r) => Ok(evaluate_const(l)?.min(evaluate_const(r)?)),
+        Expression::Max(l, r) => Ok(evaluate_const(l)?.max(evaluate_const(r)?)),
+        Expression::BitwiseAnd(l, r) => Ok(evaluate_const(l)? & evaluate_const(r)?),
+        Expression::BitwiseOr(l, r) => Ok(evaluate_const(l)? | evaluate_const(r)?),
+        Expression::BitwiseXor(l, r) => Ok(evaluate_const(l)? ^ evaluate_const(r)?),
+        Expression::LeftShift(l, r) => {
+            Ok(evaluate_const(l)?.wrapping_shl(evaluate_const(r)? as u32))
+        }
+        Expression::RightShift(l, r) => {
+            Ok(evaluate_const(l)?.wrapping_shr(evaluate_const(r)? as u32))
+        }
+        Expression::LogicalAnd(l, r) => Ok(u64::from(
+            evaluate_const(l)? != 0 && evaluate_const(r)? != 0,
+        )),
+        Expression::LogicalOr(l, r) => Ok(u64::from(
+            evaluate_const(l)? != 0 || evaluate_const(r)? != 0,
+        )),
+        Expression::LogicalNot(expression) => Ok(u64::from(!evaluate_const(expression)? != 0)),
+        Expression::BitwiseNot(expression) => Ok(!evaluate_const(expression)?),
+        Expression::Negate(expression) => Ok(evaluate_const(expression)?.wrapping_neg()),
+
+        _ => bail!("Expected constant expression"),
+    }
+}
+
 fn section_size<'data, P: Platform>(
     name: &[u8],
     section_layouts: &OutputSectionMap<OutputRecordLayout>,
@@ -602,6 +646,7 @@ mod tests {
                 assertions,
                 file_bytes: b"",
                 memory_regions: Vec::new(),
+                program_headers: Vec::new(),
             },
             symbol_id_range: SymbolIdRange::empty(),
             file_id: FileId::new(0, 0),

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -16,6 +16,7 @@ use crate::error::Error;
 use crate::error::Result;
 use crate::file_writer;
 use crate::grouping::Group;
+use crate::grouping::SequencedLinkerScript;
 use crate::input_data::FileId;
 use crate::input_data::InputRef;
 use crate::input_data::PRELUDE_FILE_ID;
@@ -197,7 +198,24 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
 
     propagate_section_attributes(&group_states, &mut output_sections);
 
-    let (output_order, program_segments) = output_sections.output_order(symbol_db.output_kind);
+    let linker_scripts: Vec<&SequencedLinkerScript<P>> = symbol_db
+        .groups
+        .iter()
+        .filter_map(|group| match group {
+            Group::LinkerScripts(scripts) => Some(scripts),
+            _ => None,
+        })
+        .flatten()
+        .collect();
+
+    let (output_order, program_segments) = if linker_scripts
+        .iter()
+        .any(|s| !s.parsed.program_headers.is_empty())
+    {
+        output_sections.output_order_from_linker_script(symbol_db.output_kind, &linker_scripts)?
+    } else {
+        output_sections.output_order(symbol_db.output_kind)
+    };
 
     tracing::trace!(
         "Output order:\n{}",
@@ -233,17 +251,8 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         &symbol_db,
     );
 
-    let memory_regions: Vec<crate::linker_script::MemoryRegion<'_>> = symbol_db
-        .groups
+    let memory_regions: Vec<crate::linker_script::MemoryRegion<'_>> = linker_scripts
         .iter()
-        .filter_map(|g| {
-            if let crate::grouping::Group::LinkerScripts(scripts) = g {
-                Some(scripts)
-            } else {
-                None
-            }
-        })
-        .flatten()
         .flat_map(|s| s.parsed.memory_regions.iter().cloned())
         .collect();
 

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -208,14 +208,8 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         .flatten()
         .collect();
 
-    let (output_order, program_segments) = if linker_scripts
-        .iter()
-        .any(|s| !s.parsed.program_headers.is_empty())
-    {
-        output_sections.output_order_from_linker_script(symbol_db.output_kind, &linker_scripts)?
-    } else {
-        output_sections.output_order(symbol_db.output_kind)
-    };
+    let (output_order, program_segments) =
+        output_sections.output_order(symbol_db.output_kind, &linker_scripts)?;
 
     tracing::trace!(
         "Output order:\n{}",
@@ -5280,10 +5274,14 @@ fn test_no_disallowed_overlaps() {
     use crate::output_section_id::OrderEvent;
 
     let mut output_sections = OutputSections::<Elf>::with_base_address(0x1000);
-    let (output_order, program_segments) =
-        output_sections.output_order(crate::output_kind::OutputKind::StaticExecutable(
-            crate::args::RelocationModel::NonRelocatable,
-        ));
+    let (output_order, program_segments) = output_sections
+        .output_order(
+            crate::output_kind::OutputKind::StaticExecutable(
+                crate::args::RelocationModel::NonRelocatable,
+            ),
+            &[],
+        )
+        .unwrap();
     let mut args = crate::args::elf::ElfArgs::default();
     if args.arch == crate::arch::Architecture::Unsupported {
         args.arch = crate::arch::Architecture::X86_64;
@@ -5412,7 +5410,7 @@ fn verify_consistent_allocation_handling<P: Platform>(
     args: &P::Args,
 ) -> Result {
     let output_sections = OutputSections::with_base_address(0);
-    let (output_order, _program_segments) = output_sections.output_order(output_kind);
+    let (output_order, _program_segments) = output_sections.output_order(output_kind, &[])?;
     let mut mem_sizes = output_sections.new_part_map();
     P::allocate_resolution(flags, &mut mem_sizes, output_kind, args);
     let mut memory_offsets = output_sections.new_part_map();

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -157,6 +157,7 @@ impl<'data> LayoutRulesBuilder<'data> {
         let mut symbol_defs = Vec::new();
         let mut assertions = Vec::new();
         let mut memory_regions = Vec::new();
+        let mut program_headers = Vec::new();
 
         let mut current_section_id = None;
         let mut loc = SymbolLoc::FirstSection;
@@ -227,6 +228,7 @@ impl<'data> LayoutRulesBuilder<'data> {
                                 SectionName(sec.output_section_name),
                                 min_alignment,
                                 section_location,
+                                sec.phdr,
                             );
                             current_section_id = Some(primary_section_id);
                             loc = SymbolLoc::SectionEnd(primary_section_id);
@@ -332,6 +334,8 @@ impl<'data> LayoutRulesBuilder<'data> {
                 assertions.push(assert_cmd.clone());
             } else if let linker_script::Command::Memory(regions) = cmd {
                 memory_regions = regions.clone();
+            } else if let linker_script::Command::Phdrs(phdrs) = cmd {
+                program_headers = phdrs.clone();
             }
         }
 
@@ -344,6 +348,7 @@ impl<'data> LayoutRulesBuilder<'data> {
             },
             file_bytes: input.script_bytes,
             memory_regions,
+            program_headers,
         })
     }
 

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -7,6 +7,7 @@ use crate::args::Modifiers;
 use crate::error;
 use crate::error::Context as _;
 use crate::error::Result;
+use object::Wrap;
 use std::path::Path;
 use winnow::BStr;
 use winnow::Parser as _;
@@ -490,14 +491,14 @@ fn parse_phdr<'input>(input: &mut &'input BStr) -> winnow::Result<Phdr<'input>> 
         let ptype_str = parse_token(input)?;
 
         match ptype_str {
-            b"PT_NULL" => Expression::Number(object::elf::PT_NULL.into()),
-            b"PT_LOAD" => Expression::Number(object::elf::PT_LOAD.into()),
-            b"PT_DYNAMIC" => Expression::Number(object::elf::PT_DYNAMIC.into()),
-            b"PT_INTERP" => Expression::Number(object::elf::PT_INTERP.into()),
-            b"PT_NOTE" => Expression::Number(object::elf::PT_NOTE.into()),
-            b"PT_SHLIB" => Expression::Number(object::elf::PT_SHLIB.into()),
-            b"PT_PHDR" => Expression::Number(object::elf::PT_PHDR.into()),
-            b"PT_TLS" => Expression::Number(object::elf::PT_TLS.into()),
+            b"PT_NULL" => Expression::Number(object::elf::PT_NULL.into_inner().into()),
+            b"PT_LOAD" => Expression::Number(object::elf::PT_LOAD.into_inner().into()),
+            b"PT_DYNAMIC" => Expression::Number(object::elf::PT_DYNAMIC.into_inner().into()),
+            b"PT_INTERP" => Expression::Number(object::elf::PT_INTERP.into_inner().into()),
+            b"PT_NOTE" => Expression::Number(object::elf::PT_NOTE.into_inner().into()),
+            b"PT_SHLIB" => Expression::Number(object::elf::PT_SHLIB.into_inner().into()),
+            b"PT_PHDR" => Expression::Number(object::elf::PT_PHDR.into_inner().into()),
+            b"PT_TLS" => Expression::Number(object::elf::PT_TLS.into_inner().into()),
             _ => {
                 return Err(ContextError::default());
             }

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -499,6 +499,15 @@ fn parse_phdr<'input>(input: &mut &'input BStr) -> winnow::Result<Phdr<'input>> 
             b"PT_SHLIB" => Expression::Number(object::elf::PT_SHLIB.into_inner().into()),
             b"PT_PHDR" => Expression::Number(object::elf::PT_PHDR.into_inner().into()),
             b"PT_TLS" => Expression::Number(object::elf::PT_TLS.into_inner().into()),
+            b"PT_GNU_EH_FRAME" => {
+                Expression::Number(object::elf::PT_GNU_EH_FRAME.into_inner().into())
+            }
+            b"PT_GNU_STACK" => Expression::Number(object::elf::PT_GNU_STACK.into_inner().into()),
+            b"PT_GNU_RELRO" => Expression::Number(object::elf::PT_GNU_RELRO.into_inner().into()),
+            b"PT_GNU_PROPERTY" => {
+                Expression::Number(object::elf::PT_GNU_PROPERTY.into_inner().into())
+            }
+            b"PT_GNU_SFRAME" => Expression::Number(object::elf::PT_GNU_SFRAME.into_inner().into()),
             _ => {
                 return Err(ContextError::default());
             }

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -74,6 +74,7 @@ pub(crate) enum Command<'a> {
     Provide(ProvideSymbolDefinition<'a>),
     Assert(AssertCommand<'a>),
     Memory(Vec<MemoryRegion<'a>>),
+    Phdrs(Vec<Phdr<'a>>),
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -102,6 +103,7 @@ pub(crate) struct Section<'a> {
     pub(crate) commands: Vec<ContentsCommand<'a>>,
     pub(crate) alignment: Option<Alignment>,
     pub(crate) start_address_expression: Option<Expression<'a>>,
+    pub(crate) phdr: Option<&'a [u8]>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -148,6 +150,13 @@ impl<'a> PartialEq for AssertCommand<'a> {
 }
 
 impl<'a> Eq for AssertCommand<'a> {}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub(crate) struct Phdr<'a> {
+    pub(crate) name: &'a [u8],
+    pub(crate) ptype: Expression<'a>,
+    pub(crate) flags: Option<Expression<'a>>,
+}
 
 /// Represents a parsed expression in linker scripts (e.g., in ASSERT commands).
 ///
@@ -357,6 +366,7 @@ fn parse_command<'input>(input: &mut &'input BStr) -> winnow::Result<Command<'in
         b"PROVIDE_HIDDEN" => Command::Provide(parse_provide(input, true)?),
         b"ASSERT" => Command::Assert(parse_assert(input)?),
         b"MEMORY" => Command::Memory(parse_memory(input)?),
+        b"PHDRS" => Command::Phdrs(parse_phdrs(input)?),
         other => {
             if input.starts_with(b"=") {
                 // Symbol definition
@@ -470,6 +480,57 @@ fn parse_memory<'input>(input: &mut &'input BStr) -> winnow::Result<Vec<MemoryRe
     skip_comments_and_whitespace(input)?;
 
     Ok(regions)
+}
+
+fn parse_phdr<'input>(input: &mut &'input BStr) -> winnow::Result<Phdr<'input>> {
+    let name = parse_token(input)?;
+    skip_comments_and_whitespace(input)?;
+
+    let ptype = if input.starts_with(b"PT_") {
+        let ptype_str = parse_token(input)?;
+
+        match ptype_str {
+            b"PT_NULL" => Expression::Number(object::elf::PT_NULL.into()),
+            b"PT_LOAD" => Expression::Number(object::elf::PT_LOAD.into()),
+            b"PT_DYNAMIC" => Expression::Number(object::elf::PT_DYNAMIC.into()),
+            b"PT_INTERP" => Expression::Number(object::elf::PT_INTERP.into()),
+            b"PT_NOTE" => Expression::Number(object::elf::PT_NOTE.into()),
+            b"PT_SHLIB" => Expression::Number(object::elf::PT_SHLIB.into()),
+            b"PT_PHDR" => Expression::Number(object::elf::PT_PHDR.into()),
+            b"PT_TLS" => Expression::Number(object::elf::PT_TLS.into()),
+            _ => {
+                return Err(ContextError::default());
+            }
+        }
+    } else {
+        parse_expression.parse_next(input)?
+    };
+
+    skip_comments_and_whitespace(input)?;
+
+    let flags = if opt("FLAGS").parse_next(input)?.is_some() {
+        '('.parse_next(input)?;
+        let flags = Some(parse_expression.parse_next(input)?);
+        ')'.parse_next(input)?;
+        skip_comments_and_whitespace(input)?;
+        flags
+    } else {
+        None
+    };
+
+    opt(';').parse_next(input)?;
+    skip_comments_and_whitespace(input)?;
+
+    Ok(Phdr { name, ptype, flags })
+}
+
+fn parse_phdrs<'input>(input: &mut &'input BStr) -> winnow::Result<Vec<Phdr<'input>>> {
+    '{'.parse_next(input)?;
+    skip_comments_and_whitespace(input)?;
+    let (phdrs, _) = repeat_till(0.., parse_phdr, '}').parse_next(input)?;
+    skip_comments_and_whitespace(input)?;
+
+    Ok(phdrs)
 }
 
 /// Parse an expression - entry point for expression parsing
@@ -1004,11 +1065,20 @@ fn parse_section_command<'input>(
 
     skip_comments_and_whitespace(input)?;
 
+    let phdr = if opt(":").parse_next(input)?.is_some() {
+        Some(parse_token(input)?)
+    } else {
+        None
+    };
+
+    skip_comments_and_whitespace(input)?;
+
     Ok(SectionCommand::Section(Section {
         output_section_name: name,
         commands,
         alignment,
         start_address_expression,
+        phdr,
     }))
 }
 
@@ -1335,6 +1405,7 @@ mod tests {
                 ],
                 alignment: None,
                 start_address_expression: None,
+                phdr: None,
             }),
         );
     }
@@ -1352,6 +1423,7 @@ mod tests {
                 })],
                 alignment: Some(Alignment::new(8).unwrap()),
                 start_address_expression: Some(Expression::Number(0)),
+                phdr: None,
             }),
         );
     }
@@ -1407,6 +1479,7 @@ mod tests {
                                 ],
                                 alignment: Some(Alignment::new(8).unwrap()),
                                 start_address_expression: None,
+                                phdr: None,
                             }),
                         ],
                     }),
@@ -1543,6 +1616,7 @@ mod tests {
                 ],
                 alignment: None,
                 start_address_expression: None,
+                phdr: None,
             }),
         );
     }
@@ -1560,6 +1634,7 @@ mod tests {
                 })],
                 alignment: None,
                 start_address_expression: None,
+                phdr: None,
             }),
         );
     }
@@ -1577,6 +1652,7 @@ mod tests {
                 })],
                 alignment: None,
                 start_address_expression: None,
+                phdr: None,
             }),
         );
     }
@@ -1602,6 +1678,7 @@ mod tests {
                             })],
                             alignment: None,
                             start_address_expression: None,
+                            phdr: None,
                         })],
                     }),
                     Command::Assert(AssertCommand {
@@ -1638,6 +1715,7 @@ mod tests {
                             })],
                             alignment: None,
                             start_address_expression: None,
+                            phdr: None,
                         }),
                         SectionCommand::Assert(AssertCommand {
                             expression: Expression::LessThan(

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -1189,6 +1189,7 @@ impl platform::Platform for MachO {
                 min_alignment: d.min_alignment,
                 location: None,
                 secondary_order: None,
+                phdr_name: None,
             })
             .collect()
     }
@@ -1467,7 +1468,8 @@ impl platform::Platform for MachO {
         crate::output_section_id::OutputOrder<'data>,
         crate::program_segments::ProgramSegments<Self::ProgramSegmentDef>,
     ) {
-        let mut builder = OutputOrderBuilder::<Self>::new(output_kind, output_sections, secondary);
+        let mut builder =
+            OutputOrderBuilder::<Self>::new(output_kind, output_sections, secondary, false);
 
         // File header and all load commands.
         builder.add_section(output_section_id::FILE_HEADER);

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -194,7 +194,7 @@ pub(crate) struct OutputOrderBuilder<'scope, 'data, P: Platform> {
     output_sections: &'scope OutputSections<'data, P>,
     secondary: &'scope OutputSectionMap<Vec<OutputSectionId>>,
     output_kind: OutputKind,
-    is_custom_phdrs: bool,
+    has_custom_phdrs: bool,
 }
 
 impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
@@ -202,7 +202,7 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
         output_kind: OutputKind,
         output_sections: &'scope OutputSections<'data, P>,
         secondary: &'scope OutputSectionMap<Vec<OutputSectionId>>,
-        is_custom_phdrs: bool,
+        has_custom_phdrs: bool,
     ) -> Self {
         Self {
             events: Vec::new(),
@@ -211,7 +211,7 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
             active_segment_kinds: vec![None; P::program_segment_defs().len()],
             secondary,
             output_kind,
-            is_custom_phdrs,
+            has_custom_phdrs,
         }
     }
 
@@ -313,7 +313,7 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
         let mut stop = Vec::new();
         let mut start = Vec::new();
 
-        if self.is_custom_phdrs {
+        if self.has_custom_phdrs {
             return (stop, start);
         }
 
@@ -409,7 +409,7 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
             self.events.push(OrderEvent::SegmentEnd(segment_id));
         }
 
-        if !self.output_kind.is_partial_object() && !self.is_custom_phdrs {
+        if !self.output_kind.is_partial_object() && !self.has_custom_phdrs {
             for def in P::unconditional_segment_defs() {
                 let segment_id = self.program_segments.add_segment(*def);
                 self.events.push(OrderEvent::SegmentStart(segment_id));
@@ -743,20 +743,45 @@ impl<'data, P: Platform> OutputSections<'data, P> {
     pub(crate) fn output_order(
         &self,
         output_kind: OutputKind,
-    ) -> (OutputOrder<'data>, ProgramSegments<P::ProgramSegmentDef>) {
+        linker_scripts: &[&SequencedLinkerScript<'data, P>],
+    ) -> Result<(OutputOrder<'data>, ProgramSegments<P::ProgramSegmentDef>)> {
         timing_phase!("Compute output order");
 
+        let has_custom_phdrs = linker_scripts
+            .iter()
+            .any(|s| !s.parsed.program_headers.is_empty());
+
         let mut custom = CustomSectionIds::default();
 
         let mut secondary: OutputSectionMap<Vec<OutputSectionId>> = self.new_section_map();
+
+        let mut phdr_map: Option<HashMap<&[u8], Vec<OutputSectionId>>> =
+            has_custom_phdrs.then(HashMap::new);
 
         self.section_infos.for_each(|id, info| {
             if let SectionKind::Secondary(primary) = info.kind {
                 secondary.get_mut(primary).push(id);
                 return;
             }
-            if id.as_usize() < NUM_BUILT_IN_SECTIONS {
-                return;
+
+            if has_custom_phdrs {
+                if let Some(phdr_name) = info.phdr_name {
+                    phdr_map
+                        .as_mut()
+                        .unwrap()
+                        .entry(phdr_name)
+                        .or_default()
+                        .push(id);
+                    return;
+                }
+
+                if id == FILE_HEADER || id == PROGRAM_HEADERS || id == SECTION_HEADERS {
+                    return;
+                }
+            } else {
+                if id.as_usize() < NUM_BUILT_IN_SECTIONS {
+                    return;
+                }
             }
 
             if info.section_attributes.is_executable() {
@@ -780,68 +805,23 @@ impl<'data, P: Platform> OutputSections<'data, P> {
             }
         });
 
-        P::build_output_order_and_program_segments(&custom, output_kind, self, &secondary)
-    }
-
-    pub(crate) fn output_order_from_linker_script(
-        &self,
-        output_kind: OutputKind,
-        linker_script: &[&SequencedLinkerScript<'data, P>],
-    ) -> Result<(OutputOrder<'data>, ProgramSegments<P::ProgramSegmentDef>)> {
-        let mut custom = CustomSectionIds::default();
-
-        let mut secondary: OutputSectionMap<Vec<OutputSectionId>> = self.new_section_map();
-        let mut phdr_map: HashMap<&[u8], Vec<OutputSectionId>> = HashMap::new();
-
-        self.section_infos.for_each(|id, info| {
-            if let SectionKind::Secondary(primary) = info.kind {
-                secondary.get_mut(primary).push(id);
-                return;
-            }
-
-            if let Some(phdr_name) = info.phdr_name {
-                let sections = phdr_map.get_mut(phdr_name);
-                if let Some(sections) = sections {
-                    sections.push(id);
-                } else {
-                    phdr_map.insert(phdr_name, vec![id]);
-                }
-                return;
-            }
-
-            if id == FILE_HEADER || id == PROGRAM_HEADERS || id == SECTION_HEADERS {
-                return;
-            }
-
-            if info.section_attributes.is_executable() {
-                custom.exec.push(id);
-            } else if info.section_attributes.is_tls() {
-                if info.section_attributes.is_no_bits() {
-                    custom.tbss.push(id);
-                } else {
-                    custom.tdata.push(id);
-                }
-            } else if !info.section_attributes.is_writable() {
-                if info.section_attributes.is_alloc() {
-                    custom.ro.push(id);
-                } else {
-                    custom.nonalloc.push(id);
-                }
-            } else if info.section_attributes.is_no_bits() {
-                custom.bss.push(id);
-            } else {
-                custom.data.push(id);
-            }
-        });
-
-        P::build_custom_output_order_and_program_segments(
-            &custom,
-            output_kind,
-            self,
-            &secondary,
-            linker_script,
-            &mut phdr_map,
-        )
+        if has_custom_phdrs {
+            P::build_custom_output_order_and_program_segments(
+                &custom,
+                output_kind,
+                self,
+                &secondary,
+                linker_scripts,
+                &mut phdr_map.unwrap(),
+            )
+        } else {
+            Ok(P::build_output_order_and_program_segments(
+                &custom,
+                output_kind,
+                self,
+                &secondary,
+            ))
+        }
     }
 
     #[must_use]

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -13,8 +13,10 @@
 //! related to `part_id.rs` and insert later in `SECTION_DEFINITIONS`, probably at the end so that
 //! you don't have to renumber. Also, update `NUM_BUILT_IN_REGULAR_SECTIONS`.
 
+use crate::Result;
 use crate::alignment::Alignment;
 use crate::alignment::NUM_ALIGNMENTS;
+use crate::grouping::SequencedLinkerScript;
 use crate::layout_rules::SectionKind;
 use crate::linker_script;
 use crate::linker_script::Expression;
@@ -192,6 +194,7 @@ pub(crate) struct OutputOrderBuilder<'scope, 'data, P: Platform> {
     output_sections: &'scope OutputSections<'data, P>,
     secondary: &'scope OutputSectionMap<Vec<OutputSectionId>>,
     output_kind: OutputKind,
+    is_custom_phdrs: bool,
 }
 
 impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
@@ -199,6 +202,7 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
         output_kind: OutputKind,
         output_sections: &'scope OutputSections<'data, P>,
         secondary: &'scope OutputSectionMap<Vec<OutputSectionId>>,
+        is_custom_phdrs: bool,
     ) -> Self {
         Self {
             events: Vec::new(),
@@ -207,6 +211,7 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
             active_segment_kinds: vec![None; P::program_segment_defs().len()],
             secondary,
             output_kind,
+            is_custom_phdrs,
         }
     }
 
@@ -308,6 +313,10 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
         let mut stop = Vec::new();
         let mut start = Vec::new();
 
+        if self.is_custom_phdrs {
+            return (stop, start);
+        }
+
         if self.output_kind.is_partial_object() {
             return (start, stop);
         }
@@ -360,6 +369,35 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
         (stop, start)
     }
 
+    pub(crate) fn add_segment_with_sections(
+        &mut self,
+        ptype: u32,
+        pflags: u32,
+        sections: &[OutputSectionId],
+        output_sections: &OutputSections<'data, P>,
+    ) -> ProgramSegmentId {
+        let segment_id = self
+            .program_segments
+            .add_segment(P::ProgramSegmentDef::from_linker_script(ptype, pflags));
+        self.events.push(OrderEvent::SegmentStart(segment_id));
+        for section in sections {
+            let section_info = output_sections.section_infos.get(*section);
+            if let Some(location) = &section_info.location
+                && section_info.section_attributes.is_alloc()
+            {
+                self.events.push(OrderEvent::SetLocation(location.clone()));
+            }
+            self.events.push(OrderEvent::Section(*section));
+
+            let secondaries: &Vec<OutputSectionId> = self.secondary.get(*section);
+            for sid in secondaries {
+                self.events.push(OrderEvent::Section(*sid));
+            }
+        }
+        self.events.push(OrderEvent::SegmentEnd(segment_id));
+        segment_id
+    }
+
     pub(crate) fn add_sections(&mut self, sections: &[OutputSectionId]) {
         for section in sections {
             self.add_section(*section);
@@ -371,7 +409,7 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
             self.events.push(OrderEvent::SegmentEnd(segment_id));
         }
 
-        if !self.output_kind.is_partial_object() {
+        if !self.output_kind.is_partial_object() && !self.is_custom_phdrs {
             for def in P::unconditional_segment_defs() {
                 let segment_id = self.program_segments.add_segment(*def);
                 self.events.push(OrderEvent::SegmentStart(segment_id));
@@ -464,6 +502,7 @@ pub(crate) struct SectionOutputInfo<'data, P: Platform> {
     pub(crate) min_alignment: Alignment,
     pub(crate) location: Option<linker_script::Expression<'data>>,
     pub(crate) secondary_order: Option<SecondaryOrder>,
+    pub(crate) phdr_name: Option<&'data [u8]>,
 }
 
 impl OutputSectionId {
@@ -601,7 +640,7 @@ impl<'data, P: Platform> OutputSections<'data, P> {
             let location = args
                 .start_address_for_section(custom.name)
                 .map(linker_script::Expression::Number);
-            let section_id = self.add_named_section(custom.name, custom.alignment, location);
+            let section_id = self.add_named_section(custom.name, custom.alignment, location, None);
 
             section_part_ids[custom.index.0] = section_id.part_id_with_alignment(custom.alignment);
         }
@@ -628,6 +667,7 @@ impl<'data, P: Platform> OutputSections<'data, P> {
         name: SectionName<'data>,
         min_alignment: Alignment,
         location: Option<linker_script::Expression<'data>>,
+        phdr_name: Option<&'data [u8]>,
     ) -> OutputSectionId {
         *self.custom_by_name.entry(name).or_insert_with(|| {
             self.section_infos.add_new(SectionOutputInfo {
@@ -638,6 +678,7 @@ impl<'data, P: Platform> OutputSections<'data, P> {
                 min_alignment,
                 location,
                 secondary_order: None,
+                phdr_name,
             })
         })
     }
@@ -655,6 +696,7 @@ impl<'data, P: Platform> OutputSections<'data, P> {
             min_alignment,
             location: None,
             secondary_order,
+            phdr_name: None,
         })
     }
 
@@ -739,6 +781,67 @@ impl<'data, P: Platform> OutputSections<'data, P> {
         });
 
         P::build_output_order_and_program_segments(&custom, output_kind, self, &secondary)
+    }
+
+    pub(crate) fn output_order_from_linker_script(
+        &self,
+        output_kind: OutputKind,
+        linker_script: &[&SequencedLinkerScript<'data, P>],
+    ) -> Result<(OutputOrder<'data>, ProgramSegments<P::ProgramSegmentDef>)> {
+        let mut custom = CustomSectionIds::default();
+
+        let mut secondary: OutputSectionMap<Vec<OutputSectionId>> = self.new_section_map();
+        let mut phdr_map: HashMap<&[u8], Vec<OutputSectionId>> = HashMap::new();
+
+        self.section_infos.for_each(|id, info| {
+            if let SectionKind::Secondary(primary) = info.kind {
+                secondary.get_mut(primary).push(id);
+                return;
+            }
+
+            if let Some(phdr_name) = info.phdr_name {
+                let sections = phdr_map.get_mut(phdr_name);
+                if let Some(sections) = sections {
+                    sections.push(id);
+                } else {
+                    phdr_map.insert(phdr_name, vec![id]);
+                }
+                return;
+            }
+
+            if id == FILE_HEADER || id == PROGRAM_HEADERS || id == SECTION_HEADERS {
+                return;
+            }
+
+            if info.section_attributes.is_executable() {
+                custom.exec.push(id);
+            } else if info.section_attributes.is_tls() {
+                if info.section_attributes.is_no_bits() {
+                    custom.tbss.push(id);
+                } else {
+                    custom.tdata.push(id);
+                }
+            } else if !info.section_attributes.is_writable() {
+                if info.section_attributes.is_alloc() {
+                    custom.ro.push(id);
+                } else {
+                    custom.nonalloc.push(id);
+                }
+            } else if info.section_attributes.is_no_bits() {
+                custom.bss.push(id);
+            } else {
+                custom.data.push(id);
+            }
+        });
+
+        P::build_custom_output_order_and_program_segments(
+            &custom,
+            output_kind,
+            self,
+            &secondary,
+            linker_script,
+            &mut phdr_map,
+        )
     }
 
     #[must_use]
@@ -855,6 +958,7 @@ impl<'data, P: Platform> OutputSections<'data, P> {
             output_sections.add_named_section(
                 SectionName(name.as_bytes()),
                 crate::alignment::MIN,
+                None,
                 None,
             )
         };

--- a/libwild/src/output_section_part_map.rs
+++ b/libwild/src/output_section_part_map.rs
@@ -230,10 +230,14 @@ fn test_merge_parts() {
 
     let output_sections =
         crate::output_section_id::OutputSections::<crate::elf::Elf>::for_testing();
-    let (output_order, _program_segments) =
-        output_sections.output_order(crate::output_kind::OutputKind::StaticExecutable(
-            crate::args::RelocationModel::NonRelocatable,
-        ));
+    let (output_order, _program_segments) = output_sections
+        .output_order(
+            crate::output_kind::OutputKind::StaticExecutable(
+                crate::args::RelocationModel::NonRelocatable,
+            ),
+            &[],
+        )
+        .unwrap();
     let mut expected_sum_of_sums = 0;
     let all_1 = output_sections.new_part_map::<u32>().output_order_map(
         &output_order,
@@ -343,10 +347,14 @@ fn test_output_order_map_consistent() {
 
     let output_sections =
         crate::output_section_id::OutputSections::<crate::elf::Elf>::for_testing();
-    let (output_order, _program_segments) =
-        output_sections.output_order(crate::output_kind::OutputKind::StaticExecutable(
-            crate::args::RelocationModel::NonRelocatable,
-        ));
+    let (output_order, _program_segments) = output_sections
+        .output_order(
+            crate::output_kind::OutputKind::StaticExecutable(
+                crate::args::RelocationModel::NonRelocatable,
+            ),
+            &[],
+        )
+        .unwrap();
     let part_map = output_sections.new_part_map::<u32>();
 
     // First, make sure that all our built-in part-ids are here. If they're not, we'd fail anyway,
@@ -396,10 +404,14 @@ fn test_output_order_map() {
 
     let output_sections =
         crate::output_section_id::OutputSections::<crate::elf::Elf>::for_testing();
-    let (output_order, _program_segments) =
-        output_sections.output_order(crate::output_kind::OutputKind::StaticExecutable(
-            crate::args::RelocationModel::NonRelocatable,
-        ));
+    let (output_order, _program_segments) = output_sections
+        .output_order(
+            crate::output_kind::OutputKind::StaticExecutable(
+                crate::args::RelocationModel::NonRelocatable,
+            ),
+            &[],
+        )
+        .unwrap();
     let mut part_map = output_sections.new_part_map::<u32>();
 
     const PART_ID1: PartId = output_section_id::DATA.part_id_with_alignment(alignment::USIZE);

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -54,6 +54,7 @@ pub(crate) struct ProcessedLinkerScript<'data, P: Platform> {
     /// `AssertCommand::remainder` when reporting errors.
     pub(crate) file_bytes: &'data [u8],
     pub(crate) memory_regions: Vec<crate::linker_script::MemoryRegion<'data>>,
+    pub(crate) program_headers: Vec<crate::linker_script::Phdr<'data>>,
 }
 
 #[derive(Debug)]

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -1166,7 +1166,7 @@ pub(crate) trait ProgramSegmentDef: Copy + Send + Sync + Display + 'static {
     }
 
     fn from_linker_script(_ptype: u32, _flags: u32) -> Self {
-        todo!()
+        unreachable!("This function is only called from platforms that support linker scripts.");
     }
 }
 

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -708,7 +708,7 @@ pub(crate) trait Platform:
         output_kind: OutputKind,
         output_sections: &OutputSections<'data, Self>,
         secondary: &OutputSectionMap<Vec<OutputSectionId>>,
-        _linker_script: &[&SequencedLinkerScript<'data, Self>],
+        _linker_scripts: &[&SequencedLinkerScript<'data, Self>],
         _phdr_map: &mut hashbrown::HashMap<&[u8], Vec<OutputSectionId>>,
     ) -> Result<(OutputOrder<'data>, ProgramSegments<Self::ProgramSegmentDef>)> {
         Ok(Self::build_output_order_and_program_segments(

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -4,6 +4,7 @@ use crate::alignment::Alignment;
 use crate::bail;
 use crate::error::Warning;
 use crate::grouping::Group;
+use crate::grouping::SequencedLinkerScript;
 use crate::input_data::FileLoader;
 use crate::input_data::InputBytes;
 use crate::input_data::InputRef;
@@ -702,6 +703,22 @@ pub(crate) trait Platform:
         secondary: &OutputSectionMap<Vec<OutputSectionId>>,
     ) -> (OutputOrder<'data>, ProgramSegments<Self::ProgramSegmentDef>);
 
+    fn build_custom_output_order_and_program_segments<'data>(
+        custom: &CustomSectionIds,
+        output_kind: OutputKind,
+        output_sections: &OutputSections<'data, Self>,
+        secondary: &OutputSectionMap<Vec<OutputSectionId>>,
+        _linker_script: &[&SequencedLinkerScript<'data, Self>],
+        _phdr_map: &mut hashbrown::HashMap<&[u8], Vec<OutputSectionId>>,
+    ) -> Result<(OutputOrder<'data>, ProgramSegments<Self::ProgramSegmentDef>)> {
+        Ok(Self::build_output_order_and_program_segments(
+            custom,
+            output_kind,
+            output_sections,
+            secondary,
+        ))
+    }
+
     fn will_emit_section_symbol_for_partial_objects(
         _output_sections: &OutputSections<Self>,
         _section_id: OutputSectionId,
@@ -1146,6 +1163,10 @@ pub(crate) trait ProgramSegmentDef: Copy + Send + Sync + Display + 'static {
     /// Returns whether the current RW segment should end when this segment ends.
     fn should_cut_rw_segment_when_ending(self) -> bool {
         false
+    }
+
+    fn from_linker_script(_ptype: u32, _flags: u32) -> Self {
+        todo!()
     }
 }
 

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -1593,6 +1593,7 @@ impl platform::Platform for Wasm {
                 min_alignment: crate::alignment::MIN,
                 location: None,
                 secondary_order: None,
+                phdr_name: None,
             })
             .collect()
     }
@@ -1815,6 +1816,7 @@ impl platform::Platform for Wasm {
             output_kind,
             output_sections,
             secondary,
+            false,
         );
 
         builder.add_section(osid::FILE_HEADER);

--- a/wild/tests/sources/elf/linker-script-phdrs/linker-script-phdrs.c
+++ b/wild/tests/sources/elf/linker-script-phdrs/linker-script-phdrs.c
@@ -7,6 +7,13 @@
 //#DiffIgnore:segment.RISCV_ATTRIBUTES.*
 // GNU ld emits `.riscv.attributes`, but Wild does not
 //#DiffIgnore:riscv_attributes.*
+//#ExpectProgramHeader:LOAD
+//#NoProgramHeader:DYNAMIC
+//#NoProgramHeader:PHDR
+//#NoProgramHeader:NOTE
+//#NoProgramHeader:GNU_STACK
+//#NoProgramHeader:GNU_RELRO
+//#NoProgramHeader:GNU_PROPERTY
 
 const char message[] = "Hello PHDRS";
 

--- a/wild/tests/sources/elf/linker-script-phdrs/linker-script-phdrs.c
+++ b/wild/tests/sources/elf/linker-script-phdrs/linker-script-phdrs.c
@@ -7,7 +7,9 @@
 //#DiffIgnore:segment.RISCV_ATTRIBUTES.*
 // GNU ld emits `.riscv.attributes`, but Wild does not
 //#DiffIgnore:riscv_attributes.*
-//#ExpectProgramHeader:LOAD
+//#ExpectProgramHeader:LOAD flags=RX,sections=[.text]
+//#ExpectProgramHeader:LOAD flags=RW,sections=[*]
+//#ExpectProgramHeader:LOAD flags=R,sections=[.rodata,*]
 //#NoProgramHeader:DYNAMIC
 //#NoProgramHeader:PHDR
 //#NoProgramHeader:NOTE

--- a/wild/tests/sources/elf/linker-script-phdrs/linker-script-phdrs.c
+++ b/wild/tests/sources/elf/linker-script-phdrs/linker-script-phdrs.c
@@ -1,0 +1,15 @@
+//#Mode:dynamic
+//#RunEnabled:false
+//#CompArgs:-fPIE -fPIC
+//#LinkArgs:-shared -z now -T ./linker-script-phdrs.ld
+//#DiffIgnore:section.got
+//#DiffIgnore:section.riscv.attributes
+//#DiffIgnore:segment.RISCV_ATTRIBUTES.*
+// GNU ld emits `.riscv.attributes`, but Wild does not
+//#DiffIgnore:riscv_attributes.*
+
+const char message[] = "Hello PHDRS";
+
+int foo(void) { return 42; }
+
+const char* bar() { return &message[0]; }

--- a/wild/tests/sources/elf/linker-script-phdrs/linker-script-phdrs.ld
+++ b/wild/tests/sources/elf/linker-script-phdrs/linker-script-phdrs.ld
@@ -1,0 +1,23 @@
+PHDRS {
+    text PT_LOAD FLAGS(5);   /* R + X */
+    data PT_LOAD FLAGS(6);   /* R + W */
+	rodata PT_LOAD FLAGS(4); /* R */
+}
+
+SECTIONS {
+    .text : {
+        *(.text*)
+    } :text
+
+    .data : {
+        *(.data*)
+    } :data
+
+    .bss : {
+        *(.bss*)
+    } :data
+
+    .rodata : {
+        *(.rodata*)
+	} :rodata
+}

--- a/wild/tests/sources/elf/linker-script-phdrs/linker-script-phdrs.ld
+++ b/wild/tests/sources/elf/linker-script-phdrs/linker-script-phdrs.ld
@@ -1,7 +1,7 @@
 PHDRS {
-    text PT_LOAD FLAGS(5);   /* R + X */
+    text PT_LOAD;
     data PT_LOAD FLAGS(6);   /* R + W */
-	rodata PT_LOAD FLAGS(4); /* R */
+    rodata PT_LOAD FLAGS(4); /* R */
 }
 
 SECTIONS {
@@ -19,5 +19,5 @@ SECTIONS {
 
     .rodata : {
         *(.rodata*)
-	} :rodata
+    } :rodata
 }


### PR DESCRIPTION
This PR adds support for defining program headers in linker scripts, using the `PHDRS` command.

This PR doesn't add support for defining multiple phdrs in the same section.