### PR TITLE
port(MachO): support for linking against stub libraries

### DIFF
--- a/fakes-debug/ld64.ld
+++ b/fakes-debug/ld64.ld
@@ -1,0 +1,1 @@
+../target/debug/wild

--- a/fakes/ld64.ld
+++ b/fakes/ld64.ld
@@ -1,0 +1,1 @@
+../target/release/wild

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -1325,12 +1325,19 @@ fn declare_common_args<T: platform::Args>(parser: &mut ArgumentParser<T>) {
             args.common_mut().write_layout = true;
             Ok(())
         });
-
     parser
         .declare()
         .long("write-trace")
         .execute(|args, _modifier_stack| {
             args.common_mut().write_trace = true;
+            Ok(())
+        });
+    parser
+        .declare_with_param()
+        .long("sym-info")
+        .help("Show symbol information. Accepts symbol name or ID.")
+        .execute(|args, _modifier_stack, value| {
+            args.common_mut().sym_info = Some(value.to_owned());
             Ok(())
         });
 }

--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -1669,15 +1669,6 @@ fn setup_argument_parser() -> ArgumentParser<ElfArgs> {
         });
 
     parser
-        .declare_with_param()
-        .long("sym-info")
-        .help("Show symbol information. Accepts symbol name or ID.")
-        .execute(|args, _modifier_stack, value| {
-            args.common_mut().sym_info = Some(value.to_owned());
-            Ok(())
-        });
-
-    parser
         .declare()
         .long("start-lib")
         .help("Start library group")

--- a/libwild/src/args/macho.rs
+++ b/libwild/src/args/macho.rs
@@ -297,6 +297,14 @@ fn setup_argument_parser() -> ArgumentParser<MachOArgs> {
             args.common_mut().file_write_mode = Some(FileWriteMode::UpdateInPlace);
             Ok(())
         });
+    parser
+        .declare_with_param()
+        .long("sym-info")
+        .help("Show symbol information. Accepts symbol name or ID.")
+        .execute(|args, _modifier_stack, value| {
+            args.common_mut().sym_info = Some(value.to_owned());
+            Ok(())
+        });
 
     super::declare_common_args(&mut parser);
 

--- a/libwild/src/args/macho.rs
+++ b/libwild/src/args/macho.rs
@@ -220,6 +220,15 @@ fn setup_argument_parser() -> ArgumentParser<MachOArgs> {
         });
     parser
         .declare_with_param()
+        .prefix("L")
+        .help("Add directory to library search path")
+        .execute(|args, _modifier_stack, value| {
+            args.common_mut().save_dir.handle_file(value);
+            args.lib_search_path.push(Box::from(Path::new(value)));
+            Ok(())
+        });
+    parser
+        .declare_with_param()
         .prefix("l")
         .help("Link with library")
         .sub_option_with_value(
@@ -348,6 +357,9 @@ mod tests {
         "-enable-linkonceodr-outlining",
         "-o",
         "a.out",
+        "-L/foo/lib",
+        "-L",
+        "/bar/lib",
         "main.o",
         "-lc++",
     ];
@@ -371,6 +383,16 @@ mod tests {
             InputSpec::Lib(f) => f.as_ref() == "c++",
             InputSpec::File(_) | InputSpec::Search(_) => false,
         }));
+        assert!(
+            args.lib_search_path
+                .iter()
+                .any(|p| p.as_ref() == Path::new("/foo/lib"))
+        );
+        assert!(
+            args.lib_search_path
+                .iter()
+                .any(|p| p.as_ref() == Path::new("/bar/lib"))
+        );
         assert_eq!(args.plugin_path, Some("/foo/bar/libLTO.dylib".to_owned()));
     }
 

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -24,6 +24,7 @@ use crate::layout;
 use crate::layout::CommonGroupState;
 use crate::layout::DynamicSymbolDefinition;
 use crate::layout::HandlerData as _;
+use crate::layout::ImportedSymbol;
 use crate::layout::ObjectLayout;
 use crate::layout::ObjectLayoutState;
 use crate::layout::OutputRecordLayout;
