### PR TITLE
ci: Always use latest released wild in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,6 @@ jobs:
           targets: x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl,aarch64-unknown-linux-gnu,aarch64-unknown-linux-musl,riscv64gc-unknown-linux-gnu,riscv64gc-unknown-linux-musl,loongarch64-unknown-linux-gnu,loongarch64-unknown-linux-musl,powerpc64le-unknown-linux-gnu
           components: rustc-codegen-cranelift-preview
       - uses: wild-linker/action@latest
-        with:
-          wild-version: "0.8.0"
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ runner.os }}-${{ matrix.container }}-${{ matrix.runs-on }}
@@ -232,8 +230,6 @@ jobs:
         with:
           components: clippy
       - uses: wild-linker/action@latest
-        with:
-          wild-version: "0.8.0"
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets --workspace --target x86_64-unknown-linux-gnu
 


### PR DESCRIPTION
There is no point in specifying a version each time.