### PR TITLE
port(wasm): Build initial output module layout

### DIFF
--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -1378,6 +1378,23 @@ impl<'data> platform::RelocationList<'data> for RelocationList<'data> {
     }
 }
 
+#[derive(Debug, Default)]
+pub(crate) struct WasmLayout<'data> {
+    pub(crate) output_types: Vec<wasmparser::FuncType>,
+    pub(crate) imports: Vec<crate::wasm_writer::OutputImport<'data>>,
+    pub(crate) function_type_indices: Vec<u32>,
+    pub(crate) globals: Vec<crate::wasm_writer::OutputGlobal<'data>>,
+    pub(crate) exports: Vec<crate::wasm_writer::OutputExport<'data>>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct WasmObjectLayout<'data> {
+    pub(crate) type_index_base: u32,
+    pub(crate) function_index_base: u32,
+    pub(crate) global_index_base: u32,
+    _phantom: std::marker::PhantomData<&'data ()>,
+}
+
 impl platform::Platform for Wasm {
     type File<'data> = File<'data>;
     type FileFlags = u32;
@@ -1403,7 +1420,7 @@ impl platform::Platform for Wasm {
     type ResolutionExt = ();
     type SymtabShndxEntry = ();
     type SymbolVersionIndex = ();
-    type LayoutExt<'data> = ();
+    type LayoutExt<'data> = WasmLayout<'data>;
     type SectionIterator<'a> = core::slice::Iter<'a, SectionHeader>;
     type DynamicTagValues<'data> = DynamicTagValues<'data>;
     type RelocationList<'data> = RelocationList<'data>;
@@ -1412,7 +1429,7 @@ impl platform::Platform for Wasm {
     type LayoutResourcesExt<'data> = ();
     type PreludeLayoutStateExt = ();
     type PreludeLayoutExt = ();
-    type ObjectLayoutStateExt<'data> = ();
+    type ObjectLayoutStateExt<'data> = WasmObjectLayout<'data>;
     type RawSymbolName<'data> = RawSymbolName<'data>;
     type VersionNames<'data> = ();
     type VerneedTable<'data> = VerneedTable<'data>;
@@ -1599,15 +1616,15 @@ impl platform::Platform for Wasm {
     }
 
     fn create_layout_properties<'data, 'states, 'files, A: platform::Arch<Platform = Self>>(
-        args: &Self::Args,
-        objects: impl Iterator<Item = &'files Self::File<'data>>,
-        states: impl Iterator<Item = &'states Self::ObjectLayoutStateExt<'data>> + Clone,
+        _args: &Self::Args,
+        _objects: impl Iterator<Item = &'files Self::File<'data>>,
+        _states: impl Iterator<Item = &'states Self::ObjectLayoutStateExt<'data>> + Clone,
     ) -> crate::error::Result<Self::LayoutExt<'data>>
     where
         'data: 'files,
         'data: 'states,
     {
-        Ok(())
+        Ok(WasmLayout::default())
     }
 
     fn load_exception_frame_data<'data, 'scope, A: platform::Arch<Platform = Self>>(

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -1670,17 +1670,15 @@ impl platform::Platform for Wasm {
     }
 
     fn finalise_object_sizes<'data>(
-        object: &mut crate::layout::ObjectLayoutState<'data, Self>,
-        common: &mut crate::layout::CommonGroupState<'data, Self>,
+        _object: &mut crate::layout::ObjectLayoutState<'data, Self>,
+        _common: &mut crate::layout::CommonGroupState<'data, Self>,
     ) {
-        todo!()
     }
 
     fn finalise_object_layout<'data>(
-        object: &crate::layout::ObjectLayoutState<'data, Self>,
-        memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
+        _object: &crate::layout::ObjectLayoutState<'data, Self>,
+        _memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
     ) {
-        todo!()
     }
 
     fn finalise_layout_dynamic<'data>(
@@ -1702,10 +1700,9 @@ impl platform::Platform for Wasm {
     }
 
     fn compute_object_addresses<'data>(
-        object: &crate::layout::ObjectLayoutState<'data, Self>,
-        memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
+        _object: &crate::layout::ObjectLayoutState<'data, Self>,
+        _memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
     ) {
-        todo!()
     }
 
     fn layout_resources_ext<'data>(
@@ -1714,15 +1711,15 @@ impl platform::Platform for Wasm {
     }
 
     fn load_object_section_relocations<'data, 'scope, A: platform::Arch<Platform = Self>>(
-        state: &mut crate::layout::ObjectLayoutState<'data, Self>,
-        common: &mut crate::layout::CommonGroupState<'data, Self>,
-        queue: &mut crate::layout::LocalWorkQueue,
-        resources: &'scope crate::layout::GraphResources<'data, '_, Self>,
-        section: crate::layout::Section,
-        section_index: object::SectionIndex,
-        scope: &rayon::Scope<'scope>,
+        _state: &mut crate::layout::ObjectLayoutState<'data, Self>,
+        _common: &mut crate::layout::CommonGroupState<'data, Self>,
+        _queue: &mut crate::layout::LocalWorkQueue,
+        _resources: &'scope crate::layout::GraphResources<'data, '_, Self>,
+        _section: crate::layout::Section,
+        _section_index: object::SectionIndex,
+        _scope: &rayon::Scope<'scope>,
     ) -> crate::error::Result {
-        todo!()
+        Ok(())
     }
 
     fn create_dynamic_symbol_definition<'data>(
