### PR TITLE
feat: implement support for the SIZEOF_HEADERS builtin function

### DIFF
--- a/LINKER_SCRIPT_SUPPORT.md
+++ b/LINKER_SCRIPT_SUPPORT.md
@@ -83,7 +83,7 @@ end lists the features required to link the Linux kernel.
 | `MAX(a, b)` | ✅ | |
 | Ternary operator (`condition ? a : b`) | 📅 | |
 | `DEFINED(sym)` | 📅 | |
-| `SIZEOF_HEADERS` | 📅 | |
+| `SIZEOF_HEADERS` | ✅ | |
 | `SEGMENT_START(segment, default)` | ✅ | Supports `"text"`, `"data"`, `"bss"`, `"rodata"`; returns `-Ttext`/`-Tdata`/`-Tbss` override if provided, otherwise `default`; unknown segment names always return `default` |
 
 ## MEMORY Command
@@ -123,4 +123,4 @@ see at a glance what remains before Wild can link the kernel.
 | `PHDRS` command for explicit program header definition | 🧪 | The FILEHDR and PHDRS keywords aren't yet supported. |
 | Ternary operator (`condition ? a : b`) | 📅 | |
 | `DEFINED(sym)` function | 📅 | |
-| `SIZEOF_HEADERS` built-in symbol | 📅 | |
+| `SIZEOF_HEADERS` built-in symbol | ✅ | |

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -2108,6 +2108,10 @@ impl platform::Platform for Elf {
     fn default_symtab_entry() -> Self::SymtabEntry {
         Default::default()
     }
+
+    fn get_sizeof_headers(header_info: &layout::HeaderInfo) -> u64 {
+        u64::from(FILE_HEADER_SIZE) + program_headers_size(header_info)
+    }
 }
 
 /// Marks the symbol version associated with the dynamic symbol `GLIBC_ABI_DT_RELR` as needed.

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -34,6 +34,7 @@ pub(crate) fn evaluate_assertions<'data, P: Platform>(
     section_layouts: &OutputSectionMap<OutputRecordLayout>,
     output_sections: &OutputSections<'data, P>,
     resolutions: &[Option<Resolution<P>>],
+    sizeof_headers: u64,
 ) -> Result {
     for group in &symbol_db.groups {
         let Group::LinkerScripts(scripts) = group else {
@@ -50,6 +51,7 @@ pub(crate) fn evaluate_assertions<'data, P: Platform>(
                     output_sections,
                     &parsed.memory_regions,
                     symbol_db,
+                    sizeof_headers,
                     &|name| {
                         let Some(target_symbol_id) =
                             symbol_db.get_unversioned(&UnversionedSymbolName::prehashed(name))
@@ -85,6 +87,7 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
     output_sections: &OutputSections<'data, P>,
     memory_regions: &[MemoryRegion<'data>],
     symbol_db: &SymbolDb<'data, P>,
+    sizeof_headers: u64,
     symbol_resolution_callback: &dyn Fn(&[u8]) -> Result<u64>,
 ) -> Result<u64> {
     macro_rules! eval {
@@ -96,6 +99,7 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
                 output_sections,
                 memory_regions,
                 symbol_db,
+                sizeof_headers,
                 symbol_resolution_callback,
             )
         };
@@ -201,6 +205,7 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
                 eval!(default_expr)
             }
         }
+        Expression::SizeofHeaders => Ok(sizeof_headers),
     }
 }
 
@@ -330,6 +335,7 @@ mod tests {
                 sections,
                 &[],
                 symbol_db,
+                0,
                 &|_| Ok(1),
             )
         })
@@ -666,7 +672,7 @@ mod tests {
                 remainder: b"",
             }]);
             symbol_db.add_group(group);
-            assert!(evaluate_assertions::<Elf>(symbol_db, layouts, sections, &[]).is_ok());
+            assert!(evaluate_assertions::<Elf>(symbol_db, layouts, sections, &[], 0).is_ok());
         });
     }
 
@@ -679,7 +685,7 @@ mod tests {
                 remainder: b"",
             }]);
             symbol_db.add_group(group);
-            let err = evaluate_assertions::<Elf>(symbol_db, layouts, sections, &[]).unwrap_err();
+            let err = evaluate_assertions::<Elf>(symbol_db, layouts, sections, &[], 0).unwrap_err();
             assert!(err.to_string().contains("intentional failure"));
         });
     }
@@ -707,6 +713,7 @@ mod tests {
                     sections,
                     &regions,
                     symbol_db,
+                    0,
                     &|_| Ok(0),
                 )
             };

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -250,6 +250,14 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         .flat_map(|s| s.parsed.memory_regions.iter().cloned())
         .collect();
 
