### PR TITLE
port(wasm): Build and emit code and memory sections

### DIFF
--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -11,9 +11,7 @@ use crate::layout::ImportedSymbol;
 use crate::layout_rules::SectionKind;
 use crate::output_section_id::SectionName;
 use crate::platform;
-use crate::wasm_writer::OutputDataSegment;
 use crate::wasm_writer::OutputExport;
-use crate::wasm_writer::OutputFunctionBody;
 use crate::wasm_writer::OutputGlobal;
 use crate::wasm_writer::OutputImport;
 use crate::wasm_writer::OutputImportEntity;
@@ -1438,9 +1436,8 @@ pub(crate) struct WasmLayout<'data> {
     pub(crate) function_type_indices: Vec<u32>,
     pub(crate) globals: Vec<OutputGlobal<'data>>,
     pub(crate) exports: Vec<OutputExport<'data>>,
-    pub(crate) function_bodies: Vec<OutputFunctionBody<'data>>,
+    pub(crate) function_bodies: Vec<WasmFunctionBody<'data>>,
     pub(crate) memories: Vec<MemoryType>,
-    pub(crate) data_segments: Vec<OutputDataSegment<'data>>,
     pub(crate) unsupported_output: Vec<&'static str>,
     pub(crate) object_index_maps: Vec<WasmObjectIndexMap>,
     pub(crate) encoded_sections: WasmEncodedSections,
@@ -1455,7 +1452,6 @@ pub(crate) struct WasmEncodedSections {
     pub(crate) export: Option<Vec<u8>>,
     pub(crate) code: Option<Vec<u8>>,
     pub(crate) memory: Option<Vec<u8>>,
-    pub(crate) data: Option<Vec<u8>>,
 }
 
 impl WasmEncodedSections {
@@ -1467,7 +1463,6 @@ impl WasmEncodedSections {
         add_encoded_section_size(sizes, crate::part_id::WASM_EXPORT, self.export.as_ref());
         add_encoded_section_size(sizes, crate::part_id::WASM_CODE, self.code.as_ref());
         add_encoded_section_size(sizes, crate::part_id::WASM_MEMORY, self.memory.as_ref());
-        add_encoded_section_size(sizes, crate::part_id::WASM_DATA, self.data.as_ref());
     }
 }
 
@@ -1520,14 +1515,11 @@ impl<'data> WasmLayout<'data> {
             self.encoded_sections.memory = Some(encode_wasm_section(&memory_section));
         }
 
-        let code_section = crate::wasm_writer::build_code_section(&self.function_bodies);
+        let code_section = crate::wasm_writer::build_code_section(
+            self.function_bodies.iter().map(|body| body.bytes),
+        );
         if !code_section.is_empty() {
             self.encoded_sections.code = Some(encode_wasm_section(&code_section));
-        }
-
-        let data_section = crate::wasm_writer::build_data_section(&self.data_segments)?;
-        if !data_section.is_empty() {
-            self.encoded_sections.data = Some(encode_wasm_section(&data_section));
         }
 
         Ok(())
@@ -1558,9 +1550,8 @@ struct WasmObjectLayoutInput<'data> {
     module_functions: Vec<WasmModuleFunction>,
     globals: Vec<OutputGlobal<'data>>,
     exports: Vec<OutputExport<'data>>,
-    function_bodies: Vec<OutputFunctionBody<'data>>,
+    function_bodies: Vec<WasmFunctionBody<'data>>,
     memories: Vec<MemoryType>,
-    data_segments: Vec<OutputDataSegment<'data>>,
     unsupported_output: Vec<&'static str>,
 }
 
@@ -1581,9 +1572,8 @@ struct WasmObjectOutputLayout<'data> {
     function_type_indices: Vec<u32>,
     globals: Vec<OutputGlobal<'data>>,
     exports: Vec<OutputExport<'data>>,
-    function_bodies: Vec<OutputFunctionBody<'data>>,
+    function_bodies: Vec<WasmFunctionBody<'data>>,
     memories: Vec<MemoryType>,
-    data_segments: Vec<OutputDataSegment<'data>>,
     unsupported_output: Vec<&'static str>,
     index_map: WasmObjectIndexMap,
 }
