### PR TITLE
fix: Don't bail when a linker plugin doesn't claim an IR archive member

### DIFF
--- a/libwild/src/input_data.rs
+++ b/libwild/src/input_data.rs
@@ -1043,14 +1043,18 @@ impl<'data, P: Platform> LoadedInputs<'data, P> {
                     file,
                     kind,
                 } = *obj;
-                let result = plugin.as_mut()
+                let plugin_result = plugin.as_mut()
                     .with_context(|| {
                         format!(
                             "Input file {input_ref} contains {kind}, but linker plugin was not supplied"
                         )
                     })
                     .and_then(|plugin| plugin.process_input(input_ref, &file, kind));
-                self.lto_objects.push(result);
+                match plugin_result {
+                    Ok(Some(info)) => self.lto_objects.push(Ok(info)),
+                    Ok(None) => {} // Skipped, e.g. unclaimed IR member inside an archive
+                    Err(e) => self.lto_objects.push(Err(e)),
+                }
             }
         }
     }

--- a/libwild/src/linker_plugins.rs
+++ b/libwild/src/linker_plugins.rs
@@ -174,20 +174,23 @@ impl<'data> LinkerPlugin<'data> {
         input_ref: InputRef<'data>,
         file: &File,
         kind: FileKind,
-    ) -> Result<Box<LtoInputInfo<'data>>> {
+    ) -> Result<Option<Box<LtoInputInfo<'data>>>> {
         verbose_timing_phase!("Linker plugin process input");
 
         let fd = file.as_raw_fd();
 
-        self.claim_file(input_ref, fd)
-            .transpose()
-            .with_context(|| {
-                format!(
+        match self.claim_file(input_ref, fd)? {
+            Some(info) => Ok(Some(info)),
+            None => {
+                if input_ref.has_archive_semantics() {
+                    return Ok(None);
+                }
+                bail!(
                     "Input file {input_ref} contains {kind}, \
                             but the linker plugin ({self}) didn't claim it"
-                )
-            })
-            .flatten()
+                );
+            }
+        }
     }
 
     /// Notify the plugin that all symbols have now been read. This will cause it to build

--- a/libwild/src/linker_plugins_disabled.rs
+++ b/libwild/src/linker_plugins_disabled.rs
@@ -34,7 +34,7 @@ impl<'data> LinkerPlugin<'data> {
         _input_ref: crate::input_data::InputRef<'_>,
         _file: &std::fs::File,
         _kind: crate::file_kind::FileKind,
-    ) -> Result<Box<LtoInputInfo<'data>>> {
+    ) -> Result<Option<Box<LtoInputInfo<'data>>>> {
         unreachable!();
     }
 

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -191,16 +191,14 @@ tests = [
 [skipped_groups.lto]
 reason = "Failing LTO tests."
 tests = [
-  "lto-no-plugin.sh",              # We don't currently support LTO without an explicit plugin
-  "lto-gcc.sh",                    # We don't currently support LTO without an explicit plugin
-  "lto-llvm2.sh",                  # -m llvm is not yet supported
-  "duplicate-error-lto.sh",        # Wild deduplicates inputs
-  "lto-comdat.sh",                 # We don't support COMDAT
-  "wrap-lto.sh",                   # We don't yet support --wrap with LTO
+  "lto-no-plugin.sh",       # We don't currently support LTO without an explicit plugin
+  "lto-gcc.sh",             # We don't currently support LTO without an explicit plugin
+  "lto-llvm2.sh",           # -m llvm is not yet supported
+  "duplicate-error-lto.sh", # Wild deduplicates inputs
+  "lto-comdat.sh",          # We don't support COMDAT
+  "wrap-lto.sh",            # We don't yet support --wrap with LTO
   "lto-archive4.sh",
   "lto-mixed-gcc-fat.sh",
-  "lto-mixed-gcc-slim-archive.sh",
-  "lto-unclaimed.sh",
 ]
 
 [skipped_groups.uncommon]

--- a/wild/tests/sources/elf/linker-plugin-lto/linker-plugin-lto.c
+++ b/wild/tests/sources/elf/linker-plugin-lto/linker-plugin-lto.c
@@ -85,6 +85,15 @@
 //#LinkerDriver:gcc
 //#LinkArgs:-flto -nostdlib -znow
 
+//#Config:gcc-driver-with-unclaimed-llvm-ir-archive:default
+//#Compiler:clang
+//#Object:runtime.c
+//#Object:linker-plugin-lto-2.c
+//#Archive:unclaimed.c:-flto
+//#SkipLinker:ld
+//#LinkerDriver:gcc
+//#LinkArgs:-flto -nostdlib
+
 // Linker message with format string.
 //#Config:clang-format-string:error
 //#Compiler:clang

--- a/wild/tests/sources/elf/linker-plugin-lto/unclaimed.c
+++ b/wild/tests/sources/elf/linker-plugin-lto/unclaimed.c
@@ -1,0 +1,1 @@
+int unclaimed_from_archive(void) { return 123; }


### PR DESCRIPTION
Archive members are only selected if their symbols are referenced. If the active LTO plugin refuses to claim one, we used to error unconditionally. Skip it instead and let later symbol resolution fail if the member turns out to be needed.