@@ -1826,7 +1823,7 @@ impl platform::Platform for Wasm {
             Item = &'groups mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         >,
     ) {
-        // No-op for now.
+        // Wasm has no non-addressable side tables.
     }
 
     fn finalise_sizes_epilogue<'data>(
@@ -1899,12 +1896,11 @@ impl platform::Platform for Wasm {
     }
 
     fn allocate_resolution(
-        flags: crate::value_flags::ValueFlags,
-        mem_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
-        output_kind: crate::output_kind::OutputKind,
-        args: &Self::Args,
+        _flags: crate::value_flags::ValueFlags,
+        _mem_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
+        _output_kind: crate::output_kind::OutputKind,
+        _args: &Self::Args,
     ) {
-        todo!()
     }
 
     fn allocate_object_symtab_space<'data>(
@@ -1943,9 +1939,14 @@ impl platform::Platform for Wasm {
         flags: crate::value_flags::ValueFlags,
         raw_value: u64,
         dynamic_symbol_index: Option<std::num::NonZeroU32>,
-        memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
+        _memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
     ) -> crate::layout::Resolution<Self> {
-        todo!()
+        crate::layout::Resolution {
+            raw_value,
+            dynamic_symbol_index,
+            flags,
+            format_specific: (),
+        }
     }
 
     fn raw_symbol_name<'data>(

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -3,6 +3,7 @@
 
 use crate::alignment::Alignment;
 use crate::args::wasm::WasmArgs;
+use crate::bail;
 use crate::ensure;
 use crate::error::Context as _;
 use crate::error::Result;
@@ -349,7 +350,7 @@ pub(crate) fn apply_relocation(
         | reloc_type::FUNCTION_INDEX_I32 => {
             slot.copy_from_slice(&value.to_le_bytes());
         }
-        other => crate::bail!("unsupported Wasm relocation type {other}"),
+        other => bail!("unsupported Wasm relocation type {other}"),
     }
     Ok(())
 }
@@ -1428,7 +1429,7 @@ where
             for group in types {
                 for ty in group?.into_types() {
                     let wasmparser::CompositeInnerType::Func(func) = ty.composite_type.inner else {
-                        crate::bail!("Wasm non-function types are not emitted")
+                        bail!("Wasm non-function types are not emitted")
                     };
                     layout.output_types.push(func);
                 }
@@ -1469,9 +1470,9 @@ where
                             entity: OutputImportEntity::Global(ty),
                         });
                     }
-                    TypeRef::Table(_) => crate::bail!("Wasm table imports are not emitted"),
-                    TypeRef::Memory(_) => crate::bail!("Wasm memory imports are not emitted"),
-                    TypeRef::Tag(_) => crate::bail!("Wasm tag imports are not emitted"),
+                    TypeRef::Table(_) => bail!("Wasm table imports are not emitted"),
+                    TypeRef::Memory(_) => bail!("Wasm memory imports are not emitted"),
+                    TypeRef::Tag(_) => bail!("Wasm tag imports are not emitted"),
                 }
             }
         }