@@ -1645,6 +1635,9 @@ impl<'data> WasmObjectLayoutInput<'data> {
         if file.standard_section_index[section_id::DATA_COUNT as usize].is_some() {
             unsupported_output.push("data_count");
         }
+        if file.standard_section_index[section_id::DATA as usize].is_some() {
+            unsupported_output.push("data");
+        }
 
         let module_functions = file.module_functions()?;
         let function_bodies = file.function_bodies()?;
@@ -1653,14 +1646,6 @@ impl<'data> WasmObjectLayoutInput<'data> {
             "Wasm function and code section counts differ"
         );
         let memories = file.memories()?;
-        let data_segments = file
-            .data_segments()?
-            .into_iter()
-            .map(|segment| OutputDataSegment {
-                kind: segment.kind,
-                data: segment.data,
-            })
-            .collect();
 
         let globals = file
             .module_globals()?
@@ -1696,12 +1681,8 @@ impl<'data> WasmObjectLayoutInput<'data> {
             module_functions,
             globals,
             exports,
-            function_bodies: function_bodies
-                .into_iter()
-                .map(|body| OutputFunctionBody { bytes: body.bytes })
-                .collect(),
+            function_bodies,
             memories,
-            data_segments,
             unsupported_output,
         })
     }
@@ -1775,19 +1756,8 @@ impl<'data> WasmObjectLayoutInput<'data> {
             index_map.global_indices.push(output_global_index);
         }
 
-        for i in 0..self.memories.len() {
-            let output_memory_index = index_bases
-                .memory_base
-                .checked_add(u32::try_from(i).context("too many Wasm memories")?)
-                .ok_or_else(|| crate::error!("Wasm memory index overflow"))?;
-            index_map.memory_indices.push(output_memory_index);
-        }
-
-        let data_segments = self
-            .data_segments
-            .into_iter()
-            .map(|segment| remap_data_segment(segment, &index_map))
-            .collect::<Result<Vec<_>>>()?;
+        index_map.memory_indices =
+            wasm_index_range(index_bases.memory_base, self.memories.len(), "memories")?;
 
         let exports = self
             .exports
@@ -1818,7 +1788,6 @@ impl<'data> WasmObjectLayoutInput<'data> {
             exports,
             function_bodies: self.function_bodies,
             memories: self.memories,
-            data_segments,
             unsupported_output: self.unsupported_output,
             index_map,
         })
@@ -1854,7 +1823,6 @@ where
         layout.exports.extend(object_layout.exports);
         layout.function_bodies.extend(object_layout.function_bodies);
         layout.memories.extend(object_layout.memories);
-        layout.data_segments.extend(object_layout.data_segments);
         layout
             .unsupported_output
             .extend(object_layout.unsupported_output);
@@ -1927,24 +1895,12 @@ fn remap_wasm_index(indices: &[u32], index: u32, kind: &str) -> Result<u32> {
         .ok_or_else(|| crate::error!("Wasm {kind} index {index} out of range"))
 }
 
-fn remap_data_segment<'data>(
-    segment: OutputDataSegment<'data>,
-    index_map: &WasmObjectIndexMap,
-) -> Result<OutputDataSegment<'data>> {
-    let kind = match segment.kind {
-        DataKind::Active {
-            memory_index,
-            offset_expr,
-        } => DataKind::Active {
-            memory_index: remap_wasm_index(&index_map.memory_indices, memory_index, "memory")?,
-            offset_expr,
-        },
-        DataKind::Passive => DataKind::Passive,
-    };
-    Ok(OutputDataSegment {
-        kind,
-        data: segment.data,
-    })
+fn wasm_index_range(base: u32, len: usize, kind: &str) -> Result<Vec<u32>> {
+    let len = u32::try_from(len).with_context(|| format!("too many Wasm {kind}"))?;
+    let end = base
+        .checked_add(len)
+        .ok_or_else(|| crate::error!("too many Wasm {kind}"))?;
+    Ok((base..end).collect())
 }
 
 impl platform::Platform for Wasm {

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -11,6 +11,7 @@ use crate::layout::ImportedSymbol;
 use crate::layout_rules::SectionKind;
 use crate::output_section_id::SectionName;
 use crate::platform;
+use crate::wasm_writer::OutputDataSegment;
 use crate::wasm_writer::OutputExport;
 use crate::wasm_writer::OutputFunctionBody;
 use crate::wasm_writer::OutputGlobal;
@@ -31,6 +32,8 @@ use wasmparser::GlobalType;
 use wasmparser::ImportSectionReader;
 use wasmparser::KnownCustom;
 use wasmparser::Linking;
+use wasmparser::MemorySectionReader;
+use wasmparser::MemoryType;
 use wasmparser::Parser;
 use wasmparser::Payload;
 use wasmparser::RelocationEntry;
@@ -444,6 +447,12 @@ impl<'data> File<'data> {
             .transpose()
     }
 
+    pub(crate) fn memory_section_reader(&self) -> Result<Option<MemorySectionReader<'data>>> {
+        self.standard_section_reader(section_id::MEMORY)
+            .map(|r| MemorySectionReader::new(r).map_err(Into::into))
+            .transpose()
+    }
+
     pub(crate) fn export_section_reader(&self) -> Result<Option<ExportSectionReader<'data>>> {
         self.standard_section_reader(section_id::EXPORT)
             .map(|r| ExportSectionReader::new(r).map_err(Into::into))
