### PR TITLE
feat: use the LMA when calling LOADADDR in linker scripts

### DIFF
--- a/LINKER_SCRIPT_SUPPORT.md
+++ b/LINKER_SCRIPT_SUPPORT.md
@@ -75,7 +75,7 @@ end lists the features required to link the Linux kernel.
 | `SIZEOF(section)` | ✅ | |
 | `ALIGNOF(section)` | ✅ | |
 | `ADDR(section)` | ✅ | |
-| `LOADADDR(section)` | 🧪 | Implemented as alias for `ADDR` (returns VMA); full LMA requires `AT(addr)` support |
+| `LOADADDR(section)` | ✅ | |
 | `ALIGN(expr)` | ✅ | |
 | `LENGTH(region)` | ✅ | |
 | `ORIGIN(region)` | ✅ | |

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -145,7 +145,7 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
 
         // TODO: This is a temporary alias for ADDR.
         // Needs to be updated when AT(expr) and disjoint LMA/VMA tracking are implemented.
-        Expression::Loadaddr(name) => section_address(name, section_layouts, output_sections),
+        Expression::Loadaddr(name) => section_load_address(name, section_layouts, output_sections),
 
         Expression::Align(expr) => {
             let align = eval!(expr)?;
@@ -293,6 +293,22 @@ fn section_address<'data, P: Platform>(
             )
         })?;
     Ok(section_layouts.get(id).mem_offset)
+}
+
+fn section_load_address<'data, P: Platform>(
+    name: &[u8],
+    section_layouts: &OutputSectionMap<OutputRecordLayout>,
+    output_sections: &OutputSections<'data, P>,
+) -> Result<u64> {
+    let id = output_sections
+        .section_id_by_name(SectionName(name))
+        .ok_or_else(|| {
+            crate::error!(
+                "LOADADDR: section '{}' not found",
+                String::from_utf8_lossy(name)
+            )
+        })?;
+    Ok(section_layouts.get(id).lma_offset)
 }
 
 #[cfg(test)]

--- a/wild/tests/sources/elf/linker-script-at/linker-script-at.ld
+++ b/wild/tests/sources/elf/linker-script-at/linker-script-at.ld
@@ -11,3 +11,5 @@ SECTIONS {
 
 ASSERT(ADDR(.text) == 0x100000, "VMA of .text should be 0x100000");
 ASSERT(ADDR(.data) == 0x200000, "VMA of .data should be 0x200000");
+ASSERT(LOADADDR(.text) == 0x200000, "LMA of .text should be 0x200000");
+ASSERT(LOADADDR(.data) == 0x300000, "LMA of .data should be 0x300000");


### PR DESCRIPTION
`LOADADDR` was earlier implemented as an alias to `ADDR`, this PR makes `LOADADDR` return the LMA instead.