### PR TITLE
docs: clarify wild output imposes no licensing requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,12 @@ queries, please email wild-mod@googlegroups.com.
 Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or [MIT license](LICENSE-MIT)
 at your option.
 
+For clarity, this is a documentation clarification and not legal advice: the licensing above applies
+to Wild's own source code and does not place any licensing or attribution requirements on binaries
+you produce with Wild. Wild does not embed its own copyrighted material in output files; it emits
+only short PLT stubs defined by the platform psABI. If Wild ever embeds substantial material in
+output files, that material will be under a very permissive license.
+
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in
 Wild by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any
 additional terms or conditions.


### PR DESCRIPTION
## Summary

Adds a short clarification to the README `## License` section stating that wild's dual MIT/Apache-2.0 license applies to wild's own source and places no licensing or attribution requirements on the binaries you link with it.

## Why this matters

A user asked whether distributing a binary linked with wild requires shipping wild's license files, noting LLD uses the Apache-2.0 LLVM exception that waives attribution for embedded portions (#1856). @davidlattimore clarified that wild does not embed its own copyrighted material into output (it emits only short, psABI-defined PLT stubs) and that relicensing the whole repo with an LLVM-style exception is impractical, but proposed documenting the situation in the README instead. This adds that paragraph in the maintainer's stated wording: the output has no licensing requirements imposed by the linker, and any future embedded content would be very permissively licensed.

The license terms themselves are unchanged; this is a clarification, not legal advice.

## Testing

Documentation only; no code paths affected.

Closes #1856
