### PR TITLE
fix: Use 0x10000 as default load address for RISC-V

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -136,12 +136,6 @@ use zerocopy::FromBytes;
 use zerocopy::IntoBytes;
 use zerocopy::KnownLayout;
 
-/// Our starting address in memory when linking non-relocatable executables. We can start memory
-/// addresses wherever we like, even from 0. We pick 400k because it's the same as what ld does and
-/// because picking a distinctive non-zero values makes it more obvious what's happening if we mix
-/// up file and memory offsets.
-pub const NON_PIE_START_MEM_ADDRESS: u64 = 0x400_000;
-
 pub(crate) const GLOBAL_POINTER_SYMBOL_NAME: &str = "__global_pointer$";
 
 /// The ppc64 TOC base symbol. Defined to point at the start of the GOT.
@@ -2064,14 +2058,6 @@ impl platform::Platform for Elf {
         }
 
         SectionRuleOutcome::Custom
-    }
-
-    fn start_memory_address(output_kind: OutputKind) -> u64 {
-        if output_kind.is_relocatable() {
-            0
-        } else {
-            crate::elf::NON_PIE_START_MEM_ADDRESS
-        }
     }
 
     fn requires_symtab_shndx(num_sections: usize) -> bool {

--- a/libwild/src/elf_riscv64.rs
+++ b/libwild/src/elf_riscv64.rs
@@ -49,6 +49,7 @@ macro_rules! rel_info_from_type {
 impl crate::platform::Arch for ElfRiscV64 {
     type Relaxation = Relaxation;
     type Platform = Elf;
+    const DEFAULT_LOAD_ADDRESS: u64 = 0x10000;
 
     fn arch_identifier() -> <Self::Platform as Platform>::ArchIdentifier {
         object::elf::EM_RISCV

--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -286,7 +286,7 @@ impl Linker {
         let mut output = file_writer::Output::new(args, output_kind);
 
         let mut output_sections =
-            OutputSections::with_base_address(P::start_memory_address(output_kind));
+            OutputSections::with_base_address(A::start_memory_address(output_kind));
         output_sections.set_rosegment(args.rosegment());
 
         let mut layout_rules_builder = LayoutRulesBuilder::default();

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -1500,10 +1500,6 @@ impl platform::Platform for MachO {
         builder.build()
     }
 
-    fn start_memory_address(_output_kind: OutputKind) -> u64 {
-        MACHO_START_MEM_ADDRESS
-    }
-
     fn align_load_segment_start(
         segment_def: ProgramSegmentDef,
         segment_alignment: Alignment,

--- a/libwild/src/macho_aarch64.rs
+++ b/libwild/src/macho_aarch64.rs
@@ -56,7 +56,9 @@ impl crate::platform::Arch for MachOAArch64 {
     type Relaxation = Relaxation;
 
     type Platform = MachO;
-
+    fn start_memory_address(_output_kind: crate::output_kind::OutputKind) -> u64 {
+        crate::macho::MACHO_START_MEM_ADDRESS
+    }
     fn arch_identifier() -> <Self::Platform as crate::platform::Platform>::ArchIdentifier {
         todo!()
     }

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -75,6 +75,10 @@ pub(crate) trait Arch: Send + Sync + 'static {
     type Relaxation: Relaxation;
     type Platform: Platform;
 
+    /// Default load address for non-PIE output.
+    /// Override this for architectures that need a different default.
+    const DEFAULT_LOAD_ADDRESS: u64 = 0x400_000;
+
     /// Returns the identifier to be written into the output file that identifies the file as
     /// belonging to this architecture. e.g. for ELF, this is the header magic for the architecture.
     fn arch_identifier() -> <Self::Platform as Platform>::ArchIdentifier;
@@ -192,6 +196,15 @@ pub(crate) trait Arch: Send + Sync + 'static {
         // Should only be called if thunk_config returns Some, in which case this must be
         // overridden.
         unimplemented!();
+    }
+
+    /// Return the starting load address for non-PIE output.
+    fn start_memory_address(output_kind: OutputKind) -> u64 {
+        if output_kind.is_relocatable() {
+            0
+        } else {
+            Self::DEFAULT_LOAD_ADDRESS
+        }
     }
 }
 
@@ -747,9 +760,6 @@ pub(crate) trait Platform:
     ) -> SectionRuleOutcome {
         SectionRuleOutcome::Custom
     }
-
-    /// Return a starting address in memory.
-    fn start_memory_address(output_kind: OutputKind) -> u64;
 
     fn requires_symtab_shndx(_num_sections: usize) -> bool {
         false

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -2367,11 +2367,6 @@ impl platform::Platform for Wasm {
     fn default_symtab_entry() -> Self::SymtabEntry {
         WasmSymbol::default()
     }
-
-    fn start_memory_address(_output_kind: crate::output_kind::OutputKind) -> u64 {
-        // Wasm uses linear memory; the linker just lays out at offset 0.
-        0
-    }
 }
 
 fn parse_wasm_module<'data>(input: &'data [u8]) -> Result<File<'data>> {

--- a/wild/tests/sources/elf/riscv64-abs-reloc/riscv64-abs-reloc.s
+++ b/wild/tests/sources/elf/riscv64-abs-reloc/riscv64-abs-reloc.s
@@ -1,0 +1,17 @@
+/*
+ * Tests that we can handle a relative relocation to address 0 from a
+ * non-relocatable RISC-V executable.
+//#Arch: riscv64
+//#LinkArgs: -nostdlib -static
+//#Mode: static
+//#RunEnabled: false
+*/
+.text
+.globl _start
+.type _start, @function
+_start:
+    jal ra, 0
+    ret
+.size _start, .-_start
+
+.section .note.GNU-stack,"",@progbits


### PR DESCRIPTION
Fixes #2053

Wild previously used 0x400000 as the default load address for all ELF architectures. Both GNU ld and lld use 0x10000 for RISC-V, which is required for JAL relocations to reach addresses within the 21-bit signed range (~1MB). Added DEFAULT_LOAD_ADDRESS const to the Arch trait so architectures can override the default load address independently of the Platform trait.

Note: There's a warning about `start_memory_address` on the Platform trait being unused since we moved the logic to the Arch trait. Happy to remove it if that's the preferred approach.