### PR TITLE
chore(clippy): allow pendantic with exceptions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -249,6 +249,17 @@ cloned_instead_of_copied = "warn"
 cast_lossless = "warn"
 needless_pass_by_ref_mut = "warn"
 
+pedantic = { level = "warn", priority = -1 }
+elidable_lifetime_names = "allow"
+used_underscore_binding = "allow"
+inline_always = "allow"
+missing_panics_doc = "allow"
+assigning_clones = "allow"
+similar_names = "allow"
+naive_bytecount = "allow"
+verbose_bit_mask = "allow"
+format_push_string = "allow"
+
 # We do a bit of hashing, especially in the integration tests. Optimising this speeds up tests.
 [profile.dev.package."foldhash"]
 opt-level = 2

--- a/libwild/src/dwarf_address_info.rs
+++ b/libwild/src/dwarf_address_info.rs
@@ -117,7 +117,7 @@ fn section_data_with_relocations<A: Arch<Platform = crate::elf::Elf>>(
                         object,
                         section_of_interest,
                         &mut section_data,
-                        relocations.flat_map(|r| r.ok()),
+                        relocations.filter_map(|r| r.ok()),
                     )?;
                 }
             }

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -716,7 +716,7 @@ impl platform::Platform for Elf {
                     queue,
                     resources,
                     section_index,
-                    relocations.flat_map(|r| r.ok()),
+                    relocations.filter_map(|r| r.ok()),
                     scope,
                 )?;
             }
@@ -1669,7 +1669,7 @@ impl platform::Platform for Elf {
             || flags.needs_got_tls_descriptor()
         {
             return Ok(());
-        };
+        }
         if let Some(got_address) = resolution.format_specific.got_address {
             let start_offset = (got_address.get() - got.sh_addr(LittleEndian)) as usize;
             let end_offset = start_offset + size_of::<u64>();
@@ -1949,7 +1949,7 @@ impl platform::Platform for Elf {
                             ],
                         );
                         first_load = true;
-                    };
+                    }
                     if ptype == 1 {
                         let is_write = (flags & 2) != 0;
                         let is_exec = (flags & 1) != 0;
@@ -2476,7 +2476,7 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
         } else {
             is_default = true;
             version_name = None;
-        };
+        }
 
         Ok(RawSymbolName {
             name: name_bytes,
@@ -3116,7 +3116,7 @@ fn decompress_into(
             zstd::stream::Decoder::new(input)?.read_exact(out)?;
         }
         c => bail!("Unsupported compression format: {}", c),
-    };
+    }
     Ok(())
 }
 
@@ -3750,7 +3750,7 @@ pub(crate) fn process_riscv_attributes(
                             .next()
                             .ok_or_else(|| crate::error!("Cannot parse major"))?
                             .to_string();
-                        let name = String::from_iter(it.rev());
+                        let name = it.rev().collect();
                         Ok((name, (major.parse()?, minor.parse()?)))
                     })
                     .collect::<Result<IndexMap<_, _>>>()?;

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -1662,7 +1662,7 @@ fn build_sym_index_map(layout: &ElfLayout<'_>) -> Vec<Option<u32>> {
                         .primary_output_section(output_section_id);
                     let sym_idx = section_sym_indices.get(primary_id);
                     map[symbol_id.as_usize()] = Some(*sym_idx);
-                };
+                }
 
                 if SymbolCopyInfo::new(
                     object.object,
@@ -1903,7 +1903,7 @@ fn write_object_section<'data, A: Arch<Platform = Elf>>(
     })?;
     if section.flags.needs_got() || section.flags.needs_plt() {
         bail!("Section has GOT or PLT");
-    };
+    }
     Ok(())
 }
 
@@ -1974,7 +1974,7 @@ fn write_section_reversed<'data, A: Arch<Platform = Elf>>(
 
     if section.flags.needs_got() || section.flags.needs_plt() {
         bail!("Section has GOT or PLT");
-    };
+    }
 
     Ok(())
 }
@@ -2382,7 +2382,7 @@ fn write_eh_frame_data<'data, A: Arch<Platform = Elf>>(
             table_writer,
             trace,
             eh_frame_section,
-            relocations.flat_map(|r| r.ok()),
+            relocations.filter_map(|r| r.ok()),
         ),
     }
 }
@@ -3287,7 +3287,7 @@ fn apply_relocation<
         value,
     )? {
         value = thunked_value;
-    };
+    }
 
     rel_info.write_to_buffer(value, &mut out[offset_in_section..])?;
 
@@ -4703,7 +4703,7 @@ fn write_regular_object_dynamic_symbol_definition<'data>(
                     layout.symbol_debug(sym_def.symbol_id)
                 )
             })?;
-    };
+    }
     Ok(())
 }
 
@@ -5299,7 +5299,7 @@ fn write_section_headers(out: &mut [u8], layout: &ElfLayout) -> Result {
                 );
                 order.next();
             }
-        };
+        }
 
         let entry = entries.next().unwrap();
         let e = LittleEndian;

--- a/libwild/src/elf_x86_64.rs
+++ b/libwild/src/elf_x86_64.rs
@@ -448,7 +448,7 @@ impl crate::platform::Arch for ElfX86_64 {
                 });
             }
             _ => return None,
-        };
+        }
         None
     }
 

--- a/libwild/src/file_writer.rs
+++ b/libwild/src/file_writer.rs
@@ -244,7 +244,7 @@ fn default_file_write_mode(args: &impl platform::Args, output_kind: OutputKind) 
 
     if std::fs::metadata(args.output()).is_err() {
         return FileWriteMode::UnlinkAndReplace;
-    };
+    }
 
     FileWriteMode::UpdateInPlaceWithFallback
 }