@@ -526,6 +535,16 @@ impl<'data> File<'data> {
                 })
                 .map_err(Into::into)
             })
+            .collect()
+    }
+
+    pub(crate) fn memories(&self) -> Result<Vec<MemoryType>> {
+        let Some(reader) = self.memory_section_reader()? else {
+            return Ok(Vec::new());
+        };
+        reader
+            .into_iter()
+            .map(|res| res.map_err(Into::into))
             .collect()
     }
 
@@ -1420,6 +1439,9 @@ pub(crate) struct WasmLayout<'data> {
     pub(crate) globals: Vec<OutputGlobal<'data>>,
     pub(crate) exports: Vec<OutputExport<'data>>,
     pub(crate) function_bodies: Vec<OutputFunctionBody<'data>>,
+    pub(crate) memories: Vec<MemoryType>,
+    pub(crate) data_segments: Vec<OutputDataSegment<'data>>,
+    pub(crate) unsupported_output: Vec<&'static str>,
     pub(crate) object_index_maps: Vec<WasmObjectIndexMap>,
     pub(crate) encoded_sections: WasmEncodedSections,
 }
@@ -1432,6 +1454,8 @@ pub(crate) struct WasmEncodedSections {
     pub(crate) global: Option<Vec<u8>>,
     pub(crate) export: Option<Vec<u8>>,
     pub(crate) code: Option<Vec<u8>>,
+    pub(crate) memory: Option<Vec<u8>>,
+    pub(crate) data: Option<Vec<u8>>,
 }
 
 impl WasmEncodedSections {
@@ -1442,6 +1466,8 @@ impl WasmEncodedSections {
         add_encoded_section_size(sizes, crate::part_id::WASM_GLOBAL, self.global.as_ref());
         add_encoded_section_size(sizes, crate::part_id::WASM_EXPORT, self.export.as_ref());
         add_encoded_section_size(sizes, crate::part_id::WASM_CODE, self.code.as_ref());
+        add_encoded_section_size(sizes, crate::part_id::WASM_MEMORY, self.memory.as_ref());
+        add_encoded_section_size(sizes, crate::part_id::WASM_DATA, self.data.as_ref());
     }
 }
 
@@ -1489,9 +1515,19 @@ impl<'data> WasmLayout<'data> {
             self.encoded_sections.export = Some(encode_wasm_section(&export_section));
         }
 
+        let memory_section = crate::wasm_writer::build_memory_section(&self.memories);
+        if !memory_section.is_empty() {
+            self.encoded_sections.memory = Some(encode_wasm_section(&memory_section));
+        }
+
         let code_section = crate::wasm_writer::build_code_section(&self.function_bodies);
         if !code_section.is_empty() {
             self.encoded_sections.code = Some(encode_wasm_section(&code_section));
+        }
+
+        let data_section = crate::wasm_writer::build_data_section(&self.data_segments)?;
+        if !data_section.is_empty() {
+            self.encoded_sections.data = Some(encode_wasm_section(&data_section));
         }
 
         Ok(())
@@ -1503,6 +1539,7 @@ pub(crate) struct WasmObjectIndexMap {
     pub(crate) type_index_base: u32,
     pub(crate) function_indices: Vec<u32>,
     pub(crate) global_indices: Vec<u32>,
+    pub(crate) memory_indices: Vec<u32>,
 }
 
 #[derive(Debug, Default)]
@@ -1522,6 +1559,9 @@ struct WasmObjectLayoutInput<'data> {
     globals: Vec<OutputGlobal<'data>>,
     exports: Vec<OutputExport<'data>>,
     function_bodies: Vec<OutputFunctionBody<'data>>,
+    memories: Vec<MemoryType>,
+    data_segments: Vec<OutputDataSegment<'data>>,
+    unsupported_output: Vec<&'static str>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1531,6 +1571,7 @@ struct WasmObjectIndexBases {
     defined_function_base: u32,
     global_import_base: u32,
     defined_global_base: u32,
+    memory_base: u32,
 }
 
 #[derive(Debug)]
@@ -1541,6 +1582,9 @@ struct WasmObjectOutputLayout<'data> {
     globals: Vec<OutputGlobal<'data>>,
     exports: Vec<OutputExport<'data>>,
     function_bodies: Vec<OutputFunctionBody<'data>>,