@@ -1521,13 +1522,13 @@ where
                         remap_wasm_index(&map.global_indices, export.index, "global")?
                     }
                     wasmparser::ExternalKind::Table => {
-                        crate::bail!("Wasm table exports are not emitted")
+                        bail!("Wasm table exports are not emitted")
                     }
                     wasmparser::ExternalKind::Memory => {
-                        crate::bail!("Wasm memory exports are not emitted")
+                        bail!("Wasm memory exports are not emitted")
                     }
                     wasmparser::ExternalKind::Tag => {
-                        crate::bail!("Wasm tag exports are not emitted")
+                        bail!("Wasm tag exports are not emitted")
                     }
                 };
                 layout.exports.push(OutputExport {
@@ -1593,7 +1594,7 @@ impl platform::Platform for Wasm {
         args: &'data Self::Args,
     ) -> crate::error::Result<crate::LinkerOutput<'data>> {
         if !cfg!(feature = "wasm") {
-            crate::bail!(
+            bail!(
                 "Wasm support is still experimental. Rebuild with `--features wasm` to enable it."
             );
         }

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -1385,10 +1385,10 @@ impl<'data> platform::RelocationList<'data> for RelocationList<'data> {
 #[derive(Debug, Default)]
 pub(crate) struct WasmLayout<'data> {
     pub(crate) output_types: Vec<wasmparser::FuncType>,
-    pub(crate) imports: Vec<crate::wasm_writer::OutputImport<'data>>,
+    pub(crate) imports: Vec<OutputImport<'data>>,
     pub(crate) function_type_indices: Vec<u32>,
-    pub(crate) globals: Vec<crate::wasm_writer::OutputGlobal<'data>>,
-    pub(crate) exports: Vec<crate::wasm_writer::OutputExport<'data>>,
+    pub(crate) globals: Vec<OutputGlobal<'data>>,
+    pub(crate) exports: Vec<OutputExport<'data>>,
     pub(crate) object_index_maps: Vec<WasmObjectIndexMap>,
 }
 

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -11,6 +11,10 @@ use crate::layout::ImportedSymbol;
 use crate::layout_rules::SectionKind;
 use crate::output_section_id::SectionName;
 use crate::platform;
+use crate::wasm_writer::OutputExport;
+use crate::wasm_writer::OutputGlobal;
+use crate::wasm_writer::OutputImport;
+use crate::wasm_writer::OutputImportEntity;
 use linker_utils::utils::u32_from_slice;
 use std::ops::Range;
 use wasmparser::BinaryReader;
@@ -1385,6 +1389,14 @@ pub(crate) struct WasmLayout<'data> {
     pub(crate) function_type_indices: Vec<u32>,
     pub(crate) globals: Vec<crate::wasm_writer::OutputGlobal<'data>>,
     pub(crate) exports: Vec<crate::wasm_writer::OutputExport<'data>>,
+    pub(crate) object_index_maps: Vec<WasmObjectIndexMap>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct WasmObjectIndexMap {
+    pub(crate) type_index_base: u32,
+    pub(crate) function_indices: Vec<u32>,
+    pub(crate) global_indices: Vec<u32>,
 }
 
 #[derive(Debug, Default)]
@@ -1393,6 +1405,149 @@ pub(crate) struct WasmObjectLayout<'data> {
     pub(crate) function_index_base: u32,
     pub(crate) global_index_base: u32,
     _phantom: std::marker::PhantomData<&'data ()>,
+}
+
+fn build_output_module_layout<'data, 'files>(
+    objects: impl Iterator<Item = &'files File<'data>>,
+) -> Result<WasmLayout<'data>>
+where
+    'data: 'files,
+{
+    let objects = objects.collect::<Vec<_>>();
+    let mut layout = WasmLayout::default();
+    let mut next_function_import_index = 0u32;
+    let mut next_global_import_index = 0u32;
+
+    for object in &objects {
+        let mut map = WasmObjectIndexMap {
+            type_index_base: u32::try_from(layout.output_types.len())
+                .context("too many Wasm types")?,
+            ..Default::default()
+        };
+
+        if let Some(types) = object.type_section_reader()? {
+            for group in types {
+                for ty in group?.into_types() {
+                    let wasmparser::CompositeInnerType::Func(func) = ty.composite_type.inner else {
+                        crate::bail!("Wasm non-function types are not emitted")
+                    };
+                    layout.output_types.push(func);
+                }
+            }
+        }
+
+        if let Some(imports) = object.import_section_reader()? {
+            for import in imports.into_imports() {
+                let import = import?;
+                match import.ty {
+                    TypeRef::Func(type_index) | TypeRef::FuncExact(type_index) => {
+                        let output_type_index = map
+                            .type_index_base
+                            .checked_add(type_index)
+                            .ok_or_else(|| crate::error!("Wasm type index overflow"))?;
+                        let output_function_index = next_function_import_index;
+                        next_function_import_index = next_function_import_index
+                            .checked_add(1)
+                            .ok_or_else(|| crate::error!("Wasm function index overflow"))?;
+                        map.function_indices.push(output_function_index);
+                        layout.imports.push(OutputImport {
+                            module: import.module,
+                            name: import.name,
+                            entity: OutputImportEntity::Function {
+                                type_index: output_type_index,
+                            },
+                        });
+                    }
+                    TypeRef::Global(ty) => {
+                        let output_global_index = next_global_import_index;
+                        next_global_import_index = next_global_import_index
+                            .checked_add(1)
+                            .ok_or_else(|| crate::error!("Wasm global index overflow"))?;
+                        map.global_indices.push(output_global_index);
+                        layout.imports.push(OutputImport {
+                            module: import.module,
+                            name: import.name,
+                            entity: OutputImportEntity::Global(ty),
+                        });
+                    }
+                    TypeRef::Table(_) => crate::bail!("Wasm table imports are not emitted"),
+                    TypeRef::Memory(_) => crate::bail!("Wasm memory imports are not emitted"),
+                    TypeRef::Tag(_) => crate::bail!("Wasm tag imports are not emitted"),
+                }
+            }
+        }
+
+        layout.object_index_maps.push(map);
+    }
+
+    let mut next_function_index = next_function_import_index;
+    let mut next_global_index = next_global_import_index;
+
+    for (object, map) in objects.iter().zip(layout.object_index_maps.iter_mut()) {
+        for function in object.module_functions()? {
+            let output_type_index = map
+                .type_index_base
+                .checked_add(function.type_index)
+                .ok_or_else(|| crate::error!("Wasm type index overflow"))?;
+            layout.function_type_indices.push(output_type_index);
+            map.function_indices.push(next_function_index);
+            next_function_index = next_function_index
+                .checked_add(1)
+                .ok_or_else(|| crate::error!("Wasm function index overflow"))?;
+        }
+
+        for global in object.module_globals()? {
+            let init_expr_body = crate::wasm_writer::const_expr_body(&global.init_expr)
+                .ok_or_else(|| crate::error!("Wasm global initializer is missing end opcode"))?;
+            layout.globals.push(OutputGlobal {
+                ty: global.ty,
+                init_expr_body,
+            });
+            map.global_indices.push(next_global_index);
+            next_global_index = next_global_index
+                .checked_add(1)
+                .ok_or_else(|| crate::error!("Wasm global index overflow"))?;
+        }
+    }
+
+    for (object, map) in objects.iter().zip(layout.object_index_maps.iter()) {
+        if let Some(exports) = object.export_section_reader()? {
+            for export in exports {
+                let export = export?;
+                let index = match export.kind {
+                    wasmparser::ExternalKind::Func | wasmparser::ExternalKind::FuncExact => {
+                        remap_wasm_index(&map.function_indices, export.index, "function")?
+                    }
+                    wasmparser::ExternalKind::Global => {
+                        remap_wasm_index(&map.global_indices, export.index, "global")?
+                    }
+                    wasmparser::ExternalKind::Table => {
+                        crate::bail!("Wasm table exports are not emitted")
+                    }
+                    wasmparser::ExternalKind::Memory => {
+                        crate::bail!("Wasm memory exports are not emitted")
+                    }
+                    wasmparser::ExternalKind::Tag => {
+                        crate::bail!("Wasm tag exports are not emitted")
+                    }
+                };
+                layout.exports.push(OutputExport {
+                    name: export.name,
+                    kind: export.kind,
+                    index,
+                });
+            }
+        }
+    }
+
+    Ok(layout)
+}
+
+fn remap_wasm_index(indices: &[u32], index: u32, kind: &str) -> Result<u32> {
+    indices
+        .get(index as usize)
+        .copied()
+        .ok_or_else(|| crate::error!("Wasm {kind} index {index} out of range"))
 }
 
 impl platform::Platform for Wasm {
@@ -1617,14 +1772,14 @@ impl platform::Platform for Wasm {
 
     fn create_layout_properties<'data, 'states, 'files, A: platform::Arch<Platform = Self>>(
         _args: &Self::Args,
-        _objects: impl Iterator<Item = &'files Self::File<'data>>,
+        objects: impl Iterator<Item = &'files Self::File<'data>>,
         _states: impl Iterator<Item = &'states Self::ObjectLayoutStateExt<'data>> + Clone,
     ) -> crate::error::Result<Self::LayoutExt<'data>>
     where
         'data: 'files,
         'data: 'states,
     {
-        Ok(WasmLayout::default())
+        build_output_module_layout(objects)
     }
 
     fn load_exception_frame_data<'data, 'scope, A: platform::Arch<Platform = Self>>(

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -1323,7 +1323,7 @@ pub(crate) struct DynamicTagValues<'data> {
 
 impl<'data> platform::DynamicTagValues<'data> for DynamicTagValues<'data> {
     fn lib_name(&self, input: &crate::input_data::InputRef<'data>) -> &'data [u8] {
-        todo!()
+        input.lib_name()
     }
 }
 
@@ -1477,25 +1477,24 @@ impl platform::Platform for Wasm {
     }
 
     fn activate_dynamic<'data>(
-        state: &mut crate::layout::DynamicLayoutState<'data, Self>,
-        common: &mut crate::layout::CommonGroupState<'data, Self>,
+        _state: &mut crate::layout::DynamicLayoutState<'data, Self>,
+        _common: &mut crate::layout::CommonGroupState<'data, Self>,
     ) {
-        todo!()
+        // Dynamic Wasm objects are not emitted by this backend.
     }
 
     fn pre_finalise_sizes_prelude<'scope, 'data>(
-        prelude: &mut crate::layout::PreludeLayoutState<'data, Self>,
-        common: &mut crate::layout::CommonGroupState<'data, Self>,
-        resources: &crate::layout::GraphResources<'data, 'scope, Self>,
+        _prelude: &mut crate::layout::PreludeLayoutState<'data, Self>,
+        _common: &mut crate::layout::CommonGroupState<'data, Self>,
+        _resources: &crate::layout::GraphResources<'data, 'scope, Self>,
     ) {
-        todo!()
     }
 
     fn finalise_sizes_dynamic<'data>(
-        object: &mut crate::layout::DynamicLayoutState<'data, Self>,
-        common: &mut crate::layout::CommonGroupState<'data, Self>,
+        _object: &mut crate::layout::DynamicLayoutState<'data, Self>,
+        _common: &mut crate::layout::CommonGroupState<'data, Self>,
     ) -> crate::error::Result {
-        todo!()
+        Ok(())
     }
 
     fn finalise_object_sizes<'data>(
@@ -1513,21 +1512,21 @@ impl platform::Platform for Wasm {
     }
 
     fn finalise_layout_dynamic<'data>(
-        state: &mut crate::layout::DynamicLayoutState<'data, Self>,
-        memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
-        resources: &crate::layout::FinaliseLayoutResources<'_, 'data, Self>,
-        resolutions_out: &mut crate::layout::ResolutionWriter<Self>,
+        _state: &mut crate::layout::DynamicLayoutState<'data, Self>,
+        _memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
+        _resources: &crate::layout::FinaliseLayoutResources<'_, 'data, Self>,
+        _resolutions_out: &mut crate::layout::ResolutionWriter<Self>,
     ) -> crate::error::Result<Self::DynamicLayoutExt<'data>> {
