### PR TITLE
port(wasm): Build and emit metadata section

### DIFF
--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -2079,13 +2079,14 @@ impl platform::Platform for Wasm {
     }
 
     fn finalise_layout_epilogue<'data>(
-        epilogue_state: &mut Self::EpilogueLayoutExt,
+        _epilogue_state: &mut Self::EpilogueLayoutExt,
         memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
-        symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
+        _symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
         common_state: &Self::LayoutExt<'data>,
-        dynsym_start_index: u32,
-        dynamic_symbol_defs: &[crate::layout::DynamicSymbolDefinition<Self>],
+        _dynsym_start_index: u32,
+        _dynamic_symbol_defs: &[crate::layout::DynamicSymbolDefinition<Self>],
     ) -> crate::error::Result {
+        common_state.encoded_sections.add_sizes_to(memory_offsets);
         Ok(())
     }
 

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -1391,6 +1391,74 @@ pub(crate) struct WasmLayout<'data> {
     pub(crate) globals: Vec<OutputGlobal<'data>>,
     pub(crate) exports: Vec<OutputExport<'data>>,
     pub(crate) object_index_maps: Vec<WasmObjectIndexMap>,
+    pub(crate) encoded_sections: WasmEncodedSections,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct WasmEncodedSections {
+    pub(crate) ty: Option<Vec<u8>>,
+    pub(crate) import: Option<Vec<u8>>,
+    pub(crate) function: Option<Vec<u8>>,
+    pub(crate) global: Option<Vec<u8>>,
+    pub(crate) export: Option<Vec<u8>>,
+}
+
+impl WasmEncodedSections {
+    fn add_sizes_to(&self, sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>) {
+        add_encoded_section_size(sizes, crate::part_id::WASM_TYPE, &self.ty);
+        add_encoded_section_size(sizes, crate::part_id::WASM_IMPORT, &self.import);
+        add_encoded_section_size(sizes, crate::part_id::WASM_FUNCTION, &self.function);
+        add_encoded_section_size(sizes, crate::part_id::WASM_GLOBAL, &self.global);
+        add_encoded_section_size(sizes, crate::part_id::WASM_EXPORT, &self.export);
+    }
+}
+
+fn add_encoded_section_size(
+    sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
+    part_id: crate::part_id::PartId,
+    section: &Option<Vec<u8>>,
+) {
+    if let Some(bytes) = section {
+        sizes.increment(part_id, bytes.len() as u64);
+    }
+}
+
+fn encode_wasm_section(section: &impl wasm_encoder::Section) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    section.append_to(&mut bytes);
+    bytes
+}
+
+impl<'data> WasmLayout<'data> {
+    fn encode_metadata_sections(&mut self) -> Result {
+        let type_section = crate::wasm_writer::build_type_section(&self.output_types)?;
+        if !type_section.is_empty() {
+            self.encoded_sections.ty = Some(encode_wasm_section(&type_section));
+        }
+
+        let import_section = crate::wasm_writer::build_import_section(&self.imports)?;
+        if !import_section.is_empty() {
+            self.encoded_sections.import = Some(encode_wasm_section(&import_section));
+        }
+
+        let function_section =
+            crate::wasm_writer::build_function_section(&self.function_type_indices);
+        if !function_section.is_empty() {
+            self.encoded_sections.function = Some(encode_wasm_section(&function_section));
+        }
+
+        let global_section = crate::wasm_writer::build_global_section(&self.globals)?;
+        if !global_section.is_empty() {
+            self.encoded_sections.global = Some(encode_wasm_section(&global_section));
+        }
+
+        let export_section = crate::wasm_writer::build_export_section(&self.exports);
+        if !export_section.is_empty() {
+            self.encoded_sections.export = Some(encode_wasm_section(&export_section));
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Debug, Default)]
@@ -1645,6 +1713,7 @@ where
         layout.exports.extend(object_layout.exports);
         layout.object_index_maps.push(object_layout.index_map);
     }