+    memories: Vec<MemoryType>,
+    data_segments: Vec<OutputDataSegment<'data>>,
+    unsupported_output: Vec<&'static str>,
     index_map: WasmObjectIndexMap,
 }
 
@@ -1585,8 +1629,21 @@ impl<'data> WasmObjectLayoutInput<'data> {
             }
         }
 
+        let mut unsupported_output = Vec::new();
         if !file.reloc_sections.is_empty() {
-            bail!("Wasm relocations are not applied during code emission")
+            unsupported_output.push("relocation");
+        }
+        if file.standard_section_index[section_id::TABLE as usize].is_some() {
+            unsupported_output.push("table");
+        }
+        if file.standard_section_index[section_id::ELEMENT as usize].is_some() {
+            unsupported_output.push("element");
+        }
+        if file.standard_section_index[section_id::START as usize].is_some() {
+            unsupported_output.push("start");
+        }
+        if file.standard_section_index[section_id::DATA_COUNT as usize].is_some() {
+            unsupported_output.push("data_count");
         }
 
         let module_functions = file.module_functions()?;
@@ -1595,10 +1652,15 @@ impl<'data> WasmObjectLayoutInput<'data> {
             module_functions.len() == function_bodies.len(),
             "Wasm function and code section counts differ"
         );
-        ensure!(
-            file.data_segments()?.is_empty(),
-            "Wasm data section emission is not implemented"
-        );
+        let memories = file.memories()?;
+        let data_segments = file
+            .data_segments()?
+            .into_iter()
+            .map(|segment| OutputDataSegment {
+                kind: segment.kind,
+                data: segment.data,
+            })
+            .collect();
 
         let globals = file
             .module_globals()?
@@ -1638,6 +1700,9 @@ impl<'data> WasmObjectLayoutInput<'data> {
                 .into_iter()
                 .map(|body| OutputFunctionBody { bytes: body.bytes })
                 .collect(),
+            memories,
+            data_segments,
+            unsupported_output,
         })
     }
 
@@ -1651,6 +1716,7 @@ impl<'data> WasmObjectLayoutInput<'data> {
                 self.function_imports.len() + self.module_functions.len(),
             ),
             global_indices: Vec::with_capacity(self.global_imports.len() + self.globals.len()),
+            memory_indices: Vec::with_capacity(self.memories.len()),
         };
 
         let mut imports =
@@ -1709,6 +1775,20 @@ impl<'data> WasmObjectLayoutInput<'data> {
             index_map.global_indices.push(output_global_index);
         }
 
+        for i in 0..self.memories.len() {
+            let output_memory_index = index_bases
+                .memory_base
+                .checked_add(u32::try_from(i).context("too many Wasm memories")?)
+                .ok_or_else(|| crate::error!("Wasm memory index overflow"))?;
+            index_map.memory_indices.push(output_memory_index);
+        }
+
+        let data_segments = self
+            .data_segments
+            .into_iter()
+            .map(|segment| remap_data_segment(segment, &index_map))
+            .collect::<Result<Vec<_>>>()?;
+
         let exports = self
             .exports
             .into_iter()
@@ -1720,10 +1800,10 @@ impl<'data> WasmObjectLayoutInput<'data> {
                     wasmparser::ExternalKind::Global => {
                         remap_wasm_index(&index_map.global_indices, export.index, "global")?
                     }
-                    wasmparser::ExternalKind::Table => bail!("Wasm table exports are not emitted"),
                     wasmparser::ExternalKind::Memory => {
-                        bail!("Wasm memory exports are not emitted")
+                        remap_wasm_index(&index_map.memory_indices, export.index, "memory")?
                     }
+                    wasmparser::ExternalKind::Table => bail!("Wasm table exports are not emitted"),
                     wasmparser::ExternalKind::Tag => bail!("Wasm tag exports are not emitted"),
                 };
                 Ok(OutputExport { index, ..export })
@@ -1737,6 +1817,9 @@ impl<'data> WasmObjectLayoutInput<'data> {
             globals: self.globals,
             exports,
             function_bodies: self.function_bodies,
+            memories: self.memories,
+            data_segments,
+            unsupported_output: self.unsupported_output,
             index_map,
         })
     }
@@ -1770,6 +1853,11 @@ where
         layout.globals.extend(object_layout.globals);
         layout.exports.extend(object_layout.exports);
         layout.function_bodies.extend(object_layout.function_bodies);
+        layout.memories.extend(object_layout.memories);
+        layout.data_segments.extend(object_layout.data_segments);
+        layout
+            .unsupported_output
+            .extend(object_layout.unsupported_output);
         layout.object_index_maps.push(object_layout.index_map);
     }
     layout.encode_metadata_sections()?;