--- a/libwild/src/input_data.rs
+++ b/libwild/src/input_data.rs
@@ -340,7 +340,7 @@ impl<'data> FileLoader<'data> {
         // files pulled in.
         let mut files_by_index = Vec::new();
         files_by_index.resize_with(temporary_state.files.len(), || None);
-        for file in temporary_state.files.into_iter() {
+        for file in temporary_state.files {
             let entry = &mut files_by_index[file.index.0];
             assert!(
                 entry.is_none(),

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -521,7 +521,7 @@ fn update_defsym_symbol_resolution<'data, P: Platform>(
         };
 
         resolution.raw_value = value;
-    };
+    }
 
     Ok(())
 }
@@ -1893,9 +1893,9 @@ fn compute_total_section_part_sizes<'data, P: Platform>(
         .num_output_sections_with_content;
 
     if P::requires_symtab_shndx(num_sections as usize) {
-        group_states.iter_mut().for_each(|s| {
+        for s in group_states.iter_mut() {
             P::compute_symtab_shndx_section_size(&mut s.common.mem_sizes, &mut total_sizes);
-        });
+        }
     }
 
     Ok(total_sizes)
@@ -3160,7 +3160,7 @@ impl<'data, P: Platform> PreludeLayoutState<'data, P> {
                 );
                 output_section_indexes[id.as_usize()] = Some(next_output_index);
                 next_output_index += 1;
-            };
+            }
         }
         output_sections.output_section_indexes = output_section_indexes;
 
@@ -3859,7 +3859,7 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
                     self.section_part_id(section_index, &resources.symbol_db.section_part_ids);
                 common.store_section_attributes(part_id, header);
             }
-        };
+        }
 
         Ok(())
     }
@@ -4131,33 +4131,30 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
                     input_offset,
                 );
                 output_offset + section_address
+            } else if let Some(x) = get_merged_string_output_address::<P>(
+                local_symbol_index,
+                0,
+                self.object,
+                &self.sections,
+                &resources.symbol_db.section_part_ids,
+                self.section_id_range,
+                resources.merged_strings,
+                resources.merged_string_start_addresses,
+                true,
+            )? {
+                x
             } else {
-                match get_merged_string_output_address::<P>(
-                    local_symbol_index,
-                    0,
-                    self.object,
-                    &self.sections,
-                    &resources.symbol_db.section_part_ids,
-                    self.section_id_range,
-                    resources.merged_strings,
-                    resources.merged_string_start_addresses,
-                    true,
-                )? {
-                    Some(x) => x,
-                    None => {
-                        // Don't error for mapping symbols. They cannot have relocations refer to
-                        // them, so we don't need to produce a resolution.
-                        if resources.symbol_db.is_mapping_symbol(symbol_id) {
-                            return Ok(None);
-                        }
-                        bail!(
-                            "Symbol is in a section that we didn't load. \
-                             Symbol: {} Section: {} Res: {flags}",
-                            resources.symbol_debug(symbol_id),
-                            section_debug::<P>(self.object, section_index),
-                        );
-                    }
+                // Don't error for mapping symbols. They cannot have relocations refer to
+                // them, so we don't need to produce a resolution.
+                if resources.symbol_db.is_mapping_symbol(symbol_id) {
+                    return Ok(None);
                 }
+                bail!(
+                    "Symbol is in a section that we didn't load. \
+                     Symbol: {} Section: {} Res: {flags}",
+                    resources.symbol_debug(symbol_id),
+                    section_debug::<P>(self.object, section_index),
+                );
             }
         } else if let Some(common) = local_symbol.as_common() {
             let offset = memory_offsets.get_mut(common.part_id);
@@ -4555,7 +4552,7 @@ fn compute_section_and_symbol_addresses<'data, P: Platform>(
                                 Ok(None) if sym.is_absolute() => {
                                     symbol_addresses[sym_id.as_usize()].store(sym.value(), Relaxed);
                                 }
-                                _ => continue,
+                                _ => {}
                             }
                         }
 
@@ -4649,9 +4646,9 @@ fn relaxation_scan_pass<'data, A: Arch>(
                     for sec_idx in &sections_to_scan {
                         let sec_idx = *sec_idx;
                         let section_index = SectionIndex(sec_idx);
-                        let relocs = match obj.object.relocations(section_index, &obj.relocations) {
-                            Ok(r) => r,
-                            Err(_) => continue,
+                        let Ok(relocs) = obj.object.relocations(section_index, &obj.relocations)
+                        else {
+                            continue;
                         };
 
                         let sec_output_addr = file_section_addrs.get(sec_idx).copied().unwrap_or(0);
@@ -4670,13 +4667,11 @@ fn relaxation_scan_pass<'data, A: Arch>(
                                 symbol_infos.resolve(def_id, per_symbol_flags)
                             };
 
-                        let section_header = match obj.object.section(section_index) {
-                            Ok(h) => h,
-                            Err(_) => continue,
+                        let Ok(section_header) = obj.object.section(section_index) else {
+                            continue;
                         };
-                        let section_bytes = match obj.object.raw_section_data(section_header) {
-                            Ok(d) => d,
-                            Err(_) => continue,
+                        let Ok(section_bytes) = obj.object.raw_section_data(section_header) else {
+                            continue;
                         };
 
                         let (raw_deltas, min_margin) = A::collect_relaxation_deltas(
@@ -4985,7 +4980,7 @@ fn layout_section_parts<'data, P: Platform>(
                         }
                     });
             }
-        };
+        }
     }
 
     Ok(records_out)