+    layout.encode_metadata_sections()?;
     Ok(layout)
 }
 
@@ -1984,11 +2053,12 @@ impl platform::Platform for Wasm {
 
     fn finalise_sizes_epilogue<'data>(
         _state: &mut Self::EpilogueLayoutExt,
-        _mem_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
+        mem_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         _dynamic_symbol_definitions: &[crate::layout::DynamicSymbolDefinition<'data, Self>],
-        _properties: &Self::LayoutExt<'data>,
+        properties: &Self::LayoutExt<'data>,
         _symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
     ) {
+        properties.encoded_sections.add_sizes_to(mem_sizes);
     }
 
     fn finalise_sizes_all<'data>(

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -1405,18 +1405,18 @@ pub(crate) struct WasmEncodedSections {
 
 impl WasmEncodedSections {
     fn add_sizes_to(&self, sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>) {
-        add_encoded_section_size(sizes, crate::part_id::WASM_TYPE, &self.ty);
-        add_encoded_section_size(sizes, crate::part_id::WASM_IMPORT, &self.import);
-        add_encoded_section_size(sizes, crate::part_id::WASM_FUNCTION, &self.function);
-        add_encoded_section_size(sizes, crate::part_id::WASM_GLOBAL, &self.global);
-        add_encoded_section_size(sizes, crate::part_id::WASM_EXPORT, &self.export);
+        add_encoded_section_size(sizes, crate::part_id::WASM_TYPE, self.ty.as_ref());
+        add_encoded_section_size(sizes, crate::part_id::WASM_IMPORT, self.import.as_ref());
+        add_encoded_section_size(sizes, crate::part_id::WASM_FUNCTION, self.function.as_ref());
+        add_encoded_section_size(sizes, crate::part_id::WASM_GLOBAL, self.global.as_ref());
+        add_encoded_section_size(sizes, crate::part_id::WASM_EXPORT, self.export.as_ref());
     }
 }
 
 fn add_encoded_section_size(
     sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
     part_id: crate::part_id::PartId,
-    section: &Option<Vec<u8>>,
+    section: Option<&Vec<u8>>,
 ) {
     if let Some(bytes) = section {
         sizes.increment(part_id, bytes.len() as u64);

--- a/libwild/src/wasm_writer.rs
+++ b/libwild/src/wasm_writer.rs
@@ -42,29 +42,29 @@ fn copy_metadata_sections(
 ) -> Result<()> {
     let encoded = &layout.encoded_sections;
     copy_encoded_section(
-        &encoded.ty,
+        encoded.ty.as_ref(),
         section_buffers.get_mut(crate::output_section_id::WASM_TYPE),
     )?;
     copy_encoded_section(
-        &encoded.import,
+        encoded.import.as_ref(),
         section_buffers.get_mut(crate::output_section_id::WASM_IMPORT),
     )?;
     copy_encoded_section(
-        &encoded.function,
+        encoded.function.as_ref(),
         section_buffers.get_mut(crate::output_section_id::WASM_FUNCTION),
     )?;
     copy_encoded_section(
-        &encoded.global,
+        encoded.global.as_ref(),
         section_buffers.get_mut(crate::output_section_id::WASM_GLOBAL),
     )?;
     copy_encoded_section(
-        &encoded.export,
+        encoded.export.as_ref(),
         section_buffers.get_mut(crate::output_section_id::WASM_EXPORT),
     )?;
     Ok(())
 }
 
-fn copy_encoded_section(encoded: &Option<Vec<u8>>, out: &mut [u8]) -> Result<()> {
+fn copy_encoded_section(encoded: Option<&Vec<u8>>, out: &mut [u8]) -> Result<()> {
     match encoded {
         Some(encoded) => {
             if out.len() != encoded.len() {

--- a/libwild/src/wasm_writer.rs
+++ b/libwild/src/wasm_writer.rs
@@ -3,11 +3,13 @@
 use crate::bail;
 use crate::error::Result;
 use crate::file_writer::SizedOutput;
+use crate::file_writer::split_output_into_sections;
 use crate::layout::Layout;
 use crate::platform::Arch;
 use crate::wasm::WASM_MAGIC;
 use crate::wasm::WASM_VERSION;
 use crate::wasm::Wasm;
+use crate::wasm::WasmLayout;
 use wasm_encoder::ExportSection;
 use wasm_encoder::FunctionSection;
 use wasm_encoder::GlobalSection;
@@ -16,16 +18,74 @@ use wasm_encoder::TypeSection;
 
 pub(crate) fn write<'data, A: Arch<Platform = Wasm>>(
     sized_output: &mut SizedOutput,
-    _layout: &Layout<'data, Wasm>,
+    layout: &Layout<'data, Wasm>,
 ) -> Result<()> {
-    let out: &mut [u8] = &mut sized_output.out;
-    let preamble = out
+    let (mut section_buffers, mut padding) =
+        split_output_into_sections(layout, &mut sized_output.out);
+    padding.fill_zero();
+
+    let preamble = section_buffers
+        .get_mut(crate::output_section_id::FILE_HEADER)
         .get_mut(..8)
         .ok_or_else(|| crate::error!("Wasm output buffer is shorter than the 8-byte preamble"))?;
     preamble[..4].copy_from_slice(&WASM_MAGIC);
     preamble[4..8].copy_from_slice(&WASM_VERSION.to_le_bytes());
 
-    bail!("Wasm section emission is not implemented yet");
+    copy_metadata_sections(&layout.properties_and_attributes, &mut section_buffers)?;
+
+    bail!("Wasm code and data section emission is not implemented yet");
+}
+
+fn copy_metadata_sections(
+    layout: &WasmLayout<'_>,
+    section_buffers: &mut crate::output_section_map::OutputSectionMap<&mut [u8]>,
+) -> Result<()> {
+    let encoded = &layout.encoded_sections;
+    copy_encoded_section(
+        &encoded.ty,
+        section_buffers.get_mut(crate::output_section_id::WASM_TYPE),
+    )?;
+    copy_encoded_section(
+        &encoded.import,
+        section_buffers.get_mut(crate::output_section_id::WASM_IMPORT),
+    )?;
+    copy_encoded_section(
+        &encoded.function,
+        section_buffers.get_mut(crate::output_section_id::WASM_FUNCTION),
+    )?;
+    copy_encoded_section(
+        &encoded.global,
+        section_buffers.get_mut(crate::output_section_id::WASM_GLOBAL),
+    )?;
+    copy_encoded_section(
+        &encoded.export,
+        section_buffers.get_mut(crate::output_section_id::WASM_EXPORT),
+    )?;
+    Ok(())
+}
+
+fn copy_encoded_section(encoded: &Option<Vec<u8>>, out: &mut [u8]) -> Result<()> {
+    match encoded {
+        Some(encoded) => {
+            if out.len() != encoded.len() {
+                bail!(
+                    "Wasm metadata section size mismatch: allocated {}, encoded {}",
+                    out.len(),
+                    encoded.len()
+                );
+            }
+            out.copy_from_slice(encoded);
+        }
+        None => {
+            if !out.is_empty() {
+                bail!(
+                    "Wasm metadata section unexpectedly allocated {} bytes",
+                    out.len()
+                );
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Build a `type` section from a list of function types in output order. Callers must have


### PR DESCRIPTION
Build the output module metadata during layout, encode the type, import, function, global and export sections, and account for their encoded sizes in the layout.

The writer now splits the output buffer by section, writes the Wasm preamble, and copies the pre-encoded metadata sections into their allocated slices. It still stops before code and data emission because those sections require function/data body layout and relocation application.

Part of #1431 