@@ -1783,6 +1871,7 @@ fn allocate_wasm_object_index_bases(
     let mut next_type_index = 0u32;
     let mut next_function_import_index = 0u32;
     let mut next_global_import_index = 0u32;
+    let mut next_memory_index = 0u32;
 
     for input in layout_inputs {
         index_bases.push(WasmObjectIndexBases {
@@ -1791,6 +1880,7 @@ fn allocate_wasm_object_index_bases(
             defined_function_base: 0,
             global_import_base: next_global_import_index,
             defined_global_base: 0,
+            memory_base: next_memory_index,
         });
         next_type_index = next_type_index
             .checked_add(u32::try_from(input.types.len()).context("too many Wasm types")?)
@@ -1807,6 +1897,9 @@ fn allocate_wasm_object_index_bases(
                     .context("too many Wasm global imports")?,
             )
             .ok_or_else(|| crate::error!("Wasm global index overflow"))?;
+        next_memory_index = next_memory_index
+            .checked_add(u32::try_from(input.memories.len()).context("too many Wasm memories")?)
+            .ok_or_else(|| crate::error!("Wasm memory index overflow"))?;
     }
 
     let mut next_defined_function_index = next_function_import_index;
@@ -1832,6 +1925,26 @@ fn remap_wasm_index(indices: &[u32], index: u32, kind: &str) -> Result<u32> {
         .get(index as usize)
         .copied()
         .ok_or_else(|| crate::error!("Wasm {kind} index {index} out of range"))
+}
+
+fn remap_data_segment<'data>(
+    segment: OutputDataSegment<'data>,
+    index_map: &WasmObjectIndexMap,
+) -> Result<OutputDataSegment<'data>> {
+    let kind = match segment.kind {
+        DataKind::Active {
+            memory_index,
+            offset_expr,
+        } => DataKind::Active {
+            memory_index: remap_wasm_index(&index_map.memory_indices, memory_index, "memory")?,
+            offset_expr,
+        },
+        DataKind::Passive => DataKind::Passive,
+    };
+    Ok(OutputDataSegment {
+        kind,
+        data: segment.data,
+    })
 }
 
 impl platform::Platform for Wasm {

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -12,6 +12,7 @@ use crate::layout_rules::SectionKind;
 use crate::output_section_id::SectionName;
 use crate::platform;
 use crate::wasm_writer::OutputExport;
+use crate::wasm_writer::OutputFunctionBody;
 use crate::wasm_writer::OutputGlobal;
 use crate::wasm_writer::OutputImport;
 use crate::wasm_writer::OutputImportEntity;
@@ -19,6 +20,7 @@ use linker_utils::utils::u32_from_slice;
 use rayon::prelude::*;
 use std::ops::Range;
 use wasmparser::BinaryReader;
+use wasmparser::CodeSectionReader;
 use wasmparser::ConstExpr;
 use wasmparser::DataKind;
 use wasmparser::DataSectionReader;
@@ -394,6 +396,11 @@ pub(crate) struct WasmDataSegment<'data> {
     pub(crate) data: &'data [u8],
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct WasmFunctionBody<'data> {
+    pub(crate) bytes: &'data [u8],
+}
+
 impl<'data> File<'data> {
     /// Construct a `BinaryReader` over the payload of the standard section with the given id,
     /// or `None` if the input has no such section.
@@ -428,6 +435,12 @@ impl<'data> File<'data> {
     pub(crate) fn data_section_reader(&self) -> Result<Option<DataSectionReader<'data>>> {
         self.standard_section_reader(section_id::DATA)
             .map(|r| DataSectionReader::new(r).map_err(Into::into))
+            .transpose()
+    }
+
+    pub(crate) fn code_section_reader(&self) -> Result<Option<CodeSectionReader<'data>>> {
+        self.standard_section_reader(section_id::CODE)
+            .map(|r| CodeSectionReader::new(r).map_err(Into::into))
             .transpose()
     }
 
@@ -510,6 +523,22 @@ impl<'data> File<'data> {
                 res.map(|g| WasmModuleGlobal {
                     ty: g.ty,
                     init_expr: g.init_expr,
+                })
+                .map_err(Into::into)
+            })
+            .collect()
+    }
+
+    /// Function bodies in code-section order. The returned bytes include the body size prefix.
+    pub(crate) fn function_bodies(&self) -> Result<Vec<WasmFunctionBody<'data>>> {
+        let Some(reader) = self.code_section_reader()? else {
+            return Ok(Vec::new());
+        };
+        reader
+            .into_iter()
+            .map(|res| {
+                res.map(|body| WasmFunctionBody {
+                    bytes: &self.data[body.range()],
                 })
                 .map_err(Into::into)
             })