--- a/libwild/src/linker_plugins.rs
+++ b/libwild/src/linker_plugins.rs
@@ -179,17 +179,14 @@ impl<'data> LinkerPlugin<'data> {
 
         let fd = file.as_raw_fd();
 
-        match self.claim_file(input_ref, fd)? {
-            Some(info) => Ok(Some(info)),
-            None => {
-                if input_ref.has_archive_semantics() {
-                    return Ok(None);
-                }
-                bail!(
-                    "Input file {input_ref} contains {kind}, \
-                            but the linker plugin ({self}) didn't claim it"
-                );
+        if let Some(info) = self.claim_file(input_ref, fd)? { Ok(Some(info)) } else {
+            if input_ref.has_archive_semantics() {
+                return Ok(None);
             }
+            bail!(
+                "Input file {input_ref} contains {kind}, \
+                        but the linker plugin ({self}) didn't claim it"
+            );
         }
     }
 
@@ -297,13 +294,13 @@ impl<'data> LinkerPlugin<'data> {
                 file_size: data.len() as libc::off_t,
                 // Whatever we store here needs to be valid for 'data, since the plugin might pass
                 // this back to us at a later point. e.g. get_symbols does so.
-                handle: handle as *const FileHandle as *mut libc::c_void,
+                handle: std::ptr::from_ref::<FileHandle>(handle) as *mut libc::c_void,
             };
 
             let mut claimed = 0;
 
             ctx.set_current_while(|| {
-                unsafe { cb(&file as *const LdPluginInputFile, &mut claimed as *mut i32) }
+                unsafe { cb(&raw const file, &raw mut claimed) }
                     .to_result("claim_file")
             })?;
 
@@ -347,8 +344,7 @@ impl<'data> WrapSymbols<'data> {
         for w in wrap {
             let w_cstring = CString::new(w.as_bytes())?;
             wrap_args
-                .push(allocator.alloc_slice_copy(w_cstring.as_bytes()).as_ptr()
-                    as *const libc::c_char);
+                .push(allocator.alloc_slice_copy(w_cstring.as_bytes()).as_ptr().cast::<libc::c_char>());
         }
         Ok(Self(&*allocator.alloc_slice_copy(wrap_args.as_slice())))
     }
@@ -870,7 +866,7 @@ extern "C" fn get_symbols_v3(
 ) -> Status {
     catch_panics(|| {
         AllSymbolsReadContext::with_current(|ctx| {
-            let handle = unsafe { &*(handle as *const FileHandle) };
+            let handle = unsafe { &*handle.cast::<FileHandle>() };
 
             let Some(file_id) = handle.file_id.load() else {
                 panic!("get_symbols_v3 called without first supplying FileId");
@@ -972,7 +968,7 @@ extern "C" fn get_input_file(handle: *const libc::c_void, file: *mut LdPluginInp
         if handle.is_null() || file.is_null() {
             return Status::Err;
         }
-        let handle = unsafe { &*(handle as *const FileHandle) };
+        let handle = unsafe { &*handle.cast::<FileHandle>() };
         let file = unsafe { &mut *file };
 
         file.fd = handle.fd;
@@ -997,8 +993,8 @@ extern "C" fn get_view(
         if handle.is_null() {
             return Status::Err;
         }
-        let handle = unsafe { &*(handle as *const FileHandle) };
-        unsafe { view_pointer.write(handle.data.as_ptr() as *const libc::c_void) };
+        let handle = unsafe { &*handle.cast::<FileHandle>() };
+        unsafe { view_pointer.write(handle.data.as_ptr().cast::<libc::c_void>()) };
         Status::Ok
     })
 }
@@ -1108,13 +1104,13 @@ impl ClaimContext<'_> {
         if ptr.is_null() {
             ERROR_MESSAGE.set(Some("Tried to obtain ClaimContext when not set".to_owned()));
             return Status::Err;
-        };
-        let ctx = unsafe { &mut *(ptr as *mut ClaimContext) };
+        }
+        let ctx = unsafe { &mut *ptr.cast::<ClaimContext>() };
         cb(ctx)
     }
 
     fn set_current_while<R>(&mut self, cb: impl FnOnce() -> R) -> R {
-        CLAIM_CONTEXT.set(self as *mut _ as *mut libc::c_void);
+        CLAIM_CONTEXT.set(std::ptr::from_mut(self).cast::<libc::c_void>());
         let r = cb();
         CLAIM_CONTEXT.take();
         r
@@ -1137,14 +1133,14 @@ impl<'scope, 'data, P: Platform> AllSymbolsReadContext<'scope, 'data, P> {
                 "Tried to obtain AllSymbolsReadContext when not set".to_owned(),
             ));
             return Status::Err;
-        };
+        }
         let ctx = unsafe { &mut *(ptr as *mut AllSymbolsReadContext<'scope, 'data, P>) };
         cb(ctx)
     }
 
     fn set_current_while<R>(&self, cb: impl FnOnce() -> R) -> R {
         ALL_SYMBOLS_READ_CONTEXT
-            .set(self as *const AllSymbolsReadContext<'scope, 'data, P> as *const libc::c_void);
+            .set(std::ptr::from_ref::<AllSymbolsReadContext<'scope, 'data, P>>(self).cast::<libc::c_void>());
         let r = cb();
         ALL_SYMBOLS_READ_CONTEXT.take();
         r

--- a/libwild/src/linker_plugins.rs
+++ b/libwild/src/linker_plugins.rs
@@ -179,7 +179,9 @@ impl<'data> LinkerPlugin<'data> {
 
         let fd = file.as_raw_fd();
 
-        if let Some(info) = self.claim_file(input_ref, fd)? { Ok(Some(info)) } else {
+        if let Some(info) = self.claim_file(input_ref, fd)? {
+            Ok(Some(info))
+        } else {
             if input_ref.has_archive_semantics() {
                 return Ok(None);
             }
@@ -300,8 +302,7 @@ impl<'data> LinkerPlugin<'data> {
             let mut claimed = 0;
 
             ctx.set_current_while(|| {
-                unsafe { cb(&raw const file, &raw mut claimed) }
-                    .to_result("claim_file")
+                unsafe { cb(&raw const file, &raw mut claimed) }.to_result("claim_file")
             })?;
 
             check_for_errors()?;
@@ -343,8 +344,12 @@ impl<'data> WrapSymbols<'data> {
         let mut wrap_args = Vec::new();
         for w in wrap {
             let w_cstring = CString::new(w.as_bytes())?;
-            wrap_args
-                .push(allocator.alloc_slice_copy(w_cstring.as_bytes()).as_ptr().cast::<libc::c_char>());
+            wrap_args.push(
+                allocator
+                    .alloc_slice_copy(w_cstring.as_bytes())
+                    .as_ptr()
+                    .cast::<libc::c_char>(),
+            );
         }
         Ok(Self(&*allocator.alloc_slice_copy(wrap_args.as_slice())))
     }
@@ -1139,8 +1144,10 @@ impl<'scope, 'data, P: Platform> AllSymbolsReadContext<'scope, 'data, P> {
     }
 
     fn set_current_while<R>(&self, cb: impl FnOnce() -> R) -> R {
-        ALL_SYMBOLS_READ_CONTEXT
-            .set(std::ptr::from_ref::<AllSymbolsReadContext<'scope, 'data, P>>(self).cast::<libc::c_void>());
+        ALL_SYMBOLS_READ_CONTEXT.set(
+            std::ptr::from_ref::<AllSymbolsReadContext<'scope, 'data, P>>(self)
+                .cast::<libc::c_void>(),
+        );
         let r = cb();
         ALL_SYMBOLS_READ_CONTEXT.take();
         r

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -239,7 +239,7 @@ impl<'a> Expression<'a> {
     pub(crate) fn visit_expressions(&self, cb: &mut impl FnMut(&Self) -> bool) {
         if !cb(self) {
             return;
-        };
+        }
         match self {
             Expression::Number(_)
             | Expression::LocationCounter
@@ -773,8 +773,8 @@ fn parse_number_with_suffix<'a>(input: &mut &'a BStr) -> winnow::Result<Expressi
     let suffix = opt(one_of(b"KkMm")).parse_next(input)?;
 
     let final_value = match suffix {
-        Some(b'K') | Some(b'k') => base_number.wrapping_mul(1024),
-        Some(b'M') | Some(b'm') => base_number.wrapping_mul(1024 * 1024),
+        Some(b'K' | b'k') => base_number.wrapping_mul(1024),
+        Some(b'M' | b'm') => base_number.wrapping_mul(1024 * 1024),
         _ => base_number,
     };
 
@@ -1282,9 +1282,9 @@ mod tests {
     #[test]
     fn test_inputs_from_script() {
         let inputs = inputs_from_script(
-            r#"/* GNU ld script */
+            r"/* GNU ld script */
             GROUP ( libgcc_s.so.1 -lgcc )
-        "#,
+        ",
         )
         .unwrap();
         assert_equal(
@@ -1311,9 +1311,9 @@ mod tests {
     #[test]
     fn test_test_inputs_from_script() {
         let inputs = inputs_from_script(
-            r#"OUTPUT_FORMAT(elf64-x86-64)
+            r"OUTPUT_FORMAT(elf64-x86-64)
             GROUP ( /lib/x86_64-linux-gnu/libc.so.6 /usr/lib/x86_64-linux-gnu/libc_nonshared.a  AS_NEEDED ( /lib64/ld-linux-x86-64.so.2 ) )
-        "#,
+        ",
         )
         .unwrap();
         assert_equal(
@@ -1501,14 +1501,14 @@ mod tests {
     #[test]
     fn test_version_command() {
         let script = parse_script(
-            r#"
+            r"
             VERSION {
                 VERS_1.0 {
                     global: foo; bar*;
                     local: *;
                 };
             }
-            "#,
+            ",
         )
         .unwrap();
 
@@ -1549,7 +1549,7 @@ mod tests {
     #[test]
     fn test_version_command_with_other_commands() {
         let script = parse_script(
-            r#"
+            r"
             ENTRY(_start)
             VERSION {
                 VERS_1.0 {
@@ -1559,7 +1559,7 @@ mod tests {
             SECTIONS {
                 .text : { *(.text) }
             }
-            "#,
+            ",
         )
         .unwrap();
 
@@ -1584,14 +1584,14 @@ mod tests {
         use crate::version_script::VersionScript;
 
         let script = parse_script(
-            r#"
+            r"
             VERSION {
                 VERS_1.0 {
                     global: foo; bar*;
                     local: *;
                 };
             }
-            "#,
+            ",
         )
         .unwrap();
 
@@ -2015,10 +2015,10 @@ mod tests {
     #[test]
     fn test_memory_block_parsing() {
         let script = parse_script(
-            r#"MEMORY {
+            r"MEMORY {
                 rom : ORIGIN = 256K, LENGTH = 1M
                 ram : org = 0x20000000, l = 32K
-            }"#,
+            }",
         )
         .unwrap();
         let Command::Memory(regions) = &script.commands[0] else {

--- a/libwild/src/macho_stub_library.rs
+++ b/libwild/src/macho_stub_library.rs
@@ -183,7 +183,7 @@ mod tests {
     #[test]
     fn parse_library_with_reexports() {
         let stub_library = parse_defined_library(
-            r#"--- !tapi-tbd
+            r"--- !tapi-tbd
 tbd-version:     4
 targets:         [ x86_64-macos, arm64-macos ]
 install-name:    '/usr/lib/libMain.dylib'
@@ -227,7 +227,7 @@ reexports:
   - targets:         [ arm64-macos ]
     symbols:         [ _b_exported_arm64 ]
     weak-symbols:    [ _b_weak_exported_arm64 ]
-"#,
+",
         )
         .expect("definition should parse");
 

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -483,7 +483,6 @@ fn apply_relocation<'data, A: Arch<Platform = MachO>>(
     .entered();
 
     let rel_info = A::relocation_from_raw(rel)?;
-    let _addend = rel.r_address;
     let (resolution, _symbol_index, local_symbol_id) = get_resolution(rel, object_layout, layout)?;
 
     let mask = get_page_mask(rel_info.mask);

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -789,10 +789,8 @@ impl<'data, P: Platform> OutputSections<'data, P> {
                 {
                     return;
                 }
-            } else {
-                if id.as_usize() < NUM_BUILT_IN_SECTIONS {
-                    return;
-                }
+            } else if id.as_usize() < NUM_BUILT_IN_SECTIONS {
+                return;
             }
 
             if info.section_attributes.is_executable() {

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -1198,7 +1198,7 @@ fn apply_init_fini_secondaries<'data, P: Platform>(
         match slot {
             SectionSlot::Unloaded(_) | SectionSlot::MustLoad(_) => {}
             _ => continue,
-        };
+        }
 
         let sid =
             output_sections.get_or_create_init_fini_secondary(d.primary, d.priority, d.alignment);
@@ -1387,7 +1387,7 @@ fn resolve_section<'data, P: Platform>(
                 part_id::UNMAPPED,
             ));
         }
-    };
+    }
 
     if part_id == part_id::CUSTOM_PLACEHOLDER {
         let custom_section = CustomSectionDetails {

--- a/libwild/src/save_dir.rs
+++ b/libwild/src/save_dir.rs
@@ -626,7 +626,7 @@ fn shell_escape_string(value: &'_ str) -> Cow<'_, str> {
     if !value.contains('\\') && !value.contains('\"') {
         return Cow::Borrowed(value);
     }
-    Cow::Owned(value.replace("\\", "\\\\").replace("\"", "\\\""))
+    Cow::Owned(value.replace('\\', "\\\\").replace('"', "\\\""))
 }
 
 #[cfg(test)]

--- a/libwild/src/subprocess.rs
+++ b/libwild/src/subprocess.rs
@@ -66,9 +66,9 @@ fn subprocess_result(mut args: Args) -> Result<i32> {
 fn inform_parent_done(fds: &[c_int]) {
     unsafe {
         libc::close(fds[0]);
-        let stream = libc::fdopen(fds[1], "w".as_ptr() as *const c_char);
+        let stream = libc::fdopen(fds[1], "w".as_ptr().cast::<c_char>());
         let bytes: [u8; 1] = *b"X";
-        libc::fwrite(bytes.as_ptr() as *const c_void, 1, 1, stream);
+        libc::fwrite(bytes.as_ptr().cast::<c_void>(), 1, 1, stream);
         libc::fclose(stream);
         libc::close(libc::STDOUT_FILENO);
         libc::close(libc::STDERR_FILENO);
@@ -83,22 +83,19 @@ fn wait_for_child_done(fds: &[c_int], child_pid: pid_t) -> i32 {
         // close our sending end of the pipe
         libc::close(fds[1]);
         // open the other end of the pipe for reading
-        let stream = libc::fdopen(fds[0], "r".as_ptr() as *const c_char);
+        let stream = libc::fdopen(fds[0], "r".as_ptr().cast::<c_char>());
 
         // Wait for child to send a byte via the pipe or for the pipe to be closed.
         let mut response: [u8; 1] = [0u8; 1];
-        match libc::fread(response.as_mut_ptr() as *mut c_void, 1, 1, stream) {
-            1 => {
-                // Child sent a byte, which indicates that it succeeded and is now shutting down in
-                // the background.
-                0
-            }
-            _ => {
-                // Child closed pipe without sending a byte - get the process exit_status
-                let mut status: libc::c_int = -1i32;
-                libc::waitpid(child_pid, &mut status, 0);
-                libc::WEXITSTATUS(status)
-            }
+        if libc::fread(response.as_mut_ptr().cast::<c_void>(), 1, 1, stream) == 1 {
+            // Child sent a byte, which indicates that it succeeded and is now shutting down in
+            // the background.
+            0
+        } else {
+            // Child closed pipe without sending a byte - get the process exit_status
+            let mut status: libc::c_int = -1i32;
+            libc::waitpid(child_pid, &raw mut status, 0);
+            libc::WEXITSTATUS(status)
         }
     }
 }

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -445,7 +445,7 @@ impl<'data, P: Platform> SymbolDb<'data, P> {
             &self.version_script,
             &mut per_group_shards,
             self.args,
-            &self.export_list,
+            self.export_list.as_ref(),
             self.output_kind,
         )?;
 
@@ -490,10 +490,9 @@ impl<'data, P: Platform> SymbolDb<'data, P> {
 
         let lto_objects = lto_objects.into_iter().collect::<Result<Vec<_>>>()?;
 
-        for group_objects in lto_objects
+        for group_objects in &lto_objects
             .into_iter()
             .chunks(crate::input_data::MAX_FILES_PER_GROUP as usize)
-            .into_iter()
         {
             let mut next_symbol_id = self.next_symbol_id();
             let group_index = self.next_group_index();
@@ -1447,7 +1446,7 @@ fn read_symbols<'data, P: Platform>(
     version_script: &VersionScript,
     shards: &mut [SymbolWriterShard<'_, '_, 'data, P>],
     args: &P::Args,
-    export_list: &Option<ExportList<'data>>,
+    export_list: Option<&ExportList<'data>>,
     output_kind: OutputKind,
 ) -> Result<Vec<SymbolLoadOutputs<'data>>> {
     timing_phase!("Read symbols");
@@ -1472,7 +1471,7 @@ fn read_symbols<'data, P: Platform>(
 fn read_symbols_for_group<'data, P: Platform>(
     shard: &mut SymbolWriterShard<'_, '_, 'data, P>,
     version_script: &VersionScript,
-    export_list: &Option<ExportList<'data>>,
+    export_list: Option<&ExportList<'data>>,
     num_buckets: usize,
     args: &P::Args,
     output_kind: OutputKind,
@@ -1635,7 +1634,7 @@ fn load_symbols_from_file<'data, P: Platform>(
     symbols_out: &mut SymbolWriterShard<'_, '_, 'data, P>,
     outputs: &mut SymbolLoadOutputs<'data>,
     args: &P::Args,
-    export_list: &Option<ExportList<'data>>,
+    export_list: Option<&ExportList<'data>>,
     output_kind: OutputKind,
 ) -> Result {
     if s.is_dynamic() {
@@ -1764,7 +1763,7 @@ struct RegularObjectSymbolLoader<'a, 'data, P: Platform> {
     version_script: &'a VersionScript<'a>,
     archive_semantics: bool,
     lib_name: &'data [u8],
-    export_list: &'a Option<ExportList<'a>>,
+    export_list: Option<&'a ExportList<'a>>,
     output_kind: OutputKind,
 }
 
@@ -1792,7 +1791,7 @@ impl<'data, P: Platform> SymbolLoader<'data, P> for RegularObjectSymbolLoader<'_
             self.args,
             sym,
             self.output_kind,
-            self.export_list.as_ref(),
+            self.export_list,
             self.lib_name,
             self.archive_semantics,
             is_undefined,

--- a/libwild/src/tidy_tests.rs
+++ b/libwild/src/tidy_tests.rs
@@ -237,7 +237,7 @@ fn check_elf_specific_code() -> Result {
         for (i, line) in contents.lines().enumerate() {
             if line.starts_with("#[test]") {
                 skip = true;
-            } else if line.starts_with("}") {
+            } else if line.starts_with('}') {
                 skip = false;
             } else if skip {
                 continue;

--- a/libwild/src/timing.rs
+++ b/libwild/src/timing.rs
@@ -189,7 +189,7 @@ where
             };
 
             println!("{indent}{reading} {name}{}", data.attributes_string);
-        };
+        }
     }
 }
 

--- a/libwild/src/version_script.rs
+++ b/libwild/src/version_script.rs
@@ -785,14 +785,14 @@ mod tests {
     #[test]
     fn parse_rust_version_script() {
         let data = ScriptData {
-            raw: br#"
+            raw: br"
                     {
                     global:
                         foo;
                         bar;
                     local:
                         *;
-                    };"#,
+                    };",
         };
         let script = VersionScript::parse(data).unwrap();
         let VersionScript::Rust(rust_script) = script else {
@@ -810,7 +810,7 @@ mod tests {
     #[test]
     fn test_parse_simple_version_script() {
         let data = ScriptData {
-            raw: br#"
+            raw: br"
                     # Comment starting with a hash
                     {global:
                         /* Single-line comment */
@@ -822,7 +822,7 @@ mod tests {
                         /* Multi-line
                            comment */
                         *;
-                    };"#,
+                    };",
         };
         let script = RegularVersionScript::parse(data).unwrap();
         let version_body = &script.versions[0].version_body;
@@ -854,7 +854,7 @@ mod tests {
     #[test]
     fn test_parse_version_script() {
         let data = ScriptData {
-            raw: br#"
+            raw: br"
                 VERS_1.1 {
                     global:
                         foo1;
@@ -865,7 +865,7 @@ mod tests {
                 VERS_1.2 {
                     foo2;
                 } VERS_1.1;
-            "#,
+            ",
         };
         let script = RegularVersionScript::parse(data).unwrap();
         assert_eq!(script.versions.len(), 3);
@@ -912,7 +912,7 @@ mod tests {
     #[test]
     fn single_line_version_script() {
         let data = ScriptData {
-            raw: br#"VERSION42 { global: *; };"#,
+            raw: br"VERSION42 { global: *; };",
         };
         RegularVersionScript::parse(data).unwrap();
     }
@@ -1082,7 +1082,7 @@ mod tests {
     #[test]
     fn test_version_order() {
         let data = ScriptData {
-            raw: br#"
+            raw: br"
                 VERS_1.1 {
                     foo;
                     foo?;
@@ -1094,7 +1094,7 @@ mod tests {
                     foo*;
                     bar;
                 } VERS_1.1;
-            "#,
+            ",
         };
         let script = RegularVersionScript::parse(data).unwrap();
         let sym = UnversionedSymbolName::prehashed;
@@ -1113,7 +1113,7 @@ mod tests {
     #[test]
     fn test_escape_sequences() {
         let data = ScriptData {
-            raw: br#"
+            raw: br"
                 {
                     global:
                         foo\*bar;
@@ -1123,7 +1123,7 @@ mod tests {
                         b*;
                         f?;
                 };
-            "#,
+            ",
         };
         let script = RegularVersionScript::parse(data).unwrap();
         let version_body = &script.versions[0].version_body;
@@ -1165,7 +1165,7 @@ mod tests {
     #[test]
     fn test_negation() {
         let data = ScriptData {
-            raw: br#"
+            raw: br"
                 VERS_1.1 {
                     f*;
                 };
@@ -1173,7 +1173,7 @@ mod tests {
                 VERS_1.2 {
                     f[^o]*;
                 } VERS_1.1;
-            "#,
+            ",
         };
         let script = RegularVersionScript::parse(data).unwrap();
         let sym = UnversionedSymbolName::prehashed;

--- a/linker-diff/src/arch.rs
+++ b/linker-diff/src/arch.rs
@@ -286,13 +286,13 @@ impl ArchKind {
                     object::elf::EM_RISCV => Ok(ArchKind::RiscV64),
                     object::elf::EM_LOONGARCH => Ok(ArchKind::LoongArch64),
                     object::elf::EM_PPC64 => Ok(ArchKind::Ppc64),
-                    other => bail!("Unsupported ELF architecture {other}",),
+                    other => bail!("Unsupported ELF architecture {other}"),
                 }
             }
             object::File::MachO64(file) => {
                 match file.macho_header().cputype.get(file.endianness()) {
                     object::macho::CPU_TYPE_ARM64 => Ok(ArchKind::Aarch64),
-                    other => bail!("Unsupported MachO architecture {other}",),
+                    other => bail!("Unsupported MachO architecture {other}"),
                 }
             }
             other => bail!("Unsupported file format: {:?}", other.format()),

--- a/linker-diff/src/asm_diff.rs
+++ b/linker-diff/src/asm_diff.rs
@@ -219,9 +219,9 @@ fn compare_sections<A: Arch>(
             .iter()
             .any(|t| t.next_modifier == RelocationModifier::SkipNextRelocation)
         {
-            testers
-                .iter_mut()
-                .for_each(|t| t.next_modifier = RelocationModifier::Normal);
+            for t in &mut testers {
+                t.next_modifier = RelocationModifier::Normal;
+            }
 
             continue;
         }
@@ -281,7 +281,7 @@ fn compare_sections<A: Arch>(
                     &mut relocations,
                 )?;
             }
-        };
+        }
     }
 
     // There are no more relocations. Diff literal bytes up to the end of the section.
@@ -337,7 +337,9 @@ fn update_offsets_if_match_failed<A: Arch>(
             .unwrap_or(section_size);
 
         // Update all testers to the new location.
-        testers.iter_mut().for_each(|t| t.previous_end = new_offset);
+        for t in testers.iter_mut() {
+            t.previous_end = new_offset;
+        }
 
         // Skip any relocations that applied to the addresses we skipped.
         while let Some((next_rel_offset, _rel)) = relocations.peek() {
@@ -347,7 +349,7 @@ fn update_offsets_if_match_failed<A: Arch>(
                 break;
             }
         }
-    };
+    }
 
     Ok(())
 }
@@ -894,80 +896,77 @@ fn diff_key_for_res_mismatch<A: Arch>(
         .as_ref()
         .and_then(|r| r.first_if_matched());
 
-    match (ours, reference) {
-        (Some(r1), Some(r2)) => {
-            let Some(orig) = original_annotations.first() else {
-                return "missing-original".to_owned();
-            };
+    if let (Some(r1), Some(r2)) = (ours, reference) {
+        let Some(orig) = original_annotations.first() else {
+            return "missing-original".to_owned();
+        };
 
-            match (
-                r1.relaxation.relaxation_kind.is_no_op(),
-                r2.relaxation.relaxation_kind.is_no_op(),
-            ) {
-                (true, false) => {
-                    format!(
-                        "rel.missing-opt.{}.{:?}.{}",
-                        orig.success.r_type,
-                        r2.relaxation.relaxation_kind,
-                        bin_attributes.type_name()
-                    )
-                }
-                (false, true) => {
-                    format!(
-                        "rel.extra-opt.{}.{:?}.{}",
-                        orig.success.r_type,
-                        r1.relaxation.relaxation_kind,
-                        bin_attributes.type_name()
-                    )
-                }
-                _ => {
-                    let ours_is_copy = resolutions[0].reference.referent.is_copy_relocation();
-                    let any_others_copy = resolutions[1..]
-                        .iter()
-                        .any(|r| r.reference.referent.is_copy_relocation());
+        match (
+            r1.relaxation.relaxation_kind.is_no_op(),
+            r2.relaxation.relaxation_kind.is_no_op(),
+        ) {
+            (true, false) => {
+                format!(
+                    "rel.missing-opt.{}.{:?}.{}",
+                    orig.success.r_type,
+                    r2.relaxation.relaxation_kind,
+                    bin_attributes.type_name()
+                )
+            }
+            (false, true) => {
+                format!(
+                    "rel.extra-opt.{}.{:?}.{}",
+                    orig.success.r_type,
+                    r1.relaxation.relaxation_kind,
+                    bin_attributes.type_name()
+                )
+            }
+            _ => {
+                let ours_is_copy = resolutions[0].reference.referent.is_copy_relocation();
+                let any_others_copy = resolutions[1..]
+                    .iter()
+                    .any(|r| r.reference.referent.is_copy_relocation());
 
-                    if ours_is_copy && !any_others_copy {
-                        format!("rel.extra-copy-relocation.{}", orig.success.r_type)
-                    } else if !ours_is_copy && any_others_copy {
-                        format!("rel.missing-copy-relocation.{}", orig.success.r_type)
-                    } else {
-                        format!(
-                            "rel.{}.{}",
-                            r1.relaxation.new_r_type, r2.relaxation.new_r_type
-                        )
-                    }
+                if ours_is_copy && !any_others_copy {
+                    format!("rel.extra-copy-relocation.{}", orig.success.r_type)
+                } else if !ours_is_copy && any_others_copy {
+                    format!("rel.missing-copy-relocation.{}", orig.success.r_type)
+                } else {
+                    format!(
+                        "rel.{}.{}",
+                        r1.relaxation.new_r_type, r2.relaxation.new_r_type
+                    )
                 }
             }
         }
-        _ => {
-            let failure_kind = |r: &ResolvedGroup<A>| {
-                if r.annotations
+    } else {
+        let failure_kind = |r: &ResolvedGroup<A>| {
+            if r.annotations
+                .iter()
+                .any(|a| matches!(a.kind, AnnotationKind::LiteralByteMismatch))
+            {
+                Some("literal-byte-mismatch".to_owned())
+            } else {
+                r.annotations
                     .iter()
-                    .any(|a| matches!(a.kind, AnnotationKind::LiteralByteMismatch))
-                {
-                    Some("literal-byte-mismatch".to_owned())
-                } else {
-                    r.annotations
-                        .iter()
-                        .zip(original_annotations)
-                        .find_map(|(a, orig)| match &a.kind {
-                            AnnotationKind::Ambiguous(_) => Some("rel.multiple_matches".to_owned()),
-                            AnnotationKind::MatchFailed(_) => {
-                                Some(format!("rel.match_failed.{}", orig.success.r_type))
-                            }
-                            AnnotationKind::MatchedRelaxation(_) => None,
-                            AnnotationKind::LiteralByteMismatch => {
-                                unreachable!();
-                            }
-                            AnnotationKind::Error(e) => Some(e.clone()),
-                        })
-                }
-            };
+                    .zip(original_annotations)
+                    .find_map(|(a, orig)| match &a.kind {
+                        AnnotationKind::Ambiguous(_) => Some("rel.multiple_matches".to_owned()),
+                        AnnotationKind::MatchFailed(_) => {
+                            Some(format!("rel.match_failed.{}", orig.success.r_type))
+                        }
+                        AnnotationKind::MatchedRelaxation(_) => None,
+                        AnnotationKind::LiteralByteMismatch => {
+                            unreachable!();
+                        }
+                        AnnotationKind::Error(e) => Some(e.clone()),
+                    })
+            }
+        };
 
-            failure_kind(&resolutions[0])
-                .or(failure_kind(&resolutions[1]))
-                .unwrap_or("rel.unknown_failure".to_owned())
-        }
+        failure_kind(&resolutions[0])
+            .or(failure_kind(&resolutions[1]))
+            .unwrap_or("rel.unknown_failure".to_owned())
     }
 }
 
@@ -2611,7 +2610,7 @@ impl<'data> RelaxationTester<'data> {
                         Err(failure) => {
                             failed_matches.push(failure);
                         }
-                    };
+                    }
                 });
 
                 let m = match matched_relaxations.len() {
@@ -3313,7 +3312,7 @@ impl<'data> AddressIndex<'data> {
                 .map(|versym| versym.0.get(e).index());
 
             let version: Option<&[u8]> = match version_index {
-                Some(object::elf::VER_NDX_LOCAL) | Some(object::elf::VER_NDX_GLOBAL)
+                Some(object::elf::VER_NDX_LOCAL | object::elf::VER_NDX_GLOBAL)
                     if !sym.is_definition() =>
                 {
                     // Unversioned, undefined symbols are sometimes emitted as VER_NDX_GLOBAL (LLD
@@ -3489,7 +3488,7 @@ impl<'data> AddressIndex<'data> {
 
         if dynamic_segment.is_none() {
             self.bin_attributes.output_kind = OutputKind::Executable;
-        };
+        }
 
         dynamic_segment
             .and_then(|seg| seg.data(e, elf_file.data()).ok())

--- a/linker-diff/src/header_diff.rs
+++ b/linker-diff/src/header_diff.rs
@@ -409,7 +409,7 @@ pub(crate) fn diff_array(
             rows[i].push(value.formatted);
         }
     }
-    rows.insert(0, Vec::from_iter(binaries.iter().map(|b| b.name.clone())));
+    rows.insert(0, binaries.iter().map(|b| b.name.clone()).collect());
 
     let mut table = Table::from_iter(rows);
     table.with(

--- a/linker-diff/src/riscv_attributes.rs
+++ b/linker-diff/src/riscv_attributes.rs
@@ -179,7 +179,7 @@ fn normalize_arch_string(arch: &str) -> String {
     // The first part is the base ISA (e.g., "rv64i2p1").
     let base = parts[0];
     let mut extensions: Vec<&str> = parts[1..].to_vec();
-    extensions.sort();
+    extensions.sort_unstable();
     let mut result = base.to_owned();
     for ext in extensions {
         result.push('_');

--- a/linker-diff/src/symbol_diff.rs
+++ b/linker-diff/src/symbol_diff.rs
@@ -44,7 +44,7 @@ fn read_dynsym(bin: &crate::Binary) -> Result<FieldValues> {
                 format!("{}.section", String::from_utf8_lossy(name)),
                 section_name,
             );
-        };
+        }
     }
 
     Ok(values)

--- a/linker-diff/src/utils.rs
+++ b/linker-diff/src/utils.rs
@@ -56,7 +56,7 @@ pub fn decode_insn_with_objdump(insn: &[u8], address: u64, arch: ArchKind) -> Re
         .split_whitespace()
         .skip(2)
         .join(" ")
-        .replacen(" ", "\t", 1)
+        .replacen(' ', "\t", 1)
         .clone())
 }
 

--- a/linker-diff/src/version_diff.rs
+++ b/linker-diff/src/version_diff.rs
@@ -64,7 +64,7 @@ fn read_gnu_version_d(bin: &crate::Binary) -> Result<FieldValues> {
         // Thus, we strip it here.
         if verdef.vd_flags.get(e).contains(VER_FLG_BASE) {
             verdef_version = verdef_version.trim_end_matches(".so").to_string();
-            if let Some(pos) = verdef_version.rfind(".") {
+            if let Some(pos) = verdef_version.rfind('.') {
                 verdef_version.truncate(pos);
             }
         }

--- a/linker-diff/src/x86_64.rs
+++ b/linker-diff/src/x86_64.rs
@@ -212,7 +212,7 @@ impl Arch for X86_64 {
                 );
             }
             _ => {}
-        };
+        }
 
         cb(no_op_relaxation);
     }

--- a/linker-utils/src/bit_misc.rs
+++ b/linker-utils/src/bit_misc.rs
@@ -39,6 +39,7 @@ impl BitExtraction for u64 {
             return self;
         }
         debug_assert!(range.start < range.end);
+        debug_assert!(range.end <= u64::BITS);
         (self >> range.start) & ((1 << range.len()) - 1)
     }
 
@@ -75,7 +76,7 @@ mod tests {
 
     #[test]
     #[cfg(debug_assertions)]
-    #[should_panic]
+    #[should_panic = "assertion failed: range.start < range.end"]
     #[allow(clippy::reversed_empty_ranges)]
     fn test_extract_bits_wrong_range() {
         let _ = 0u64.extract_bit_range(2..1);
@@ -83,7 +84,7 @@ mod tests {
 
     #[test]
     #[cfg(debug_assertions)]
-    #[should_panic]
+    #[should_panic = "assertion failed: range.end <= u64::BITS"]
     fn test_extract_bits_too_large() {
         let _ = 0u64.extract_bit_range(0..100);
     }

--- a/linker-utils/src/loongarch64.rs
+++ b/linker-utils/src/loongarch64.rs
@@ -673,7 +673,7 @@ impl LoongArch64Instruction {
                 let high_part = ((extracted_value + 0x8000) >> 16) << 5;
                 or_from_slice(dest, &(low_part | high_part).to_le_bytes());
             }
-        };
+        }
     }
 
     #[must_use]

--- a/linker-utils/src/riscv64.rs
+++ b/linker-utils/src/riscv64.rs
@@ -553,7 +553,7 @@ impl RiscVInstruction {
                 and_from_slice(dest, CLUITYPE_IMMEDIATE_MASK.to_le_bytes().as_slice());
                 or_from_slice(dest, &(mask as u16).to_le_bytes());
             }
-        };
+        }
     }
 
     /// The inverse of `write_to_value`. Returns `(extracted_value, negative)`. Supplied `bytes`


### PR DESCRIPTION
When experimenting with clippy, I noticed the vast majority of `pedantic` lints are reasonable to me and I would like to enable them. Thoughts on that?