-        todo!()
+        Ok(())
     }
 
     fn take_dynsym_index(
-        memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
-        section_layouts: &crate::output_section_map::OutputSectionMap<
+        _memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
+        _section_layouts: &crate::output_section_map::OutputSectionMap<
             crate::layout::OutputRecordLayout,
         >,
     ) -> crate::error::Result<u32> {
-        todo!()
+        crate::bail!("Wasm dynamic symbol table is not emitted")
     }
 
     fn compute_object_addresses<'data>(
@@ -1555,18 +1554,17 @@ impl platform::Platform for Wasm {
     }
 
     fn create_dynamic_symbol_definition<'data>(
-        symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
-        symbol_id: crate::symbol_db::SymbolId,
+        _symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
+        _symbol_id: crate::symbol_db::SymbolId,
     ) -> crate::error::Result<crate::layout::DynamicSymbolDefinition<'data, Self>> {
-        todo!()
+        crate::bail!("Wasm dynamic symbol definitions are not emitted")
     }
 
     fn update_segment_keep_list(
-        program_segments: &crate::program_segments::ProgramSegments<Self::ProgramSegmentDef>,
-        keep_segments: &mut [bool],
-        args: &Self::Args,
+        _program_segments: &crate::program_segments::ProgramSegments<Self::ProgramSegmentDef>,
+        _keep_segments: &mut [bool],
+        _args: &Self::Args,
     ) {
-        todo!()
     }
 
     fn program_segment_defs() -> &'static [Self::ProgramSegmentDef] {