@@ -1390,6 +1419,7 @@ pub(crate) struct WasmLayout<'data> {
     pub(crate) function_type_indices: Vec<u32>,
     pub(crate) globals: Vec<OutputGlobal<'data>>,
     pub(crate) exports: Vec<OutputExport<'data>>,
+    pub(crate) function_bodies: Vec<OutputFunctionBody<'data>>,
     pub(crate) object_index_maps: Vec<WasmObjectIndexMap>,
     pub(crate) encoded_sections: WasmEncodedSections,
 }
@@ -1401,6 +1431,7 @@ pub(crate) struct WasmEncodedSections {
     pub(crate) function: Option<Vec<u8>>,
     pub(crate) global: Option<Vec<u8>>,
     pub(crate) export: Option<Vec<u8>>,
+    pub(crate) code: Option<Vec<u8>>,
 }
 
 impl WasmEncodedSections {
@@ -1410,6 +1441,7 @@ impl WasmEncodedSections {
         add_encoded_section_size(sizes, crate::part_id::WASM_FUNCTION, self.function.as_ref());
         add_encoded_section_size(sizes, crate::part_id::WASM_GLOBAL, self.global.as_ref());
         add_encoded_section_size(sizes, crate::part_id::WASM_EXPORT, self.export.as_ref());
+        add_encoded_section_size(sizes, crate::part_id::WASM_CODE, self.code.as_ref());
     }
 }
 
@@ -1457,6 +1489,11 @@ impl<'data> WasmLayout<'data> {
             self.encoded_sections.export = Some(encode_wasm_section(&export_section));
         }
 
+        let code_section = crate::wasm_writer::build_code_section(&self.function_bodies);
+        if !code_section.is_empty() {
+            self.encoded_sections.code = Some(encode_wasm_section(&code_section));
+        }
+
         Ok(())
     }
 }
@@ -1484,6 +1521,7 @@ struct WasmObjectLayoutInput<'data> {
     module_functions: Vec<WasmModuleFunction>,
     globals: Vec<OutputGlobal<'data>>,
     exports: Vec<OutputExport<'data>>,
+    function_bodies: Vec<OutputFunctionBody<'data>>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1502,6 +1540,7 @@ struct WasmObjectOutputLayout<'data> {
     function_type_indices: Vec<u32>,
     globals: Vec<OutputGlobal<'data>>,
     exports: Vec<OutputExport<'data>>,
+    function_bodies: Vec<OutputFunctionBody<'data>>,
     index_map: WasmObjectIndexMap,
 }
 
@@ -1546,7 +1585,21 @@ impl<'data> WasmObjectLayoutInput<'data> {
             }
         }
 
+        if !file.reloc_sections.is_empty() {
+            bail!("Wasm relocations are not applied during code emission")
+        }
+
         let module_functions = file.module_functions()?;
+        let function_bodies = file.function_bodies()?;
+        ensure!(
+            module_functions.len() == function_bodies.len(),
+            "Wasm function and code section counts differ"
+        );
+        ensure!(
+            file.data_segments()?.is_empty(),
+            "Wasm data section emission is not implemented"
+        );
+
         let globals = file
             .module_globals()?
             .into_iter()
@@ -1581,6 +1634,10 @@ impl<'data> WasmObjectLayoutInput<'data> {
             module_functions,
             globals,
             exports,
+            function_bodies: function_bodies
+                .into_iter()
+                .map(|body| OutputFunctionBody { bytes: body.bytes })
+                .collect(),
         })
     }
 
@@ -1679,6 +1736,7 @@ impl<'data> WasmObjectLayoutInput<'data> {
             function_type_indices,
             globals: self.globals,
             exports,
+            function_bodies: self.function_bodies,
             index_map,
         })
     }
@@ -1711,6 +1769,7 @@ where
             .extend(object_layout.function_type_indices);
         layout.globals.extend(object_layout.globals);
         layout.exports.extend(object_layout.exports);
+        layout.function_bodies.extend(object_layout.function_bodies);
         layout.object_index_maps.push(object_layout.index_map);
     }
     layout.encode_metadata_sections()?;

--- a/libwild/src/wasm_writer.rs
+++ b/libwild/src/wasm_writer.rs
@@ -10,6 +10,7 @@ use crate::wasm::WASM_MAGIC;
 use crate::wasm::WASM_VERSION;
 use crate::wasm::Wasm;
 use crate::wasm::WasmLayout;
