### PR TITLE
Fix: Support R_X86_64_PC32 relocations to absolute addresses

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2854,9 +2854,22 @@ fn apply_relocation<
 
             return Ok(RelocationModifier::Normal);
         }
+        RelocationKind::Relative if rel.symbol().is_none() => {
+            if layout.symbol_db.output_kind.is_relocatable() {
+                bail!(
+                    "relocation of type {} to absolute address cannot be used in \
+                    position-independent output; recompile with -fPIC",
+                    rel.raw_type()
+                );
+            }
+            let place = section_info.section_address + offset_in_section;
+            let value = (rel.addend() as u64).wrapping_sub(place);
+            A::relocation_from_raw(r_type)?
+                .write_to_buffer(value, &mut out[offset_in_section as usize..])?;
+            return Ok(RelocationModifier::Normal);
+        }
         _ => {}
     }
-
     let (resolution, symbol_index, local_symbol_id) = get_resolution(rel, object_layout, layout)?;
     let flags = layout.flags_for_symbol(local_symbol_id);
     let mut next_modifier = RelocationModifier::Normal;

--- a/wild/tests/sources/elf/abs-reloc/abs-reloc.s
+++ b/wild/tests/sources/elf/abs-reloc/abs-reloc.s
@@ -1,0 +1,17 @@
+// Test that R_X86_64_PC32 to absolute address is handled for non-PIE executables.
+// `call 0` generates R_X86_64_PC32 with no symbol and addend=-4.
+// lld and GNU ld handle this by computing a PC-relative offset to address 0.
+//#Arch:x86_64
+//#LinkArgs:-nostdlib -z noexecstack
+//#Mode:static
+//#RunEnabled:false
+
+.text
+.globl _start
+.type _start, @function
+_start:
+    callq 0
+    ret
+.size _start, .-_start
+
+.section .note.GNU-stack,"",@progbits


### PR DESCRIPTION
Fixes #1420
Previously, Wild would error with "Unsupported absolute relocation" when  encountering a PC-relative relocation to an absolute address (e.g. `callq 0`). lld and GNU ld both handle this for non-PIE executables by computing the PC-relative offset to the absolute target address. For PIE/shared objects, we now emit a clearer error message similar to mold.