@@ -1625,14 +1623,14 @@ impl platform::Platform for Wasm {
     }
 
     fn non_empty_section_loaded<'data, 'scope, A: platform::Arch<Platform = Self>>(
-        object: &mut crate::layout::ObjectLayoutState<'data, Self>,
-        common: &mut crate::layout::CommonGroupState<'data, Self>,
-        queue: &mut crate::layout::LocalWorkQueue,
-        unloaded: crate::resolution::UnloadedSection,
-        resources: &'scope crate::layout::GraphResources<'data, 'scope, Self>,
-        scope: &rayon::Scope<'scope>,
+        _object: &mut crate::layout::ObjectLayoutState<'data, Self>,
+        _common: &mut crate::layout::CommonGroupState<'data, Self>,
+        _queue: &mut crate::layout::LocalWorkQueue,
+        _unloaded: crate::resolution::UnloadedSection,
+        _resources: &'scope crate::layout::GraphResources<'data, 'scope, Self>,
+        _scope: &rayon::Scope<'scope>,
     ) -> crate::error::Result {
-        todo!()
+        Ok(())
     }
 
     fn new_epilogue_layout(
@@ -1660,20 +1658,18 @@ impl platform::Platform for Wasm {
     }
 
     fn finalise_sizes_epilogue<'data>(
-        state: &mut Self::EpilogueLayoutExt,
-        mem_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
-        dynamic_symbol_definitions: &[crate::layout::DynamicSymbolDefinition<'data, Self>],
-        properties: &Self::LayoutExt<'data>,
-        symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
+        _state: &mut Self::EpilogueLayoutExt,
+        _mem_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
+        _dynamic_symbol_definitions: &[crate::layout::DynamicSymbolDefinition<'data, Self>],
+        _properties: &Self::LayoutExt<'data>,
+        _symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
     ) {
-        todo!()
     }
 
     fn finalise_sizes_all<'data>(
-        mem_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
-        symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
+        _mem_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
+        _symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
     ) {
-        todo!()
     }
 
     fn apply_late_size_adjustments_epilogue(
@@ -1722,12 +1718,12 @@ impl platform::Platform for Wasm {
     }
 
     fn finalise_sizes_for_symbol<'data>(
-        common: &mut crate::layout::CommonGroupState<'data, Self>,
-        symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
-        symbol_id: crate::symbol_db::SymbolId,
-        flags: crate::value_flags::ValueFlags,
+        _common: &mut crate::layout::CommonGroupState<'data, Self>,
+        _symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
+        _symbol_id: crate::symbol_db::SymbolId,
+        _flags: crate::value_flags::ValueFlags,
     ) -> crate::error::Result {
-        todo!()
+        Ok(())
     }
 
     fn allocate_resolution(
@@ -1740,28 +1736,27 @@ impl platform::Platform for Wasm {
     }
 
     fn allocate_object_symtab_space<'data>(
-        state: &crate::layout::ObjectLayoutState<'data, Self>,
-        common: &mut crate::layout::CommonGroupState<'data, Self>,
-        symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
-        per_symbol_flags: &crate::value_flags::AtomicPerSymbolFlags,
+        _state: &crate::layout::ObjectLayoutState<'data, Self>,
+        _common: &mut crate::layout::CommonGroupState<'data, Self>,
+        _symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
+        _per_symbol_flags: &crate::value_flags::AtomicPerSymbolFlags,
     ) -> crate::error::Result {
-        todo!()
+        Ok(())
     }
 
     fn allocate_internal_symbol(
-        symbol_id: crate::symbol_db::SymbolId,
-        def_info: &crate::parsing::InternalSymDefInfo<Self>,
-        sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
-        symbol_db: &crate::symbol_db::SymbolDb<Self>,
+        _symbol_id: crate::symbol_db::SymbolId,
+        _def_info: &crate::parsing::InternalSymDefInfo<Self>,
+        _sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
+        _symbol_db: &crate::symbol_db::SymbolDb<Self>,
     ) -> crate::error::Result {
-        todo!()
+        Ok(())
     }
 
     fn allocate_prelude(
-        common: &mut crate::layout::CommonGroupState<Self>,
-        symbol_db: &crate::symbol_db::SymbolDb<Self>,
+        _common: &mut crate::layout::CommonGroupState<Self>,
+        _symbol_db: &crate::symbol_db::SymbolDb<Self>,
     ) {
-        todo!()
     }
 
     fn finalise_prelude_layout<'data>(

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -1,5 +1,4 @@
 // TODO
-#![allow(unused_variables)]
 #![allow(unused)]
 
 use crate::alignment::Alignment;

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -16,6 +16,7 @@ use crate::wasm_writer::OutputGlobal;
 use crate::wasm_writer::OutputImport;
 use crate::wasm_writer::OutputImportEntity;
 use linker_utils::utils::u32_from_slice;
+use rayon::prelude::*;
 use std::ops::Range;
 use wasmparser::BinaryReader;
 use wasmparser::ConstExpr;
@@ -1407,67 +1408,67 @@ pub(crate) struct WasmObjectLayout<'data> {
     _phantom: std::marker::PhantomData<&'data ()>,
 }
 