+use wasm_encoder::CodeSection;
 use wasm_encoder::ExportSection;
 use wasm_encoder::FunctionSection;
 use wasm_encoder::GlobalSection;
@@ -33,7 +34,7 @@ pub(crate) fn write<'data, A: Arch<Platform = Wasm>>(
 
     copy_metadata_sections(&layout.properties_and_attributes, &mut section_buffers)?;
 
-    bail!("Wasm code and data section emission is not implemented yet");
+    bail!("Wasm data and remaining section emission is not implemented yet")
 }
 
 fn copy_metadata_sections(
@@ -60,6 +61,10 @@ fn copy_metadata_sections(
     copy_encoded_section(
         encoded.export.as_ref(),
         section_buffers.get_mut(crate::output_section_id::WASM_EXPORT),
+    )?;
+    copy_encoded_section(
+        encoded.code.as_ref(),
+        section_buffers.get_mut(crate::output_section_id::WASM_CODE),
     )?;
     Ok(())
 }
@@ -149,6 +154,22 @@ pub(crate) fn build_global_section(globals: &[OutputGlobal<'_>]) -> Result<Globa
     Ok(section)
 }
 
+pub(crate) fn build_memory_section(memories: &[wasmparser::MemoryType]) -> MemorySection {
+    let mut section = MemorySection::new();
+    for &memory in memories {
+        section.memory(convert_memory_type(memory));
+    }
+    section
+}
+
+pub(crate) fn build_code_section(function_bodies: &[OutputFunctionBody<'_>]) -> CodeSection {
+    let mut section = CodeSection::new();
+    for body in function_bodies {
+        section.raw(body.bytes);
+    }
+    section
+}
+
 /// Build an `export` section.
 pub(crate) fn build_export_section(exports: &[OutputExport<'_>]) -> ExportSection {
     let mut section = ExportSection::new();
@@ -176,6 +197,11 @@ pub(crate) struct OutputGlobal<'a> {
     pub(crate) ty: wasmparser::GlobalType,
     /// Const-expression body without the trailing `end` opcode.
     pub(crate) init_expr_body: &'a [u8],
+}
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct OutputFunctionBody<'a> {
+    pub(crate) bytes: &'a [u8],
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/libwild/src/wasm_writer.rs
+++ b/libwild/src/wasm_writer.rs
@@ -11,7 +11,6 @@ use crate::wasm::WASM_VERSION;
 use crate::wasm::Wasm;
 use crate::wasm::WasmLayout;
 use wasm_encoder::CodeSection;
-use wasm_encoder::DataSection;
 use wasm_encoder::ExportSection;
 use wasm_encoder::FunctionSection;
 use wasm_encoder::GlobalSection;
@@ -75,10 +74,6 @@ fn copy_metadata_sections(
     copy_encoded_section(
         encoded.memory.as_ref(),
         section_buffers.get_mut(crate::output_section_id::WASM_MEMORY),
-    )?;
-    copy_encoded_section(
-        encoded.data.as_ref(),
-        section_buffers.get_mut(crate::output_section_id::WASM_DATA),
     )?;
     Ok(())
 }
@@ -176,32 +171,14 @@ pub(crate) fn build_memory_section(memories: &[wasmparser::MemoryType]) -> Memor
     section
 }
 
-pub(crate) fn build_code_section(function_bodies: &[OutputFunctionBody<'_>]) -> CodeSection {
+pub(crate) fn build_code_section<'a>(
+    function_bodies: impl IntoIterator<Item = &'a [u8]>,
+) -> CodeSection {
     let mut section = CodeSection::new();
     for body in function_bodies {
-        section.raw(body.bytes);
+        section.raw(body);
     }
     section
-}
-
-pub(crate) fn build_data_section(data_segments: &[OutputDataSegment<'_>]) -> Result<DataSection> {
-    let mut section = DataSection::new();
-    for segment in data_segments {
-        match &segment.kind {
-            wasmparser::DataKind::Active {
-                memory_index,
-                offset_expr,
-            } => {
-                let offset_body = const_expr_body(offset_expr).ok_or_else(|| {
-                    crate::error!("Wasm data segment offset expression is missing end opcode")
-                })?;
-                let offset = wasm_encoder::ConstExpr::raw(offset_body.iter().copied());
-                section.active(*memory_index, &offset, segment.data.iter().copied());
-            }
-            wasmparser::DataKind::Passive => bail!("Wasm passive data segments are not emitted"),
-        }
-    }
-    Ok(section)
 }
 
 /// Build an `export` section.
@@ -231,17 +208,6 @@ pub(crate) struct OutputGlobal<'a> {
     pub(crate) ty: wasmparser::GlobalType,
     /// Const-expression body without the trailing `end` opcode.
     pub(crate) init_expr_body: &'a [u8],
-}
-
-#[derive(Debug, Copy, Clone)]
-pub(crate) struct OutputFunctionBody<'a> {
-    pub(crate) bytes: &'a [u8],
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct OutputDataSegment<'a> {
-    pub(crate) kind: wasmparser::DataKind<'a>,
-    pub(crate) data: &'a [u8],
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/libwild/src/wasm_writer.rs
+++ b/libwild/src/wasm_writer.rs
@@ -11,10 +11,12 @@ use crate::wasm::WASM_VERSION;
 use crate::wasm::Wasm;
 use crate::wasm::WasmLayout;
 use wasm_encoder::CodeSection;
+use wasm_encoder::DataSection;
 use wasm_encoder::ExportSection;
 use wasm_encoder::FunctionSection;
 use wasm_encoder::GlobalSection;
 use wasm_encoder::ImportSection;
+use wasm_encoder::MemorySection;
 use wasm_encoder::TypeSection;
 
 pub(crate) fn write<'data, A: Arch<Platform = Wasm>>(
@@ -34,7 +36,11 @@ pub(crate) fn write<'data, A: Arch<Platform = Wasm>>(
 
     copy_metadata_sections(&layout.properties_and_attributes, &mut section_buffers)?;
 
-    bail!("Wasm data and remaining section emission is not implemented yet")
+    if let Some(unsupported) = layout.properties_and_attributes.unsupported_output.first() {
+        bail!("Wasm {unsupported} emission is not implemented yet");
+    }
+
+    Ok(())
 }
 
 fn copy_metadata_sections(
@@ -65,6 +71,14 @@ fn copy_metadata_sections(
     copy_encoded_section(
         encoded.code.as_ref(),
         section_buffers.get_mut(crate::output_section_id::WASM_CODE),
+    )?;
+    copy_encoded_section(
+        encoded.memory.as_ref(),
+        section_buffers.get_mut(crate::output_section_id::WASM_MEMORY),
+    )?;
+    copy_encoded_section(
+        encoded.data.as_ref(),
+        section_buffers.get_mut(crate::output_section_id::WASM_DATA),
     )?;
     Ok(())
 }
@@ -170,6 +184,26 @@ pub(crate) fn build_code_section(function_bodies: &[OutputFunctionBody<'_>]) -> 
     section
 }
 
+pub(crate) fn build_data_section(data_segments: &[OutputDataSegment<'_>]) -> Result<DataSection> {
+    let mut section = DataSection::new();
+    for segment in data_segments {
+        match &segment.kind {
+            wasmparser::DataKind::Active {
+                memory_index,
+                offset_expr,
+            } => {
+                let offset_body = const_expr_body(offset_expr).ok_or_else(|| {
+                    crate::error!("Wasm data segment offset expression is missing end opcode")
+                })?;
+                let offset = wasm_encoder::ConstExpr::raw(offset_body.iter().copied());
+                section.active(*memory_index, &offset, segment.data.iter().copied());
+            }
+            wasmparser::DataKind::Passive => bail!("Wasm passive data segments are not emitted"),
+        }
+    }
+    Ok(section)
+}
+
 /// Build an `export` section.
 pub(crate) fn build_export_section(exports: &[OutputExport<'_>]) -> ExportSection {
     let mut section = ExportSection::new();
@@ -202,6 +236,12 @@ pub(crate) struct OutputGlobal<'a> {
 #[derive(Debug, Copy, Clone)]
 pub(crate) struct OutputFunctionBody<'a> {
     pub(crate) bytes: &'a [u8],
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct OutputDataSegment<'a> {
+    pub(crate) kind: wasmparser::DataKind<'a>,
+    pub(crate) data: &'a [u8],
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -238,6 +278,16 @@ fn convert_global_type(t: wasmparser::GlobalType) -> Result<wasm_encoder::Global
         mutable: t.mutable,
         shared: t.shared,
     })
+}
+
+fn convert_memory_type(t: wasmparser::MemoryType) -> wasm_encoder::MemoryType {
+    wasm_encoder::MemoryType {
+        minimum: t.initial,
+        maximum: t.maximum,
+        memory64: t.memory64,
+        shared: t.shared,
+        page_size_log2: t.page_size_log2,
+    }
 }
 
 fn convert_export_kind(k: wasmparser::ExternalKind) -> wasm_encoder::ExportKind {


### PR DESCRIPTION
As with #2042, this patch enables building and emitting code and memory sections.

Part of #1431