### PR TITLE
feat: Support `--rosegment` and `--no-rosegment`

### DIFF
--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -128,6 +128,7 @@ pub struct ElfArgs {
     pub(crate) should_output_partial_object: bool,
 
     pub(crate) nmagic: bool,
+    pub(crate) rosegment: bool,
 
     rpath_set: IndexSet<String>,
 
@@ -318,6 +319,7 @@ impl Default for ElfArgs {
             discard_sframe: false,
 
             nmagic: false,
+            rosegment: true,
 
             unresolved_symbols: UnresolvedSymbols::ReportAll,
             error_unresolved_symbols: true,
@@ -1830,6 +1832,24 @@ fn setup_argument_parser() -> ArgumentParser<ElfArgs> {
 
     parser
         .declare()
+        .long("rosegment")
+        .help("Put read-only non-executable sections in their own segment (default)")
+        .execute(|args, _modifier_stack| {
+            args.rosegment = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("no-rosegment")
+        .help("Don't put read-only non-executable sections in their own segment")
+        .execute(|args, _modifier_stack| {
+            args.rosegment = false;
+            Ok(())
+        });
+
+    parser
+        .declare()
         .long("discard-sframe")
         .help("Discard SFrame section")
         .execute(|args, _modifier_stack| {
@@ -1890,6 +1910,10 @@ impl platform::Args for ElfArgs {
 
     fn verbose_gc_stats(&self) -> bool {
         self.verbose_gc_stats
+    }
+
+    fn rosegment(&self) -> bool {
+        self.rosegment
     }
 
     fn common(&self) -> &crate::args::CommonArgs {

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -4340,15 +4340,20 @@ impl platform::ProgramSegmentDef for ProgramSegmentDef {
         self,
         info: &crate::output_section_id::SectionOutputInfo<Elf>,
         section_id: OutputSectionId,
+        rosegment: bool,
     ) -> bool {
         match self.segment_type {
             pt::NOTE => info.section_attributes.ty == sht::NOTE,
             pt::TLS => info.section_attributes.flags.contains(shf::TLS),
             pt::LOAD => {
+                let mut exec = info.section_attributes.flags.contains(shf::EXECINSTR);
+                if !rosegment && !info.section_attributes.flags.contains(shf::WRITE) {
+                    exec = true;
+                }
+
                 info.section_attributes.flags.contains(shf::ALLOC)
                     && info.section_attributes.flags.contains(shf::WRITE) == self.is_writable()
-                    && info.section_attributes.flags.contains(shf::EXECINSTR)
-                        == self.is_executable()
+                    && exec == self.is_executable()
             }
             pt::GNU_RELRO => {
                 info.section_attributes.flags.contains(shf::TLS)

--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -284,6 +284,7 @@ impl Linker {
 
         let mut output_sections =
             OutputSections::with_base_address(P::start_memory_address(output_kind));
+        output_sections.set_rosegment(args.rosegment());
 
         let mut layout_rules_builder = LayoutRulesBuilder::default();
 

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -869,6 +869,7 @@ impl platform::ProgramSegmentDef for ProgramSegmentDef {
         self,
         section_info: &crate::output_section_id::SectionOutputInfo<Self::Platform>,
         section_id: crate::output_section_id::OutputSectionId,
+        _rosegment: bool,
     ) -> bool {
         let mapped_segment = match section_id {
             output_section_id::FILE_HEADER => SegmentType::Text,

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -166,6 +166,8 @@ pub(crate) struct OutputSections<'data, P: Platform> {
     custom_by_name: HashMap<SectionName<'data>, OutputSectionId>,
 
     init_fini_by_priority: HashMap<(OutputSectionId, u16), OutputSectionId>,
+
+    rosegment: bool,
 }
 
 /// Encodes the order of output sections and the start and end of each program segment. This struct
@@ -452,7 +454,7 @@ impl<'data, P: Platform> OutputSections<'data, P> {
         segment_def: P::ProgramSegmentDef,
     ) -> bool {
         let info = self.output_info(section_id);
-        segment_def.should_include_section(info, section_id)
+        segment_def.should_include_section(info, section_id, self.rosegment)
     }
 }
 
@@ -668,7 +670,12 @@ impl<'data, P: Platform> OutputSections<'data, P> {
             custom_by_name: HashMap::new(),
             output_section_indexes: Default::default(),
             init_fini_by_priority: HashMap::new(),
+            rosegment: true,
         }
+    }
+
+    pub(crate) fn set_rosegment(&mut self, rosegment: bool) {
+        self.rosegment = rosegment;
     }
 
     pub(crate) fn bump_min_alignment(&mut self, sid: OutputSectionId, a: Alignment) {

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -1141,6 +1141,7 @@ pub(crate) trait ProgramSegmentDef: Copy + Send + Sync + Display + 'static {
         self,
         section_info: &crate::output_section_id::SectionOutputInfo<Self::Platform>,
         section_id: OutputSectionId,
+        rosegment: bool,
     ) -> bool;
 
     /// Returns whether the current RW segment should end when this segment ends.
@@ -1220,6 +1221,10 @@ pub(crate) trait Args: std::fmt::Debug + Send + Sync + 'static {
 
     fn should_relax(&self) -> bool {
         false
+    }
+
+    fn rosegment(&self) -> bool {
+        true
     }
 
     fn should_emit_got_plt_syms(&self) -> bool {

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -1198,6 +1198,7 @@ impl platform::ProgramSegmentDef for ProgramSegmentDef {
         self,
         _section_info: &crate::output_section_id::SectionOutputInfo<Self::Platform>,
         section_id: crate::output_section_id::OutputSectionId,
+        _rosegment: bool,
     ) -> bool {
         use crate::output_section_id as osid;
 

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -33,7 +33,6 @@ tests = [
   "require-defined.sh",
   "response-file-quoting.sh",
   "retain-symbols-file.sh",
-  "rosegment.sh",
   "run.sh",
   "section-align.sh",                      # `--section-alignment`
   "sort-debug-info-compressed.sh",         # `-Map`


### PR DESCRIPTION
`--rosegment` places read-only and non-executable sections into the `R` segment, while `--no-rosegment` merges them into executable segments.

Closes #1993 