-fn build_output_module_layout<'data, 'files>(
-    objects: impl Iterator<Item = &'files File<'data>>,
-) -> Result<WasmLayout<'data>>
-where
-    'data: 'files,
-{
-    let objects = objects.collect::<Vec<_>>();
-    let mut layout = WasmLayout::default();
-    let mut next_function_import_index = 0u32;
-    let mut next_global_import_index = 0u32;
+#[derive(Debug)]
+struct WasmObjectLayoutInput<'data> {
+    types: Vec<wasmparser::FuncType>,
+    function_imports: Vec<WasmFunctionImport<'data>>,
+    global_imports: Vec<WasmGlobalImport<'data>>,
+    module_functions: Vec<WasmModuleFunction>,
+    globals: Vec<OutputGlobal<'data>>,
+    exports: Vec<OutputExport<'data>>,
+}
 
-    for object in &objects {
-        let mut map = WasmObjectIndexMap {
-            type_index_base: u32::try_from(layout.output_types.len())
-                .context("too many Wasm types")?,
-            ..Default::default()
-        };
+#[derive(Debug, Clone, Copy)]
+struct WasmObjectIndexBases {
+    type_index_base: u32,
+    function_import_base: u32,
+    defined_function_base: u32,
+    global_import_base: u32,
+    defined_global_base: u32,
+}
 
-        if let Some(types) = object.type_section_reader()? {
-            for group in types {
+#[derive(Debug)]
+struct WasmObjectOutputLayout<'data> {
+    types: Vec<wasmparser::FuncType>,
+    imports: Vec<OutputImport<'data>>,
+    function_type_indices: Vec<u32>,
+    globals: Vec<OutputGlobal<'data>>,
+    exports: Vec<OutputExport<'data>>,
+    index_map: WasmObjectIndexMap,
+}
+
+impl<'data> WasmObjectLayoutInput<'data> {
+    fn from_file(file: &File<'data>) -> Result<Self> {
+        let mut types = Vec::new();
+        if let Some(type_section) = file.type_section_reader()? {
+            for group in type_section {
                 for ty in group?.into_types() {
                     let wasmparser::CompositeInnerType::Func(func) = ty.composite_type.inner else {
                         bail!("Wasm non-function types are not emitted")
                     };
-                    layout.output_types.push(func);
+                    types.push(func);
                 }
             }
         }
 
-        if let Some(imports) = object.import_section_reader()? {
+        let mut function_imports = Vec::new();
+        let mut global_imports = Vec::new();
+        if let Some(imports) = file.import_section_reader()? {
             for import in imports.into_imports() {
                 let import = import?;
                 match import.ty {
                     TypeRef::Func(type_index) | TypeRef::FuncExact(type_index) => {
-                        let output_type_index = map
-                            .type_index_base
-                            .checked_add(type_index)
-                            .ok_or_else(|| crate::error!("Wasm type index overflow"))?;
-                        let output_function_index = next_function_import_index;
-                        next_function_import_index = next_function_import_index
-                            .checked_add(1)
-                            .ok_or_else(|| crate::error!("Wasm function index overflow"))?;
-                        map.function_indices.push(output_function_index);
-                        layout.imports.push(OutputImport {
+                        function_imports.push(WasmFunctionImport {
                             module: import.module,
                             name: import.name,
-                            entity: OutputImportEntity::Function {
-                                type_index: output_type_index,
-                            },
+                            type_index,
                         });
                     }
                     TypeRef::Global(ty) => {
-                        let output_global_index = next_global_import_index;
-                        next_global_import_index = next_global_import_index
-                            .checked_add(1)
-                            .ok_or_else(|| crate::error!("Wasm global index overflow"))?;
-                        map.global_indices.push(output_global_index);
-                        layout.imports.push(OutputImport {
+                        global_imports.push(WasmGlobalImport {
                             module: import.module,
                             name: import.name,
-                            entity: OutputImportEntity::Global(ty),
+                            ty,
                         });
                     }
                     TypeRef::Table(_) => bail!("Wasm table imports are not emitted"),
@@ -1477,70 +1478,225 @@ where
             }
         }
 
-        layout.object_index_maps.push(map);
-    }
+        let module_functions = file.module_functions()?;
+        let globals = file
+            .module_globals()?
+            .into_iter()
+            .map(|global| {
+                let init_expr_body = crate::wasm_writer::const_expr_body(&global.init_expr)
+                    .ok_or_else(|| {
+                        crate::error!("Wasm global initializer is missing end opcode")
+                    })?;
+                Ok(OutputGlobal {
+                    ty: global.ty,
+                    init_expr_body,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
 
-    let mut next_function_index = next_function_import_index;
-    let mut next_global_index = next_global_import_index;
-
-    for (object, map) in objects.iter().zip(layout.object_index_maps.iter_mut()) {
-        for function in object.module_functions()? {
-            let output_type_index = map
-                .type_index_base
-                .checked_add(function.type_index)
-                .ok_or_else(|| crate::error!("Wasm type index overflow"))?;
-            layout.function_type_indices.push(output_type_index);
-            map.function_indices.push(next_function_index);
-            next_function_index = next_function_index
-                .checked_add(1)
-                .ok_or_else(|| crate::error!("Wasm function index overflow"))?;
-        }
-
-        for global in object.module_globals()? {
-            let init_expr_body = crate::wasm_writer::const_expr_body(&global.init_expr)
-                .ok_or_else(|| crate::error!("Wasm global initializer is missing end opcode"))?;
-            layout.globals.push(OutputGlobal {
-                ty: global.ty,
-                init_expr_body,
-            });
-            map.global_indices.push(next_global_index);
-            next_global_index = next_global_index
-                .checked_add(1)
-                .ok_or_else(|| crate::error!("Wasm global index overflow"))?;
-        }
-    }
-
-    for (object, map) in objects.iter().zip(layout.object_index_maps.iter()) {
-        if let Some(exports) = object.export_section_reader()? {
-            for export in exports {
+        let mut exports = Vec::new();
+        if let Some(export_section) = file.export_section_reader()? {
+            for export in export_section {
                 let export = export?;
-                let index = match export.kind {
-                    wasmparser::ExternalKind::Func | wasmparser::ExternalKind::FuncExact => {
-                        remap_wasm_index(&map.function_indices, export.index, "function")?
-                    }
-                    wasmparser::ExternalKind::Global => {
-                        remap_wasm_index(&map.global_indices, export.index, "global")?
-                    }
-                    wasmparser::ExternalKind::Table => {
-                        bail!("Wasm table exports are not emitted")
-                    }
-                    wasmparser::ExternalKind::Memory => {
-                        bail!("Wasm memory exports are not emitted")
-                    }
-                    wasmparser::ExternalKind::Tag => {
-                        bail!("Wasm tag exports are not emitted")
-                    }
-                };
-                layout.exports.push(OutputExport {
+                exports.push(OutputExport {
                     name: export.name,
                     kind: export.kind,
-                    index,
+                    index: export.index,
                 });
             }
         }
+
+        Ok(Self {
+            types,
+            function_imports,
+            global_imports,
+            module_functions,
+            globals,
+            exports,
+        })
     }
 
+    fn into_output_layout(
+        self,
+        index_bases: WasmObjectIndexBases,
+    ) -> Result<WasmObjectOutputLayout<'data>> {
+        let mut index_map = WasmObjectIndexMap {
+            type_index_base: index_bases.type_index_base,
+            function_indices: Vec::with_capacity(
+                self.function_imports.len() + self.module_functions.len(),
+            ),
+            global_indices: Vec::with_capacity(self.global_imports.len() + self.globals.len()),
+        };
+
+        let mut imports =
+            Vec::with_capacity(self.function_imports.len() + self.global_imports.len());
+        for (i, import) in self.function_imports.iter().enumerate() {
+            let output_type_index = index_bases
+                .type_index_base
+                .checked_add(import.type_index)
+                .ok_or_else(|| crate::error!("Wasm type index overflow"))?;
+            let output_function_index = index_bases
+                .function_import_base
+                .checked_add(u32::try_from(i).context("too many Wasm function imports")?)
+                .ok_or_else(|| crate::error!("Wasm function index overflow"))?;
+            index_map.function_indices.push(output_function_index);
+            imports.push(OutputImport {
+                module: import.module,
+                name: import.name,
+                entity: OutputImportEntity::Function {
+                    type_index: output_type_index,
+                },
+            });
+        }
+
+        for (i, import) in self.global_imports.iter().enumerate() {
+            let output_global_index = index_bases
+                .global_import_base
+                .checked_add(u32::try_from(i).context("too many Wasm global imports")?)
+                .ok_or_else(|| crate::error!("Wasm global index overflow"))?;
+            index_map.global_indices.push(output_global_index);
+            imports.push(OutputImport {
+                module: import.module,
+                name: import.name,
+                entity: OutputImportEntity::Global(import.ty),
+            });
+        }
+
+        let mut function_type_indices = Vec::with_capacity(self.module_functions.len());
+        for (i, function) in self.module_functions.iter().enumerate() {
+            let output_type_index = index_bases
+                .type_index_base
+                .checked_add(function.type_index)
+                .ok_or_else(|| crate::error!("Wasm type index overflow"))?;
+            let output_function_index = index_bases
+                .defined_function_base
+                .checked_add(u32::try_from(i).context("too many Wasm functions")?)
+                .ok_or_else(|| crate::error!("Wasm function index overflow"))?;
+            function_type_indices.push(output_type_index);
+            index_map.function_indices.push(output_function_index);
+        }
+
+        for i in 0..self.globals.len() {
+            let output_global_index = index_bases
+                .defined_global_base
+                .checked_add(u32::try_from(i).context("too many Wasm globals")?)
+                .ok_or_else(|| crate::error!("Wasm global index overflow"))?;
+            index_map.global_indices.push(output_global_index);
+        }
+
+        let exports = self
+            .exports
+            .into_iter()
+            .map(|export| {
+                let index = match export.kind {
+                    wasmparser::ExternalKind::Func | wasmparser::ExternalKind::FuncExact => {
+                        remap_wasm_index(&index_map.function_indices, export.index, "function")?
+                    }
+                    wasmparser::ExternalKind::Global => {
+                        remap_wasm_index(&index_map.global_indices, export.index, "global")?
+                    }
+                    wasmparser::ExternalKind::Table => bail!("Wasm table exports are not emitted"),
+                    wasmparser::ExternalKind::Memory => {
+                        bail!("Wasm memory exports are not emitted")
+                    }
+                    wasmparser::ExternalKind::Tag => bail!("Wasm tag exports are not emitted"),
+                };
+                Ok(OutputExport { index, ..export })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(WasmObjectOutputLayout {
+            types: self.types,
+            imports,
+            function_type_indices,
+            globals: self.globals,
+            exports,
+            index_map,
+        })
+    }
+}
+
+fn build_output_module_layout<'data, 'files>(
+    objects: impl Iterator<Item = &'files File<'data>>,
+) -> Result<WasmLayout<'data>>
+where
+    'data: 'files,
+{
+    let objects = objects.collect::<Vec<_>>();
+    let layout_inputs = objects
+        .par_iter()
+        .map(|object| WasmObjectLayoutInput::from_file(object))
+        .collect::<Result<Vec<_>>>()?;
+    let index_bases = allocate_wasm_object_index_bases(&layout_inputs)?;
+    let object_layouts = layout_inputs
+        .into_par_iter()
+        .zip(index_bases.into_par_iter())
+        .map(|(input, index_bases)| input.into_output_layout(index_bases))
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut layout = WasmLayout::default();
+    for object_layout in object_layouts {
+        layout.output_types.extend(object_layout.types);
+        layout.imports.extend(object_layout.imports);
+        layout
+            .function_type_indices
+            .extend(object_layout.function_type_indices);
+        layout.globals.extend(object_layout.globals);
+        layout.exports.extend(object_layout.exports);
+        layout.object_index_maps.push(object_layout.index_map);
+    }
     Ok(layout)
+}
+
+fn allocate_wasm_object_index_bases(
+    layout_inputs: &[WasmObjectLayoutInput<'_>],
+) -> Result<Vec<WasmObjectIndexBases>> {
+    let mut index_bases = Vec::with_capacity(layout_inputs.len());
+    let mut next_type_index = 0u32;
+    let mut next_function_import_index = 0u32;
+    let mut next_global_import_index = 0u32;
+
+    for input in layout_inputs {
+        index_bases.push(WasmObjectIndexBases {
+            type_index_base: next_type_index,
+            function_import_base: next_function_import_index,
+            defined_function_base: 0,
+            global_import_base: next_global_import_index,
+            defined_global_base: 0,
+        });
+        next_type_index = next_type_index
+            .checked_add(u32::try_from(input.types.len()).context("too many Wasm types")?)
+            .ok_or_else(|| crate::error!("Wasm type index overflow"))?;
+        next_function_import_index = next_function_import_index
+            .checked_add(
+                u32::try_from(input.function_imports.len())
+                    .context("too many Wasm function imports")?,
+            )
+            .ok_or_else(|| crate::error!("Wasm function index overflow"))?;
+        next_global_import_index = next_global_import_index
+            .checked_add(
+                u32::try_from(input.global_imports.len())
+                    .context("too many Wasm global imports")?,
+            )
+            .ok_or_else(|| crate::error!("Wasm global index overflow"))?;
+    }
+
+    let mut next_defined_function_index = next_function_import_index;
+    let mut next_defined_global_index = next_global_import_index;
+    for (input, index_base) in layout_inputs.iter().zip(index_bases.iter_mut()) {
+        index_base.defined_function_base = next_defined_function_index;
+        index_base.defined_global_base = next_defined_global_index;
+        next_defined_function_index = next_defined_function_index
+            .checked_add(
+                u32::try_from(input.module_functions.len()).context("too many Wasm functions")?,
+            )
+            .ok_or_else(|| crate::error!("Wasm function index overflow"))?;
+        next_defined_global_index = next_defined_global_index
+            .checked_add(u32::try_from(input.globals.len()).context("too many Wasm globals")?)
+            .ok_or_else(|| crate::error!("Wasm global index overflow"))?;
+    }
+
+    Ok(index_bases)
 }
 
 fn remap_wasm_index(indices: &[u32], index: u32, kind: &str) -> Result<u32> {

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -1881,12 +1881,12 @@ impl platform::Platform for Wasm {
     }
 
     fn allocate_header_sizes(
-        prelude: &mut crate::layout::PreludeLayoutState<Self>,
+        _prelude: &mut crate::layout::PreludeLayoutState<Self>,
         sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
-        header_info: &crate::layout::HeaderInfo,
-        output_sections: &crate::output_section_id::OutputSections<Self>,
+        _header_info: &crate::layout::HeaderInfo,
+        _output_sections: &crate::output_section_id::OutputSections<Self>,
     ) {
-        todo!()
+        sizes.increment(crate::part_id::FILE_HEADER, (WASM_MAGIC.len() + 4) as u64);
     }
 
     fn finalise_sizes_for_symbol<'data>(

--- a/libwild/src/wasm_writer.rs
+++ b/libwild/src/wasm_writer.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use crate::bail;
 use crate::error::Result;
 use crate::file_writer::SizedOutput;
 use crate::layout::Layout;
@@ -24,7 +25,7 @@ pub(crate) fn write<'data, A: Arch<Platform = Wasm>>(
     preamble[..4].copy_from_slice(&WASM_MAGIC);
     preamble[4..8].copy_from_slice(&WASM_VERSION.to_le_bytes());
 
-    crate::bail!("Wasm section emission is not implemented yet");
+    bail!("Wasm section emission is not implemented yet");
 }
 
 /// Build a `type` section from a list of function types in output order. Callers must have
@@ -140,8 +141,8 @@ fn convert_val_type(t: wasmparser::ValType) -> Result<wasm_encoder::ValType> {
         wasmparser::ValType::I64 => wasm_encoder::ValType::I64,
         wasmparser::ValType::F32 => wasm_encoder::ValType::F32,
         wasmparser::ValType::F64 => wasm_encoder::ValType::F64,
-        wasmparser::ValType::V128 => crate::bail!("V128 value type is not supported yet"),
-        wasmparser::ValType::Ref(_) => crate::bail!("reference value types are not supported yet"),
+        wasmparser::ValType::V128 => bail!("V128 value type is not supported yet"),
+        wasmparser::ValType::Ref(_) => bail!("reference value types are not supported yet"),
     })
 }
 


### PR DESCRIPTION
Add inert implementations for Wasm layout hooks that don't map to the current output model, and introduce `WasmLayout` as the layout state for output module data.

Part of #1431