### PR TITLE
feat: always emit .riscv.attribute when using linker scripts

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -1734,6 +1734,10 @@ impl platform::Platform for Elf {
             secnames::COMMENT_SECTION_NAME,
             output_section_id::COMMENT,
         ));
+        rule_builder.add_section_rule(SectionRule::exact(
+            secnames::RISCV_ATTRIBUTES_SECTION_NAME,
+            SectionRuleOutcome::RiscVAttribute,
+        ));
     }
 
     fn init_section_priority(name: &[u8]) -> Option<u16> {
@@ -1981,6 +1985,12 @@ impl platform::Platform for Elf {
             builder.add_section(id);
         }
 
+        builder.add_segment_with_sections(
+            pt::RISCV_ATTRIBUTES.0,
+            pf::READABLE.0,
+            &[output_section_id::RISCV_ATTRIBUTES],
+            output_sections,
+        );
         Ok(builder.build())
     }
 

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -782,7 +782,11 @@ impl<'data, P: Platform> OutputSections<'data, P> {
                     return;
                 }
 
-                if id == FILE_HEADER || id == PROGRAM_HEADERS || id == SECTION_HEADERS {
+                if id == FILE_HEADER
+                    || id == PROGRAM_HEADERS
+                    || id == SECTION_HEADERS
+                    || id == RISCV_ATTRIBUTES
+                {
                     return;
                 }
             } else {

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -3987,7 +3987,7 @@ impl Assertions {
                 _ => section.flags() != object::SectionFlags::None,
             };
 
-            if !is_alloc && header.p_type(endian).0 != object::elf::PT_RISCV_ATTRIBUTES.0 {
+            if !is_alloc && header.p_type(endian) != object::elf::PT_RISCV_ATTRIBUTES {
                 continue;
             }
 

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -899,6 +899,7 @@ enum ProgramHeaderType {
     Null = object::elf::PT_NULL.0,
     Phdr = object::elf::PT_PHDR.0,
     Tls = object::elf::PT_TLS.0,
+    RiscvAttributes = object::elf::PT_RISCV_ATTRIBUTES.0,
 }
 
 bitflags! {
@@ -3986,12 +3987,14 @@ impl Assertions {
                 _ => section.flags() != object::SectionFlags::None,
             };
 
-            if !is_alloc {
+            if !is_alloc && header.p_type(endian).0 != object::elf::PT_RISCV_ATTRIBUTES.0 {
                 continue;
             }
 
-            let in_mem =
-                sh_addr >= p_vaddr && sh_addr + sh_size <= p_vaddr + p_memsz && p_memsz > 0;
+            let in_mem = is_alloc
+                && sh_addr >= p_vaddr
+                && sh_addr + sh_size <= p_vaddr + p_memsz
+                && p_memsz > 0;
             let in_file = sh_offset >= p_offset
                 && sh_offset + sh_filesz <= p_offset + p_filesz
                 && p_filesz > 0

--- a/wild/tests/sources/elf/linker-script-discard/linker-script-discard.c
+++ b/wild/tests/sources/elf/linker-script-discard/linker-script-discard.c
@@ -4,10 +4,6 @@
 //#EnableLinker:lld
 //#LinkArgs:-shared -z now -T ./linker-script-discard.ld
 //#DiffIgnore:section.got
-//#DiffIgnore:section.riscv.attributes
-//#DiffIgnore:segment.RISCV_ATTRIBUTES.*
-// lld emits `.riscv.attributes`, but Wild does not
-//#DiffIgnore:riscv_attributes.*
 //#DiffIgnore:segment.LOAD.RX.alignment
 //#DiffIgnore:segment.LOAD.RWX.alignment
 // Wild does not emit the `.eh_frame` section as all code sections are discarded, but lld still

--- a/wild/tests/sources/elf/linker-script-glob/linker-script-glob.c
+++ b/wild/tests/sources/elf/linker-script-glob/linker-script-glob.c
@@ -12,10 +12,6 @@
 //#ExpectSym:val_hello_world section="helloworld"
 //#ExpectSym:val_hello_dash_world section="helloworld"
 //#ExpectSym:val_hello_baz section="other"
-//#DiffIgnore:section.riscv.attributes
-//#DiffIgnore:segment.RISCV_ATTRIBUTES.*
-// GNU ld emits `.riscv.attributes`, but Wild does not
-//#DiffIgnore:riscv_attributes.*
 
 static int val_0 __attribute__((used, section(".mydata.0"))) = 0;
 static int val_1 __attribute__((used, section(".mydata.1"))) = 1;

--- a/wild/tests/sources/elf/linker-script-phdrs/linker-script-phdrs.c
+++ b/wild/tests/sources/elf/linker-script-phdrs/linker-script-phdrs.c
@@ -1,12 +1,9 @@
+//#Config:default
 //#Mode:dynamic
 //#RunEnabled:false
 //#CompArgs:-fPIE -fPIC
 //#LinkArgs:-shared -z now -T ./linker-script-phdrs.ld
 //#DiffIgnore:section.got
-//#DiffIgnore:section.riscv.attributes
-//#DiffIgnore:segment.RISCV_ATTRIBUTES.*
-// GNU ld emits `.riscv.attributes`, but Wild does not
-//#DiffIgnore:riscv_attributes.*
 //#ExpectProgramHeader:LOAD flags=RX,sections=[.text]
 //#ExpectProgramHeader:LOAD flags=RW,sections=[*]
 //#ExpectProgramHeader:LOAD flags=R,sections=[.rodata,*]
@@ -16,6 +13,10 @@
 //#NoProgramHeader:GNU_STACK
 //#NoProgramHeader:GNU_RELRO
 //#NoProgramHeader:GNU_PROPERTY
+
+//#Config:riscv:default
+//#Arch:riscv64
+//#ExpectProgramHeader:RISCV_ATTRIBUTES flags=R,sections=[.riscv.attributes]
 
 const char message[] = "Hello PHDRS";
 

--- a/wild/tests/sources/elf/linker-script-provide/linker-script-provide.c
+++ b/wild/tests/sources/elf/linker-script-provide/linker-script-provide.c
@@ -23,10 +23,6 @@
 //#DiffIgnore:rel.extra-opt.R_X86_64_REX_GOTPCRELX.MovIndirectToLea.invalid-shared-object
 //#DiffIgnore:rel.missing-got-dynamic.shared-object
 //#DiffIgnore:rel.R_AARCH64_ADR_GOT_PAGE.R_AARCH64_ADR_GOT_PAGE
-//#DiffIgnore:section.riscv.attributes
-//#DiffIgnore:segment.RISCV_ATTRIBUTES.*
-// GNU ld emits `.riscv.attributes`, but Wild does not
-//#DiffIgnore:riscv_attributes.*
 // GNU ld behaves strangely when a symbol referenced in a linker script is empty. See this:
 // https://github.com/wild-linker/wild/pull/1525#discussion_r2785478582
 //#DiffIgnore:dynsym.__data_start.section

--- a/wild/tests/sources/elf/linker-script/linker-script.c
+++ b/wild/tests/sources/elf/linker-script/linker-script.c
@@ -14,10 +14,6 @@
 //#ExpectSym:defsym_hex address=0x1244
 //#ExpectSym:sections_start address=0xabcd
 //#ExpectSym:sections_end address=0xcdef
-//#DiffIgnore:section.riscv.attributes
-//#DiffIgnore:segment.RISCV_ATTRIBUTES.*
-// GNU ld emits `.riscv.attributes`, but Wild does not
-//#DiffIgnore:riscv_attributes.*
 // Different linkers emit different corresponding sections.
 //#DiffIgnore:dynsym.sections_start.section
 //#DiffIgnore:dynsym.sections_end.section


### PR DESCRIPTION
Both ld and lld always emit a `RISCV_ATTRIBUTE` segment along with a `.riscv.attribute` section, regardless of whether or not it is defined in the linker script.