@@ -1294,6 +1295,7 @@ impl platform::Platform for Elf {
         current_sizes: &OutputSectionPartMap<u64>,
         extra_sizes: &mut OutputSectionPartMap<u64>,
         dynamic_symbol_defs: &[DynamicSymbolDefinition<Self>],
+        _imported_symbols: &[ImportedSymbol],
         args: &ElfArgs,
     ) -> Result {
         if args.hash_style.includes_sysv() {

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -319,7 +319,7 @@ impl platform::Platform for Elf {
     type SymbolVersionIndex = Versym;
     type NonAddressableCounts = NonAddressableCounts;
     type NonAddressableIndexes = NonAddressableIndexes;
-    type EpilogueLayoutExt<'data> = EpilogueLayoutExt;
+    type EpilogueLayoutExt = EpilogueLayoutExt;
     type GroupLayoutExt = GroupLayoutExt;
     type CommonGroupStateExt = CommonGroupStateExt;
     type PreludeLayoutStateExt = PreludeLayoutStateExt;
@@ -1081,7 +1081,6 @@ impl platform::Platform for Elf {
         args: &ElfArgs,
         output_kind: OutputKind,
         dynamic_symbol_definitions: &mut [DynamicSymbolDefinition<'_, Self>],
-        _imported_symbols: &[ImportedSymbol],
     ) -> EpilogueLayoutExt {
         let gnu_hash_layout = create_gnu_hash_layout(args, output_kind, dynamic_symbol_definitions);
 

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -319,7 +319,7 @@ impl platform::Platform for Elf {
     type SymbolVersionIndex = Versym;
     type NonAddressableCounts = NonAddressableCounts;
     type NonAddressableIndexes = NonAddressableIndexes;
-    type EpilogueLayoutExt = EpilogueLayoutExt;
+    type EpilogueLayoutExt<'data> = EpilogueLayoutExt;
     type GroupLayoutExt = GroupLayoutExt;
     type CommonGroupStateExt = CommonGroupStateExt;
     type PreludeLayoutStateExt = PreludeLayoutStateExt;
@@ -1081,6 +1081,7 @@ impl platform::Platform for Elf {
         args: &ElfArgs,
         output_kind: OutputKind,
         dynamic_symbol_definitions: &mut [DynamicSymbolDefinition<'_, Self>],
+        _imported_symbols: &[ImportedSymbol],
     ) -> EpilogueLayoutExt {
         let gnu_hash_layout = create_gnu_hash_layout(args, output_kind, dynamic_symbol_definitions);
 

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -315,7 +315,7 @@ impl platform::Platform for Elf {
     type DynamicEntry = DynamicEntry;
     type DynamicSymbolDefinitionExt = DynamicSymbolDefinitionExt;
     type RelocationInfo = u32;
-    type LayoutExt = LayoutExt;
+    type LayoutExt<'data> = LayoutExt;
     type SymbolVersionIndex = Versym;
     type NonAddressableCounts = NonAddressableCounts;
     type NonAddressableIndexes = NonAddressableIndexes;

--- a/libwild/src/input_data.rs
+++ b/libwild/src/input_data.rs
@@ -8,7 +8,6 @@ use crate::args::Input;
 use crate::args::InputSpec;
 use crate::args::Modifiers;
 use crate::bail;
-use crate::ensure;
 use crate::error::Context as _;
 use crate::error::Error;
 use crate::error::Result;
@@ -206,6 +205,8 @@ enum LoadedFileState<'data, P: Platform> {
 enum InputRecord<'data, P: Platform> {
     Object(Result<Box<ParsedInputObject<'data, P>>>),
     LtoInput(Box<UnclaimedLtoInput<'data>>),
+    // TODO: remove
+    Empty,
 }
 
 struct UnclaimedLtoInput<'data> {
@@ -527,7 +528,7 @@ fn process_archive<'data, P: Platform>(
                 let kind = FileKind::identify_bytes(input_ref.data())
                     .with_context(|| format!("Failed process input `{input_ref}`"))?;
 
-                outputs.push(state.process_input(input_ref, file, kind)?);
+                outputs.push(state.process_input(state, input_ref, file, kind)?);
             }
             ArchiveEntry::Thin(_) => unreachable!(),
         }
@@ -580,7 +581,7 @@ fn process_thin_archive<'data, P: Platform>(
                 let kind = FileKind::identify_bytes(input_ref.data())
                     .with_context(|| format!("Failed process input `{input_ref}`"))?;
 
-                parsed_files.push(state.process_input(input_ref, &Arc::new(file), kind)?);
+                parsed_files.push(state.process_input(state, input_ref, &Arc::new(file), kind)?);
                 files.push(input_file);
             }
             ArchiveEntry::Regular(_) => {}
@@ -667,7 +668,7 @@ impl<'data, P: Platform> TemporaryState<'data, P> {
                 Ok(LoadedFileState::StubLibrary(input_file, defined_library))
             }
             _ => {
-                let parsed = self.process_input(input_ref, &Arc::new(file), kind)?;
+                let parsed = self.process_input(self, input_ref, &Arc::new(file), kind)?;
                 Ok(LoadedFileState::Loaded(input_file, parsed))
             }
         }
@@ -714,6 +715,7 @@ impl<'data, P: Platform> TemporaryState<'data, P> {
 
     fn process_input(
         &self,
+        state: &TemporaryState<'data, P>,
         input_ref: InputRef<'data>,
         file: &Arc<std::fs::File>,
         kind: FileKind,
@@ -739,10 +741,17 @@ impl<'data, P: Platform> TemporaryState<'data, P> {
         if input_ref.is_archive_entry() && kind != FileKind::ElfObject {
             bail!("Unexpected archive member of kind {kind:?}: {input_ref}");
         }
-        ensure!(
-            kind != FileKind::FatMachOObject,
-            "Fat object file is not supported yet: {input_ref}"
-        );
+        // TODO
+        // ensure!(
+        //     kind != FileKind::FatMachOObject,
+        //     "Fat object file is not supported yet: {input_ref}"
+        // );
+        if kind == FileKind::FatMachOObject {
+            state
+                .args
+                .warning(format!("Fat object file is not supported yet: {input_ref}"));
+            return Ok(InputRecord::Empty);
+        }
 
         let input_bytes = InputBytes {
             kind,
@@ -1056,6 +1065,7 @@ impl<'data, P: Platform> LoadedInputs<'data, P> {
                     Err(e) => self.lto_objects.push(Err(e)),
                 }
             }
+            InputRecord::Empty => {}
         }
     }
 

--- a/libwild/src/input_data.rs
+++ b/libwild/src/input_data.rs
@@ -741,10 +741,7 @@ impl<'data, P: Platform> TemporaryState<'data, P> {
         if input_ref.is_archive_entry() && kind != FileKind::ElfObject {
             bail!("Unexpected archive member of kind {kind:?}: {input_ref}");
         }
-        // ensure!(
-        //     kind != FileKind::FatMachOObject,
-        //     "Fat object file is not supported yet: {input_ref}"
-        // );
+
         if kind == FileKind::FatMachOObject {
             state
                 .args

--- a/libwild/src/input_data.rs
+++ b/libwild/src/input_data.rs
@@ -205,7 +205,7 @@ enum LoadedFileState<'data, P: Platform> {
 enum InputRecord<'data, P: Platform> {
     Object(Result<Box<ParsedInputObject<'data, P>>>),
     LtoInput(Box<UnclaimedLtoInput<'data>>),
-    // TODO: remove
+    // TODO: remove once FAT objects are properly supported
     Empty,
 }
 
@@ -741,7 +741,6 @@ impl<'data, P: Platform> TemporaryState<'data, P> {
         if input_ref.is_archive_entry() && kind != FileKind::ElfObject {
             bail!("Unexpected archive member of kind {kind:?}: {input_ref}");
         }
-        // TODO
         // ensure!(
         //     kind != FileKind::FatMachOObject,
         //     "Fat object file is not supported yet: {input_ref}"

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -1220,9 +1220,17 @@ impl<'data, P: Platform> CommonGroupState<'data, P> {
         self.mem_sizes.increment(part_id, size);
     }
 
-    pub(crate) fn add_imported_symbol(&mut self, symbol_id: SymbolId, name: &'data [u8]) {
-        self.imported_symbols
-            .push(ImportedSymbol { symbol_id, name });
+    pub(crate) fn add_imported_symbol(
+        &mut self,
+        symbol_id: SymbolId,
+        name: &'data [u8],
+        library_index: u8,
+    ) {
+        self.imported_symbols.push(ImportedSymbol {
+            symbol_id,
+            name,
+            library_index,
+        });
     }
 
     /// Allocate resources and update attributes based on a section having been loaded.
@@ -1312,6 +1320,8 @@ pub(crate) struct ImportedSymbol<'data> {
     pub(crate) symbol_id: SymbolId,
     #[debug("{:?}", String::from_utf8_lossy(name))]
     pub(crate) name: &'data [u8],
+    // One-based index of the stub library that defines the symbol.
+    pub(crate) library_index: u8,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -157,12 +157,14 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
 
     let mut dynamic_symbol_definitions =
         merge_dynamic_symbol_definitions(&group_states, &symbol_db)?;
+    let imported_symbols = collect_imported_symbols(&group_states);
 
     group_states.push(GroupState {
         files: vec![FileLayoutState::Epilogue(EpilogueLayoutState::new(
             symbol_db.args,
             symbol_db.output_kind,
             &mut dynamic_symbol_definitions,
+            &imported_symbols,
         ))],
         queue: LocalWorkQueue::new(epilogue_file_id.group()),
         common: CommonGroupState::new(&output_sections),
@@ -190,7 +192,6 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         &finalise_sizes_resources,
     )?;
 
-    let imported_symbols = collect_imported_symbols(&group_states);
     finalise_sizes_resources.imported_symbols = &imported_symbols;
 
     // Dropping `symbol_info_printer` will cause it to print. So we'll either print now, or, if we
@@ -709,7 +710,7 @@ pub(crate) enum FileLayout<'data, P: Platform> {
     Object(ObjectLayout<'data, P>),
     Dynamic(DynamicLayout<'data, P>),
     SyntheticSymbols(SyntheticSymbolsLayout<'data, P>),
-    Epilogue(EpilogueLayout<P>),
+    Epilogue(EpilogueLayout<'data, P>),
     NotLoaded,
     LinkerScript(LinkerScriptLayoutState<'data, P>),
 }
@@ -768,7 +769,7 @@ pub(crate) enum FileLayoutState<'data, P: Platform> {
     StubLibrary(StubLibraryLayoutState<'data>),
     NotLoaded(NotLoaded),
     SyntheticSymbols(SyntheticSymbolsLayoutState<'data, P>),
-    Epilogue(EpilogueLayoutState<P>),
+    Epilogue(EpilogueLayoutState<'data, P>),
     LinkerScript(LinkerScriptLayoutState<'data, P>),
 }
 
@@ -790,8 +791,8 @@ pub(crate) struct SyntheticSymbolsLayoutState<'data, P: Platform> {
     internal_symbols: InternalSymbols<'data, P>,
 }
 
-pub(crate) struct EpilogueLayoutState<P: Platform> {
-    format_specific: P::EpilogueLayoutExt,
+pub(crate) struct EpilogueLayoutState<'data, P: Platform> {
+    format_specific: P::EpilogueLayoutExt<'data>,
 }
 
 #[derive(Debug)]
@@ -815,8 +816,8 @@ pub(crate) struct SyntheticSymbolsLayout<'data, P: Platform> {
 }
 
 #[derive(Debug)]
-pub(crate) struct EpilogueLayout<P: Platform> {
-    pub(crate) format_specific: P::EpilogueLayoutExt,
+pub(crate) struct EpilogueLayout<'data, P: Platform> {
+    pub(crate) format_specific: P::EpilogueLayoutExt<'data>,
     pub(crate) dynsym_start_index: u32,
 }
 
@@ -2707,7 +2708,7 @@ impl<P: Platform> std::fmt::Display for PreludeLayoutState<'_, P> {
     }
 }
 
-impl<P: Platform> std::fmt::Display for EpilogueLayoutState<P> {
+impl<P: Platform> std::fmt::Display for EpilogueLayoutState<'_, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt("<epilogue>", f)
     }
@@ -3674,14 +3675,20 @@ impl<'data, P: Platform> SyntheticSymbolsLayoutState<'data, P> {
     }
 }
 
-impl<'data, P: Platform> EpilogueLayoutState<P> {
+impl<'data, P: Platform> EpilogueLayoutState<'data, P> {
     fn new(
         args: &P::Args,
         output_kind: OutputKind,
         dynamic_symbol_definitions: &mut [DynamicSymbolDefinition<P>],
+        imported_symbols: &[ImportedSymbol<'data>],
     ) -> Self {
         EpilogueLayoutState {
-            format_specific: P::new_epilogue_layout(args, output_kind, dynamic_symbol_definitions),
+            format_specific: P::new_epilogue_layout(
+                args,
+                output_kind,
+                dynamic_symbol_definitions,
+                imported_symbols,
+            ),
         }
     }
 
@@ -3728,7 +3735,7 @@ impl<'data, P: Platform> EpilogueLayoutState<P> {
         mut self,
         memory_offsets: &mut OutputSectionPartMap<u64>,
         resources: &FinaliseLayoutResources<'_, 'data, P>,
-    ) -> Result<EpilogueLayout<P>> {
+    ) -> Result<EpilogueLayout<'data, P>> {
         let dynsym_start_index = ((memory_offsets.get(part_id::DYNSYM)
             - resources
                 .section_layouts

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -782,6 +782,7 @@ pub(crate) struct EpilogueLayoutState<P: Platform> {
 #[derive(Debug)]
 pub(crate) struct StubLibraryLayoutState<'data> {
     input: InputRef<'data>,
+    file_id: FileId,
     symbol_id_range: SymbolIdRange,
 }
 
@@ -1066,6 +1067,29 @@ impl<'data, P: Platform> SymbolRequestHandler<'data, P> for LinkerScriptLayoutSt
     }
 }
 
+impl HandlerData for StubLibraryLayoutState<'_> {
+    fn file_id(&self) -> FileId {
+        self.file_id
+    }
+
+    fn symbol_id_range(&self) -> SymbolIdRange {
+        self.symbol_id_range
+    }
+}
+
+impl<'data, P: Platform> SymbolRequestHandler<'data, P> for StubLibraryLayoutState<'data> {
+    fn load_symbol<'scope, A: Arch<Platform = P>>(
+        &mut self,
+        _common: &mut CommonGroupState<'data, P>,
+        _symbol_id: SymbolId,
+        _resources: &GraphResources<'data, 'scope, P>,
+        _queue: &mut LocalWorkQueue,
+        _scope: &Scope<'scope>,
+    ) -> Result {
+        Ok(())
+    }
+}
+
 impl<P: Platform> HandlerData for SyntheticSymbolsLayoutState<'_, P> {
     fn file_id(&self) -> FileId {
         self.file_id
@@ -1173,6 +1197,10 @@ impl<'data, P: Platform> CommonGroupState<'data, P> {
 
     pub(crate) fn allocate(&mut self, part_id: PartId, size: u64) {
         self.mem_sizes.increment(part_id, size);
+    }
+
+    pub(crate) fn size(&mut self, part_id: PartId) -> u64 {
+        self.mem_sizes.size(part_id)
     }
 
     /// Allocate resources and update attributes based on a section having been loaded.
@@ -2473,7 +2501,9 @@ impl<'data, P: Platform> FileLayoutState<'data, P> {
                 s.finalise_sizes(common, per_symbol_flags, resources)?;
                 s.finalise_symbol_sizes(common, per_symbol_flags, resources)?;
             }
-            FileLayoutState::StubLibrary(_) => {}
+            FileLayoutState::StubLibrary(s) => {
+                s.finalise_symbol_sizes(common, per_symbol_flags, resources)?;
+            }
             FileLayoutState::NotLoaded(_) => {}
         }
 
@@ -4401,9 +4431,10 @@ impl<P: Platform> ResolutionWriter<'_, '_, P> {
 }
 
 impl<'data> StubLibraryLayoutState<'data> {
-    fn new(stub: resolution::ResolvedStubLibrary<'data>) -> Self {
+    fn new(stub: &resolution::ResolvedStubLibrary<'data>) -> Self {
         Self {
             input: stub.input,
+            file_id: stub.file_id,
             symbol_id_range: stub.symbol_id_range,
         }
     }
@@ -4440,7 +4471,7 @@ impl<'data, P: Platform> resolution::ResolvedFile<'data, P> {
             resolution::ResolvedFile::Object(s) => new_object_layout_state(s),
             resolution::ResolvedFile::Dynamic(s) => new_dynamic_object_layout_state(&s),
             resolution::ResolvedFile::StubLibrary(s) => {
-                FileLayoutState::StubLibrary(StubLibraryLayoutState::new(s))
+                FileLayoutState::StubLibrary(StubLibraryLayoutState::new(&s))
             }
             resolution::ResolvedFile::Prelude(s) => {
                 FileLayoutState::Prelude(PreludeLayoutState::new(s, args))

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -157,14 +157,12 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
 
     let mut dynamic_symbol_definitions =
         merge_dynamic_symbol_definitions(&group_states, &symbol_db)?;
-    let imported_symbols = collect_imported_symbols(&group_states);
 
     group_states.push(GroupState {
         files: vec![FileLayoutState::Epilogue(EpilogueLayoutState::new(
             symbol_db.args,
             symbol_db.output_kind,
             &mut dynamic_symbol_definitions,
-            &imported_symbols,
         ))],
         queue: LocalWorkQueue::new(epilogue_file_id.group()),
         common: CommonGroupState::new(&output_sections),
@@ -192,6 +190,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         &finalise_sizes_resources,
     )?;
 
+    let imported_symbols = collect_imported_symbols(&group_states);
     finalise_sizes_resources.imported_symbols = &imported_symbols;
 
     // Dropping `symbol_info_printer` will cause it to print. So we'll either print now, or, if we
@@ -710,7 +709,7 @@ pub(crate) enum FileLayout<'data, P: Platform> {
     Object(ObjectLayout<'data, P>),
     Dynamic(DynamicLayout<'data, P>),
     SyntheticSymbols(SyntheticSymbolsLayout<'data, P>),
-    Epilogue(EpilogueLayout<'data, P>),
+    Epilogue(EpilogueLayout<P>),
     NotLoaded,
     LinkerScript(LinkerScriptLayoutState<'data, P>),
 }
@@ -769,7 +768,7 @@ pub(crate) enum FileLayoutState<'data, P: Platform> {
     StubLibrary(StubLibraryLayoutState<'data>),
     NotLoaded(NotLoaded),
     SyntheticSymbols(SyntheticSymbolsLayoutState<'data, P>),
-    Epilogue(EpilogueLayoutState<'data, P>),
+    Epilogue(EpilogueLayoutState<P>),
     LinkerScript(LinkerScriptLayoutState<'data, P>),
 }
 
@@ -791,8 +790,8 @@ pub(crate) struct SyntheticSymbolsLayoutState<'data, P: Platform> {
     internal_symbols: InternalSymbols<'data, P>,
 }
 
-pub(crate) struct EpilogueLayoutState<'data, P: Platform> {
-    format_specific: P::EpilogueLayoutExt<'data>,
+pub(crate) struct EpilogueLayoutState<P: Platform> {
+    format_specific: P::EpilogueLayoutExt,
 }
 
 #[derive(Debug)]
@@ -816,8 +815,8 @@ pub(crate) struct SyntheticSymbolsLayout<'data, P: Platform> {
 }
 
 #[derive(Debug)]
-pub(crate) struct EpilogueLayout<'data, P: Platform> {
-    pub(crate) format_specific: P::EpilogueLayoutExt<'data>,
+pub(crate) struct EpilogueLayout<P: Platform> {
+    pub(crate) format_specific: P::EpilogueLayoutExt,
     pub(crate) dynsym_start_index: u32,
 }
 
@@ -2708,7 +2707,7 @@ impl<P: Platform> std::fmt::Display for PreludeLayoutState<'_, P> {
     }
 }
 
-impl<P: Platform> std::fmt::Display for EpilogueLayoutState<'_, P> {
+impl<P: Platform> std::fmt::Display for EpilogueLayoutState<P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt("<epilogue>", f)
     }
@@ -3675,20 +3674,14 @@ impl<'data, P: Platform> SyntheticSymbolsLayoutState<'data, P> {
     }
 }
 
-impl<'data, P: Platform> EpilogueLayoutState<'data, P> {
+impl<'data, P: Platform> EpilogueLayoutState<P> {
     fn new(
         args: &P::Args,
         output_kind: OutputKind,
         dynamic_symbol_definitions: &mut [DynamicSymbolDefinition<P>],
-        imported_symbols: &[ImportedSymbol<'data>],
     ) -> Self {
         EpilogueLayoutState {
-            format_specific: P::new_epilogue_layout(
-                args,
-                output_kind,
-                dynamic_symbol_definitions,
-                imported_symbols,
-            ),
+            format_specific: P::new_epilogue_layout(args, output_kind, dynamic_symbol_definitions),
         }
     }
 
@@ -3735,7 +3728,7 @@ impl<'data, P: Platform> EpilogueLayoutState<'data, P> {
         mut self,
         memory_offsets: &mut OutputSectionPartMap<u64>,
         resources: &FinaliseLayoutResources<'_, 'data, P>,
-    ) -> Result<EpilogueLayout<'data, P>> {
+    ) -> Result<EpilogueLayout<P>> {
         let dynsym_start_index = ((memory_offsets.get(part_id::DYNSYM)
             - resources
                 .section_layouts

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -395,7 +395,11 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
     let relocation_statistics = OutputSectionMap::with_size(section_layouts.len());
 
     let num_sections = output_sections.num_sections();
-    P::set_imported_symbols(&mut properties_and_attributes, imported_symbols);
+    P::set_imported_symbols(
+        &mut properties_and_attributes,
+        &symbol_resolutions,
+        imported_symbols,
+    )?;
 
     let mut layout = Layout {
         symbol_db,
@@ -702,6 +706,12 @@ pub(crate) struct SegmentLayout {
 #[derive(Debug)]
 pub(crate) struct SymbolResolutions<P: Platform> {
     resolutions: Vec<Option<Resolution<P>>>,
+}
+
+impl<P: Platform> SymbolResolutions<P> {
+    pub(crate) fn get(&self, symbol_id: SymbolId) -> Option<&Resolution<P>> {
+        self.resolutions[symbol_id.as_usize()].as_ref()
+    }
 }
 
 pub(crate) enum FileLayout<'data, P: Platform> {
@@ -1502,7 +1512,7 @@ impl<'data, P: Platform> Layout<'data, P> {
     }
 
     pub(crate) fn local_symbol_resolution(&self, symbol_id: SymbolId) -> Option<&Resolution<P>> {
-        self.symbol_resolutions.resolutions[symbol_id.as_usize()].as_ref()
+        self.symbol_resolutions.get(symbol_id)
     }
 
     pub(crate) fn resolutions_in_range(

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -1199,10 +1199,6 @@ impl<'data, P: Platform> CommonGroupState<'data, P> {
         self.mem_sizes.increment(part_id, size);
     }
 
-    pub(crate) fn size(&mut self, part_id: PartId) -> u64 {
-        self.mem_sizes.size(part_id)
-    }
-
     /// Allocate resources and update attributes based on a section having been loaded.
     fn section_loaded(
         &mut self,

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -1309,8 +1309,6 @@ pub(crate) struct DynamicSymbolDefinition<'data, P: Platform> {
 
 #[derive(derive_more::Debug, Clone, Copy)]
 pub(crate) struct ImportedSymbol<'data> {
-    // TODO
-    #[allow(unused)]
     pub(crate) symbol_id: SymbolId,
     #[debug("{:?}", String::from_utf8_lossy(name))]
     pub(crate) name: &'data [u8],

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -169,7 +169,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         num_symbols: 0,
     });
 
-    let properties_and_attributes = P::create_layout_properties::<A>(
+    let mut properties_and_attributes = P::create_layout_properties::<A>(
         symbol_db.args,
         objects_iter(&group_states).map(|obj| obj.object),
         objects_iter(&group_states).map(|obj| &obj.format_specific),
@@ -395,6 +395,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
     let relocation_statistics = OutputSectionMap::with_size(section_layouts.len());
 
     let num_sections = output_sections.num_sections();
+    P::set_imported_symbols(&mut properties_and_attributes, imported_symbols);
 
     let mut layout = Layout {
         symbol_db,
@@ -415,7 +416,6 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         relocation_statistics,
         per_symbol_flags,
         dynamic_symbol_definitions,
-        imported_symbols,
         properties_and_attributes,
         thunk_block_addresses,
         compressed_debug_sections: OutputSectionMap::with_size(num_sections),
@@ -433,7 +433,7 @@ struct FinaliseSizesResources<'data, 'scope, P: Platform> {
     imported_symbols: &'scope [ImportedSymbol<'data>],
     symbol_db: &'scope SymbolDb<'data, P>,
     merged_strings: &'scope OutputSectionMap<MergedStringsSection<'data>>,
-    format_specific: &'scope P::LayoutExt,
+    format_specific: &'scope P::LayoutExt<'data>,
 }
 
 /// Update resolutions for symbol redirects.
@@ -677,9 +677,7 @@ pub struct Layout<'data, P: Platform> {
     pub(crate) has_variant_pcs: bool,
     pub(crate) per_symbol_flags: PerSymbolFlags,
     pub(crate) dynamic_symbol_definitions: Vec<DynamicSymbolDefinition<'data, P>>,
-    /// A list of imported STUB library symbols (Mach-O specific).
-    pub(crate) imported_symbols: Vec<ImportedSymbol<'data>>,
-    pub(crate) properties_and_attributes: P::LayoutExt,
+    pub(crate) properties_and_attributes: P::LayoutExt<'data>,
     /// Thunk address maps indexed by ThunkBlockId. Each entry maps SymbolId to the memory address
     /// of the thunk for that symbol within the block.
     pub(crate) thunk_block_addresses: Vec<BTreeMap<SymbolId, u64>>,
@@ -1418,7 +1416,7 @@ pub(crate) struct FinaliseLayoutResources<'scope, 'data, P: Platform> {
     dynamic_symbol_definitions: &'scope Vec<DynamicSymbolDefinition<'data, P>>,
     segment_layouts: &'scope SegmentLayouts,
     program_segments: &'scope ProgramSegments<P::ProgramSegmentDef>,
-    format_specific: &'scope P::LayoutExt,
+    format_specific: &'scope P::LayoutExt<'data>,
 
     pub(crate) thunk_blocks: &'scope [crate::thunks::ThunkBlock],
 

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -415,6 +415,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         relocation_statistics,
         per_symbol_flags,
         dynamic_symbol_definitions,
+        imported_symbols,
         properties_and_attributes,
         thunk_block_addresses,
         compressed_debug_sections: OutputSectionMap::with_size(num_sections),
@@ -677,6 +678,7 @@ pub struct Layout<'data, P: Platform> {
     pub(crate) per_symbol_flags: PerSymbolFlags,
     pub(crate) dynamic_symbol_definitions: Vec<DynamicSymbolDefinition<'data, P>>,
     /// A list of imported STUB library symbols (Mach-O specific).
+    pub(crate) imported_symbols: Vec<ImportedSymbol<'data>>,
     pub(crate) properties_and_attributes: P::LayoutExt,
     /// Thunk address maps indexed by ThunkBlockId. Each entry maps SymbolId to the memory address
     /// of the thunk for that symbol within the block.

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -175,8 +175,9 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         objects_iter(&group_states).map(|obj| &obj.format_specific),
     )?;
 
-    let finalise_sizes_resources = FinaliseSizesResources {
+    let mut finalise_sizes_resources = FinaliseSizesResources {
         dynamic_symbol_definitions: &dynamic_symbol_definitions,
+        imported_symbols: &[],
         symbol_db: &symbol_db,
         merged_strings: &merged_strings,
         format_specific: &properties_and_attributes,
@@ -188,6 +189,9 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         &atomic_per_symbol_flags,
         &finalise_sizes_resources,
     )?;
+
+    let imported_symbols = collect_imported_symbols(&group_states);
+    finalise_sizes_resources.imported_symbols = &imported_symbols;
 
     // Dropping `symbol_info_printer` will cause it to print. So we'll either print now, or, if we
     // got an error or panic, then we'll have printed at that point.
@@ -425,6 +429,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
 
 struct FinaliseSizesResources<'data, 'scope, P: Platform> {
     dynamic_symbol_definitions: &'scope [DynamicSymbolDefinition<'data, P>],
+    imported_symbols: &'scope [ImportedSymbol<'data>],
     symbol_db: &'scope SymbolDb<'data, P>,
     merged_strings: &'scope OutputSectionMap<MergedStringsSection<'data>>,
     format_specific: &'scope P::LayoutExt,
@@ -581,6 +586,15 @@ fn merge_dynamic_symbol_definitions<'data, P: Platform>(
     Ok(dynamic_symbol_definitions)
 }
 
+fn collect_imported_symbols<'data, P: Platform>(
+    group_states: &[GroupState<'data, P>],
+) -> Vec<ImportedSymbol<'data>> {
+    group_states
+        .iter()
+        .flat_map(|group| group.common.imported_symbols.iter().copied())
+        .collect()
+}
+
 fn append_prelude_defsym_dynamic_symbols<'data, P: Platform>(
     group_states: &[GroupState<'data, P>],
     symbol_db: &SymbolDb<'data, P>,
@@ -662,6 +676,7 @@ pub struct Layout<'data, P: Platform> {
     pub(crate) has_variant_pcs: bool,
     pub(crate) per_symbol_flags: PerSymbolFlags,
     pub(crate) dynamic_symbol_definitions: Vec<DynamicSymbolDefinition<'data, P>>,
+    /// A list of imported STUB library symbols (Mach-O specific).
     pub(crate) properties_and_attributes: P::LayoutExt,
     /// Thunk address maps indexed by ThunkBlockId. Each entry maps SymbolId to the memory address
     /// of the thunk for that symbol within the block.
@@ -1142,6 +1157,9 @@ pub(crate) struct CommonGroupState<'data, P: Platform> {
     /// symbol. That's OK though because the epilogue will sort all dynamic symbols.
     dynamic_symbol_definitions: Vec<DynamicSymbolDefinition<'data, P>>,
 
+    /// A list of imported STUB library symbols (Mach-O specific).
+    imported_symbols: Vec<ImportedSymbol<'data>>,
+
     pub(crate) format_specific: P::CommonGroupStateExt,
 }
 
@@ -1151,6 +1169,7 @@ impl<'data, P: Platform> CommonGroupState<'data, P> {
             mem_sizes: output_sections.new_part_map(),
             section_attributes: output_sections.new_section_map(),
             dynamic_symbol_definitions: Default::default(),
+            imported_symbols: Default::default(),
             format_specific: Default::default(),
         }
     }
@@ -1197,6 +1216,11 @@ impl<'data, P: Platform> CommonGroupState<'data, P> {
 
     pub(crate) fn allocate(&mut self, part_id: PartId, size: u64) {
         self.mem_sizes.increment(part_id, size);
+    }
+
+    pub(crate) fn add_imported_symbol(&mut self, symbol_id: SymbolId, name: &'data [u8]) {
+        self.imported_symbols
+            .push(ImportedSymbol { symbol_id, name });
     }
 
     /// Allocate resources and update attributes based on a section having been loaded.
@@ -1279,6 +1303,15 @@ pub(crate) struct DynamicSymbolDefinition<'data, P: Platform> {
     #[debug("{:?}", String::from_utf8_lossy(name))]
     pub(crate) name: &'data [u8],
     pub(crate) format_specific: P::DynamicSymbolDefinitionExt,
+}
+
+#[derive(derive_more::Debug, Clone, Copy)]
+pub(crate) struct ImportedSymbol<'data> {
+    // TODO
+    #[allow(unused)]
+    pub(crate) symbol_id: SymbolId,
+    #[debug("{:?}", String::from_utf8_lossy(name))]
+    pub(crate) name: &'data [u8],
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -3664,6 +3697,7 @@ impl<'data, P: Platform> EpilogueLayoutState<P> {
             total_sizes,
             &mut extra_sizes,
             resources.dynamic_symbol_definitions,
+            resources.imported_symbols,
             resources.symbol_db.args,
         )?;
 

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -750,6 +750,7 @@ pub(crate) enum FileLayoutState<'data, P: Platform> {
     Prelude(PreludeLayoutState<'data, P>),
     Object(ObjectLayoutState<'data, P>),
     Dynamic(DynamicLayoutState<'data, P>),
+    StubLibrary(StubLibraryLayoutState<'data>),
     NotLoaded(NotLoaded),
     SyntheticSymbols(SyntheticSymbolsLayoutState<'data, P>),
     Epilogue(EpilogueLayoutState<P>),
@@ -776,6 +777,12 @@ pub(crate) struct SyntheticSymbolsLayoutState<'data, P: Platform> {
 
 pub(crate) struct EpilogueLayoutState<P: Platform> {
     format_specific: P::EpilogueLayoutExt,
+}
+
+#[derive(Debug)]
+pub(crate) struct StubLibraryLayoutState<'data> {
+    input: InputRef<'data>,
+    symbol_id_range: SymbolIdRange,
 }
 
 #[derive(Debug)]
@@ -2319,6 +2326,7 @@ fn activate<'data, 'scope, A: Arch>(
         FileLayoutState::Dynamic(s) => s.activate::<A>(common, resources, queue, scope)?,
         FileLayoutState::LinkerScript(s) => s.activate::<A>(common, resources, queue, scope)?,
         FileLayoutState::Epilogue(_) => {}
+        FileLayoutState::StubLibrary(_) => {}
         FileLayoutState::NotLoaded(_) => {}
         FileLayoutState::SyntheticSymbols(_) => {}
     }
@@ -2465,6 +2473,7 @@ impl<'data, P: Platform> FileLayoutState<'data, P> {
                 s.finalise_sizes(common, per_symbol_flags, resources)?;
                 s.finalise_symbol_sizes(common, per_symbol_flags, resources)?;
             }
+            FileLayoutState::StubLibrary(_) => {}
             FileLayoutState::NotLoaded(_) => {}
         }
 
@@ -2551,6 +2560,7 @@ impl<'data, P: Platform> FileLayoutState<'data, P> {
                 )?;
             }
             FileLayoutState::LinkerScript(_) => {}
+            FileLayoutState::StubLibrary(_) => {}
             FileLayoutState::NotLoaded(_) => {}
             FileLayoutState::SyntheticSymbols(state) => {
                 SymbolRequestHandler::load_symbol::<A>(
@@ -2600,6 +2610,10 @@ impl<'data, P: Platform> FileLayoutState<'data, P> {
                 resolutions_out,
                 resources,
             )?),
+            Self::StubLibrary(s) => {
+                s.finalise_layout(memory_offsets, resolutions_out, resources)?;
+                FileLayout::NotLoaded
+            }
             Self::LinkerScript(s) => {
                 s.finalise_layout(memory_offsets, resolutions_out, resources)?;
                 FileLayout::LinkerScript(s)
@@ -2652,11 +2666,18 @@ impl<P: Platform> std::fmt::Display for LinkerScriptLayoutState<'_, P> {
     }
 }
 
+impl std::fmt::Display for StubLibraryLayoutState<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.input, f)
+    }
+}
+
 impl<'data, P: Platform> std::fmt::Display for FileLayoutState<'data, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             FileLayoutState::Object(s) => std::fmt::Display::fmt(s, f),
             FileLayoutState::Dynamic(s) => std::fmt::Display::fmt(s, f),
+            FileLayoutState::StubLibrary(s) => std::fmt::Display::fmt(s, f),
             FileLayoutState::LinkerScript(s) => std::fmt::Display::fmt(s, f),
             FileLayoutState::Prelude(_) => std::fmt::Display::fmt("<prelude>", f),
             FileLayoutState::SyntheticSymbols(_) => std::fmt::Display::fmt("<synthetic>", f),
@@ -4379,18 +4400,48 @@ impl<P: Platform> ResolutionWriter<'_, '_, P> {
     }
 }
 
+impl<'data> StubLibraryLayoutState<'data> {
+    fn new(stub: resolution::ResolvedStubLibrary<'data>) -> Self {
+        Self {
+            input: stub.input,
+            symbol_id_range: stub.symbol_id_range,
+        }
+    }
+
+    fn finalise_layout<P: Platform>(
+        &self,
+        memory_offsets: &mut OutputSectionPartMap<u64>,
+        resolutions_out: &mut ResolutionWriter<P>,
+        resources: &FinaliseLayoutResources<'_, 'data, P>,
+    ) -> Result {
+        for symbol_id in self.symbol_id_range {
+            let flags: ValueFlags = resources
+                .symbol_db
+                .flags_for_symbol(resources.per_symbol_flags, symbol_id);
+            if flags.has_resolution() && resources.symbol_db.is_canonical(symbol_id) {
+                resolutions_out.write(Some(P::create_resolution(
+                    flags,
+                    0,
+                    None,
+                    memory_offsets,
+                )))?;
+            } else {
+                resolutions_out.write(None)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
 impl<'data, P: Platform> resolution::ResolvedFile<'data, P> {
     fn create_layout_state(self, args: &P::Args) -> FileLayoutState<'data, P> {
         match self {
             resolution::ResolvedFile::Object(s) => new_object_layout_state(s),
             resolution::ResolvedFile::Dynamic(s) => new_dynamic_object_layout_state(&s),
-            resolution::ResolvedFile::StubLibrary(s) => FileLayoutState::NotLoaded(NotLoaded {
-                symbol_id_range: s.symbol_id_range,
-                section_id_range: crate::input_section_id::SectionIdRange::input(
-                    crate::input_section_id::InputSectionId::from_usize(0),
-                    0,
-                ),
-            }),
+            resolution::ResolvedFile::StubLibrary(s) => {
+                FileLayoutState::StubLibrary(StubLibraryLayoutState::new(s))
+            }
             resolution::ResolvedFile::Prelude(s) => {
                 FileLayoutState::Prelude(PreludeLayoutState::new(s, args))
             }
@@ -5211,6 +5262,9 @@ impl<'data, P: Platform> std::fmt::Debug for FileLayoutState<'data, P> {
             FileLayoutState::Object(s) => f.debug_tuple("Object").field(&s.input).finish(),
             FileLayoutState::Prelude(_) => f.debug_tuple("Internal").finish(),
             FileLayoutState::Dynamic(s) => f.debug_tuple("Dynamic").field(&s.input).finish(),
+            FileLayoutState::StubLibrary(s) => {
+                f.debug_tuple("StubLibrary").field(&s.input).finish()
+            }
             FileLayoutState::LinkerScript(s) => {
                 f.debug_tuple("LinkerScript").field(&s.input).finish()
             }

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -1832,11 +1832,13 @@ pub(crate) const PROGRAM_SEGMENT_DEFS: &[ProgramSegmentDef] = &[
     ProgramSegmentDef {
         // Not a real segment from the Macho-O definition.
         segment_type: SegmentType::LoadCommands,
+        // included in SegmentType::Text
         part_id: None,
     },
     ProgramSegmentDef {
         segment_type: SegmentType::TextSections,
-        part_id: Some(part_id::TEXT_SEGMENT),
+        // included in SegmentType::Text
+        part_id: None,
     },
     ProgramSegmentDef {
         segment_type: SegmentType::DataSections,

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -78,6 +78,7 @@ pub(crate) const MACHO_COMMAND_ALIGNMENT: usize = 8;
 
 /// A path to the default dynamic linker.
 pub(crate) const DYLINKER_PATH: &[u8] = b"/usr/lib/dyld";
+pub(crate) const LIBSYSTEM_PATH: &[u8] = b"/usr/lib/libSystem.B.dylib";
 // TODO: optionality of __DATA and __CONST_DATA segments not respected
 pub(crate) const DEFAULT_SEGMENT_COUNT: usize = 5;
 pub(crate) const CHAINED_FIXUP_TABLE_BASE_SIZE: u64 = (size_of::<ChainedFixupsHeader>()
@@ -100,6 +101,7 @@ pub(crate) type SegmentCommand = object::macho::SegmentCommand64<Endianness>;
 pub(crate) type SectionEntry = object::macho::Section64<Endianness>;
 pub(crate) type EntryPointCommand = object::macho::EntryPointCommand<Endianness>;
 pub(crate) type DylinkerCommand = object::macho::DylinkerCommand<Endianness>;
+pub(crate) type DylibCommand = object::macho::DylibCommand<Endianness>;
 pub(crate) type CodeSignatureCommand = object::macho::LinkeditDataCommand<Endianness>;
 pub(crate) type DyldChainedFixupsCommand = object::macho::LinkeditDataCommand<Endianness>;
 pub(crate) type ChainedFixupsHeader = DyldChainedFixupsHeader;
@@ -917,6 +919,7 @@ impl platform::ProgramSegmentDef for ProgramSegmentDef {
             | output_section_id::LINK_EDIT_SEGMENT
             | output_section_id::ENTRY_POINT
             | output_section_id::INTERP
+            | output_section_id::LOAD_DYLIB
             | output_section_id::DYLD_CHAINED_FIXUPS
             | output_section_id::SYMTAB_COMMAND
             | output_section_id::CODE_SIGNATURE_COMMAND => SegmentType::LoadCommands,
@@ -1408,6 +1411,11 @@ impl platform::Platform for MachO {
                 .next_multiple_of(MACHO_COMMAND_ALIGNMENT)) as u64,
         );
         sizes.increment(
+            part_id::LOAD_DYLIB,
+            ((size_of::<DylibCommand>() + LIBSYSTEM_PATH.len())
+                .next_multiple_of(MACHO_COMMAND_ALIGNMENT)) as u64,
+        );
+        sizes.increment(
             part_id::DYLD_CHAINED_FIXUPS,
             size_of::<DyldChainedFixupsCommand>() as u64,
         );
@@ -1563,6 +1571,7 @@ impl platform::Platform for MachO {
         builder.add_section(output_section_id::LINK_EDIT_SEGMENT);
         builder.add_section(output_section_id::ENTRY_POINT);
         builder.add_section(output_section_id::INTERP); // DYLINKER
+        builder.add_section(output_section_id::LOAD_DYLIB);
         builder.add_section(output_section_id::DYLD_CHAINED_FIXUPS);
         builder.add_section(output_section_id::SYMTAB_COMMAND);
         builder.add_section(output_section_id::CODE_SIGNATURE_COMMAND);
@@ -1669,6 +1678,11 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
     };
     defs[output_section_id::INTERP.as_usize()] = BuiltInSectionDetails {
         kind: SectionKind::Primary(SectionName(b"LC_LOAD_DYLINKER")),
+        target_segment_type: Some(SegmentType::LoadCommands),
+        ..DEFAULT_DEFS
+    };
+    defs[output_section_id::LOAD_DYLIB.as_usize()] = BuiltInSectionDetails {
+        kind: SectionKind::Primary(SectionName(b"LC_LOAD_DYLIB")),
         target_segment_type: Some(SegmentType::LoadCommands),
         ..DEFAULT_DEFS
     };

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -6,6 +6,7 @@ use crate::alignment;
 use crate::alignment::Alignment;
 use crate::alignment::MACHO_PAGE_ALIGNMENT;
 use crate::args::macho::MachOArgs;
+use crate::bail;
 use crate::ensure;
 use crate::error;
 use crate::error::Result;
@@ -34,6 +35,7 @@ use crate::platform::Args;
 use crate::platform::ObjectFile;
 use crate::symbol_db::Visibility;
 use crate::value_flags::ValueFlags;
+use anyhow::Context;
 use linker_utils::elf::RelocationKind::TlsGdGotBase;
 use object::Endianness;
 use object::SymbolIndex;
@@ -1442,7 +1444,16 @@ impl platform::Platform for MachO {
     ) -> crate::error::Result {
         if flags.has_resolution() && symbol_db.is_stub_library_symbol(symbol_id) {
             let symbol_name = symbol_db.symbol_name(symbol_id)?;
-            common.add_imported_symbol(symbol_id, symbol_name.bytes());
+            let SequencedInput::StubLibrary(stub) =
+                symbol_db.file(symbol_db.file_id_for_symbol(symbol_id))
+            else {
+                bail!("stub library expected");
+            };
+            common.add_imported_symbol(
+                symbol_id,
+                symbol_name.bytes(),
+                u8::try_from(stub.file_id.file() + 1).with_context(|| "too many stub libraries")?,
+            );
         }
         Ok(())
     }

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -303,6 +303,12 @@ pub(crate) fn code_signature_padded_identifier_size(args: &MachOArgs) -> u64 {
     (code_signature_identifier(args).len() as u64 + 1).next_multiple_of(CS_SECTION_ALIGNMENT)
 }
 
+#[derive(Debug, Default)]
+pub(crate) struct LayoutExt<'data> {
+    /// A list of imported STUB library symbols.
+    pub(crate) imported_symbols: Vec<ImportedSymbol<'data>>,
+}
+
 #[derive(derive_more::Debug)]
 pub(crate) struct File<'data> {
     #[debug(skip)]
@@ -1055,7 +1061,7 @@ impl platform::Platform for MachO {
     type ResolutionExt = ResolutionExt;
     type SymtabShndxEntry = ();
     type SymbolVersionIndex = ();
-    type LayoutExt = ();
+    type LayoutExt<'data> = LayoutExt<'data>;
     type SectionIterator<'a> = core::slice::Iter<'a, SectionHeader>;
     type DynamicTagValues<'data> = DynamicTagValues<'data>;
     type RelocationList<'data> = RelocationList<'data>;
@@ -1251,12 +1257,19 @@ impl platform::Platform for MachO {
         args: &Self::Args,
         objects: impl Iterator<Item = &'files Self::File<'data>>,
         states: impl Iterator<Item = &'states Self::ObjectLayoutStateExt<'data>> + Clone,
-    ) -> crate::error::Result<Self::LayoutExt>
+    ) -> crate::error::Result<Self::LayoutExt<'data>>
     where
         'data: 'files,
         'data: 'states,
     {
-        Ok(())
+        Ok(LayoutExt::default())
+    }
+
+    fn set_imported_symbols<'data>(
+        properties: &mut Self::LayoutExt<'data>,
+        imported_symbols: Vec<ImportedSymbol<'data>>,
+    ) {
+        properties.imported_symbols = imported_symbols;
     }
 
     fn load_exception_frame_data<'data, 'scope, A: platform::Arch<Platform = Self>>(
@@ -1307,7 +1320,7 @@ impl platform::Platform for MachO {
         state: &mut Self::EpilogueLayoutExt,
         mem_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         dynamic_symbol_definitions: &[crate::layout::DynamicSymbolDefinition<'data, Self>],
-        properties: &Self::LayoutExt,
+        properties: &Self::LayoutExt<'data>,
         symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
     ) {
         mem_sizes.increment(part_id::CHAINED_FIXUP_TABLE, CHAINED_FIXUP_TABLE_BASE_SIZE);
@@ -1349,7 +1362,7 @@ impl platform::Platform for MachO {
         epilogue_state: &mut Self::EpilogueLayoutExt,
         memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
-        common_state: &Self::LayoutExt,
+        common_state: &Self::LayoutExt<'data>,
         dynsym_start_index: u32,
         dynamic_symbol_defs: &[crate::layout::DynamicSymbolDefinition<Self>],
     ) -> crate::error::Result {

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -1959,10 +1959,11 @@ fn process_relocation<'data, 'scope, A: platform::Arch<Platform = MachO>>(
             SequencedInput::StubLibrary(_)
         ) {
             flags_to_add |= ValueFlags::GOT;
-        }
-        // TODO: classify symbols more reliably, likely by checking whether their section is __text.
-        if rel_info.r_type == object::macho::ARM64_RELOC_BRANCH26 {
-            flags_to_add |= ValueFlags::FUNCTION | ValueFlags::PLT;
+            // TODO: classify symbols more reliably, likely by checking whether their section is
+            // __text.
+            if rel_info.r_type == object::macho::ARM64_RELOC_BRANCH26 {
+                flags_to_add |= ValueFlags::FUNCTION | ValueFlags::PLT;
+            }
         }
 
         let atomic_flags = &resources.per_symbol_flags.get_atomic(symbol_id);

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -60,6 +60,7 @@ use zerocopy::FromBytes;
 use zerocopy::Immutable;
 use zerocopy::IntoBytes;
 use zerocopy::KnownLayout;
+use zerocopy::U16;
 use zerocopy::U32;
 use zerocopy::U64;
 
@@ -140,6 +141,34 @@ pub(crate) struct DyldChainedFixupsHeader {
 //     uint32_t    seg_info_offset[1];  // each entry is offset into this struct for that segment
 //     // followed by pool of dyld_chain_starts_in_segment data
 // };
+
+// This struct is embedded in dyld_chain_starts_in_image
+// and passed down to the kernel for page-in linking
+#[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Clone, Copy)]
+#[repr(C)]
+struct DyldChainedStartsInSegment {
+    // size of this (amount kernel needs to copy)
+    pub(crate) size: U32<zerocopy::LittleEndian>,
+    // 0x1000 or 0x4000
+    pub(crate) page_size: U16<zerocopy::LittleEndian>,
+    // DYLD_CHAINED_PTR_*
+    pub(crate) pointer_format: U16<zerocopy::LittleEndian>,
+    // offset in memory to start of segment
+    pub(crate) segment_offset: U64<zerocopy::LittleEndian>,
+    // for 32-bit OS, any value beyond this is not a pointer
+    pub(crate) max_valid_pointer: U32<zerocopy::LittleEndian>,
+    // how many pages are in array
+    pub(crate) page_count: U16<zerocopy::LittleEndian>,
+    // each entry is offset in each page of first element in chain
+    // or DYLD_CHAINED_PTR_START_NONE if no fixups on paget
+    // uint16_t page_start[1];
+    //
+    // some 32-bit formats may require multiple starts per page.
+    // for those, if high bit is set in page_starts[], then it
+    // is index into chain_starts[] which is a list of starts
+    // the last of which has the high bit set
+    // uint16_t chain_starts[1];
+}
 
 // Code signature data structures are always stored big-endian, regardless of
 // the target architecture's byte order.

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -18,6 +18,7 @@ use crate::layout::Layout;
 use crate::layout::OutputRecordLayout;
 use crate::layout::Resolution;
 use crate::layout::SymbolCopyInfo;
+use crate::layout::SymbolResolutions;
 use crate::layout_rules::SectionKind;
 use crate::layout_rules::SectionRule;
 use crate::macho_writer;
@@ -36,6 +37,7 @@ use crate::platform::ObjectFile;
 use crate::symbol_db::Visibility;
 use crate::value_flags::ValueFlags;
 use anyhow::Context;
+use itertools::Itertools;
 use linker_utils::elf::RelocationKind::TlsGdGotBase;
 use object::Endianness;
 use object::SymbolIndex;
@@ -305,8 +307,15 @@ pub(crate) fn code_signature_padded_identifier_size(args: &MachOArgs) -> u64 {
 
 #[derive(Debug, Default)]
 pub(crate) struct LayoutExt<'data> {
-    /// A list of imported STUB library symbols.
-    pub(crate) imported_symbols: Vec<ImportedSymbol<'data>>,
+    /// Imported STUB library symbols, sorted by GOT.
+    pub(crate) imported_symbols: Vec<ImportedSymbolWithResolution<'data>>,
+}
+
+#[derive(derive_more::Debug, Clone, Copy)]
+pub(crate) struct ImportedSymbolWithResolution<'data> {
+    pub(crate) symbol: ImportedSymbol<'data>,
+    pub(crate) got_address: NonZeroU64,
+    pub(crate) plt_address: Option<NonZeroU64>,
 }
 
 #[derive(derive_more::Debug)]
@@ -1267,9 +1276,34 @@ impl platform::Platform for MachO {
 
     fn set_imported_symbols<'data>(
         properties: &mut Self::LayoutExt<'data>,
+        resolutions: &SymbolResolutions<Self>,
         imported_symbols: Vec<ImportedSymbol<'data>>,
-    ) {
-        properties.imported_symbols = imported_symbols;
+    ) -> Result {
+        let mut imported_symbols = imported_symbols
+            .iter()
+            .map(|symbol| {
+                let resolution = resolutions
+                    .get(symbol.symbol_id)
+                    .with_context(|| "missing resolution for a stub library symbol".to_string())?;
+                let got_address = resolution
+                    .format_specific
+                    .got_address
+                    .ok_or_else(|| error!("missing GOT entry for a stub library symbol"))?;
+
+                Ok(ImportedSymbolWithResolution {
+                    symbol: *symbol,
+                    got_address,
+                    plt_address: resolution.format_specific.plt_address,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        properties.imported_symbols = imported_symbols
+            .into_iter()
+            .sorted_by_key(|symbol| symbol.got_address)
+            .collect();
+
+        Ok(())
     }
 
     fn load_exception_frame_data<'data, 'scope, A: platform::Arch<Platform = Self>>(

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -73,8 +73,10 @@ pub(crate) const MACHO_COMMAND_ALIGNMENT: usize = 8;
 pub(crate) const DYLINKER_PATH: &[u8] = b"/usr/lib/dyld";
 // TODO: optionality of __DATA and __CONST_DATA segments not respected
 pub(crate) const DEFAULT_SEGMENT_COUNT: usize = 4;
-pub(crate) const CHAINED_FIXUP_TABLE_SIZE: u64 =
-    (size_of::<ChainedFixupsHeader>() + size_of::<u32>() * (DEFAULT_SEGMENT_COUNT + 1 + 1)) as u64;
+pub(crate) const CHAINED_FIXUP_TABLE_BASE_SIZE: u64 =
+    (size_of::<ChainedFixupsHeader>() + size_of::<u32>() * (DEFAULT_SEGMENT_COUNT + 1)) as u64;
+pub(crate) const CHAINED_FIXUP_IMPORT_SIZE: u64 = size_of::<u32>() as u64;
+pub(crate) const GOT_ENTRY_SIZE: u64 = 8;
 
 type SectionHeader = Section64<crate::macho::Endianness>;
 type SectionTable<'data> = &'data [Section64<crate::macho::Endianness>];
@@ -878,6 +880,7 @@ impl platform::ProgramSegmentDef for ProgramSegmentDef {
             output_section_id::PAGEZERO_SEGMENT
             | output_section_id::TEXT_SEGMENT
             | output_section_id::DATA_SEGMENT
+            | output_section_id::DATA_CONST_SEGMENT
             | output_section_id::LINK_EDIT_SEGMENT
             | output_section_id::ENTRY_POINT
             | output_section_id::INTERP
@@ -886,6 +889,7 @@ impl platform::ProgramSegmentDef for ProgramSegmentDef {
             | output_section_id::CODE_SIGNATURE_COMMAND => SegmentType::LoadCommands,
             output_section_id::TEXT | output_section_id::CSTRING => SegmentType::TextSections,
             output_section_id::DATA => SegmentType::DataSections,
+            output_section_id::GOT => SegmentType::DataConstSections,
             output_section_id::CHAINED_FIXUP_TABLE
             | output_section_id::SYMTAB_GLOBAL
             | output_section_id::STRTAB
@@ -1359,6 +1363,13 @@ impl platform::Platform for MachO {
         symbol_id: crate::symbol_db::SymbolId,
         flags: crate::value_flags::ValueFlags,
     ) -> crate::error::Result {
+        if flags.has_resolution() && symbol_db.is_stub_library_symbol(symbol_id) {
+            let symbol_name = symbol_db.symbol_name(symbol_id)?;
+            common.allocate(
+                part_id::CHAINED_FIXUP_TABLE,
+                CHAINED_FIXUP_IMPORT_SIZE + symbol_name.bytes().len() as u64 + 1,
+            );
+        }
         Ok(())
     }
 
@@ -1368,6 +1379,9 @@ impl platform::Platform for MachO {
         output_kind: crate::output_kind::OutputKind,
         _args: &Self::Args,
     ) {
+        if flags.is_dynamic() && flags.needs_got() {
+            dbg!(mem_sizes.increment(part_id::GOT, GOT_ENTRY_SIZE));
+        }
     }
 
     fn allocate_object_symtab_space<'data>(
@@ -1419,7 +1433,7 @@ impl platform::Platform for MachO {
     ) {
         // Allocate one extra character as n_strx == 0 is treated as unnamed.
         common.allocate(part_id::STRTAB, 1);
-        common.allocate(part_id::CHAINED_FIXUP_TABLE, CHAINED_FIXUP_TABLE_SIZE);
+        common.allocate(part_id::CHAINED_FIXUP_TABLE, CHAINED_FIXUP_TABLE_BASE_SIZE);
         common.allocate(
             part_id::CODE_SIGNATURE,
             CS_HEADERS_SIZE + code_signature_padded_identifier_size(symbol_db.args),
@@ -1479,6 +1493,7 @@ impl platform::Platform for MachO {
         builder.add_section(output_section_id::PAGEZERO_SEGMENT);
         builder.add_section(output_section_id::TEXT_SEGMENT);
         builder.add_section(output_section_id::DATA_SEGMENT);
+        builder.add_section(output_section_id::DATA_CONST_SEGMENT);
         builder.add_section(output_section_id::LINK_EDIT_SEGMENT);
         builder.add_section(output_section_id::ENTRY_POINT);
         builder.add_section(output_section_id::INTERP); // DYLINKER
@@ -1489,6 +1504,7 @@ impl platform::Platform for MachO {
         builder.add_section(output_section_id::TEXT);
         builder.add_section(output_section_id::CSTRING);
         builder.add_section(output_section_id::DATA);
+        builder.add_section(output_section_id::GOT);
         // The rest (e.g. symbol table, string table).
         builder.add_section(output_section_id::CHAINED_FIXUP_TABLE);
         builder.add_section(output_section_id::SYMTAB_GLOBAL);
@@ -1570,6 +1586,11 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         target_segment_type: Some(SegmentType::LoadCommands),
         ..DEFAULT_DEFS
     };
+    defs[output_section_id::DATA_CONST_SEGMENT.as_usize()] = BuiltInSectionDetails {
+        kind: SectionKind::Primary(SectionName(b"__DATA_CONST")),
+        target_segment_type: Some(SegmentType::LoadCommands),
+        ..DEFAULT_DEFS
+    };
     defs[output_section_id::LINK_EDIT_SEGMENT.as_usize()] = BuiltInSectionDetails {
         kind: SectionKind::Primary(SectionName(SEG_LINKEDIT.as_bytes())),
         target_segment_type: Some(SegmentType::LoadCommands),
@@ -1621,6 +1642,10 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         min_alignment: Alignment {
             exponent: CS_SECTION_ALIGNMENT_EXP,
         },
+        ..DEFAULT_DEFS
+    };
+    defs[output_section_id::GOT.as_usize()] = BuiltInSectionDetails {
+        kind: SectionKind::Primary(SectionName(b"__got")),
         ..DEFAULT_DEFS
     };
     // Multi-part generated sections

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -12,6 +12,7 @@ use crate::error::Result;
 use crate::file_writer::copy_section_data;
 use crate::grouping::SequencedInput;
 use crate::layout;
+use crate::layout::ImportedSymbol;
 use crate::layout::Layout;
 use crate::layout::OutputRecordLayout;
 use crate::layout::Resolution;
@@ -52,6 +53,7 @@ use object::read::macho::Nlist;
 use object::read::macho::Section;
 use object::read::macho::Segment;
 use std::borrow::Cow;
+use std::io::Read;
 use std::num::NonZeroU64;
 use zerocopy::BigEndian;
 use zerocopy::FromBytes;
@@ -1284,20 +1286,24 @@ impl platform::Platform for MachO {
         current_sizes: &crate::output_section_part_map::OutputSectionPartMap<u64>,
         extra_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         dynamic_symbol_defs: &[crate::layout::DynamicSymbolDefinition<Self>],
+        imported_symbols: &[ImportedSymbol],
         args: &Self::Args,
     ) -> crate::error::Result {
+        extra_sizes.increment(
+            part_id::CHAINED_FIXUP_TABLE,
+            imported_symbols
+                .iter()
+                .map(|s| CHAINED_FIXUP_IMPORT_SIZE + s.name.len() as u64 + 1)
+                .sum(),
+        );
         // Chained fixups record start information per page. At this point the final GOT size is
         // known, so reserve the fixup table entries needed to describe the GOT pages.
         extra_sizes.increment(
             part_id::CHAINED_FIXUP_TABLE,
-            // TODO
-            dbg!(
-                size_of::<u32>() as u64
-                    * current_sizes
-                        .get(part_id::GOT)
-                        .div_ceil(MACHO_PAGE_ALIGNMENT.value())
-            ),
+            size_of::<u32>() as u64
+                * (imported_symbols.len() as u64).div_ceil(MACHO_PAGE_ALIGNMENT.value()),
         );
+
         Ok(())
     }
 
@@ -1395,10 +1401,7 @@ impl platform::Platform for MachO {
     ) -> crate::error::Result {
         if flags.has_resolution() && symbol_db.is_stub_library_symbol(symbol_id) {
             let symbol_name = symbol_db.symbol_name(symbol_id)?;
-            common.allocate(
-                part_id::CHAINED_FIXUP_TABLE,
-                CHAINED_FIXUP_IMPORT_SIZE + symbol_name.bytes().len() as u64 + 1,
-            );
+            common.add_imported_symbol(symbol_id, symbol_name.bytes());
         }
         Ok(())
     }
@@ -1412,10 +1415,6 @@ impl platform::Platform for MachO {
         if flags.is_dynamic() && flags.needs_got() {
             mem_sizes.increment(part_id::GOT, GOT_ENTRY_SIZE);
         }
-    }
-
-    fn epilogue_allocated_part_ids() -> &'static [crate::part_id::PartId] {
-        &[part_id::CHAINED_FIXUP_TABLE]
     }
 
     fn allocate_object_symtab_space<'data>(

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -87,6 +87,7 @@ pub(crate) const CHAINED_FIXUP_TABLE_BASE_SIZE: u64 = (size_of::<ChainedFixupsHe
     as u64;
 pub(crate) const CHAINED_FIXUP_IMPORT_SIZE: u64 = size_of::<u32>() as u64;
 pub(crate) const GOT_ENTRY_SIZE: u64 = 8;
+pub(crate) const PLT_ENTRY_SIZE: u64 = 12;
 
 pub(crate) const SEG_DATA_CONST: &str = "__DATA_CONST";
 
@@ -923,7 +924,9 @@ impl platform::ProgramSegmentDef for ProgramSegmentDef {
             | output_section_id::DYLD_CHAINED_FIXUPS
             | output_section_id::SYMTAB_COMMAND
             | output_section_id::CODE_SIGNATURE_COMMAND => SegmentType::LoadCommands,
-            output_section_id::TEXT | output_section_id::CSTRING => SegmentType::TextSections,
+            output_section_id::TEXT | output_section_id::CSTRING | output_section_id::PLT_GOT => {
+                SegmentType::TextSections
+            }
             output_section_id::DATA => SegmentType::DataSections,
             output_section_id::GOT => SegmentType::DataConstSections,
             output_section_id::CHAINED_FIXUP_TABLE
@@ -1445,6 +1448,9 @@ impl platform::Platform for MachO {
         output_kind: crate::output_kind::OutputKind,
         _args: &Self::Args,
     ) {
+        if flags.is_dynamic() && flags.needs_plt() {
+            mem_sizes.increment(part_id::PLT_GOT, PLT_ENTRY_SIZE);
+        }
         if flags.is_dynamic() && flags.needs_got() {
             mem_sizes.increment(part_id::GOT, GOT_ENTRY_SIZE);
         }
@@ -1522,13 +1528,20 @@ impl platform::Platform for MachO {
         let mut resolution: Resolution<MachO> = Resolution {
             raw_value,
             dynamic_symbol_index,
-            format_specific: ResolutionExt { got_address: None },
+            format_specific: ResolutionExt {
+                got_address: None,
+                plt_address: None,
+            },
             flags,
         };
 
-        if flags.needs_got() {
+        if flags.needs_plt() {
+            let plt_address = allocate_plt(memory_offsets);
+            resolution.raw_value = plt_address.get();
+            resolution.format_specific.plt_address = Some(plt_address);
+            resolution.format_specific.got_address = Some(allocate_got(memory_offsets));
+        } else if flags.needs_got() {
             let got_address = allocate_got(memory_offsets);
-            // TODO: point to PLT
             resolution.raw_value = got_address.get();
             resolution.format_specific.got_address = Some(got_address);
         }
@@ -1578,6 +1591,7 @@ impl platform::Platform for MachO {
         // Content of the sections (e.g. __text, __data).
         builder.add_section(output_section_id::TEXT);
         builder.add_section(output_section_id::CSTRING);
+        builder.add_section(output_section_id::PLT_GOT);
         builder.add_section(output_section_id::DATA);
         builder.add_section(output_section_id::GOT);
         // The rest (e.g. symbol table, string table).
@@ -1728,6 +1742,15 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         kind: SectionKind::Primary(SectionName(b"__got")),
         ..DEFAULT_DEFS
     };
+    defs[output_section_id::PLT_GOT.as_usize()] = BuiltInSectionDetails {
+        kind: SectionKind::Primary(SectionName(b"__stubs")),
+        section_flags: macho::S_SYMBOL_STUBS
+            .to_flags()
+            .with(macho::S_ATTR_PURE_INSTRUCTIONS)
+            .with(macho::S_ATTR_SOME_INSTRUCTIONS),
+        min_alignment: Alignment { exponent: 2 },
+        ..DEFAULT_DEFS
+    };
     // Multi-part generated sections
     // Start of regular sections
     defs[output_section_id::TEXT.as_usize()] = BuiltInSectionDetails {
@@ -1755,12 +1778,19 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
 #[derive(Debug, Default, Clone, Copy)]
 pub(crate) struct ResolutionExt {
     pub(crate) got_address: Option<NonZeroU64>,
+    pub(crate) plt_address: Option<NonZeroU64>,
 }
 
 fn allocate_got(memory_offsets: &mut OutputSectionPartMap<u64>) -> NonZeroU64 {
     let got_address = NonZeroU64::new(*memory_offsets.get(part_id::GOT)).unwrap();
     memory_offsets.increment(part_id::GOT, GOT_ENTRY_SIZE);
     got_address
+}
+
+fn allocate_plt(memory_offsets: &mut OutputSectionPartMap<u64>) -> NonZeroU64 {
+    let plt_address = NonZeroU64::new(*memory_offsets.get(part_id::PLT_GOT)).unwrap();
+    memory_offsets.increment(part_id::PLT_GOT, PLT_ENTRY_SIZE);
+    plt_address
 }
 
 // TODO: sort properly

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -9,6 +9,7 @@ use crate::ensure;
 use crate::error;
 use crate::error::Result;
 use crate::file_writer::copy_section_data;
+use crate::grouping::SequencedInput;
 use crate::layout;
 use crate::layout::Layout;
 use crate::layout::OutputRecordLayout;
@@ -28,6 +29,7 @@ use crate::platform;
 use crate::platform::Args;
 use crate::platform::ObjectFile;
 use crate::symbol_db::Visibility;
+use crate::value_flags::ValueFlags;
 use object::Endianness;
 use object::SymbolIndex;
 use object::macho;
@@ -506,7 +508,7 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
     }
 
     fn symbol_version_debug(&self, symbol_index: object::SymbolIndex) -> Option<String> {
-        todo!()
+        None
     }
 
     fn section_display_name(&self, index: object::SectionIndex) -> Cow<'data, str> {
@@ -708,7 +710,7 @@ impl platform::Symbol for SymtabEntry {
     }
 
     fn is_interposable(&self) -> bool {
-        false
+        self.visibility() == Visibility::Default
     }
 
     fn is_func(&self) -> bool {
@@ -1773,6 +1775,12 @@ fn process_relocation<'data, 'scope, A: platform::Arch<Platform = MachO>>(
 
         let rel_info = A::relocation_from_raw(rel_info)?;
         let mut flags_to_add = layout::resolution_flags(rel_info.kind);
+        if matches!(
+            symbol_db.file(symbol_db.file_id_for_symbol(symbol_id)),
+            SequencedInput::StubLibrary(_)
+        ) {
+            flags_to_add |= ValueFlags::GOT | ValueFlags::PLT;
+        }
 
         let atomic_flags = &resources.per_symbol_flags.get_atomic(symbol_id);
         let previous_flags = atomic_flags.fetch_or(flags_to_add);

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -1801,7 +1801,7 @@ const DEFAULT_SECTION_RULES: &[SectionRule<'static>] = &[
     // SectionRule::exact_section_keep(b"__compact_unwind", crate::output_section_id::EH_FRAME),
 ];
 
-const PROGRAM_SEGMENT_DEFS: &[ProgramSegmentDef] = &[
+pub(crate) const PROGRAM_SEGMENT_DEFS: &[ProgramSegmentDef] = &[
     ProgramSegmentDef {
         segment_type: SegmentType::Text,
     },

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -66,6 +66,11 @@ use zerocopy::U64;
 #[derive(Debug, Copy, Clone, Default)]
 pub(crate) struct MachO;
 
+#[derive(Debug, Default)]
+pub(crate) struct EpilogueLayoutExt<'data> {
+    pub(crate) imported_symbols: Vec<ImportedSymbol<'data>>,
+}
+
 const LE: Endianness = Endianness::Little;
 
 /// Mach-O uses a zero page for all 32bit addresses and thus we begin the memory
@@ -1009,7 +1014,7 @@ impl platform::Platform for MachO {
     type RelocationInfo = object::macho::RelocationInfo;
     type NonAddressableIndexes = NonAddressableIndexes;
     type NonAddressableCounts = ();
-    type EpilogueLayoutExt = ();
+    type EpilogueLayoutExt<'data> = EpilogueLayoutExt<'data>;
     type GroupLayoutExt = ();
     type CommonGroupStateExt = ();
     type ArchIdentifier = ();
@@ -1243,16 +1248,20 @@ impl platform::Platform for MachO {
         Ok(())
     }
 
-    fn new_epilogue_layout(
+    fn new_epilogue_layout<'data>(
         args: &Self::Args,
         output_kind: crate::output_kind::OutputKind,
         dynamic_symbol_definitions: &mut [crate::layout::DynamicSymbolDefinition<'_, Self>],
-    ) -> Self::EpilogueLayoutExt {
+        imported_symbols: &[ImportedSymbol<'data>],
+    ) -> Self::EpilogueLayoutExt<'data> {
+        EpilogueLayoutExt {
+            imported_symbols: imported_symbols.to_vec(),
+        }
     }
 
     fn apply_non_addressable_indexes_epilogue(
         counts: &mut Self::NonAddressableCounts,
-        state: &mut Self::EpilogueLayoutExt,
+        state: &mut Self::EpilogueLayoutExt<'_>,
     ) {
     }
 
@@ -1266,7 +1275,7 @@ impl platform::Platform for MachO {
     }
 
     fn finalise_sizes_epilogue<'data>(
-        state: &mut Self::EpilogueLayoutExt,
+        state: &mut Self::EpilogueLayoutExt<'data>,
         mem_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         dynamic_symbol_definitions: &[crate::layout::DynamicSymbolDefinition<'data, Self>],
         properties: &Self::LayoutExt,
@@ -1282,16 +1291,17 @@ impl platform::Platform for MachO {
     }
 
     fn apply_late_size_adjustments_epilogue(
-        state: &mut Self::EpilogueLayoutExt,
+        state: &mut Self::EpilogueLayoutExt<'_>,
         current_sizes: &crate::output_section_part_map::OutputSectionPartMap<u64>,
         extra_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         dynamic_symbol_defs: &[crate::layout::DynamicSymbolDefinition<Self>],
-        imported_symbols: &[ImportedSymbol],
+        _imported_symbols: &[ImportedSymbol],
         args: &Self::Args,
     ) -> crate::error::Result {
         extra_sizes.increment(
             part_id::CHAINED_FIXUP_TABLE,
-            imported_symbols
+            state
+                .imported_symbols
                 .iter()
                 .map(|s| CHAINED_FIXUP_IMPORT_SIZE + s.name.len() as u64 + 1)
                 .sum(),
@@ -1301,14 +1311,14 @@ impl platform::Platform for MachO {
         extra_sizes.increment(
             part_id::CHAINED_FIXUP_TABLE,
             size_of::<u32>() as u64
-                * (imported_symbols.len() as u64).div_ceil(MACHO_PAGE_ALIGNMENT.value()),
+                * (state.imported_symbols.len() as u64).div_ceil(MACHO_PAGE_ALIGNMENT.value()),
         );
 
         Ok(())
     }
 
     fn finalise_layout_epilogue<'data>(
-        epilogue_state: &mut Self::EpilogueLayoutExt,
+        epilogue_state: &mut Self::EpilogueLayoutExt<'data>,
         memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
         common_state: &Self::LayoutExt,

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -25,6 +25,7 @@ use crate::output_section_id::OrderEvent;
 use crate::output_section_id::OutputOrderBuilder;
 use crate::output_section_id::SectionName;
 use crate::output_section_id::SectionOutputInfo;
+use crate::output_section_part_map::OutputSectionPartMap;
 use crate::part_id;
 use crate::platform;
 use crate::platform::Args;
@@ -50,6 +51,7 @@ use object::read::macho::Nlist;
 use object::read::macho::Section;
 use object::read::macho::Segment;
 use std::borrow::Cow;
+use std::num::NonZeroU64;
 use zerocopy::BigEndian;
 use zerocopy::FromBytes;
 use zerocopy::Immutable;
@@ -1007,7 +1009,7 @@ impl platform::Platform for MachO {
     type CommonGroupStateExt = ();
     type ArchIdentifier = ();
     type Args = MachOArgs;
-    type ResolutionExt = ();
+    type ResolutionExt = ResolutionExt;
     type SymtabShndxEntry = ();
     type SymbolVersionIndex = ();
     type LayoutExt = ();
@@ -1463,12 +1465,21 @@ impl platform::Platform for MachO {
         dynamic_symbol_index: Option<std::num::NonZeroU32>,
         memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
     ) -> crate::layout::Resolution<Self> {
-        Resolution {
+        let mut resolution: Resolution<MachO> = Resolution {
             raw_value,
             dynamic_symbol_index,
-            format_specific: (),
+            format_specific: ResolutionExt { got_address: None },
             flags,
+        };
+
+        if flags.needs_got() {
+            let got_address = allocate_got(memory_offsets);
+            // TODO: point to PLT
+            resolution.raw_value = got_address.get();
+            resolution.format_specific.got_address = Some(got_address);
         }
+
+        resolution
     }
 
     fn raw_symbol_name<'data>(
@@ -1680,6 +1691,17 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
 
     defs
 };
+
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct ResolutionExt {
+    pub(crate) got_address: Option<NonZeroU64>,
+}
+
+fn allocate_got(memory_offsets: &mut OutputSectionPartMap<u64>) -> NonZeroU64 {
+    let got_address = NonZeroU64::new(*memory_offsets.get(part_id::GOT)).unwrap();
+    memory_offsets.increment(part_id::GOT, GOT_ENTRY_SIZE);
+    got_address
+}
 
 // TODO: sort properly
 const DEFAULT_SECTION_RULES: &[SectionRule<'static>] = &[

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -81,6 +81,8 @@ pub(crate) const CHAINED_FIXUP_TABLE_BASE_SIZE: u64 =
 pub(crate) const CHAINED_FIXUP_IMPORT_SIZE: u64 = size_of::<u32>() as u64;
 pub(crate) const GOT_ENTRY_SIZE: u64 = 8;
 
+pub(crate) const SEG_DATA_CONST: &str = "__DATA_CONST";
+
 type SectionHeader = Section64<crate::macho::Endianness>;
 type SectionTable<'data> = &'data [Section64<crate::macho::Endianness>];
 type SymbolTable<'data> = object::read::macho::SymbolTable<'data, macho::MachHeader64<Endianness>>;
@@ -1347,6 +1349,17 @@ impl platform::Platform for MachO {
                         )) as u64,
             );
         }
+        if has_active_segment(header_info, SegmentType::DataConstSections) {
+            sizes.increment(
+                part_id::DATA_CONST_SEGMENT,
+                (size_of::<SegmentCommand>()
+                    + size_of::<SectionEntry>()
+                        * count_sections_for_segment_type(
+                            output_sections,
+                            SegmentType::DataConstSections,
+                        )) as u64,
+            );
+        }
         sizes.increment(
             part_id::LINK_EDIT_SEGMENT,
             size_of::<SegmentCommand>() as u64,
@@ -1607,7 +1620,7 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         ..DEFAULT_DEFS
     };
     defs[output_section_id::DATA_CONST_SEGMENT.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"__DATA_CONST")),
+        kind: SectionKind::Primary(SectionName(SEG_DATA_CONST.as_bytes())),
         target_segment_type: Some(SegmentType::LoadCommands),
         ..DEFAULT_DEFS
     };

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -1595,9 +1595,9 @@ impl platform::Platform for MachO {
         builder.add_section(output_section_id::DATA);
         builder.add_section(output_section_id::GOT);
         // The rest (e.g. symbol table, string table).
+        builder.add_section(output_section_id::STRTAB);
         builder.add_section(output_section_id::CHAINED_FIXUP_TABLE);
         builder.add_section(output_section_id::SYMTAB_GLOBAL);
-        builder.add_section(output_section_id::STRTAB);
         builder.add_section(output_section_id::CODE_SIGNATURE);
 
         builder.build()
@@ -1715,6 +1715,11 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         target_segment_type: Some(SegmentType::LoadCommands),
         ..DEFAULT_DEFS
     };
+    defs[output_section_id::STRTAB.as_usize()] = BuiltInSectionDetails {
+        kind: SectionKind::Primary(SectionName(b"STRTAB")),
+        target_segment_type: Some(SegmentType::LinkeditSections),
+        ..DEFAULT_DEFS
+    };
     defs[output_section_id::CHAINED_FIXUP_TABLE.as_usize()] = BuiltInSectionDetails {
         kind: SectionKind::Primary(SectionName(b"DYLD_CHAINED_FIXUPS_TABLE")),
         target_segment_type: Some(SegmentType::LinkeditSections),
@@ -1722,11 +1727,6 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
     };
     defs[output_section_id::SYMTAB_GLOBAL.as_usize()] = BuiltInSectionDetails {
         kind: SectionKind::Primary(SectionName(b"SYMTAB")),
-        target_segment_type: Some(SegmentType::LinkeditSections),
-        ..DEFAULT_DEFS
-    };
-    defs[output_section_id::STRTAB.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"STRTAB")),
         target_segment_type: Some(SegmentType::LinkeditSections),
         ..DEFAULT_DEFS
     };
@@ -1925,11 +1925,11 @@ fn process_relocation<'data, 'scope, A: platform::Arch<Platform = MachO>>(
             symbol_db.file(symbol_db.file_id_for_symbol(symbol_id)),
             SequencedInput::StubLibrary(_)
         ) {
-            flags_to_add |= ValueFlags::GOT | ValueFlags::PLT;
+            flags_to_add |= ValueFlags::GOT;
         }
         // TODO: classify symbols more reliably, likely by checking whether their section is __text.
         if rel_info.r_type == object::macho::ARM64_RELOC_BRANCH26 {
-            flags_to_add |= ValueFlags::FUNCTION;
+            flags_to_add |= ValueFlags::FUNCTION | ValueFlags::PLT;
         }
 
         let atomic_flags = &resources.per_symbol_flags.get_atomic(symbol_id);

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -76,7 +76,7 @@ pub(crate) const MACHO_COMMAND_ALIGNMENT: usize = 8;
 /// A path to the default dynamic linker.
 pub(crate) const DYLINKER_PATH: &[u8] = b"/usr/lib/dyld";
 // TODO: optionality of __DATA and __CONST_DATA segments not respected
-pub(crate) const DEFAULT_SEGMENT_COUNT: usize = 4;
+pub(crate) const DEFAULT_SEGMENT_COUNT: usize = 5;
 pub(crate) const CHAINED_FIXUP_TABLE_BASE_SIZE: u64 =
     (size_of::<ChainedFixupsHeader>() + size_of::<u32>() * (DEFAULT_SEGMENT_COUNT + 1)) as u64;
 pub(crate) const CHAINED_FIXUP_IMPORT_SIZE: u64 = size_of::<u32>() as u64;
@@ -1270,6 +1270,7 @@ impl platform::Platform for MachO {
         properties: &Self::LayoutExt,
         symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
     ) {
+        mem_sizes.increment(part_id::CHAINED_FIXUP_TABLE, CHAINED_FIXUP_TABLE_BASE_SIZE);
     }
 
     fn finalise_sizes_all<'data>(
@@ -1289,9 +1290,13 @@ impl platform::Platform for MachO {
         // known, so reserve the fixup table entries needed to describe the GOT pages.
         extra_sizes.increment(
             part_id::CHAINED_FIXUP_TABLE,
-            MACHO_PAGE_ALIGNMENT
-                .value()
-                .div_ceil(*current_sizes.get(part_id::GOT)),
+            // TODO
+            dbg!(
+                size_of::<u32>() as u64
+                    * current_sizes
+                        .get(part_id::GOT)
+                        .div_ceil(MACHO_PAGE_ALIGNMENT.value())
+            ),
         );
         Ok(())
     }
@@ -1409,6 +1414,10 @@ impl platform::Platform for MachO {
         }
     }
 
+    fn epilogue_allocated_part_ids() -> &'static [crate::part_id::PartId] {
+        &[part_id::CHAINED_FIXUP_TABLE]
+    }
+
     fn allocate_object_symtab_space<'data>(
         state: &crate::layout::ObjectLayoutState<'data, Self>,
         common: &mut crate::layout::CommonGroupState<'data, Self>,
@@ -1458,7 +1467,6 @@ impl platform::Platform for MachO {
     ) {
         // Allocate one extra character as n_strx == 0 is treated as unnamed.
         common.allocate(part_id::STRTAB, 1);
-        common.allocate(part_id::CHAINED_FIXUP_TABLE, CHAINED_FIXUP_TABLE_BASE_SIZE);
         common.allocate(
             part_id::CODE_SIGNATURE,
             CS_HEADERS_SIZE + code_signature_padded_identifier_size(symbol_db.args),

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -66,11 +66,6 @@ use zerocopy::U64;
 #[derive(Debug, Copy, Clone, Default)]
 pub(crate) struct MachO;
 
-#[derive(Debug, Default)]
-pub(crate) struct EpilogueLayoutExt<'data> {
-    pub(crate) imported_symbols: Vec<ImportedSymbol<'data>>,
-}
-
 const LE: Endianness = Endianness::Little;
 
 /// Mach-O uses a zero page for all 32bit addresses and thus we begin the memory
@@ -1014,7 +1009,7 @@ impl platform::Platform for MachO {
     type RelocationInfo = object::macho::RelocationInfo;
     type NonAddressableIndexes = NonAddressableIndexes;
     type NonAddressableCounts = ();
-    type EpilogueLayoutExt<'data> = EpilogueLayoutExt<'data>;
+    type EpilogueLayoutExt = ();
     type GroupLayoutExt = ();
     type CommonGroupStateExt = ();
     type ArchIdentifier = ();
@@ -1248,20 +1243,16 @@ impl platform::Platform for MachO {
         Ok(())
     }
 
-    fn new_epilogue_layout<'data>(
+    fn new_epilogue_layout(
         args: &Self::Args,
         output_kind: crate::output_kind::OutputKind,
         dynamic_symbol_definitions: &mut [crate::layout::DynamicSymbolDefinition<'_, Self>],
-        imported_symbols: &[ImportedSymbol<'data>],
-    ) -> Self::EpilogueLayoutExt<'data> {
-        EpilogueLayoutExt {
-            imported_symbols: imported_symbols.to_vec(),
-        }
+    ) -> Self::EpilogueLayoutExt {
     }
 
     fn apply_non_addressable_indexes_epilogue(
         counts: &mut Self::NonAddressableCounts,
-        state: &mut Self::EpilogueLayoutExt<'_>,
+        state: &mut Self::EpilogueLayoutExt,
     ) {
     }
 
@@ -1275,7 +1266,7 @@ impl platform::Platform for MachO {
     }
 
     fn finalise_sizes_epilogue<'data>(
-        state: &mut Self::EpilogueLayoutExt<'data>,
+        state: &mut Self::EpilogueLayoutExt,
         mem_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         dynamic_symbol_definitions: &[crate::layout::DynamicSymbolDefinition<'data, Self>],
         properties: &Self::LayoutExt,
@@ -1291,17 +1282,16 @@ impl platform::Platform for MachO {
     }
 
     fn apply_late_size_adjustments_epilogue(
-        state: &mut Self::EpilogueLayoutExt<'_>,
+        state: &mut Self::EpilogueLayoutExt,
         current_sizes: &crate::output_section_part_map::OutputSectionPartMap<u64>,
         extra_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         dynamic_symbol_defs: &[crate::layout::DynamicSymbolDefinition<Self>],
-        _imported_symbols: &[ImportedSymbol],
+        imported_symbols: &[ImportedSymbol],
         args: &Self::Args,
     ) -> crate::error::Result {
         extra_sizes.increment(
             part_id::CHAINED_FIXUP_TABLE,
-            state
-                .imported_symbols
+            imported_symbols
                 .iter()
                 .map(|s| CHAINED_FIXUP_IMPORT_SIZE + s.name.len() as u64 + 1)
                 .sum(),
@@ -1311,14 +1301,14 @@ impl platform::Platform for MachO {
         extra_sizes.increment(
             part_id::CHAINED_FIXUP_TABLE,
             size_of::<u32>() as u64
-                * (state.imported_symbols.len() as u64).div_ceil(MACHO_PAGE_ALIGNMENT.value()),
+                * (imported_symbols.len() as u64).div_ceil(MACHO_PAGE_ALIGNMENT.value()),
         );
 
         Ok(())
     }
 
     fn finalise_layout_epilogue<'data>(
-        epilogue_state: &mut Self::EpilogueLayoutExt<'data>,
+        epilogue_state: &mut Self::EpilogueLayoutExt,
         memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
         common_state: &Self::LayoutExt,

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -105,14 +105,8 @@ pub(crate) type SymtabCommand = object::macho::SymtabCommand<Endianness>;
 
 // TODO: move the following data types to object crate
 
-// values for dyld_chained_fixups_header.imports_format
-#[allow(non_camel_case_types)]
-#[repr(u32)]
-pub(crate) enum DyldChainedFixupsImporstFormat {
-    DYLD_CHAINED_IMPORT = 1,
-    DYLD_CHAINED_IMPORT_ADDEND = 2,
-    DYLD_CHAINED_IMPORT_ADDEND64 = 3,
-}
+pub(crate) const DYLD_CHAINED_IMPORT: u32 = 1;
+pub(crate) const DYLD_CHAINED_PTR_64_OFFSET: u16 = 6;
 
 // header of the LC_DYLD_CHAINED_FIXUPS payload
 #[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Clone, Copy)]
@@ -146,7 +140,7 @@ pub(crate) struct DyldChainedFixupsHeader {
 // and passed down to the kernel for page-in linking
 #[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Clone, Copy)]
 #[repr(C)]
-struct DyldChainedStartsInSegment {
+pub(crate) struct DyldChainedStartsInSegment {
     // size of this (amount kernel needs to copy)
     pub(crate) size: U32<zerocopy::LittleEndian>,
     // 0x1000 or 0x4000

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -1449,6 +1449,12 @@ impl platform::Platform for MachO {
             else {
                 bail!("stub library expected");
             };
+            // TODO: support more stub libraries once we can emit arbitrary number of LC_LOAD_DYLIB
+            // commands!
+            ensure!(
+                stub.file_id.file() == 0,
+                "Only single stub library supported"
+            );
             common.add_imported_symbol(
                 symbol_id,
                 symbol_name.bytes(),

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -28,6 +28,7 @@ use crate::output_section_id::SectionName;
 use crate::output_section_id::SectionOutputInfo;
 use crate::output_section_part_map::OutputSectionPartMap;
 use crate::part_id;
+use crate::part_id::PartId;
 use crate::platform;
 use crate::platform::Args;
 use crate::platform::ObjectFile;
@@ -79,13 +80,16 @@ pub(crate) const MACHO_COMMAND_ALIGNMENT: usize = 8;
 /// A path to the default dynamic linker.
 pub(crate) const DYLINKER_PATH: &[u8] = b"/usr/lib/dyld";
 pub(crate) const LIBSYSTEM_PATH: &[u8] = b"/usr/lib/libSystem.B.dylib";
-// TODO: optionality of __DATA and __CONST_DATA segments not respected
-pub(crate) const DEFAULT_SEGMENT_COUNT: usize = 5;
+
+// TODO: Getting the number of active segments in epilogue depends on determine_header_size
+// which is called later for the prologue. We potentially over-allocate a couple of bytes.
+pub(crate) const MAX_SEGMENT_COUNT: usize = 6;
 pub(crate) const CHAINED_FIXUP_TABLE_BASE_SIZE: u64 = (size_of::<ChainedFixupsHeader>()
-    + size_of::<u32>() * (DEFAULT_SEGMENT_COUNT + 1)
+    + size_of::<u32>() * (MAX_SEGMENT_COUNT + /* leading segment count */ 1)
     + size_of::<DyldChainedStartsInSegment>())
     as u64;
 pub(crate) const CHAINED_FIXUP_IMPORT_SIZE: u64 = size_of::<u32>() as u64;
+pub(crate) const CHAINED_FIXUP_PAGE_START_SIZE: u64 = size_of::<u16>() as u64;
 pub(crate) const GOT_ENTRY_SIZE: u64 = 8;
 pub(crate) const PLT_ENTRY_SIZE: u64 = 12;
 
@@ -860,6 +864,7 @@ impl platform::SegmentType for SegmentType {}
 #[derive(Debug, Copy, Clone, Default, PartialEq)]
 pub(crate) struct ProgramSegmentDef {
     pub(crate) segment_type: SegmentType,
+    pub(crate) part_id: Option<PartId>,
 }
 
 impl std::fmt::Display for ProgramSegmentDef {
@@ -1331,7 +1336,7 @@ impl platform::Platform for MachO {
         // known, so reserve the fixup table entries needed to describe the GOT pages.
         extra_sizes.increment(
             part_id::CHAINED_FIXUP_TABLE,
-            size_of::<u32>() as u64
+            CHAINED_FIXUP_PAGE_START_SIZE
                 * (imported_symbols.len() as u64).div_ceil(MACHO_PAGE_ALIGNMENT.value()),
         );
 
@@ -1804,21 +1809,29 @@ const DEFAULT_SECTION_RULES: &[SectionRule<'static>] = &[
 pub(crate) const PROGRAM_SEGMENT_DEFS: &[ProgramSegmentDef] = &[
     ProgramSegmentDef {
         segment_type: SegmentType::Text,
+        // Not a real segment from the Macho-O definition.
+        part_id: Some(part_id::TEXT_SEGMENT),
     },
     ProgramSegmentDef {
+        // Not a real segment from the Macho-O definition.
         segment_type: SegmentType::LoadCommands,
+        part_id: None,
     },
     ProgramSegmentDef {
         segment_type: SegmentType::TextSections,
+        part_id: Some(part_id::TEXT_SEGMENT),
     },
     ProgramSegmentDef {
         segment_type: SegmentType::DataSections,
+        part_id: Some(part_id::DATA_SEGMENT),
     },
     ProgramSegmentDef {
         segment_type: SegmentType::DataConstSections,
+        part_id: Some(part_id::DATA_CONST_SEGMENT),
     },
     ProgramSegmentDef {
         segment_type: SegmentType::LinkeditSections,
+        part_id: Some(part_id::LINK_EDIT_SEGMENT),
     },
 ];
 
@@ -1834,7 +1847,10 @@ fn count_sections_for_segment_type(
     output_sections: &crate::output_section_id::OutputSections<MachO>,
     segment_type: SegmentType,
 ) -> usize {
-    let segment_def = ProgramSegmentDef { segment_type };
+    let segment_def = ProgramSegmentDef {
+        segment_type,
+        part_id: None,
+    };
     output_sections
         .ids_with_info()
         .filter(|(section_id, _)| {

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -1842,13 +1842,17 @@ fn process_relocation<'data, 'scope, A: platform::Arch<Platform = MachO>>(
         flags.merge(resources.local_flags_for_symbol(local_symbol_id));
         let rel_offset = rel_info.r_address;
 
-        let rel_info = A::relocation_from_raw(rel_info)?;
-        let mut flags_to_add = layout::resolution_flags(rel_info.kind);
+        let relocation = A::relocation_from_raw(rel_info)?;
+        let mut flags_to_add = layout::resolution_flags(relocation.kind);
         if matches!(
             symbol_db.file(symbol_db.file_id_for_symbol(symbol_id)),
             SequencedInput::StubLibrary(_)
         ) {
             flags_to_add |= ValueFlags::GOT | ValueFlags::PLT;
+        }
+        // TODO: classify symbols more reliably, likely by checking whether their section is __text.
+        if rel_info.r_type == object::macho::ARM64_RELOC_BRANCH26 {
+            flags_to_add |= ValueFlags::FUNCTION;
         }
 
         let atomic_flags = &resources.per_symbol_flags.get_atomic(symbol_id);

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -4,6 +4,7 @@
 use crate::OutputKind;
 use crate::alignment;
 use crate::alignment::Alignment;
+use crate::alignment::MACHO_PAGE_ALIGNMENT;
 use crate::args::macho::MachOArgs;
 use crate::ensure;
 use crate::error;
@@ -1279,6 +1280,14 @@ impl platform::Platform for MachO {
         dynamic_symbol_defs: &[crate::layout::DynamicSymbolDefinition<Self>],
         args: &Self::Args,
     ) -> crate::error::Result {
+        // Chained fixups record start information per page. At this point the final GOT size is
+        // known, so reserve the fixup table entries needed to describe the GOT pages.
+        extra_sizes.increment(
+            part_id::CHAINED_FIXUP_TABLE,
+            MACHO_PAGE_ALIGNMENT
+                .value()
+                .div_ceil(*current_sizes.get(part_id::GOT)),
+        );
         Ok(())
     }
 
@@ -1380,7 +1389,7 @@ impl platform::Platform for MachO {
         _args: &Self::Args,
     ) {
         if flags.is_dynamic() && flags.needs_got() {
-            dbg!(mem_sizes.increment(part_id::GOT, GOT_ENTRY_SIZE));
+            mem_sizes.increment(part_id::GOT, GOT_ENTRY_SIZE);
         }
     }
 

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -32,6 +32,7 @@ use crate::platform::Args;
 use crate::platform::ObjectFile;
 use crate::symbol_db::Visibility;
 use crate::value_flags::ValueFlags;
+use linker_utils::elf::RelocationKind::TlsGdGotBase;
 use object::Endianness;
 use object::SymbolIndex;
 use object::macho;

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -80,8 +80,10 @@ pub(crate) const MACHO_COMMAND_ALIGNMENT: usize = 8;
 pub(crate) const DYLINKER_PATH: &[u8] = b"/usr/lib/dyld";
 // TODO: optionality of __DATA and __CONST_DATA segments not respected
 pub(crate) const DEFAULT_SEGMENT_COUNT: usize = 5;
-pub(crate) const CHAINED_FIXUP_TABLE_BASE_SIZE: u64 =
-    (size_of::<ChainedFixupsHeader>() + size_of::<u32>() * (DEFAULT_SEGMENT_COUNT + 1)) as u64;
+pub(crate) const CHAINED_FIXUP_TABLE_BASE_SIZE: u64 = (size_of::<ChainedFixupsHeader>()
+    + size_of::<u32>() * (DEFAULT_SEGMENT_COUNT + 1)
+    + size_of::<DyldChainedStartsInSegment>())
+    as u64;
 pub(crate) const CHAINED_FIXUP_IMPORT_SIZE: u64 = size_of::<u32>() as u64;
 pub(crate) const GOT_ENTRY_SIZE: u64 = 8;
 

--- a/libwild/src/macho_aarch64.rs
+++ b/libwild/src/macho_aarch64.rs
@@ -2,6 +2,7 @@
 #![allow(unused_variables)]
 
 use crate::bail;
+use crate::ensure;
 use crate::macho::MachO;
 use linker_utils::elf::AArch64Instruction;
 use linker_utils::elf::AllowedRange;
@@ -10,9 +11,21 @@ use linker_utils::elf::PageMask;
 use linker_utils::elf::RelocationKind;
 use linker_utils::elf::RelocationKindInfo;
 use linker_utils::elf::RelocationSize;
+use linker_utils::elf::SIZE_4KB;
 use linker_utils::elf::Sign;
 
 pub(crate) struct MachOAArch64;
+
+// ADRP+ADD+BR symbol stub template.
+const STUB_TEMPLATE: &[u8] = &[
+    0x10, 0x00, 0x00, 0x90, // ADRP x16, page(got)
+    0x10, 0x02, 0x40, 0xf9, // LDR  x16, [x16, #off]
+    0x00, 0x02, 0x1f, 0xd6, // BR   x16
+];
+
+const _ASSERTS: () = {
+    assert!(STUB_TEMPLATE.len() as u64 == crate::macho::PLT_ENTRY_SIZE);
+};
 
 #[derive(Debug, Clone)]
 pub(crate) struct Relaxation {}
@@ -57,7 +70,24 @@ impl crate::platform::Arch for MachOAArch64 {
         got_address: u64,
         plt_address: u64,
     ) -> crate::error::Result {
-        todo!()
+        // TODO: For simplicity, we assume now the PLT entry precedes the GOT entry, so we can
+        // make the offset calculation in the unsigned type.
+        debug_assert!(plt_address < got_address);
+
+        plt_entry.copy_from_slice(STUB_TEMPLATE);
+        let plt_page_address = plt_address & !PAGE_MASK_4KB;
+        let offset = got_address.wrapping_sub(plt_page_address);
+        ensure!(
+            offset < (1 << 32),
+            "Mach-O stub is more than 4GiB away from GOT"
+        );
+        AArch64Instruction::Adr.write_to_value(offset / SIZE_4KB, false, &mut plt_entry[0..4]);
+        AArch64Instruction::MachOLow12.write_to_value(
+            offset & PAGE_MASK_4KB,
+            false,
+            &mut plt_entry[4..8],
+        );
+        Ok(())
     }
 
     fn relocation_from_raw(

--- a/libwild/src/macho_aarch64.rs
+++ b/libwild/src/macho_aarch64.rs
@@ -105,6 +105,27 @@ impl crate::platform::Arch for MachOAArch64 {
                     1,
                 )
             }
+            object::macho::ARM64_RELOC_GOT_LOAD_PAGE21 => {
+                debug_assert_eq!(rel_kind, RelocationKind::Relative);
+                debug_assert_eq!(rel_size, RelocationSize::ByteSize(4));
+                (
+                    RelocationKind::GotRelative,
+                    RelocationSize::bit_mask_aarch64(12, 33, AArch64Instruction::Adr),
+                    Some(PageMask::SymbolPlusAddendAndPosition(PAGE_MASK_4KB)),
+                    AllowedRange::from_bit_size(33, Sign::Signed),
+                    1,
+                )
+            }
+            object::macho::ARM64_RELOC_GOT_LOAD_PAGEOFF12 => {
+                debug_assert_eq!(rel_size, RelocationSize::ByteSize(4));
+                (
+                    RelocationKind::Got,
+                    RelocationSize::bit_mask_aarch64(0, 12, AArch64Instruction::MachOLow12),
+                    None,
+                    AllowedRange::no_check(),
+                    1,
+                )
+            }
             _ => bail!("Unknown relocation: {}", rel.r_type),
         };
         Ok(RelocationKindInfo {

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -19,6 +19,7 @@ use crate::layout::PreludeLayout;
 use crate::layout::Resolution;
 use crate::layout::Section;
 use crate::layout::SymbolCopyInfo;
+use crate::macho::CHAINED_FIXUP_PAGE_START_SIZE;
 use crate::macho::CS_ADHOC;
 use crate::macho::CS_BLOB_HEADERS_SIZE;
 use crate::macho::CS_BLOCK_SIZE;
@@ -36,7 +37,6 @@ use crate::macho::CodeSignatureBlobIndex;
 use crate::macho::CodeSignatureCodeDirectory;
 use crate::macho::CodeSignatureCommand;
 use crate::macho::CodeSignatureSuperBlob;
-use crate::macho::DEFAULT_SEGMENT_COUNT;
 use crate::macho::DYLD_CHAINED_IMPORT;
 use crate::macho::DYLD_CHAINED_PTR_64_OFFSET;
 use crate::macho::DYLINKER_PATH;
@@ -50,6 +50,7 @@ use crate::macho::GOT_ENTRY_SIZE;
 use crate::macho::LIBSYSTEM_PATH;
 use crate::macho::MACHO_COMMAND_ALIGNMENT;
 use crate::macho::MACHO_START_MEM_ADDRESS;
+use crate::macho::MAX_SEGMENT_COUNT;
 use crate::macho::MachO;
 use crate::macho::PLT_ENTRY_SIZE;
 use crate::macho::PROGRAM_SEGMENT_DEFS;
@@ -826,9 +827,22 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
     let symbols = &layout.imported_symbols;
     let _imported_symbols_strings_len: usize = symbols.iter().map(|sym| sym.name.len() + 1).sum();
 
-    // TODO: DEFAULT_SEGMENT_COUNT should be dynamically allocated
-    let starts_in_image_len = size_of::<u32>() * (DEFAULT_SEGMENT_COUNT + 1);
-    let starts_in_segment_len = size_of::<DyldChainedStartsInSegment>() + size_of::<u16>();
+    let active_segments = PROGRAM_SEGMENT_DEFS
+        .iter()
+        .filter(|segment| {
+            segment.part_id.is_some()
+                && get_segment_sections(layout, segment.segment_type).is_some()
+        })
+        .collect_vec();
+    // The __PAGEZERO segment needs to be added manually.
+    let segment_count = active_segments.len() + 1;
+    ensure!(
+        segment_count <= MAX_SEGMENT_COUNT,
+        "unexpected number of active segments"
+    );
+    let starts_in_image_len = size_of::<u32>() * (segment_count + 1);
+    let starts_in_segment_len =
+        size_of::<DyldChainedStartsInSegment>() + CHAINED_FIXUP_PAGE_START_SIZE as usize;
     let imports_len = size_of::<u32>() * symbols.len();
 
     let starts_offset = size_of::<ChainedFixupsHeader>();
@@ -837,9 +851,8 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
 
     let (header, rest) = ChainedFixupsHeader::mut_from_prefix(chained_fixup_table)
         .map_err(|_| error!("Invalid chained fixups header allocation"))?;
-    let (starts_in_image, rest) =
-        slice_from_bytes_mut::<U32<Endianness>>(rest, DEFAULT_SEGMENT_COUNT + 1)
-            .map_err(|_| error!("Invalid chained fixups starts allocation"))?;
+    let (starts_in_image, rest) = slice_from_bytes_mut::<U32<Endianness>>(rest, segment_count + 1)
+        .map_err(|_| error!("Invalid chained fixups starts allocation"))?;
     let (starts_in_segment, rest) = DyldChainedStartsInSegment::mut_from_prefix(rest)
         .map_err(|_| error!("Invalid chained fixups starts in segment allocation"))?;
     let (page_starts, rest) = slice_from_bytes_mut::<U16<Endianness>>(rest, 1)
@@ -858,15 +871,14 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
 
     // 2) fill up dyld_chained_starts_in_image, which is `seg_count` (u32) followed by
     //    `seg_info_offset` ([u32; seg_count]); only __DATA_CONST,__got segment is covered
-    starts_in_image[0].set(LE, DEFAULT_SEGMENT_COUNT as u32);
+    starts_in_image[0].set(LE, segment_count as u32);
     starts_in_image[1..].fill(U32::new(LE, 0));
 
-    let data_const_segment_index = PROGRAM_SEGMENT_DEFS
+    let data_const_segment_index = active_segments
         .iter()
-        .filter(|segment| get_segment_sections(layout, segment.segment_type).is_some())
         .position(|segment_type| segment_type.segment_type == SegmentType::DataConstSections)
         .ok_or_else(|| error!("__DATA_CONST segment expected"))?;
-    starts_in_image[data_const_segment_index].set(LE, starts_in_image_len as u32);
+    starts_in_image[data_const_segment_index + 1].set(LE, starts_in_image_len as u32);
 
     // 3) fill up DyldChainedStartsInSegment for the __got section
     let data_const_segment = get_segment_sections(layout, SegmentType::DataConstSections)
@@ -924,6 +936,9 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
     for i in 0..sorted_symbols.len() {
         imports[i].set(Endianness::Little, 1 + (symbol_offsets[i] << 9) as u32);
     }
+
+    // Pad a couple of bytes (related to the MAX_SEGMENT_COUNT).
+    string_pool[str_offset..].fill(0);
 
     Ok(())
 }

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -1,3 +1,4 @@
+use crate::alignment::MACHO_PAGE_ALIGNMENT;
 use crate::bail;
 use crate::elf::get_page_mask;
 use crate::ensure;
@@ -36,9 +37,11 @@ use crate::macho::CodeSignatureCodeDirectory;
 use crate::macho::CodeSignatureCommand;
 use crate::macho::CodeSignatureSuperBlob;
 use crate::macho::DEFAULT_SEGMENT_COUNT;
+use crate::macho::DYLD_CHAINED_IMPORT;
+use crate::macho::DYLD_CHAINED_PTR_64_OFFSET;
 use crate::macho::DYLINKER_PATH;
 use crate::macho::DyldChainedFixupsCommand;
-use crate::macho::DyldChainedFixupsImporstFormat;
+use crate::macho::DyldChainedStartsInSegment;
 use crate::macho::DylinkerCommand;
 use crate::macho::EntryPointCommand;
 use crate::macho::FileHeader;
@@ -241,7 +244,7 @@ fn write_epilogue<A: Arch<Platform = MachO>>(
         }
     }
 
-    write_chained_fixup_table::<A>(buffers.get_mut(part_id::CHAINED_FIXUP_TABLE))?;
+    write_chained_fixup_table::<A>(layout, buffers.get_mut(part_id::CHAINED_FIXUP_TABLE))?;
 
     Ok(())
 }
@@ -714,36 +717,23 @@ fn write_code_signature_command<A: Arch<Platform = MachO>>(
     command.datasize.set(LE, code_signature.file_size as u32);
 }
 
-fn write_chained_fixup_table<A: Arch<Platform = MachO>>(chained_fixup_table: &mut [u8]) -> Result {
+fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
+    layout: &MachOLayout,
+    chained_fixup_table: &mut [u8],
+) -> Result {
     dbg!(chained_fixup_table.len());
+    // TODO: DEFAULT_SEGMENT_COUNT should be dynamically allocated
     let starts_len = size_of::<u32>() * (DEFAULT_SEGMENT_COUNT + 1);
-    let min_len = size_of::<ChainedFixupsHeader>() + starts_len;
-    if chained_fixup_table.len() < min_len {
-        bail!(
-            "CHAINED_FIXUP_TABLE allocation too small. Need at least {} bytes, got {}",
-            min_len,
-            chained_fixup_table.len()
-        );
-    }
 
-    // TODO: remove in the future once we handle a dynamic number of segments
-    chained_fixup_table.fill(0);
-
-    let (header, rest): (&mut ChainedFixupsHeader, &mut [u8]) =
-        ChainedFixupsHeader::mut_from_prefix(chained_fixup_table)
-            .map_err(|_| error!("Invalid chained fixups header allocation"))?;
-    let (starts_in_image, _) =
+    let (header, rest) = ChainedFixupsHeader::mut_from_prefix(chained_fixup_table)
+        .map_err(|_| error!("Invalid chained fixups header allocation"))?;
+    let (starts_in_image, rest) =
         slice_from_bytes_mut::<U32<Endianness>>(rest, DEFAULT_SEGMENT_COUNT + 1)
             .map_err(|_| error!("Invalid chained fixups starts allocation"))?;
+    let (starts_in_segment, rest) = DyldChainedStartsInSegment::mut_from_prefix(rest)
+        .map_err(|_| error!("Invalid chained fixups starts in segment allocation"))?;
 
-    if starts_in_image.len() != DEFAULT_SEGMENT_COUNT + 1 {
-        bail!(
-            "Invalid chained fixups starts allocation. Expected {} entries, got {}",
-            DEFAULT_SEGMENT_COUNT + 1,
-            starts_in_image.len()
-        );
-    }
-
+    // 1) fill up ChainedFixupsHeader
     header.fixups_version.set(0);
     header
         .starts_offset
@@ -755,13 +745,37 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(chained_fixup_table: &mu
         .symbols_offset
         .set((size_of::<ChainedFixupsHeader>() + starts_len) as u32);
     header.imports_count.set(0);
-    header
-        .imports_format
-        .set(DyldChainedFixupsImporstFormat::DYLD_CHAINED_IMPORT as u32);
+    header.imports_format.set(DYLD_CHAINED_IMPORT);
     header.symbols_format.set(0);
 
+    // 2) fill up dyld_chained_starts_in_image, which is `seg_count` (u32) followed by
+    //    `seg_info_offset` ([u32; seg_count]); only __DATA_CONST,__got segment is covered
     starts_in_image[0].set(LE, DEFAULT_SEGMENT_COUNT as u32);
     starts_in_image[1..].fill(U32::new(LE, 0));
+
+    // 3) fill up DyldChainedStartsInSegment for the __got section
+    let data_const_segment = get_segment_sections(layout, SegmentType::DataConstSections)
+        .ok_or_else(|| error!("__DATA_CONST segment expected"))?
+        .segment_size;
+
+    starts_in_segment
+        .size
+        .set(size_of::<DyldChainedStartsInSegment>() as u32);
+    starts_in_segment
+        .page_size
+        .set(MACHO_PAGE_ALIGNMENT.value() as u16);
+    starts_in_segment
+        .pointer_format
+        .set(DYLD_CHAINED_PTR_64_OFFSET);
+    starts_in_segment
+        .segment_offset
+        .set(data_const_segment.mem_offset);
+    starts_in_segment.max_valid_pointer.set(0);
+    // TODO
+    starts_in_segment.page_count.set(1);
+
+    // 4) fill up all imported symbols chunked by the pages
+    // TODO
 
     Ok(())
 }

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -485,6 +485,7 @@ fn apply_relocation<'data, A: Arch<Platform = MachO>>(
     let rel_info = A::relocation_from_raw(rel)?;
     let _addend = rel.r_address;
     let (resolution, _symbol_index, local_symbol_id) = get_resolution(rel, object_layout, layout)?;
+    let flags = layout.flags_for_symbol(local_symbol_id);
 
     let mask = get_page_mask(rel_info.mask);
     let value = match rel_info.kind {
@@ -498,6 +499,7 @@ fn apply_relocation<'data, A: Arch<Platform = MachO>>(
     };
 
     tracing::trace!(
+            %flags,
             ?rel_info.kind,
             %rel_info.size,
             value,

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -522,6 +522,11 @@ fn apply_relocation<'data, A: Arch<Platform = MachO>>(
             .raw_value
             .bitand(mask.symbol_plus_addend)
             .wrapping_sub(place.bitand(mask.place)),
+        RelocationKind::GotRelative => resolution
+            .raw_value
+            .bitand(mask.symbol_plus_addend)
+            .wrapping_sub(place.bitand(mask.place)),
+        RelocationKind::Got => resolution.raw_value.bitand(mask.symbol_plus_addend),
         _ => todo!(),
     };
 

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -246,9 +246,9 @@ fn write_got_entries(layout: &MachOLayout<'_>, got: &mut [u8]) -> Result {
     let got_layout = layout.section_layouts.get(output_section_id::GOT);
 
     for imported_symbol in &layout.imported_symbols {
-        let Some(resolution) = layout.local_symbol_resolution(imported_symbol.symbol_id) else {
-            continue;
-        };
+        let resolution = layout
+            .local_symbol_resolution(imported_symbol.symbol_id)
+            .with_context(|| "missing resolution for a stub library symbol".to_string())?;
         let Some(got_address) = resolution.format_specific.got_address else {
             continue;
         };
@@ -256,11 +256,11 @@ fn write_got_entries(layout: &MachOLayout<'_>, got: &mut [u8]) -> Result {
         let offset = got_address
             .get()
             .checked_sub(got_layout.mem_offset)
-            .ok_or_else(|| error!("Mach-O GOT entry address is before __got"))?
+            .ok_or_else(|| error!("GOT entry address is before __got"))?
             as usize;
         let end = offset + GOT_ENTRY_SIZE as usize;
-        ensure!(end <= got.len(), "Mach-O GOT entry is outside __got");
 
+        // TODO: add const
         got[offset..end].copy_from_slice(&(1u64 << 63).to_le_bytes());
     }
 
@@ -274,25 +274,26 @@ fn write_plt_entries<A: Arch<Platform = MachO>>(
     let plt_layout = layout.section_layouts.get(output_section_id::PLT_GOT);
 
     for imported_symbol in &layout.imported_symbols {
-        let Some(resolution) = layout.local_symbol_resolution(imported_symbol.symbol_id) else {
-            continue;
-        };
-        let Some(plt_address) = resolution.format_specific.plt_address else {
-            continue;
-        };
-        let Some(got_address) = resolution.format_specific.got_address else {
-            continue;
-        };
+        let resolution = layout
+            .local_symbol_resolution(imported_symbol.symbol_id)
+            .ok_or(error!("missing resolution for a stub library symbol"))?;
+        let stub_address = resolution
+            .format_specific
+            .plt_address
+            .ok_or(error!("missing __stub address"))?;
+        let got_address = resolution
+            .format_specific
+            .got_address
+            .ok_or(error!("missing GOT entry"))?;
 
-        let offset = plt_address
+        let offset = stub_address
             .get()
             .checked_sub(plt_layout.mem_offset)
-            .ok_or_else(|| error!("Mach-O PLT entry address is before __stubs"))?
+            .ok_or_else(|| error!("STUB entry address is before __stubs"))?
             as usize;
         let end = offset + PLT_ENTRY_SIZE as usize;
-        ensure!(end <= plt.len(), "Mach-O PLT entry is outside __stubs");
 
-        A::write_plt_entry(&mut plt[offset..end], got_address.get(), plt_address.get())?;
+        A::write_plt_entry(&mut plt[offset..end], got_address.get(), stub_address.get())?;
     }
 
     Ok(())

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -224,33 +224,24 @@ fn write_epilogue<A: Arch<Platform = MachO>>(
             .symbol_db
             .stub_library_install_name_for_symbol(imported_symbol.symbol_id)
             .unwrap_or("<unknown Mach-O stub library>");
-        eprintln!(
-            "Mach-O imported symbol: {} from stub library {}",
-            String::from_utf8_lossy(imported_symbol.name),
-            stub_library_name,
-        );
+        if let Some(resolution) = layout.local_symbol_resolution(imported_symbol.symbol_id) {
+            eprintln!(
+                "Mach-O imported symbol: {} from stub library {} raw_value {:#x} ({})",
+                String::from_utf8_lossy(imported_symbol.name),
+                stub_library_name,
+                resolution.raw_value,
+                resolution.raw_value,
+            );
+        } else {
+            eprintln!(
+                "Mach-O imported symbol: {} from stub library {} raw_value <none>",
+                String::from_utf8_lossy(imported_symbol.name),
+                stub_library_name,
+            );
+        }
     }
 
-    let chained_fixup_table = buffers.get_mut(part_id::CHAINED_FIXUP_TABLE);
-    dbg!(chained_fixup_table.len());
-    // TODO: remove in the future once we handle a dynamic number of segments
-    chained_fixup_table.fill(0);
-    let starts_len = size_of::<u32>() * (DEFAULT_SEGMENT_COUNT + 1);
-    let min_len = size_of::<ChainedFixupsHeader>() + starts_len;
-    if chained_fixup_table.len() < min_len {
-        bail!(
-            "CHAINED_FIXUP_TABLE allocation too small. Need at least {} bytes, got {}",
-            min_len,
-            chained_fixup_table.len()
-        );
-    }
-    let (chained_fixups_header, rest): (&mut ChainedFixupsHeader, &mut [u8]) =
-        ChainedFixupsHeader::mut_from_prefix(chained_fixup_table)
-            .map_err(|_| error!("Invalid chained fixups header allocation"))?;
-    let (starts_in_image, _) =
-        slice_from_bytes_mut::<U32<Endianness>>(rest, DEFAULT_SEGMENT_COUNT + 1)
-            .map_err(|_| error!("Invalid chained fixups starts allocation"))?;
-    write_chained_fixup_table::<A>(chained_fixups_header, starts_in_image)?;
+    write_chained_fixup_table::<A>(buffers.get_mut(part_id::CHAINED_FIXUP_TABLE))?;
 
     Ok(())
 }
@@ -723,11 +714,28 @@ fn write_code_signature_command<A: Arch<Platform = MachO>>(
     command.datasize.set(LE, code_signature.file_size as u32);
 }
 
-fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
-    header: &mut ChainedFixupsHeader,
-    starts_in_image: &mut [U32<Endianness>],
-) -> Result {
+fn write_chained_fixup_table<A: Arch<Platform = MachO>>(chained_fixup_table: &mut [u8]) -> Result {
+    dbg!(chained_fixup_table.len());
     let starts_len = size_of::<u32>() * (DEFAULT_SEGMENT_COUNT + 1);
+    let min_len = size_of::<ChainedFixupsHeader>() + starts_len;
+    if chained_fixup_table.len() < min_len {
+        bail!(
+            "CHAINED_FIXUP_TABLE allocation too small. Need at least {} bytes, got {}",
+            min_len,
+            chained_fixup_table.len()
+        );
+    }
+
+    // TODO: remove in the future once we handle a dynamic number of segments
+    chained_fixup_table.fill(0);
+
+    let (header, rest): (&mut ChainedFixupsHeader, &mut [u8]) =
+        ChainedFixupsHeader::mut_from_prefix(chained_fixup_table)
+            .map_err(|_| error!("Invalid chained fixups header allocation"))?;
+    let (starts_in_image, _) =
+        slice_from_bytes_mut::<U32<Endianness>>(rest, DEFAULT_SEGMENT_COUNT + 1)
+            .map_err(|_| error!("Invalid chained fixups starts allocation"))?;
+
     if starts_in_image.len() != DEFAULT_SEGMENT_COUNT + 1 {
         bail!(
             "Invalid chained fixups starts allocation. Expected {} entries, got {}",

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -817,7 +817,7 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
         .set(DYLD_CHAINED_PTR_64_OFFSET);
     starts_in_segment
         .segment_offset
-        .set(data_const_segment.mem_offset);
+        .set(data_const_segment.file_offset as u64);
     starts_in_segment.max_valid_pointer.set(0);
     // TODO
     starts_in_segment.page_count.set(1);

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -933,8 +933,11 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
     // lib_ordinal: 8
     // weak_import: 1
     // name_offset: 23
-    for i in 0..sorted_symbols.len() {
-        imports[i].set(Endianness::Little, 1 + (symbol_offsets[i] << 9) as u32);
+    for (i, imported_symbol) in sorted_symbols.iter().enumerate() {
+        imports[i].set(
+            Endianness::Little,
+            u32::from(imported_symbol.symbol.library_index) | ((symbol_offsets[i] as u32) << 9),
+        );
     }
 
     // Pad a couple of bytes (related to the MAX_SEGMENT_COUNT).

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -246,7 +246,21 @@ fn write_epilogue<A: Arch<Platform = MachO>>(
 fn write_got_entries(layout: &MachOLayout<'_>, got: &mut [u8]) -> Result {
     let got_layout = layout.section_layouts.get(output_section_id::GOT);
 
-    for imported_symbol in &layout.imported_symbols {
+    // TODO
+    let sorted_symbols = layout
+        .imported_symbols
+        .iter()
+        .map(|sym| {
+            (
+                sym,
+                layout.local_symbol_resolution(sym.symbol_id).expect("TODO"),
+            )
+        })
+        // TODO
+        .sorted_by_key(|(_, res)| res.format_specific.got_address.unwrap())
+        .map(|(sym, _)| sym)
+        .collect_vec();
+    for (i, imported_symbol) in sorted_symbols.iter().enumerate() {
         let resolution = layout
             .local_symbol_resolution(imported_symbol.symbol_id)
             .with_context(|| "missing resolution for a stub library symbol".to_string())?;
@@ -262,7 +276,8 @@ fn write_got_entries(layout: &MachOLayout<'_>, got: &mut [u8]) -> Result {
         let end = offset + GOT_ENTRY_SIZE as usize;
 
         // TODO: add const
-        got[offset..end].copy_from_slice(&(1u64 << 63).to_le_bytes());
+        let next = if i == sorted_symbols.len() - 1 { 0 } else { 2 };
+        got[offset..end].copy_from_slice(&((1u64 << 63) | (next << 52) | (i as u64)).to_le_bytes());
     }
 
     Ok(())
@@ -278,10 +293,9 @@ fn write_plt_entries<A: Arch<Platform = MachO>>(
         let resolution = layout
             .local_symbol_resolution(imported_symbol.symbol_id)
             .ok_or(error!("missing resolution for a stub library symbol"))?;
-        let stub_address = resolution
-            .format_specific
-            .plt_address
-            .ok_or(error!("missing __stub address"))?;
+        let Some(stub_address) = resolution.format_specific.plt_address else {
+            continue;
+        };
         let got_address = resolution
             .format_specific
             .got_address
@@ -883,11 +897,16 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
         .map(|sym| {
             (
                 sym,
-                layout.local_symbol_resolution(sym.symbol_id).expect("TODO"),
+                layout
+                    .local_symbol_resolution(sym.symbol_id)
+                    .expect("TODO")
+                    .format_specific
+                    .got_address
+                    .unwrap(),
             )
         })
         // TODO
-        .sorted_by_key(|(_, res)| res.raw_value)
+        .sorted_by_key(|(_, got_address)| *got_address)
         .collect_vec();
     let mut symbol_offsets = Vec::with_capacity(sorted_symbols.len());
     let mut str_offset = 0;

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -44,6 +44,7 @@ use crate::macho::FileHeader;
 use crate::macho::MACHO_COMMAND_ALIGNMENT;
 use crate::macho::MACHO_START_MEM_ADDRESS;
 use crate::macho::MachO;
+use crate::macho::SEG_DATA_CONST;
 use crate::macho::SectionEntry;
 use crate::macho::SegmentCommand;
 use crate::macho::SegmentSectionsInfo;
@@ -336,6 +337,32 @@ fn write_segment_commands<A: Arch<Platform = MachO>>(
             data_segment_sections.len(),
         );
         write_sections(SEG_DATA, data_sections, &data_segment_sections)?;
+    }
+
+    if let Some(data_const_segment_info) =
+        get_segment_sections(layout, SegmentType::DataConstSections)
+    {
+        let data_const_segment_sections = data_const_segment_info.segment_sections;
+        let data_const_segment_size = data_const_segment_info.segment_size;
+        let (data_const_segment, data_const_sections) = split_segment_command_buffer(
+            buffers.get_mut(part_id::DATA_CONST_SEGMENT),
+            data_const_segment_sections.len(),
+        )?;
+        write_segment(
+            SEG_DATA_CONST,
+            macho::VM_PROT_READ,
+            data_const_segment,
+            data_const_segment_size.file_offset as u64,
+            data_const_segment_size.file_size as u64,
+            data_const_segment_size.mem_offset,
+            data_const_segment_size.mem_size,
+            data_const_segment_sections.len(),
+        );
+        write_sections(
+            SEG_DATA_CONST,
+            data_const_sections,
+            &data_const_segment_sections,
+        )?;
     }
 
     let linkedit_segment_size = get_segment_sections(layout, SegmentType::LinkeditSections)

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -293,9 +293,20 @@ fn write_got_entries(layout: &MachOLayout<'_>, got: &mut [u8]) -> Result {
             as usize;
         let end = offset + GOT_ENTRY_SIZE as usize;
 
-        // TODO: add const
+        /* DYLD_CHAINED_PTR_64 format:
+        struct dyld_chained_ptr_64_bind
+        {
+            uint64_t    ordinal   : 24,
+                        addend    :  8,   // 0 thru 255
+                        reserved  : 19,   // all zeros
+                        next      : 12,   // 4-byte stride
+                        bind      :  1;   // == 1
+        }; */
+        let bind = 1u64 << 63;
         let next = if i == sorted_symbols.len() - 1 { 0 } else { 2 };
-        got[offset..end].copy_from_slice(&((1u64 << 63) | (next << 51) | (i as u64)).to_le_bytes());
+        let next = next << 51;
+        let ordinal = i as u64;
+        got[offset..end].copy_from_slice(&(bind | next | ordinal).to_le_bytes());
     }
 
     Ok(())

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -8,6 +8,7 @@ use crate::file_writer::SizedOutput;
 use crate::file_writer::split_buffers_by_alignment;
 use crate::file_writer::split_output_by_group;
 use crate::file_writer::split_output_into_sections;
+use crate::layout::EpilogueLayout;
 use crate::layout::FileLayout;
 use crate::layout::HeaderInfo;
 use crate::layout::Layout;
@@ -158,6 +159,7 @@ fn write_file<'data, A: Arch<Platform = MachO>>(
             write_object::<A>(s, buffers, layout, symbol_writer)?;
         }
         FileLayout::Prelude(s) => write_prelude::<A>(s, buffers, layout)?,
+        FileLayout::Epilogue(s) => write_epilogue::<A>(s, buffers)?,
         _ => {
             // TODO
         }
@@ -206,7 +208,18 @@ fn write_prelude<'data, A: Arch<Platform = MachO>>(
             .0;
     write_code_signature_command::<A>(layout, code_signature_command);
 
+    // Fill up one extra character as n_strx == 0 is treated as unnamed.
+    buffers.get_mut(part_id::STRTAB).fill(0);
+
+    Ok(())
+}
+
+fn write_epilogue<A: Arch<Platform = MachO>>(
+    _epilogue: &EpilogueLayout<MachO>,
+    buffers: &mut OutputSectionPartMap<&mut [u8]>,
+) -> Result {
     let chained_fixup_table = buffers.get_mut(part_id::CHAINED_FIXUP_TABLE);
+    dbg!(chained_fixup_table.len());
     // TODO: remove in the future once we handle a dynamic number of segments
     chained_fixup_table.fill(0);
     let starts_len = size_of::<u32>() * (DEFAULT_SEGMENT_COUNT + 1);
@@ -225,9 +238,6 @@ fn write_prelude<'data, A: Arch<Platform = MachO>>(
         slice_from_bytes_mut::<U32<Endianness>>(rest, DEFAULT_SEGMENT_COUNT + 1)
             .map_err(|_| error!("Invalid chained fixups starts allocation"))?;
     write_chained_fixup_table::<A>(chained_fixups_header, starts_in_image)?;
-
-    // Fill up one extra character as n_strx == 0 is treated as unnamed.
-    buffers.get_mut(part_id::STRTAB).fill(0);
 
     Ok(())
 }

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -248,15 +248,16 @@ fn write_epilogue<A: Arch<Platform = MachO>>(
 
 #[derive(derive_more::Debug, Clone, Copy)]
 struct ImportedSymbolWithResolution<'data> {
-    symbol: ImportedSymbol<'data>,
+    symbol: &'data ImportedSymbol<'data>,
     got_address: NonZeroU64,
     plt_address: Option<NonZeroU64>,
 }
 
 fn get_imported_sorted_by_got<'data>(
-    layout: &MachOLayout<'data>,
+    layout: &'data MachOLayout<'_>,
 ) -> Result<Vec<ImportedSymbolWithResolution<'data>>> {
     let mut imported = layout
+        .properties_and_attributes
         .imported_symbols
         .iter()
         .map(|symbol| {
@@ -269,7 +270,7 @@ fn get_imported_sorted_by_got<'data>(
                 .ok_or_else(|| error!("missing GOT entry for a stub library symbol"))?;
 
             Ok(ImportedSymbolWithResolution {
-                symbol: *symbol,
+                symbol,
                 got_address,
                 plt_address: resolution.format_specific.plt_address,
             })
@@ -848,7 +849,7 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
     layout: &MachOLayout,
     chained_fixup_table: &mut [u8],
 ) -> Result {
-    let symbols = &layout.imported_symbols;
+    let symbols = &layout.properties_and_attributes.imported_symbols;
     let _imported_symbols_strings_len: usize = symbols.iter().map(|sym| sym.name.len() + 1).sum();
 
     let active_segments = PROGRAM_SEGMENT_DEFS

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -864,23 +864,41 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
         .segment_offset
         .set(data_const_segment.file_offset as u64);
     starts_in_segment.max_valid_pointer.set(0);
-    // TODO
+    // TODO:
     starts_in_segment.page_count.set(1);
     page_starts[0].set(LE, 0);
 
     // 4) fill up all imported symbols chunked by the pages
-    // TODO
-    let symbol = symbols.iter().exactly_one().unwrap();
+    // TODO: support more pages
+    assert!(symbols.len() < MACHO_PAGE_ALIGNMENT.value() as usize / size_of::<u32>());
+
+    let sorted_symbols = symbols
+        .iter()
+        .map(|sym| {
+            (
+                sym,
+                layout.local_symbol_resolution(sym.symbol_id).expect("TODO"),
+            )
+        })
+        // TODO
+        .sorted_by_key(|(_, res)| res.raw_value)
+        .collect_vec();
+    let mut symbol_offsets = Vec::with_capacity(sorted_symbols.len());
+    let mut str_offset = 0;
+    for (symbol, _) in &sorted_symbols {
+        string_pool[str_offset..str_offset + symbol.name.len()].copy_from_slice(symbol.name);
+        string_pool[str_offset + symbol.name.len()] = b'\0';
+        symbol_offsets.push(str_offset);
+        str_offset += symbol.name.len() + 1;
+    }
 
     // Emit `dyld_chained_import` that is built by 3 pieces:
     // lib_ordinal: 8
     // weak_import: 1
     // name_offset: 23
-    imports[0].set(Endianness::Little, 1);
-
-    // 5) fill up string pool for the symbol names
-    string_pool[..symbol.name.len()].copy_from_slice(symbol.name);
-    string_pool[symbol.name.len()] = b'\0';
+    for i in 0..sorted_symbols.len() {
+        imports[i].set(Endianness::Little, 1 + (symbol_offsets[i] << 9) as u32);
+    }
 
     Ok(())
 }

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -52,6 +52,7 @@ use crate::macho::MACHO_COMMAND_ALIGNMENT;
 use crate::macho::MACHO_START_MEM_ADDRESS;
 use crate::macho::MachO;
 use crate::macho::PLT_ENTRY_SIZE;
+use crate::macho::PROGRAM_SEGMENT_DEFS;
 use crate::macho::SEG_DATA_CONST;
 use crate::macho::SectionEntry;
 use crate::macho::SegmentCommand;
@@ -845,8 +846,13 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
     //    `seg_info_offset` ([u32; seg_count]); only __DATA_CONST,__got segment is covered
     starts_in_image[0].set(LE, DEFAULT_SEGMENT_COUNT as u32);
     starts_in_image[1..].fill(U32::new(LE, 0));
-    // TODO: find the index of the segment properly
-    starts_in_image[4].set(LE, starts_in_image_len as u32);
+
+    let data_const_segment_index = PROGRAM_SEGMENT_DEFS
+        .iter()
+        .filter(|segment| get_segment_sections(layout, segment.segment_type).is_some())
+        .position(|segment_type| segment_type.segment_type == SegmentType::DataConstSections)
+        .ok_or_else(|| error!("__DATA_CONST segment expected"))?;
+    starts_in_image[data_const_segment_index].set(LE, starts_in_image_len as u32);
 
     // 3) fill up DyldChainedStartsInSegment for the __got section
     let data_const_segment = get_segment_sections(layout, SegmentType::DataConstSections)

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -294,14 +294,13 @@ fn write_got_entries(layout: &MachOLayout<'_>, got: &mut [u8]) -> Result {
         let end = offset + GOT_ENTRY_SIZE as usize;
 
         /* DYLD_CHAINED_PTR_64 format:
-        struct dyld_chained_ptr_64_bind
-        {
-            uint64_t    ordinal   : 24,
-                        addend    :  8,   // 0 thru 255
-                        reserved  : 19,   // all zeros
-                        next      : 12,   // 4-byte stride
-                        bind      :  1;   // == 1
-        }; */
+        uint64_t dyld_chained_ptr_64_bind:
+          ordinal: 24
+          addend: 8 // 0 thru 255
+          reserved: 19 // all zeros
+          next: 12 // 4-byte stride
+          bind: 1 // == 1
+        */
         let bind = 1u64 << 63;
         let next = if i == sorted_symbols.len() - 1 { 0 } else { 2 };
         let next = next << 51;

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -77,6 +77,7 @@ use linker_utils::elf::RelocationKind;
 use object::BigEndian;
 use object::Endianness;
 use object::SymbolIndex;
+use object::U16;
 use object::U32;
 use object::from_bytes_mut;
 use object::macho;
@@ -222,28 +223,6 @@ fn write_epilogue<A: Arch<Platform = MachO>>(
     buffers: &mut OutputSectionPartMap<&mut [u8]>,
     layout: &MachOLayout<'_>,
 ) -> Result {
-    for imported_symbol in &layout.imported_symbols {
-        let stub_library_name = layout
-            .symbol_db
-            .stub_library_install_name_for_symbol(imported_symbol.symbol_id)
-            .unwrap_or("<unknown Mach-O stub library>");
-        if let Some(resolution) = layout.local_symbol_resolution(imported_symbol.symbol_id) {
-            eprintln!(
-                "Mach-O imported symbol: {} from stub library {} raw_value {:#x} ({})",
-                String::from_utf8_lossy(imported_symbol.name),
-                stub_library_name,
-                resolution.raw_value,
-                resolution.raw_value,
-            );
-        } else {
-            eprintln!(
-                "Mach-O imported symbol: {} from stub library {} raw_value <none>",
-                String::from_utf8_lossy(imported_symbol.name),
-                stub_library_name,
-            );
-        }
-    }
-
     write_chained_fixup_table::<A>(layout, buffers.get_mut(part_id::CHAINED_FIXUP_TABLE))?;
 
     Ok(())
@@ -721,9 +700,41 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
     layout: &MachOLayout,
     chained_fixup_table: &mut [u8],
 ) -> Result {
+    // TODO: remove
+    for imported_symbol in &layout.imported_symbols {
+        let stub_library_name = layout
+            .symbol_db
+            .stub_library_install_name_for_symbol(imported_symbol.symbol_id)
+            .unwrap_or("<unknown Mach-O stub library>");
+        if let Some(resolution) = layout.local_symbol_resolution(imported_symbol.symbol_id) {
+            eprintln!(
+                "Mach-O imported symbol: {} from stub library {} raw_value {:#x} ({})",
+                String::from_utf8_lossy(imported_symbol.name),
+                stub_library_name,
+                resolution.raw_value,
+                resolution.raw_value,
+            );
+        } else {
+            eprintln!(
+                "Mach-O imported symbol: {} from stub library {} raw_value <none>",
+                String::from_utf8_lossy(imported_symbol.name),
+                stub_library_name,
+            );
+        }
+    }
+
+    let symbols = &layout.imported_symbols;
+    let _imported_symbols_strings_len: usize = symbols.iter().map(|sym| sym.name.len() + 1).sum();
     dbg!(chained_fixup_table.len());
+
     // TODO: DEFAULT_SEGMENT_COUNT should be dynamically allocated
-    let starts_len = size_of::<u32>() * (DEFAULT_SEGMENT_COUNT + 1);
+    let starts_in_image_len = size_of::<u32>() * (DEFAULT_SEGMENT_COUNT + 1);
+    let starts_in_segment_len = size_of::<DyldChainedStartsInSegment>() + size_of::<u16>();
+    let imports_len = size_of::<u32>() * symbols.len();
+
+    let starts_offset = size_of::<ChainedFixupsHeader>();
+    let imports_offset = starts_offset + starts_in_image_len + starts_in_segment_len;
+    let symbols_offset = imports_offset + imports_len;
 
     let (header, rest) = ChainedFixupsHeader::mut_from_prefix(chained_fixup_table)
         .map_err(|_| error!("Invalid chained fixups header allocation"))?;
@@ -732,19 +743,17 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
             .map_err(|_| error!("Invalid chained fixups starts allocation"))?;
     let (starts_in_segment, rest) = DyldChainedStartsInSegment::mut_from_prefix(rest)
         .map_err(|_| error!("Invalid chained fixups starts in segment allocation"))?;
+    let (page_starts, rest) = slice_from_bytes_mut::<U16<Endianness>>(rest, 1)
+        .map_err(|_| error!("Invalid chained fixups page starts allocation"))?;
+    let (imports, string_pool) = slice_from_bytes_mut::<U32<Endianness>>(rest, symbols.len())
+        .map_err(|_| error!("Invalid chained fixups imports allocation"))?;
 
     // 1) fill up ChainedFixupsHeader
     header.fixups_version.set(0);
-    header
-        .starts_offset
-        .set(size_of::<ChainedFixupsHeader>() as u32);
-    header
-        .imports_offset
-        .set((size_of::<ChainedFixupsHeader>() + starts_len) as u32);
-    header
-        .symbols_offset
-        .set((size_of::<ChainedFixupsHeader>() + starts_len) as u32);
-    header.imports_count.set(0);
+    header.starts_offset.set(starts_offset as u32);
+    header.imports_offset.set(imports_offset as u32);
+    header.symbols_offset.set(symbols_offset as u32);
+    header.imports_count.set(symbols.len() as u32);
     header.imports_format.set(DYLD_CHAINED_IMPORT);
     header.symbols_format.set(0);
 
@@ -752,15 +761,15 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
     //    `seg_info_offset` ([u32; seg_count]); only __DATA_CONST,__got segment is covered
     starts_in_image[0].set(LE, DEFAULT_SEGMENT_COUNT as u32);
     starts_in_image[1..].fill(U32::new(LE, 0));
+    // TODO: find the index of the segment properly
+    starts_in_image[4].set(LE, starts_in_image_len as u32);
 
     // 3) fill up DyldChainedStartsInSegment for the __got section
     let data_const_segment = get_segment_sections(layout, SegmentType::DataConstSections)
         .ok_or_else(|| error!("__DATA_CONST segment expected"))?
         .segment_size;
 
-    starts_in_segment
-        .size
-        .set(size_of::<DyldChainedStartsInSegment>() as u32);
+    starts_in_segment.size.set(starts_in_segment_len as u32);
     starts_in_segment
         .page_size
         .set(MACHO_PAGE_ALIGNMENT.value() as u16);
@@ -773,9 +782,21 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
     starts_in_segment.max_valid_pointer.set(0);
     // TODO
     starts_in_segment.page_count.set(1);
+    page_starts[0].set(LE, 0);
 
     // 4) fill up all imported symbols chunked by the pages
     // TODO
+    let symbol = symbols.iter().exactly_one().unwrap();
+
+    // Emit `dyld_chained_import` that is built by 3 pieces:
+    // lib_ordinal: 8
+    // weak_import: 1
+    // name_offset: 23
+    imports[0].set(Endianness::Little, 1);
+
+    // 5) fill up string pool for the symbol names
+    string_pool[..symbol.name.len()].copy_from_slice(symbol.name);
+    string_pool[symbol.name.len()] = b'\0';
 
     Ok(())
 }

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -807,29 +807,6 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
     layout: &MachOLayout,
     chained_fixup_table: &mut [u8],
 ) -> Result {
-    // TODO: remove
-    for imported_symbol in &layout.imported_symbols {
-        let stub_library_name = layout
-            .symbol_db
-            .stub_library_install_name_for_symbol(imported_symbol.symbol_id)
-            .unwrap_or("<unknown Mach-O stub library>");
-        if let Some(resolution) = layout.local_symbol_resolution(imported_symbol.symbol_id) {
-            eprintln!(
-                "Mach-O imported symbol: {} from stub library {} raw_value {:#x} ({})",
-                String::from_utf8_lossy(imported_symbol.name),
-                stub_library_name,
-                resolution.raw_value,
-                resolution.raw_value,
-            );
-        } else {
-            eprintln!(
-                "Mach-O imported symbol: {} from stub library {} raw_value <none>",
-                String::from_utf8_lossy(imported_symbol.name),
-                stub_library_name,
-            );
-        }
-    }
-
     let symbols = &layout.imported_symbols;
     let _imported_symbols_strings_len: usize = symbols.iter().map(|sym| sym.name.len() + 1).sum();
 

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -159,7 +159,7 @@ fn write_file<'data, A: Arch<Platform = MachO>>(
             write_object::<A>(s, buffers, layout, symbol_writer)?;
         }
         FileLayout::Prelude(s) => write_prelude::<A>(s, buffers, layout)?,
-        FileLayout::Epilogue(s) => write_epilogue::<A>(s, buffers)?,
+        FileLayout::Epilogue(s) => write_epilogue::<A>(s, buffers, layout)?,
         _ => {
             // TODO
         }
@@ -217,7 +217,20 @@ fn write_prelude<'data, A: Arch<Platform = MachO>>(
 fn write_epilogue<A: Arch<Platform = MachO>>(
     _epilogue: &EpilogueLayout<MachO>,
     buffers: &mut OutputSectionPartMap<&mut [u8]>,
+    layout: &MachOLayout<'_>,
 ) -> Result {
+    for imported_symbol in &layout.imported_symbols {
+        let stub_library_name = layout
+            .symbol_db
+            .stub_library_install_name_for_symbol(imported_symbol.symbol_id)
+            .unwrap_or("<unknown Mach-O stub library>");
+        eprintln!(
+            "Mach-O imported symbol: {} from stub library {}",
+            String::from_utf8_lossy(imported_symbol.name),
+            stub_library_name,
+        );
+    }
+
     let chained_fixup_table = buffers.get_mut(part_id::CHAINED_FIXUP_TABLE);
     dbg!(chained_fixup_table.len());
     // TODO: remove in the future once we handle a dynamic number of segments

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -354,7 +354,7 @@ fn write_segment_commands<A: Arch<Platform = MachO>>(
         )?;
         write_segment(
             SEG_DATA_CONST,
-            macho::VM_PROT_READ,
+            macho::VM_PROT_READ | macho::VM_PROT_WRITE,
             data_const_segment,
             data_const_segment_size.file_offset as u64,
             data_const_segment_size.file_size as u64,

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -302,6 +302,7 @@ fn write_got_entries(layout: &MachOLayout<'_>, got: &mut [u8]) -> Result {
           bind: 1 // == 1
         */
         let bind = 1u64 << 63;
+        // TODO: when crossing a page boundary, next is equal to zero
         let next = if i == sorted_symbols.len() - 1 { 0 } else { 2 };
         let next = next << 51;
         let ordinal = i as u64;

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -12,6 +12,7 @@ use crate::file_writer::split_output_into_sections;
 use crate::layout::EpilogueLayout;
 use crate::layout::FileLayout;
 use crate::layout::HeaderInfo;
+use crate::layout::ImportedSymbol;
 use crate::layout::Layout;
 use crate::layout::ObjectLayout;
 use crate::layout::OutputRecordLayout;
@@ -111,6 +112,7 @@ use rayon::iter::ParallelIterator;
 use rayon::slice::ParallelSlice;
 use sha2::Digest;
 use sha2::Sha256;
+use std::num::NonZeroU64;
 use std::ops::BitAnd;
 use tracing::debug_span;
 use zerocopy::FromBytes;
@@ -244,32 +246,47 @@ fn write_epilogue<A: Arch<Platform = MachO>>(
     Ok(())
 }
 
+#[derive(derive_more::Debug, Clone, Copy)]
+struct ImportedSymbolWithResolution<'data> {
+    symbol: ImportedSymbol<'data>,
+    got_address: NonZeroU64,
+    plt_address: Option<NonZeroU64>,
+}
+
+fn get_imported_sorted_by_got<'data>(
+    layout: &MachOLayout<'data>,
+) -> Result<Vec<ImportedSymbolWithResolution<'data>>> {
+    let mut imported = layout
+        .imported_symbols
+        .iter()
+        .map(|symbol| {
+            let resolution = layout
+                .local_symbol_resolution(symbol.symbol_id)
+                .with_context(|| "missing resolution for a stub library symbol".to_string())?;
+            let got_address = resolution
+                .format_specific
+                .got_address
+                .ok_or_else(|| error!("missing GOT entry for a stub library symbol"))?;
+
+            Ok(ImportedSymbolWithResolution {
+                symbol: *symbol,
+                got_address,
+                plt_address: resolution.format_specific.plt_address,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    imported.sort_by_key(|symbol| symbol.got_address);
+    Ok(imported)
+}
+
 fn write_got_entries(layout: &MachOLayout<'_>, got: &mut [u8]) -> Result {
     let got_layout = layout.section_layouts.get(output_section_id::GOT);
 
-    // TODO
-    let sorted_symbols = layout
-        .imported_symbols
-        .iter()
-        .map(|sym| {
-            (
-                sym,
-                layout.local_symbol_resolution(sym.symbol_id).expect("TODO"),
-            )
-        })
-        // TODO
-        .sorted_by_key(|(_, res)| res.format_specific.got_address.unwrap())
-        .map(|(sym, _)| sym)
-        .collect_vec();
+    let sorted_symbols = get_imported_sorted_by_got(layout)?;
     for (i, imported_symbol) in sorted_symbols.iter().enumerate() {
-        let resolution = layout
-            .local_symbol_resolution(imported_symbol.symbol_id)
-            .with_context(|| "missing resolution for a stub library symbol".to_string())?;
-        let Some(got_address) = resolution.format_specific.got_address else {
-            continue;
-        };
-
-        let offset = got_address
+        let offset = imported_symbol
+            .got_address
             .get()
             .checked_sub(got_layout.mem_offset)
             .ok_or_else(|| error!("GOT entry address is before __got"))?
@@ -290,17 +307,10 @@ fn write_plt_entries<A: Arch<Platform = MachO>>(
 ) -> Result {
     let plt_layout = layout.section_layouts.get(output_section_id::PLT_GOT);
 
-    for imported_symbol in &layout.imported_symbols {
-        let resolution = layout
-            .local_symbol_resolution(imported_symbol.symbol_id)
-            .ok_or(error!("missing resolution for a stub library symbol"))?;
-        let Some(stub_address) = resolution.format_specific.plt_address else {
+    for imported_symbol in get_imported_sorted_by_got(layout)? {
+        let Some(stub_address) = imported_symbol.plt_address else {
             continue;
         };
-        let got_address = resolution
-            .format_specific
-            .got_address
-            .ok_or(error!("missing GOT entry"))?;
 
         let offset = stub_address
             .get()
@@ -309,7 +319,11 @@ fn write_plt_entries<A: Arch<Platform = MachO>>(
             as usize;
         let end = offset + PLT_ENTRY_SIZE as usize;
 
-        A::write_plt_entry(&mut plt[offset..end], got_address.get(), stub_address.get())?;
+        A::write_plt_entry(
+            &mut plt[offset..end],
+            imported_symbol.got_address.get(),
+            stub_address.get(),
+        )?;
     }
 
     Ok(())
@@ -904,25 +918,11 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
     // TODO: support more pages
     assert!(symbols.len() < MACHO_PAGE_ALIGNMENT.value() as usize / size_of::<u32>());
 
-    let sorted_symbols = symbols
-        .iter()
-        .map(|sym| {
-            (
-                sym,
-                layout
-                    .local_symbol_resolution(sym.symbol_id)
-                    .expect("TODO")
-                    .format_specific
-                    .got_address
-                    .unwrap(),
-            )
-        })
-        // TODO
-        .sorted_by_key(|(_, got_address)| *got_address)
-        .collect_vec();
+    let sorted_symbols = get_imported_sorted_by_got(layout)?;
     let mut symbol_offsets = Vec::with_capacity(sorted_symbols.len());
     let mut str_offset = 0;
-    for (symbol, _) in &sorted_symbols {
+    for imported_symbol in &sorted_symbols {
+        let symbol = imported_symbol.symbol;
         string_pool[str_offset..str_offset + symbol.name.len()].copy_from_slice(symbol.name);
         string_pool[str_offset + symbol.name.len()] = b'\0';
         symbol_offsets.push(str_offset);

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -42,9 +42,11 @@ use crate::macho::DYLD_CHAINED_PTR_64_OFFSET;
 use crate::macho::DYLINKER_PATH;
 use crate::macho::DyldChainedFixupsCommand;
 use crate::macho::DyldChainedStartsInSegment;
+use crate::macho::DylibCommand;
 use crate::macho::DylinkerCommand;
 use crate::macho::EntryPointCommand;
 use crate::macho::FileHeader;
+use crate::macho::LIBSYSTEM_PATH;
 use crate::macho::MACHO_COMMAND_ALIGNMENT;
 use crate::macho::MACHO_START_MEM_ADDRESS;
 use crate::macho::MachO;
@@ -85,6 +87,7 @@ use object::macho::CPU_SUBTYPE_ARM64_ALL;
 use object::macho::CPU_TYPE_ARM64;
 use object::macho::LC_CODE_SIGNATURE;
 use object::macho::LC_DYLD_CHAINED_FIXUPS;
+use object::macho::LC_LOAD_DYLIB;
 use object::macho::LC_LOAD_DYLINKER;
 use object::macho::LC_MAIN;
 use object::macho::LC_SEGMENT_64;
@@ -195,6 +198,11 @@ fn write_prelude<'data, A: Arch<Platform = MachO>>(
         from_bytes_mut(buffers.get_mut(part_id::INTERP))
             .map_err(|_| error!("Invalid INTERP command allocation"))?;
     write_dylinker_command::<A>(dylinker_command, dylinker_path_buffer);
+
+    let (dylib_command, dylib_path_buffer): (&mut DylibCommand, &mut [u8]) =
+        from_bytes_mut(buffers.get_mut(part_id::LOAD_DYLIB))
+            .map_err(|_| error!("Invalid LOAD_DYLIB command allocation"))?;
+    write_dylib_command::<A>(dylib_command, dylib_path_buffer);
 
     let chained_fixups_command: &mut DyldChainedFixupsCommand =
         from_bytes_mut(buffers.get_mut(part_id::DYLD_CHAINED_FIXUPS))
@@ -641,6 +649,37 @@ fn write_dylinker_command<A: Arch<Platform = MachO>>(
 
     path_buffer[0..DYLINKER_PATH.len()].copy_from_slice(DYLINKER_PATH);
     path_buffer[DYLINKER_PATH.len()..].zero();
+}
+
+fn write_dylib_command<A: Arch<Platform = MachO>>(
+    command: &mut DylibCommand,
+    path_buffer: &mut [u8],
+) {
+    command.cmd.set(LE, LC_LOAD_DYLIB);
+    command.cmdsize.set(
+        LE,
+        ((size_of::<DylibCommand>() + LIBSYSTEM_PATH.len())
+            .next_multiple_of(MACHO_COMMAND_ALIGNMENT)) as u32,
+    );
+    command
+        .dylib
+        .name
+        .offset
+        .set(LE, size_of::<DylibCommand>() as u32);
+    // TODO
+    command.dylib.timestamp.set(LE, 2);
+    // TODO
+    command
+        .dylib
+        .current_version
+        .set(LE, macho::Version(1356 << 16));
+    command
+        .dylib
+        .compatibility_version
+        .set(LE, macho::Version(1 << 16));
+
+    path_buffer[0..LIBSYSTEM_PATH.len()].copy_from_slice(LIBSYSTEM_PATH);
+    path_buffer[LIBSYSTEM_PATH.len()..].zero();
 }
 
 fn write_dyld_chained_fixups_command<A: Arch<Platform = MachO>>(

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -277,7 +277,7 @@ fn write_got_entries(layout: &MachOLayout<'_>, got: &mut [u8]) -> Result {
 
         // TODO: add const
         let next = if i == sorted_symbols.len() - 1 { 0 } else { 2 };
-        got[offset..end].copy_from_slice(&((1u64 << 63) | (next << 52) | (i as u64)).to_le_bytes());
+        got[offset..end].copy_from_slice(&((1u64 << 63) | (next << 51) | (i as u64)).to_le_bytes());
     }
 
     Ok(())

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -51,6 +51,7 @@ use crate::macho::LIBSYSTEM_PATH;
 use crate::macho::MACHO_COMMAND_ALIGNMENT;
 use crate::macho::MACHO_START_MEM_ADDRESS;
 use crate::macho::MachO;
+use crate::macho::PLT_ENTRY_SIZE;
 use crate::macho::SEG_DATA_CONST;
 use crate::macho::SectionEntry;
 use crate::macho::SegmentCommand;
@@ -152,6 +153,7 @@ pub(crate) fn write<'data, A: Arch<Platform = MachO>>(
 
     let mut section_buffers = split_output_into_sections(layout, &mut sized_output.out).0;
     write_got_entries(layout, section_buffers.get_mut(output_section_id::GOT))?;
+    write_plt_entries::<A>(layout, section_buffers.get_mut(output_section_id::PLT_GOT))?;
 
     write_code_signature(layout, sized_output)?;
 
@@ -260,6 +262,37 @@ fn write_got_entries(layout: &MachOLayout<'_>, got: &mut [u8]) -> Result {
         ensure!(end <= got.len(), "Mach-O GOT entry is outside __got");
 
         got[offset..end].copy_from_slice(&(1u64 << 63).to_le_bytes());
+    }
+
+    Ok(())
+}
+
+fn write_plt_entries<A: Arch<Platform = MachO>>(
+    layout: &MachOLayout<'_>,
+    plt: &mut [u8],
+) -> Result {
+    let plt_layout = layout.section_layouts.get(output_section_id::PLT_GOT);
+
+    for imported_symbol in &layout.imported_symbols {
+        let Some(resolution) = layout.local_symbol_resolution(imported_symbol.symbol_id) else {
+            continue;
+        };
+        let Some(plt_address) = resolution.format_specific.plt_address else {
+            continue;
+        };
+        let Some(got_address) = resolution.format_specific.got_address else {
+            continue;
+        };
+
+        let offset = plt_address
+            .get()
+            .checked_sub(plt_layout.mem_offset)
+            .ok_or_else(|| error!("Mach-O PLT entry address is before __stubs"))?
+            as usize;
+        let end = offset + PLT_ENTRY_SIZE as usize;
+        ensure!(end <= plt.len(), "Mach-O PLT entry is outside __stubs");
+
+        A::write_plt_entry(&mut plt[offset..end], got_address.get(), plt_address.get())?;
     }
 
     Ok(())
@@ -467,13 +500,19 @@ fn write_sections(
         section.addr.set(LE, size.mem_offset);
         section.size.set(LE, size.mem_size);
         section.offset.set(LE, size.file_offset as u32);
-        // TODO
-        section.align.set(LE, 0);
+        section.align.set(LE, u32::from(size.alignment.exponent));
         section.reloff.set(LE, 0);
         section.nreloc.set(LE, 0);
         section.flags.set(LE, *section_flags);
         section.reserved1.set(LE, 0);
-        section.reserved2.set(LE, 0);
+        // TODO: find a better place
+        let reserved2 =
+            if section_flags.0 & macho::SECTION_TYPE == u32::from(macho::S_SYMBOL_STUBS.0) {
+                PLT_ENTRY_SIZE as u32
+            } else {
+                0
+            };
+        section.reserved2.set(LE, reserved2);
         section.reserved3.set(LE, 0);
     }
 
@@ -793,7 +832,6 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
 
     let symbols = &layout.imported_symbols;
     let _imported_symbols_strings_len: usize = symbols.iter().map(|sym| sym.name.len() + 1).sum();
-    dbg!(chained_fixup_table.len());
 
     // TODO: DEFAULT_SEGMENT_COUNT should be dynamically allocated
     let starts_in_image_len = size_of::<u32>() * (DEFAULT_SEGMENT_COUNT + 1);

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -12,7 +12,6 @@ use crate::file_writer::split_output_into_sections;
 use crate::layout::EpilogueLayout;
 use crate::layout::FileLayout;
 use crate::layout::HeaderInfo;
-use crate::layout::ImportedSymbol;
 use crate::layout::Layout;
 use crate::layout::ObjectLayout;
 use crate::layout::OutputRecordLayout;
@@ -112,7 +111,6 @@ use rayon::iter::ParallelIterator;
 use rayon::slice::ParallelSlice;
 use sha2::Digest;
 use sha2::Sha256;
-use std::num::NonZeroU64;
 use std::ops::BitAnd;
 use tracing::debug_span;
 use zerocopy::FromBytes;
@@ -246,45 +244,10 @@ fn write_epilogue<A: Arch<Platform = MachO>>(
     Ok(())
 }
 
-#[derive(derive_more::Debug, Clone, Copy)]
-struct ImportedSymbolWithResolution<'data> {
-    symbol: &'data ImportedSymbol<'data>,
-    got_address: NonZeroU64,
-    plt_address: Option<NonZeroU64>,
-}
-
-fn get_imported_sorted_by_got<'data>(
-    layout: &'data MachOLayout<'_>,
-) -> Result<Vec<ImportedSymbolWithResolution<'data>>> {
-    let mut imported = layout
-        .properties_and_attributes
-        .imported_symbols
-        .iter()
-        .map(|symbol| {
-            let resolution = layout
-                .local_symbol_resolution(symbol.symbol_id)
-                .with_context(|| "missing resolution for a stub library symbol".to_string())?;
-            let got_address = resolution
-                .format_specific
-                .got_address
-                .ok_or_else(|| error!("missing GOT entry for a stub library symbol"))?;
-
-            Ok(ImportedSymbolWithResolution {
-                symbol,
-                got_address,
-                plt_address: resolution.format_specific.plt_address,
-            })
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    imported.sort_by_key(|symbol| symbol.got_address);
-    Ok(imported)
-}
-
 fn write_got_entries(layout: &MachOLayout<'_>, got: &mut [u8]) -> Result {
     let got_layout = layout.section_layouts.get(output_section_id::GOT);
 
-    let sorted_symbols = get_imported_sorted_by_got(layout)?;
+    let sorted_symbols = &layout.properties_and_attributes.imported_symbols;
     for (i, imported_symbol) in sorted_symbols.iter().enumerate() {
         let offset = imported_symbol
             .got_address
@@ -319,7 +282,7 @@ fn write_plt_entries<A: Arch<Platform = MachO>>(
 ) -> Result {
     let plt_layout = layout.section_layouts.get(output_section_id::PLT_GOT);
 
-    for imported_symbol in get_imported_sorted_by_got(layout)? {
+    for imported_symbol in &layout.properties_and_attributes.imported_symbols {
         let Some(stub_address) = imported_symbol.plt_address else {
             continue;
         };
@@ -850,7 +813,6 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
     chained_fixup_table: &mut [u8],
 ) -> Result {
     let symbols = &layout.properties_and_attributes.imported_symbols;
-    let _imported_symbols_strings_len: usize = symbols.iter().map(|sym| sym.name.len() + 1).sum();
 
     let active_segments = PROGRAM_SEGMENT_DEFS
         .iter()
@@ -936,11 +898,11 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
     // TODO: support more pages
     assert!(symbols.len() < MACHO_PAGE_ALIGNMENT.value() as usize / size_of::<u32>());
 
-    let sorted_symbols = get_imported_sorted_by_got(layout)?;
+    let sorted_symbols = &layout.properties_and_attributes.imported_symbols;
     let mut symbol_offsets = Vec::with_capacity(sorted_symbols.len());
     let mut str_offset = 0;
-    for imported_symbol in &sorted_symbols {
-        let symbol = imported_symbol.symbol;
+    for imported_symbol in sorted_symbols {
+        let symbol = &imported_symbol.symbol;
         string_pool[str_offset..str_offset + symbol.name.len()].copy_from_slice(symbol.name);
         string_pool[str_offset + symbol.name.len()] = b'\0';
         symbol_offsets.push(str_offset);

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -46,6 +46,7 @@ use crate::macho::DylibCommand;
 use crate::macho::DylinkerCommand;
 use crate::macho::EntryPointCommand;
 use crate::macho::FileHeader;
+use crate::macho::GOT_ENTRY_SIZE;
 use crate::macho::LIBSYSTEM_PATH;
 use crate::macho::MACHO_COMMAND_ALIGNMENT;
 use crate::macho::MACHO_START_MEM_ADDRESS;
@@ -149,6 +150,9 @@ pub(crate) fn write<'data, A: Arch<Platform = MachO>>(
             Ok(())
         })?;
 
+    let mut section_buffers = split_output_into_sections(layout, &mut sized_output.out).0;
+    write_got_entries(layout, section_buffers.get_mut(output_section_id::GOT))?;
+
     write_code_signature(layout, sized_output)?;
 
     Ok(())
@@ -232,6 +236,31 @@ fn write_epilogue<A: Arch<Platform = MachO>>(
     layout: &MachOLayout<'_>,
 ) -> Result {
     write_chained_fixup_table::<A>(layout, buffers.get_mut(part_id::CHAINED_FIXUP_TABLE))?;
+
+    Ok(())
+}
+
+fn write_got_entries(layout: &MachOLayout<'_>, got: &mut [u8]) -> Result {
+    let got_layout = layout.section_layouts.get(output_section_id::GOT);
+
+    for imported_symbol in &layout.imported_symbols {
+        let Some(resolution) = layout.local_symbol_resolution(imported_symbol.symbol_id) else {
+            continue;
+        };
+        let Some(got_address) = resolution.format_specific.got_address else {
+            continue;
+        };
+
+        let offset = got_address
+            .get()
+            .checked_sub(got_layout.mem_offset)
+            .ok_or_else(|| error!("Mach-O GOT entry address is before __got"))?
+            as usize;
+        let end = offset + GOT_ENTRY_SIZE as usize;
+        ensure!(end <= got.len(), "Mach-O GOT entry is outside __got");
+
+        got[offset..end].copy_from_slice(&(1u64 << 63).to_le_bytes());
+    }
 
     Ok(())
 }

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -867,12 +867,6 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
         .map_err(|_| error!("Invalid chained fixups header allocation"))?;
     let (starts_in_image, rest) = slice_from_bytes_mut::<U32<Endianness>>(rest, segment_count + 1)
         .map_err(|_| error!("Invalid chained fixups starts allocation"))?;
-    let (starts_in_segment, rest) = DyldChainedStartsInSegment::mut_from_prefix(rest)
-        .map_err(|_| error!("Invalid chained fixups starts in segment allocation"))?;
-    let (page_starts, rest) = slice_from_bytes_mut::<U16<Endianness>>(rest, 1)
-        .map_err(|_| error!("Invalid chained fixups page starts allocation"))?;
-    let (imports, string_pool) = slice_from_bytes_mut::<U32<Endianness>>(rest, symbols.len())
-        .map_err(|_| error!("Invalid chained fixups imports allocation"))?;
 
     // 1) fill up ChainedFixupsHeader
     header.fixups_version.set(0);
@@ -883,16 +877,29 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
     header.imports_format.set(DYLD_CHAINED_IMPORT);
     header.symbols_format.set(0);
 
+    let data_const_segment_index = active_segments
+        .iter()
+        .position(|segment_type| segment_type.segment_type == SegmentType::DataConstSections);
+
     // 2) fill up dyld_chained_starts_in_image, which is `seg_count` (u32) followed by
     //    `seg_info_offset` ([u32; seg_count]); only __DATA_CONST,__got segment is covered
     starts_in_image[0].set(LE, segment_count as u32);
     starts_in_image[1..].fill(U32::new(LE, 0));
 
-    let data_const_segment_index = active_segments
-        .iter()
-        .position(|segment_type| segment_type.segment_type == SegmentType::DataConstSections)
-        .ok_or_else(|| error!("__DATA_CONST segment expected"))?;
+    // Early exit if we don't have any GOT entry to be encoded.
+    let Some(data_const_segment_index) = data_const_segment_index else {
+        rest.zero();
+        return Ok(());
+    };
+
     starts_in_image[data_const_segment_index + 1].set(LE, starts_in_image_len as u32);
+
+    let (starts_in_segment, rest) = DyldChainedStartsInSegment::mut_from_prefix(rest)
+        .map_err(|_| error!("Invalid chained fixups starts in segment allocation"))?;
+    let (page_starts, rest) = slice_from_bytes_mut::<U16<Endianness>>(rest, 1)
+        .map_err(|_| error!("Invalid chained fixups page starts allocation"))?;
+    let (imports, string_pool) = slice_from_bytes_mut::<U32<Endianness>>(rest, symbols.len())
+        .map_err(|_| error!("Invalid chained fixups imports allocation"))?;
 
     // 3) fill up DyldChainedStartsInSegment for the __got section
     let data_const_segment = get_segment_sections(layout, SegmentType::DataConstSections)

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -106,6 +106,8 @@ pub(crate) const SYMTAB_SHNDX_GLOBAL: OutputSectionId =
 pub(crate) const PAGEZERO_SEGMENT: OutputSectionId = part_id::PAGEZERO_SEGMENT.output_section_id();
 pub(crate) const TEXT_SEGMENT: OutputSectionId = part_id::TEXT_SEGMENT.output_section_id();
 pub(crate) const DATA_SEGMENT: OutputSectionId = part_id::DATA_SEGMENT.output_section_id();
+pub(crate) const DATA_CONST_SEGMENT: OutputSectionId =
+    part_id::DATA_CONST_SEGMENT.output_section_id();
 pub(crate) const LINK_EDIT_SEGMENT: OutputSectionId =
     part_id::LINK_EDIT_SEGMENT.output_section_id();
 pub(crate) const ENTRY_POINT: OutputSectionId = part_id::ENTRY_POINT.output_section_id();

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -113,6 +113,7 @@ pub(crate) const LINK_EDIT_SEGMENT: OutputSectionId =
 pub(crate) const ENTRY_POINT: OutputSectionId = part_id::ENTRY_POINT.output_section_id();
 pub(crate) const DYLD_CHAINED_FIXUPS: OutputSectionId =
     part_id::DYLD_CHAINED_FIXUPS.output_section_id();
+pub(crate) const LOAD_DYLIB: OutputSectionId = part_id::LOAD_DYLIB.output_section_id();
 pub(crate) const CHAINED_FIXUP_TABLE: OutputSectionId =
     part_id::CHAINED_FIXUP_TABLE.output_section_id();
 pub(crate) const SYMTAB_COMMAND: OutputSectionId = part_id::SYMTAB_COMMAND.output_section_id();

--- a/libwild/src/output_section_part_map.rs
+++ b/libwild/src/output_section_part_map.rs
@@ -258,6 +258,7 @@ fn test_merge_parts() {
         output_section_id::PAGEZERO_SEGMENT,
         output_section_id::TEXT_SEGMENT,
         output_section_id::DATA_SEGMENT,
+        output_section_id::DATA_CONST_SEGMENT,
         output_section_id::CSTRING,
         output_section_id::ENTRY_POINT,
         output_section_id::LINK_EDIT_SEGMENT,

--- a/libwild/src/output_section_part_map.rs
+++ b/libwild/src/output_section_part_map.rs
@@ -264,6 +264,7 @@ fn test_merge_parts() {
         output_section_id::LINK_EDIT_SEGMENT,
         output_section_id::ENTRY_POINT,
         output_section_id::DYLD_CHAINED_FIXUPS,
+        output_section_id::LOAD_DYLIB,
         output_section_id::CHAINED_FIXUP_TABLE,
         output_section_id::SYMTAB_COMMAND,
         output_section_id::CODE_SIGNATURE,

--- a/libwild/src/output_section_part_map.rs
+++ b/libwild/src/output_section_part_map.rs
@@ -82,6 +82,10 @@ impl OutputSectionPartMap<u64> {
         );
         *v -= size;
     }
+
+    pub(crate) fn size(&mut self, part_id: PartId) -> u64 {
+        *self.get_mut(part_id)
+    }
 }
 
 impl<T: Default + PartialEq> OutputSectionPartMap<T> {

--- a/libwild/src/output_section_part_map.rs
+++ b/libwild/src/output_section_part_map.rs
@@ -82,10 +82,6 @@ impl OutputSectionPartMap<u64> {
         );
         *v -= size;
     }
-
-    pub(crate) fn size(&mut self, part_id: PartId) -> u64 {
-        *self.get_mut(part_id)
-    }
 }
 
 impl<T: Default + PartialEq> OutputSectionPartMap<T> {

--- a/libwild/src/part_id.rs
+++ b/libwild/src/part_id.rs
@@ -56,29 +56,30 @@ pub(crate) const SYMTAB_SHNDX_GLOBAL: PartId = PartId(31);
 pub(crate) const PAGEZERO_SEGMENT: PartId = PartId(32);
 pub(crate) const TEXT_SEGMENT: PartId = PartId(33);
 pub(crate) const DATA_SEGMENT: PartId = PartId(34);
-pub(crate) const LINK_EDIT_SEGMENT: PartId = PartId(35);
-pub(crate) const ENTRY_POINT: PartId = PartId(36);
-pub(crate) const DYLD_CHAINED_FIXUPS: PartId = PartId(37);
-pub(crate) const CHAINED_FIXUP_TABLE: PartId = PartId(38);
-pub(crate) const SYMTAB_COMMAND: PartId = PartId(39);
-pub(crate) const CODE_SIGNATURE_COMMAND: PartId = PartId(40);
-pub(crate) const CODE_SIGNATURE: PartId = PartId(41);
+pub(crate) const DATA_CONST_SEGMENT: PartId = PartId(35);
+pub(crate) const LINK_EDIT_SEGMENT: PartId = PartId(36);
+pub(crate) const ENTRY_POINT: PartId = PartId(37);
+pub(crate) const DYLD_CHAINED_FIXUPS: PartId = PartId(38);
+pub(crate) const CHAINED_FIXUP_TABLE: PartId = PartId(39);
+pub(crate) const SYMTAB_COMMAND: PartId = PartId(40);
+pub(crate) const CODE_SIGNATURE_COMMAND: PartId = PartId(41);
+pub(crate) const CODE_SIGNATURE: PartId = PartId(42);
 
 // Wasm specific sections. Each one corresponds to a single standard Wasm section.
-pub(crate) const WASM_TYPE: PartId = PartId(42);
-pub(crate) const WASM_IMPORT: PartId = PartId(43);
-pub(crate) const WASM_FUNCTION: PartId = PartId(44);
-pub(crate) const WASM_TABLE: PartId = PartId(45);
-pub(crate) const WASM_MEMORY: PartId = PartId(46);
-pub(crate) const WASM_GLOBAL: PartId = PartId(47);
-pub(crate) const WASM_EXPORT: PartId = PartId(48);
-pub(crate) const WASM_START: PartId = PartId(49);
-pub(crate) const WASM_ELEMENT: PartId = PartId(50);
-pub(crate) const WASM_DATA_COUNT: PartId = PartId(51);
-pub(crate) const WASM_CODE: PartId = PartId(52);
-pub(crate) const WASM_DATA: PartId = PartId(53);
+pub(crate) const WASM_TYPE: PartId = PartId(43);
+pub(crate) const WASM_IMPORT: PartId = PartId(44);
+pub(crate) const WASM_FUNCTION: PartId = PartId(45);
+pub(crate) const WASM_TABLE: PartId = PartId(46);
+pub(crate) const WASM_MEMORY: PartId = PartId(47);
+pub(crate) const WASM_GLOBAL: PartId = PartId(48);
+pub(crate) const WASM_EXPORT: PartId = PartId(49);
+pub(crate) const WASM_START: PartId = PartId(50);
+pub(crate) const WASM_ELEMENT: PartId = PartId(51);
+pub(crate) const WASM_DATA_COUNT: PartId = PartId(52);
+pub(crate) const WASM_CODE: PartId = PartId(53);
+pub(crate) const WASM_DATA: PartId = PartId(54);
 
-pub(crate) const NUM_SINGLE_PART_SECTIONS: u32 = 54;
+pub(crate) const NUM_SINGLE_PART_SECTIONS: u32 = 55;
 
 #[cfg(test)]
 pub(crate) const NUM_BUILT_IN_PARTS: usize = NUM_SINGLE_PART_SECTIONS as usize

--- a/libwild/src/part_id.rs
+++ b/libwild/src/part_id.rs
@@ -60,26 +60,27 @@ pub(crate) const DATA_CONST_SEGMENT: PartId = PartId(35);
 pub(crate) const LINK_EDIT_SEGMENT: PartId = PartId(36);
 pub(crate) const ENTRY_POINT: PartId = PartId(37);
 pub(crate) const DYLD_CHAINED_FIXUPS: PartId = PartId(38);
-pub(crate) const CHAINED_FIXUP_TABLE: PartId = PartId(39);
+pub(crate) const LOAD_DYLIB: PartId = PartId(39);
 pub(crate) const SYMTAB_COMMAND: PartId = PartId(40);
 pub(crate) const CODE_SIGNATURE_COMMAND: PartId = PartId(41);
 pub(crate) const CODE_SIGNATURE: PartId = PartId(42);
+pub(crate) const CHAINED_FIXUP_TABLE: PartId = PartId(43);
 
 // Wasm specific sections. Each one corresponds to a single standard Wasm section.
-pub(crate) const WASM_TYPE: PartId = PartId(43);
-pub(crate) const WASM_IMPORT: PartId = PartId(44);
-pub(crate) const WASM_FUNCTION: PartId = PartId(45);
-pub(crate) const WASM_TABLE: PartId = PartId(46);
-pub(crate) const WASM_MEMORY: PartId = PartId(47);
-pub(crate) const WASM_GLOBAL: PartId = PartId(48);
-pub(crate) const WASM_EXPORT: PartId = PartId(49);
-pub(crate) const WASM_START: PartId = PartId(50);
-pub(crate) const WASM_ELEMENT: PartId = PartId(51);
-pub(crate) const WASM_DATA_COUNT: PartId = PartId(52);
-pub(crate) const WASM_CODE: PartId = PartId(53);
-pub(crate) const WASM_DATA: PartId = PartId(54);
+pub(crate) const WASM_TYPE: PartId = PartId(44);
+pub(crate) const WASM_IMPORT: PartId = PartId(45);
+pub(crate) const WASM_FUNCTION: PartId = PartId(46);
+pub(crate) const WASM_TABLE: PartId = PartId(47);
+pub(crate) const WASM_MEMORY: PartId = PartId(48);
+pub(crate) const WASM_GLOBAL: PartId = PartId(49);
+pub(crate) const WASM_EXPORT: PartId = PartId(50);
+pub(crate) const WASM_START: PartId = PartId(51);
+pub(crate) const WASM_ELEMENT: PartId = PartId(52);
+pub(crate) const WASM_DATA_COUNT: PartId = PartId(53);
+pub(crate) const WASM_CODE: PartId = PartId(54);
+pub(crate) const WASM_DATA: PartId = PartId(55);
 
-pub(crate) const NUM_SINGLE_PART_SECTIONS: u32 = 55;
+pub(crate) const NUM_SINGLE_PART_SECTIONS: u32 = 56;
 
 #[cfg(test)]
 pub(crate) const NUM_BUILT_IN_PARTS: usize = NUM_SINGLE_PART_SECTIONS as usize

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -11,6 +11,7 @@ use crate::input_data::InputRef;
 use crate::layout;
 use crate::layout::CommonGroupState;
 use crate::layout::DynamicSymbolDefinition;
+use crate::layout::ImportedSymbol;
 use crate::layout::Layout;
 use crate::layout::ObjectLayoutState;
 use crate::layout::OutputRecordLayout;
@@ -543,6 +544,7 @@ pub(crate) trait Platform:
         current_sizes: &OutputSectionPartMap<u64>,
         extra_sizes: &mut OutputSectionPartMap<u64>,
         dynamic_symbol_defs: &[DynamicSymbolDefinition<Self>],
+        imported_symbols: &[ImportedSymbol],
         args: &Self::Args,
     ) -> Result;
 
@@ -617,12 +619,6 @@ pub(crate) trait Platform:
         output_kind: OutputKind,
         args: &Self::Args,
     );
-
-    /// Section parts whose allocations may be discovered while processing regular input files,
-    /// but whose bytes are emitted by the epilogue.
-    fn epilogue_allocated_part_ids() -> &'static [PartId] {
-        &[]
-    }
 
     fn allocate_object_symtab_space<'data>(
         state: &ObjectLayoutState<'data, Self>,

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -618,6 +618,12 @@ pub(crate) trait Platform:
         args: &Self::Args,
     );
 
+    /// Section parts whose allocations may be discovered while processing regular input files,
+    /// but whose bytes are emitted by the epilogue.
+    fn epilogue_allocated_part_ids() -> &'static [PartId] {
+        &[]
+    }
+
     fn allocate_object_symtab_space<'data>(
         state: &ObjectLayoutState<'data, Self>,
         common: &mut CommonGroupState<'data, Self>,

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -233,7 +233,7 @@ pub(crate) trait Platform:
     type RelocationInfo: Copy + Send + Sync + 'static;
     type NonAddressableIndexes: NonAddressableIndexes + Send + Sync + 'static;
     type NonAddressableCounts: Default + Send + Sync + 'static;
-    type EpilogueLayoutExt: Send + Sync + 'static;
+    type EpilogueLayoutExt<'data>: Send + Sync + 'data;
     type GroupLayoutExt: std::fmt::Debug + Send + Sync + 'static;
     type CommonGroupStateExt: Default + std::fmt::Debug + Send + Sync + 'static;
     type ArchIdentifier: Send + Sync + 'static;
@@ -509,15 +509,16 @@ pub(crate) trait Platform:
         scope: &Scope<'scope>,
     ) -> Result;
 
-    fn new_epilogue_layout(
+    fn new_epilogue_layout<'data>(
         args: &Self::Args,
         output_kind: OutputKind,
         dynamic_symbol_definitions: &mut [DynamicSymbolDefinition<'_, Self>],
-    ) -> Self::EpilogueLayoutExt;
+        imported_symbols: &[ImportedSymbol<'data>],
+    ) -> Self::EpilogueLayoutExt<'data>;
 
     fn apply_non_addressable_indexes_epilogue(
         counts: &mut Self::NonAddressableCounts,
-        state: &mut Self::EpilogueLayoutExt,
+        state: &mut Self::EpilogueLayoutExt<'_>,
     );
 
     fn apply_non_addressable_indexes<'data, 'groups>(
@@ -527,7 +528,7 @@ pub(crate) trait Platform:
     );
 
     fn finalise_sizes_epilogue<'data>(
-        state: &mut Self::EpilogueLayoutExt,
+        state: &mut Self::EpilogueLayoutExt<'data>,
         mem_sizes: &mut OutputSectionPartMap<u64>,
         dynamic_symbol_definitions: &[DynamicSymbolDefinition<'data, Self>],
         properties: &Self::LayoutExt,
@@ -540,7 +541,7 @@ pub(crate) trait Platform:
     );
 
     fn apply_late_size_adjustments_epilogue(
-        state: &mut Self::EpilogueLayoutExt,
+        state: &mut Self::EpilogueLayoutExt<'_>,
         current_sizes: &OutputSectionPartMap<u64>,
         extra_sizes: &mut OutputSectionPartMap<u64>,
         dynamic_symbol_defs: &[DynamicSymbolDefinition<Self>],
@@ -558,7 +559,7 @@ pub(crate) trait Platform:
     }
 
     fn finalise_layout_epilogue<'data>(
-        epilogue_state: &mut Self::EpilogueLayoutExt,
+        epilogue_state: &mut Self::EpilogueLayoutExt<'data>,
         memory_offsets: &mut OutputSectionPartMap<u64>,
         symbol_db: &SymbolDb<'data, Self>,
         common_state: &Self::LayoutExt,

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -16,6 +16,7 @@ use crate::layout::Layout;
 use crate::layout::ObjectLayoutState;
 use crate::layout::OutputRecordLayout;
 use crate::layout::PreludeLayoutState;
+use crate::layout::SymbolResolutions;
 use crate::layout_rules;
 use crate::layout_rules::LayoutRulesBuilder;
 use crate::layout_rules::SectionRule;
@@ -491,8 +492,10 @@ pub(crate) trait Platform:
 
     fn set_imported_symbols<'data>(
         _properties: &mut Self::LayoutExt<'data>,
+        _resolutions: &SymbolResolutions<Self>,
         _imported_symbols: Vec<ImportedSymbol<'data>>,
-    ) {
+    ) -> Result {
+        Ok(())
     }
 
     fn load_exception_frame_data<'data, 'scope, A: Arch<Platform = Self>>(

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -245,7 +245,7 @@ pub(crate) trait Platform:
     type SymbolVersionIndex: Send + Sync + Copy;
 
     /// Format-specific properties produced by the layout phase.
-    type LayoutExt: Send + Sync + 'static;
+    type LayoutExt<'data>: Send + Sync;
 
     type SectionIterator<'a>: Iterator<Item = &'a Self::SectionHeader>
     where
@@ -484,10 +484,16 @@ pub(crate) trait Platform:
         args: &Self::Args,
         objects: impl Iterator<Item = &'files Self::File<'data>>,
         states: impl Iterator<Item = &'states Self::ObjectLayoutStateExt<'data>> + Clone,
-    ) -> Result<Self::LayoutExt>
+    ) -> Result<Self::LayoutExt<'data>>
     where
         'data: 'files,
         'data: 'states;
+
+    fn set_imported_symbols<'data>(
+        _properties: &mut Self::LayoutExt<'data>,
+        _imported_symbols: Vec<ImportedSymbol<'data>>,
+    ) {
+    }
 
     fn load_exception_frame_data<'data, 'scope, A: Arch<Platform = Self>>(
         object: &mut ObjectLayoutState<'data, Self>,
@@ -530,7 +536,7 @@ pub(crate) trait Platform:
         state: &mut Self::EpilogueLayoutExt,
         mem_sizes: &mut OutputSectionPartMap<u64>,
         dynamic_symbol_definitions: &[DynamicSymbolDefinition<'data, Self>],
-        properties: &Self::LayoutExt,
+        properties: &Self::LayoutExt<'data>,
         symbol_db: &SymbolDb<'data, Self>,
     );
 
@@ -561,7 +567,7 @@ pub(crate) trait Platform:
         epilogue_state: &mut Self::EpilogueLayoutExt,
         memory_offsets: &mut OutputSectionPartMap<u64>,
         symbol_db: &SymbolDb<'data, Self>,
-        common_state: &Self::LayoutExt,
+        common_state: &Self::LayoutExt<'data>,
         dynsym_start_index: u32,
         dynamic_symbol_defs: &[DynamicSymbolDefinition<Self>],
     ) -> Result;

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -233,7 +233,7 @@ pub(crate) trait Platform:
     type RelocationInfo: Copy + Send + Sync + 'static;
     type NonAddressableIndexes: NonAddressableIndexes + Send + Sync + 'static;
     type NonAddressableCounts: Default + Send + Sync + 'static;
-    type EpilogueLayoutExt<'data>: Send + Sync + 'data;
+    type EpilogueLayoutExt: Send + Sync + 'static;
     type GroupLayoutExt: std::fmt::Debug + Send + Sync + 'static;
     type CommonGroupStateExt: Default + std::fmt::Debug + Send + Sync + 'static;
     type ArchIdentifier: Send + Sync + 'static;
@@ -509,16 +509,15 @@ pub(crate) trait Platform:
         scope: &Scope<'scope>,
     ) -> Result;
 
-    fn new_epilogue_layout<'data>(
+    fn new_epilogue_layout(
         args: &Self::Args,
         output_kind: OutputKind,
         dynamic_symbol_definitions: &mut [DynamicSymbolDefinition<'_, Self>],
-        imported_symbols: &[ImportedSymbol<'data>],
-    ) -> Self::EpilogueLayoutExt<'data>;
+    ) -> Self::EpilogueLayoutExt;
 
     fn apply_non_addressable_indexes_epilogue(
         counts: &mut Self::NonAddressableCounts,
-        state: &mut Self::EpilogueLayoutExt<'_>,
+        state: &mut Self::EpilogueLayoutExt,
     );
 
     fn apply_non_addressable_indexes<'data, 'groups>(
@@ -528,7 +527,7 @@ pub(crate) trait Platform:
     );
 
     fn finalise_sizes_epilogue<'data>(
-        state: &mut Self::EpilogueLayoutExt<'data>,
+        state: &mut Self::EpilogueLayoutExt,
         mem_sizes: &mut OutputSectionPartMap<u64>,
         dynamic_symbol_definitions: &[DynamicSymbolDefinition<'data, Self>],
         properties: &Self::LayoutExt,
@@ -541,7 +540,7 @@ pub(crate) trait Platform:
     );
 
     fn apply_late_size_adjustments_epilogue(
-        state: &mut Self::EpilogueLayoutExt<'_>,
+        state: &mut Self::EpilogueLayoutExt,
         current_sizes: &OutputSectionPartMap<u64>,
         extra_sizes: &mut OutputSectionPartMap<u64>,
         dynamic_symbol_defs: &[DynamicSymbolDefinition<Self>],
@@ -559,7 +558,7 @@ pub(crate) trait Platform:
     }
 
     fn finalise_layout_epilogue<'data>(
-        epilogue_state: &mut Self::EpilogueLayoutExt<'data>,
+        epilogue_state: &mut Self::EpilogueLayoutExt,
         memory_offsets: &mut OutputSectionPartMap<u64>,
         symbol_db: &SymbolDb<'data, Self>,
         common_state: &Self::LayoutExt,

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -785,17 +785,6 @@ impl<'data, P: Platform> SymbolDb<'data, P> {
         matches!(self.groups[file_id.group()], Group::StubLibraries(_))
     }
 
-    pub(crate) fn stub_library_install_name_for_symbol(&self, symbol_id: SymbolId) -> Option<&str> {
-        let file_id = self.file_id_for_symbol(symbol_id);
-        match &self.groups[file_id.group()] {
-            Group::StubLibraries(stubs) => stubs
-                .iter()
-                .find(|stub| stub.symbol_id_range.contains(symbol_id))
-                .map(|stub| stub.defined_symbols.install_name.as_str()),
-            _ => None,
-        }
-    }
-
     pub(crate) fn definition(&self, symbol_id: SymbolId) -> SymbolId {
         // We need to do two steps when finding the definition for a symbol, since the definition
         // may have changed since we did the original name lookup. It would be possible to avoid

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -785,6 +785,17 @@ impl<'data, P: Platform> SymbolDb<'data, P> {
         matches!(self.groups[file_id.group()], Group::StubLibraries(_))
     }
 
+    pub(crate) fn stub_library_install_name_for_symbol(&self, symbol_id: SymbolId) -> Option<&str> {
+        let file_id = self.file_id_for_symbol(symbol_id);
+        match &self.groups[file_id.group()] {
+            Group::StubLibraries(stubs) => stubs
+                .iter()
+                .find(|stub| stub.symbol_id_range.contains(symbol_id))
+                .map(|stub| stub.defined_symbols.install_name.as_str()),
+            _ => None,
+        }
+    }
+
     pub(crate) fn definition(&self, symbol_id: SymbolId) -> SymbolId {
         // We need to do two steps when finding the definition for a symbol, since the definition
         // may have changed since we did the original name lookup. It would be possible to avoid

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -780,6 +780,11 @@ impl<'data, P: Platform> SymbolDb<'data, P> {
         resolution == symbol_id
     }
 
+    pub(crate) fn is_stub_library_symbol(&self, symbol_id: SymbolId) -> bool {
+        let file_id = self.file_id_for_symbol(symbol_id);
+        matches!(self.groups[file_id.group()], Group::StubLibraries(_))
+    }
+
     pub(crate) fn definition(&self, symbol_id: SymbolId) -> SymbolId {
         // We need to do two steps when finding the definition for a symbol, since the definition
         // may have changed since we did the original name lookup. It would be possible to avoid

--- a/libwild/src/verification.rs
+++ b/libwild/src/verification.rs
@@ -120,6 +120,7 @@ pub(crate) fn clear_ignored(expected: &mut OutputSectionPartMap<u64>) {
         part_id::SHSTRTAB,
         part_id::TEXT_SEGMENT,
         part_id::DATA_SEGMENT,
+        part_id::DATA_CONST_SEGMENT,
         part_id::PAGEZERO_SEGMENT,
         part_id::LINK_EDIT_SEGMENT,
         part_id::ENTRY_POINT,

--- a/libwild/src/verification.rs
+++ b/libwild/src/verification.rs
@@ -114,6 +114,7 @@ pub(crate) fn clear_ignored(expected: &mut OutputSectionPartMap<u64>) {
         part_id::GNU_HASH,
         part_id::DYNAMIC,
         part_id::INTERP,
+        part_id::LOAD_DYLIB,
         part_id::FILE_HEADER,
         part_id::PROGRAM_HEADERS,
         part_id::SECTION_HEADERS,

--- a/libwild/src/verification.rs
+++ b/libwild/src/verification.rs
@@ -93,6 +93,7 @@ fn should_ignore_alignment(part_id: PartId) -> bool {
             part_id::EH_FRAME,
             part_id::GNU_VERSION_D,
             part_id::CODE_SIGNATURE,
+            part_id::STRTAB,
         ]
         .contains(&part_id)
 }

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -1395,7 +1395,7 @@ impl platform::Platform for Wasm {
     type RelocationInfo = u32;
     type NonAddressableIndexes = NonAddressableIndexes;
     type NonAddressableCounts = ();
-    type EpilogueLayoutExt = ();
+    type EpilogueLayoutExt<'data> = ();
     type GroupLayoutExt = ();
     type CommonGroupStateExt = ();
     type ArchIdentifier = ();
@@ -1635,16 +1635,17 @@ impl platform::Platform for Wasm {
         todo!()
     }
 
-    fn new_epilogue_layout(
+    fn new_epilogue_layout<'data>(
         args: &Self::Args,
         output_kind: crate::output_kind::OutputKind,
         dynamic_symbol_definitions: &mut [crate::layout::DynamicSymbolDefinition<'_, Self>],
-    ) -> Self::EpilogueLayoutExt {
+        imported_symbols: &[ImportedSymbol<'data>],
+    ) -> Self::EpilogueLayoutExt<'data> {
     }
 
     fn apply_non_addressable_indexes_epilogue(
         counts: &mut Self::NonAddressableCounts,
-        state: &mut Self::EpilogueLayoutExt,
+        state: &mut Self::EpilogueLayoutExt<'_>,
     ) {
         // No-op: Wasm has no version table.
     }
@@ -1660,7 +1661,7 @@ impl platform::Platform for Wasm {
     }
 
     fn finalise_sizes_epilogue<'data>(
-        state: &mut Self::EpilogueLayoutExt,
+        state: &mut Self::EpilogueLayoutExt<'data>,
         mem_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         dynamic_symbol_definitions: &[crate::layout::DynamicSymbolDefinition<'data, Self>],
         properties: &Self::LayoutExt,
@@ -1677,7 +1678,7 @@ impl platform::Platform for Wasm {
     }
 
     fn apply_late_size_adjustments_epilogue(
-        state: &mut Self::EpilogueLayoutExt,
+        state: &mut Self::EpilogueLayoutExt<'_>,
         current_sizes: &crate::output_section_part_map::OutputSectionPartMap<u64>,
         extra_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         dynamic_symbol_defs: &[crate::layout::DynamicSymbolDefinition<Self>],
@@ -1688,7 +1689,7 @@ impl platform::Platform for Wasm {
     }
 
     fn finalise_layout_epilogue<'data>(
-        epilogue_state: &mut Self::EpilogueLayoutExt,
+        epilogue_state: &mut Self::EpilogueLayoutExt<'data>,
         memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
         common_state: &Self::LayoutExt,

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -1403,7 +1403,7 @@ impl platform::Platform for Wasm {
     type ResolutionExt = ();
     type SymtabShndxEntry = ();
     type SymbolVersionIndex = ();
-    type LayoutExt = ();
+    type LayoutExt<'data> = ();
     type SectionIterator<'a> = core::slice::Iter<'a, SectionHeader>;
     type DynamicTagValues<'data> = DynamicTagValues<'data>;
     type RelocationList<'data> = RelocationList<'data>;
@@ -1604,7 +1604,7 @@ impl platform::Platform for Wasm {
         args: &Self::Args,
         objects: impl Iterator<Item = &'files Self::File<'data>>,
         states: impl Iterator<Item = &'states Self::ObjectLayoutStateExt<'data>> + Clone,
-    ) -> crate::error::Result<Self::LayoutExt>
+    ) -> crate::error::Result<Self::LayoutExt<'data>>
     where
         'data: 'files,
         'data: 'states,
@@ -1663,7 +1663,7 @@ impl platform::Platform for Wasm {
         state: &mut Self::EpilogueLayoutExt,
         mem_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         dynamic_symbol_definitions: &[crate::layout::DynamicSymbolDefinition<'data, Self>],
-        properties: &Self::LayoutExt,
+        properties: &Self::LayoutExt<'data>,
         symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
     ) {
         todo!()
@@ -1691,7 +1691,7 @@ impl platform::Platform for Wasm {
         epilogue_state: &mut Self::EpilogueLayoutExt,
         memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
-        common_state: &Self::LayoutExt,
+        common_state: &Self::LayoutExt<'data>,
         dynsym_start_index: u32,
         dynamic_symbol_defs: &[crate::layout::DynamicSymbolDefinition<Self>],
     ) -> crate::error::Result {

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -7,6 +7,7 @@ use crate::args::wasm::WasmArgs;
 use crate::ensure;
 use crate::error::Context as _;
 use crate::error::Result;
+use crate::layout::ImportedSymbol;
 use crate::layout_rules::SectionKind;
 use crate::output_section_id::SectionName;
 use crate::platform;
@@ -1680,6 +1681,7 @@ impl platform::Platform for Wasm {
         current_sizes: &crate::output_section_part_map::OutputSectionPartMap<u64>,
         extra_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         dynamic_symbol_defs: &[crate::layout::DynamicSymbolDefinition<Self>],
+        imported_symbols: &[ImportedSymbol],
         args: &Self::Args,
     ) -> crate::error::Result {
         Ok(())

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -1395,7 +1395,7 @@ impl platform::Platform for Wasm {
     type RelocationInfo = u32;
     type NonAddressableIndexes = NonAddressableIndexes;
     type NonAddressableCounts = ();
-    type EpilogueLayoutExt<'data> = ();
+    type EpilogueLayoutExt = ();
     type GroupLayoutExt = ();
     type CommonGroupStateExt = ();
     type ArchIdentifier = ();
@@ -1635,17 +1635,16 @@ impl platform::Platform for Wasm {
         todo!()
     }
 
-    fn new_epilogue_layout<'data>(
+    fn new_epilogue_layout(
         args: &Self::Args,
         output_kind: crate::output_kind::OutputKind,
         dynamic_symbol_definitions: &mut [crate::layout::DynamicSymbolDefinition<'_, Self>],
-        imported_symbols: &[ImportedSymbol<'data>],
-    ) -> Self::EpilogueLayoutExt<'data> {
+    ) -> Self::EpilogueLayoutExt {
     }
 
     fn apply_non_addressable_indexes_epilogue(
         counts: &mut Self::NonAddressableCounts,
-        state: &mut Self::EpilogueLayoutExt<'_>,
+        state: &mut Self::EpilogueLayoutExt,
     ) {
         // No-op: Wasm has no version table.
     }
@@ -1661,7 +1660,7 @@ impl platform::Platform for Wasm {
     }
 
     fn finalise_sizes_epilogue<'data>(
-        state: &mut Self::EpilogueLayoutExt<'data>,
+        state: &mut Self::EpilogueLayoutExt,
         mem_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         dynamic_symbol_definitions: &[crate::layout::DynamicSymbolDefinition<'data, Self>],
         properties: &Self::LayoutExt,
@@ -1678,7 +1677,7 @@ impl platform::Platform for Wasm {
     }
 
     fn apply_late_size_adjustments_epilogue(
-        state: &mut Self::EpilogueLayoutExt<'_>,
+        state: &mut Self::EpilogueLayoutExt,
         current_sizes: &crate::output_section_part_map::OutputSectionPartMap<u64>,
         extra_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         dynamic_symbol_defs: &[crate::layout::DynamicSymbolDefinition<Self>],
@@ -1689,7 +1688,7 @@ impl platform::Platform for Wasm {
     }
 
     fn finalise_layout_epilogue<'data>(
-        epilogue_state: &mut Self::EpilogueLayoutExt<'data>,
+        epilogue_state: &mut Self::EpilogueLayoutExt,
         memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
         common_state: &Self::LayoutExt,

--- a/linker-utils/src/aarch64.rs
+++ b/linker-utils/src/aarch64.rs
@@ -1046,7 +1046,8 @@ impl AArch64Instruction {
                         scale = 4;
                     }
                 }
-                mask = (extracted_value as u32) >> scale;
+                and_from_slice(dest, &(!(0xfff_u32 << 10)).to_le_bytes());
+                mask = ((extracted_value as u32) >> scale) << 10;
             }
         }
         // Read the original value and combine it with the prepared mask.

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -4764,12 +4764,12 @@ fn available_linkers_for_linux() -> Result<Vec<Linker>> {
 fn available_linkers_for_mac() -> Result<Vec<Linker>> {
     let mut linkers = Vec::new();
 
-    if let Ok(path) = find_bin(&["ld.lld"]) {
+    if let Ok(path) = find_bin(&["ld64.lld"]) {
         linkers.push(Linker::ThirdParty(ThirdPartyLinker {
             name: "lld",
             gcc_name: "lld",
             path,
-            cross_paths: find_cross_paths("ld.lld"),
+            cross_paths: find_cross_paths("ld64.lld"),
             enabled_by_default: true,
         }));
     }

--- a/wild/tests/sources/macho/trivial-libsystem/trivial-libsystem.c
+++ b/wild/tests/sources/macho/trivial-libsystem/trivial-libsystem.c
@@ -1,0 +1,23 @@
+//#TestUpdateInPlace:true
+//#DiffIgnore:section.__const
+//#DiffIgnore:section.__unwind_info
+//#LinkerDriver:clang
+//#ExpectWarningWild:Fat object file is not supported yet
+//#SkipLinker:lld
+
+#include <stdio.h>
+#include <string.h>
+
+int value = 121;
+
+int main() {
+  char buf[128];
+  sprintf(buf, "Hello %s: %d", "world", value);
+  printf("buf: '%s'\n", buf);
+
+  unsigned char csum = 0;
+  for (int i = 0; i < strlen(buf); ++i) {
+    csum += buf[i];
+  }
+  return csum;
+}

--- a/wild/tests/sources/macho/trivial-libsystem/trivial-libsystem.c
+++ b/wild/tests/sources/macho/trivial-libsystem/trivial-libsystem.c
@@ -1,9 +1,6 @@
 //#TestUpdateInPlace:true
-//#DiffIgnore:section.__const
-//#DiffIgnore:section.__unwind_info
 //#LinkerDriver:clang
 //#ExpectWarningWild:Fat object file is not supported yet
-//#SkipLinker:lld
 
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
This PR is a nice milestone: we can now properly link against stub libraries such as `libSystem` and `libc++`. As a result, a typical “Hello, world!” program can be linked with Wild and run successfully.

```
❯ cat hw.c
#include <stdio.h>

int main() {
  printf("hello world\n");
  return 0;
}
❯ clang hw.c -fuse-ld=/users/apple/Programming/wild/fakes-debug/ld64.ld && ./a.out
wild: warning: Fat object file is not supported yet: /opt/homebrew/Cellar/llvm/22.1.3/lib/clang/22/lib/darwin/libclang_rt.osx.a
hello world
```

The change adds support for emitting `__got`, `__stubs` - the Mach-O equivalent of ELF’s `.plt` section - and the chained fixups section.

Known limitations:
- currently only a single stub library supported - the load command allocation needs to be reworked so that we can allocate multiple `LC_LOAD_DYLIB` commands (one for each library)
- linking against classical `.dylib` not supported yet
- the allocation and emission of `CHAINED_FIXUPS` is pretty complex: depends on number of active segments, number of symbols from libraries and their names -> that's why the streaming happens in Epilogue and why I introduced the `ImportedSymbol` type - maybe we can come up with a better approach @davidlattimore
- the implicitly used archive (`libclang_rt.osx.a`) is skipped right now as we don't support FAT objects yet

Anyway, once the PR gets merged, I am planning to spend some time on refactoring and filling up of MachO-related issues. I feel it's a good time for others to join the initiative as we'll have the foundation established.

Issue: #757