+    let sizeof_headers = if let Some(FileLayoutState::Prelude(internal)) =
+        group_states.first().and_then(|g| g.files.first())
+    {
+        P::get_sizeof_headers(internal.header_info.as_ref().unwrap())
+    } else {
+        unreachable!();
+    };
+
     let mut section_part_layouts = layout_section_parts::<A::Platform>(
         &section_part_sizes,
         &output_sections,
@@ -257,6 +265,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         &output_order,
         &symbol_db,
         &memory_regions,
+        sizeof_headers,
     )?;
 
     if symbol_db.args.should_relax() && A::supports_size_reduction_relaxations() {
@@ -270,6 +279,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
             &symbol_db,
             &per_symbol_flags,
             &memory_regions,
+            sizeof_headers,
         )?;
     }
 
@@ -372,6 +382,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         &mut symbol_resolutions.resolutions,
         &output_sections,
         &section_layouts,
+        sizeof_headers,
     )?;
     crate::gc_stats::maybe_write_gc_stats(&group_layouts, &symbol_db)?;
 
@@ -381,6 +392,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         &section_layouts,
         &output_sections,
         &symbol_resolutions.resolutions,
+        sizeof_headers,
     )?;
 
     let thunk_block_addresses = thunk_block_addresses_out
@@ -436,6 +448,7 @@ fn update_redirect_resolutions<'data, P: Platform>(
     resolutions: &mut [Option<Resolution<P>>],
     output_sections: &OutputSections<'data, P>,
     section_layouts: &OutputSectionMap<OutputRecordLayout>,
+    sizeof_headers: u64,
 ) -> Result {
     verbose_timing_phase!("Update symdef resolutions");
 
@@ -453,6 +466,7 @@ fn update_redirect_resolutions<'data, P: Platform>(
                         output_sections,
                         section_layouts,
                         &[],
+                        sizeof_headers,
                     )?;
                     symbol_id = symbol_id.next();
                 }
@@ -468,6 +482,7 @@ fn update_redirect_resolutions<'data, P: Platform>(
                             output_sections,
                             section_layouts,
                             &script.parsed.memory_regions,
+                            sizeof_headers,
                         )?;
                         symbol_id = symbol_id.next();
                     }
@@ -490,6 +505,7 @@ fn update_defsym_symbol_resolution<'data, P: Platform>(
     output_sections: &OutputSections<'data, P>,
     section_layouts: &OutputSectionMap<OutputRecordLayout>,
     memory_regions: &[crate::linker_script::MemoryRegion<'data>],
+    sizeof_headers: u64,
 ) -> Result {
     if let SymbolPlacement::Redirect(redirect) = &def_info.placement {
         let value = crate::expression_eval::evaluate_expression(
@@ -499,6 +515,7 @@ fn update_defsym_symbol_resolution<'data, P: Platform>(
             output_sections,
             memory_regions,
             symbol_db,
+            sizeof_headers,
             &|name| {
                 let Some(target_symbol_id) =
                     symbol_db.get_unversioned(&UnversionedSymbolName::prehashed(name))
@@ -4751,6 +4768,7 @@ fn perform_iterative_relaxation<'data, A: Arch>(
     symbol_db: &SymbolDb<'data, A::Platform>,
     per_symbol_flags: &PerSymbolFlags,
     memory_regions: &[crate::linker_script::MemoryRegion<'data>],
+    sizeof_headers: u64,
 ) -> Result {
     timing_phase!("Iterative relaxation");
 
@@ -4807,6 +4825,7 @@ fn perform_iterative_relaxation<'data, A: Arch>(
             output_order,
             symbol_db,
             memory_regions,
+            sizeof_headers,
         )?;
     }
     Ok(())
@@ -4819,6 +4838,7 @@ fn layout_section_parts<'data, P: Platform>(
     output_order: &OutputOrder<'data>,
     symbol_db: &SymbolDb<'data, P>,
     memory_regions: &[crate::linker_script::MemoryRegion<'data>],
+    sizeof_headers: u64,
 ) -> Result<OutputSectionPartMap<OutputRecordLayout>> {
     let args = symbol_db.args;
     let segment_alignments = compute_segment_alignments::<P>(
@@ -4841,6 +4861,7 @@ fn layout_section_parts<'data, P: Platform>(
             output_sections,
             memory_regions,
             symbol_db,
+            sizeof_headers,
             &|_| {
                 bail!("Symbols with the set location operation are not yet supported.");
             },
@@ -5299,6 +5320,7 @@ fn test_no_disallowed_overlaps() {
         &output_order,
         &symbol_db,
         &[],
+        0,
     )
     .unwrap();
 

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -222,6 +222,7 @@ pub(crate) enum Expression<'a> {
     LogicalNot(Box<Expression<'a>>),
     BitwiseNot(Box<Expression<'a>>),
     Negate(Box<Expression<'a>>),
+    SizeofHeaders,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -249,7 +250,8 @@ impl<'a> Expression<'a> {
             | Expression::Length(_)
             | Expression::Addr(_)
             | Expression::Loadaddr(_)
-            | Expression::Symbol(_) => {}
+            | Expression::Symbol(_)
+            | Expression::SizeofHeaders => {}
             Expression::Add(l, r)
             | Expression::Subtract(l, r)
             | Expression::Multiply(l, r)
@@ -894,8 +896,12 @@ fn parse_identifier_or_function<'a>(input: &mut &'a BStr) -> winnow::Result<Expr
             _ => Err(ContextError::default()),
         }
     } else {
-        // It's a symbol
-        Ok(Expression::Symbol(ident))
+        if ident == b"SIZEOF_HEADERS" {
+            Ok(Expression::SizeofHeaders)
+        } else {
+            // It's a symbol
+            Ok(Expression::Symbol(ident))
+        }
     }
 }
 

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -895,13 +895,11 @@ fn parse_identifier_or_function<'a>(input: &mut &'a BStr) -> winnow::Result<Expr
             }
             _ => Err(ContextError::default()),
         }
+    } else if ident == b"SIZEOF_HEADERS" {
+        Ok(Expression::SizeofHeaders)
     } else {
-        if ident == b"SIZEOF_HEADERS" {
-            Ok(Expression::SizeofHeaders)
-        } else {
-            // It's a symbol
-            Ok(Expression::Symbol(ident))
-        }
+        // It's a symbol
+        Ok(Expression::Symbol(ident))
     }
 }
 

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -749,6 +749,10 @@ pub(crate) trait Platform:
         _total_sizes: &mut OutputSectionPartMap<u64>,
     ) {
     }
+
+    fn get_sizeof_headers(_header_info: &layout::HeaderInfo) -> u64 {
+        0
+    }
 }
 
 /// Abstracts over the different object file formats that we support (or may support). e.g. ELF.

--- a/wild/tests/sources/elf/linker-script-phdrs/linker-script-phdrs.c
+++ b/wild/tests/sources/elf/linker-script-phdrs/linker-script-phdrs.c
@@ -2,7 +2,7 @@
 //#Mode:dynamic
 //#RunEnabled:false
 //#CompArgs:-fPIE -fPIC
-//#LinkArgs:-shared -z now -T ./linker-script-phdrs.ld
+//#LinkArgs:-shared -z now -T ./linker-script-phdrs.ld --defsym=is_riscv=0
 //#DiffIgnore:section.got
 //#ExpectProgramHeader:LOAD flags=RX,sections=[.text]
 //#ExpectProgramHeader:LOAD flags=RW,sections=[*]
@@ -13,10 +13,12 @@
 //#NoProgramHeader:GNU_STACK
 //#NoProgramHeader:GNU_RELRO
 //#NoProgramHeader:GNU_PROPERTY
+//#SkipArch:riscv64
 
 //#Config:riscv:default
 //#Arch:riscv64
 //#ExpectProgramHeader:RISCV_ATTRIBUTES flags=R,sections=[.riscv.attributes]
+//#LinkArgs:-shared -z now -T ./linker-script-phdrs.ld --defsym=is_riscv=1
 
 const char message[] = "Hello PHDRS";
 

--- a/wild/tests/sources/elf/linker-script-phdrs/linker-script-phdrs.ld
+++ b/wild/tests/sources/elf/linker-script-phdrs/linker-script-phdrs.ld
@@ -21,3 +21,5 @@ SECTIONS {
         *(.rodata*)
     } :rodata
 }
+
+ASSERT(SIZEOF_HEADERS == 64 + (3 * 56), "Wrong size of headers");

--- a/wild/tests/sources/elf/linker-script-phdrs/linker-script-phdrs.ld
+++ b/wild/tests/sources/elf/linker-script-phdrs/linker-script-phdrs.ld
@@ -5,6 +5,8 @@ PHDRS {
 }
 
 SECTIONS {
+    . = SIZEOF_HEADERS;
+    start_of_sections = .;
     .text : {
         *(.text*)
     } :text
@@ -22,4 +24,5 @@ SECTIONS {
     } :rodata
 }
 
-ASSERT(SIZEOF_HEADERS == 64 + (3 * 56), "Wrong size of headers");
+ASSERT(start_of_sections == 0x40 + ((3 + is_riscv) * 0x38), "Wrong start of sections");
+ASSERT(SIZEOF_HEADERS == 0x40 + ((3 + is_riscv) * 0x38), "Wrong size of headers");


### PR DESCRIPTION
This PR adds support for the `SIZEOF_HEADERS` builtin, which is used to get the combined size of the elf header and program headers.