### PR TITLE
port(wasm): Apply code section index relocations

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -123,7 +123,6 @@ use rayon::Scope;
 use rayon::prelude::*;
 use smallvec::SmallVec;
 use std::borrow::Cow;
-use std::io::Cursor;
 use std::io::Read as _;
 use std::mem::offset_of;
 use std::num::NonZeroU32;
@@ -3673,10 +3672,7 @@ pub(crate) fn gnu_property_notes_section_size(gnu_property_notes: &[GnuProperty]
 }
 
 fn riscv_attributes_section_size(riscv_attributes: &[RiscVAttribute]) -> u64 {
-    let size_of_uleb_encoded = |value| {
-        let mut cursor = Cursor::new([0u8; 10]);
-        leb128::write::unsigned(&mut cursor, value).unwrap()
-    };
+    let size_of_uleb_encoded = linker_utils::utils::uleb128_size;
 
     (if riscv_attributes.is_empty() {
         0

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -16,6 +16,7 @@ use crate::wasm_writer::OutputGlobal;
 use crate::wasm_writer::OutputImport;
 use crate::wasm_writer::OutputImportEntity;
 use linker_utils::utils::u32_from_slice;
+use linker_utils::utils::uleb128_size;
 use rayon::prelude::*;
 use std::ops::Range;
 use wasmparser::BinaryReader;
@@ -296,31 +297,10 @@ impl WasmRelocation {
     }
 }
 
-/// Number of bytes needed to encode `value` as an unsigned LEB128.
-pub(crate) fn uleb128_size(mut value: u32) -> usize {
-    let mut size = 1;
-    while value >= 0x80 {
-        value >>= 7;
-        size += 1;
-    }
-    size
-}
-
 /// Write `value` as an unsigned LEB128 into `buf`, returning the number of bytes written.
-pub(crate) fn write_uleb128(buf: &mut [u8], mut value: u32) -> usize {
-    let mut i = 0;
-    loop {
-        let mut byte = (value & 0x7f) as u8;
-        value >>= 7;
-        if value != 0 {
-            byte |= 0x80;
-        }
-        buf[i] = byte;
-        i += 1;
-        if value == 0 {
-            return i;
-        }
-    }
+pub(crate) fn write_uleb128(buf: &mut [u8], value: u64) -> usize {
+    let mut writable = &mut *buf;
+    leb128::write::unsigned(&mut writable, value).unwrap()
 }
 
 /// Write `value` as a 5-byte fixed-width unsigned LEB128. Used for wasm reloc slots that reserve
@@ -1583,16 +1563,16 @@ fn compute_code_section_size(bodies: &[WasmFunctionBody<'_>]) -> u64 {
         return 0;
     }
     let count = bodies.len() as u32;
-    let count_leb_size = uleb128_size(count) as u64;
+    let count_leb_size = uleb128_size(u64::from(count)) as u64;
     let bodies_with_prefix_total: u64 = bodies
         .iter()
         .map(|b| {
-            let body_len = b.bytes.len() as u32;
-            uleb128_size(body_len) as u64 + b.bytes.len() as u64
+            let body_len = b.bytes.len() as u64;
+            uleb128_size(body_len) as u64 + body_len
         })
         .sum();
     let payload_size = count_leb_size + bodies_with_prefix_total;
-    let payload_size_leb_size = uleb128_size(payload_size as u32) as u64;
+    let payload_size_leb_size = uleb128_size(payload_size) as u64;
 
     // section id (1 byte) + payload size LEB + payload
     1 + payload_size_leb_size + payload_size

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -400,6 +400,8 @@ pub(crate) struct WasmDataSegment<'data> {
 #[derive(Debug, Clone)]
 pub(crate) struct WasmFunctionBody<'data> {
     pub(crate) bytes: &'data [u8],
+    /// Byte offset of this body (starting at its size prefix) within the code section payload.
+    pub(crate) code_offset: u32,
 }
 
 impl<'data> File<'data> {
@@ -551,11 +553,19 @@ impl<'data> File<'data> {
         let Some(reader) = self.code_section_reader()? else {
             return Ok(Vec::new());
         };
+        let code_payload_start = self
+            .standard_section_index[section_id::CODE as usize]
+            .and_then(|i| self.sections.get(i as usize))
+            .map_or(0, |h| h.payload_range.start);
         reader
             .into_iter()
             .map(|res| {
-                res.map(|body| WasmFunctionBody {
-                    bytes: &self.data[body.range()],
+                res.map(|body| {
+                    let range = body.range();
+                    WasmFunctionBody {
+                        bytes: &self.data[range.clone()],
+                        code_offset: range.start as u32 - code_payload_start,
+                    }
                 })
                 .map_err(Into::into)
             })

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -424,13 +424,23 @@ pub(crate) struct WasmDataSegment<'data> {
     pub(crate) data: &'data [u8],
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ResolvedCodeReloc {
+    /// Byte offset within the body's bytes where the relocation should be applied.
+    pub(crate) offset: u32,
+    /// Wasm relocation type code.
+    pub(crate) ty: u8,
+    /// Resolved output value to write at the relocation site.
+    pub(crate) value: u32,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct WasmFunctionBody<'data> {
-    /// Raw body bytes (locals + operators) without the LEB128 size prefix. Borrowed when no
-    /// relocations are applied; owned when the body has been patched.
-    pub(crate) bytes: std::borrow::Cow<'data, [u8]>,
+    /// Raw body bytes (locals + operators) without the LEB128 size prefix.
+    pub(crate) bytes: &'data [u8],
     /// Byte offset of this body (starting at its size prefix) within the code section payload.
     pub(crate) code_offset: u32,
+    pub(crate) relocations: Vec<ResolvedCodeReloc>,
 }
 
 impl<'data> File<'data> {
@@ -591,8 +601,9 @@ impl<'data> File<'data> {
                 res.map(|body| {
                     let range = body.range();
                     WasmFunctionBody {
-                        bytes: std::borrow::Cow::Borrowed(&self.data[range.clone()]),
+                        bytes: &self.data[range.clone()],
                         code_offset: range.start as u32 - code_payload_start,
+                        relocations: Vec::new(),
                     }
                 })
                 .map_err(Into::into)
@@ -1922,8 +1933,9 @@ impl<'data> WasmObjectLayoutInput<'data> {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        let function_bodies = apply_code_relocations(
-            self.function_bodies,
+        let mut function_bodies = self.function_bodies;
+        resolve_code_relocations(
+            &mut function_bodies,
             &self.code_relocations,
             &self.symbols,
             &index_map,
@@ -2037,53 +2049,38 @@ fn allocate_wasm_object_index_bases(
     Ok(index_bases)
 }
 
-/// Apply code relocations to function bodies. Bodies with relocations get an owned copy;
-/// bodies without relocations remain borrowed from the input.
-fn apply_code_relocations<'data>(
-    mut bodies: Vec<WasmFunctionBody<'data>>,
+fn resolve_code_relocations<'data>(
+    bodies: &mut [WasmFunctionBody<'data>],
     relocs: &[WasmRelocation],
     symbols: &[WasmSymbol],
     index_map: &WasmObjectIndexMap,
-) -> Result<Vec<WasmFunctionBody<'data>>> {
+) -> Result {
     if relocs.is_empty() {
-        return Ok(bodies);
+        return Ok(());
     }
 
-    // Group relocations by body. Both relocs (by offset) and bodies (by code_offset) are ordered.
     let mut reloc_iter = relocs.iter().peekable();
-    for body in &mut bodies {
+    for body in bodies.iter_mut() {
         let body_start = body.code_offset;
         let body_end = body_start + body.bytes.len() as u32;
 
-        // Collect relocations that fall within this body's range.
-        let mut body_relocs: Vec<WasmRelocation> = Vec::new();
         while let Some(reloc) = reloc_iter.peek().copied() {
             if reloc.offset >= body_end {
                 break;
             }
             reloc_iter.next();
             if reloc.offset >= body_start {
-                body_relocs.push(*reloc);
+                let value = index_map.resolve_reloc(reloc, symbols)?;
+                body.relocations.push(ResolvedCodeReloc {
+                    offset: reloc.offset - body_start,
+                    ty: reloc.ty,
+                    value,
+                });
             }
         }
-
-        if body_relocs.is_empty() {
-            continue;
-        }
-
-        let mut patched = body.bytes.to_vec();
-        for reloc in &body_relocs {
-            let value = index_map.resolve_reloc(reloc, symbols)?;
-            let local_reloc = WasmRelocation {
-                offset: reloc.offset - body_start,
-                ..*reloc
-            };
-            apply_relocation(&mut patched, &local_reloc, value)?;
-        }
-        body.bytes = std::borrow::Cow::Owned(patched);
     }
 
-    Ok(bodies)
+    Ok(())
 }
 
 fn remap_wasm_index(indices: &[u32], index: u32, kind: &str) -> Result<u32> {

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -296,6 +296,33 @@ impl WasmRelocation {
     }
 }
 
+/// Number of bytes needed to encode `value` as an unsigned LEB128.
+pub(crate) fn uleb128_size(mut value: u32) -> usize {
+    let mut size = 1;
+    while value >= 0x80 {
+        value >>= 7;
+        size += 1;
+    }
+    size
+}
+
+/// Write `value` as an unsigned LEB128 into `buf`, returning the number of bytes written.
+pub(crate) fn write_uleb128(buf: &mut [u8], mut value: u32) -> usize {
+    let mut i = 0;
+    loop {
+        let mut byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value != 0 {
+            byte |= 0x80;
+        }
+        buf[i] = byte;
+        i += 1;
+        if value == 0 {
+            return i;
+        }
+    }
+}
+
 /// Write `value` as a 5-byte fixed-width unsigned LEB128. Used for wasm reloc slots that reserve
 /// exactly 5 bytes regardless of the encoded value.
 pub(crate) fn write_uleb128_5(buf: &mut [u8; 5], value: u32) {
@@ -399,8 +426,8 @@ pub(crate) struct WasmDataSegment<'data> {
 
 #[derive(Debug, Clone)]
 pub(crate) struct WasmFunctionBody<'data> {
-    /// Raw body bytes including the size prefix. Borrowed when no relocations are applied;
-    /// owned when the body has been patched.
+    /// Raw body bytes (locals + operators) without the LEB128 size prefix. Borrowed when no
+    /// relocations are applied; owned when the body has been patched.
     pub(crate) bytes: std::borrow::Cow<'data, [u8]>,
     /// Byte offset of this body (starting at its size prefix) within the code section payload.
     pub(crate) code_offset: u32,
@@ -1452,6 +1479,7 @@ pub(crate) struct WasmLayout<'data> {
     pub(crate) unsupported_output: Vec<&'static str>,
     pub(crate) object_index_maps: Vec<WasmObjectIndexMap>,
     pub(crate) encoded_sections: WasmEncodedSections,
+    pub(crate) code_section_size: u64,
 }
 
 #[derive(Debug, Default)]
@@ -1461,7 +1489,6 @@ pub(crate) struct WasmEncodedSections {
     pub(crate) function: Option<Vec<u8>>,
     pub(crate) global: Option<Vec<u8>>,
     pub(crate) export: Option<Vec<u8>>,
-    pub(crate) code: Option<Vec<u8>>,
     pub(crate) memory: Option<Vec<u8>>,
 }
 
@@ -1472,7 +1499,6 @@ impl WasmEncodedSections {
         add_encoded_section_size(sizes, crate::part_id::WASM_FUNCTION, self.function.as_ref());
         add_encoded_section_size(sizes, crate::part_id::WASM_GLOBAL, self.global.as_ref());
         add_encoded_section_size(sizes, crate::part_id::WASM_EXPORT, self.export.as_ref());
-        add_encoded_section_size(sizes, crate::part_id::WASM_CODE, self.code.as_ref());
         add_encoded_section_size(sizes, crate::part_id::WASM_MEMORY, self.memory.as_ref());
     }
 }
@@ -1526,15 +1552,39 @@ impl<'data> WasmLayout<'data> {
             self.encoded_sections.memory = Some(encode_wasm_section(&memory_section));
         }
 
-        let code_section = crate::wasm_writer::build_code_section(
-            self.function_bodies.iter().map(|body| body.bytes.as_ref()),
-        );
-        if !code_section.is_empty() {
-            self.encoded_sections.code = Some(encode_wasm_section(&code_section));
-        }
+        self.code_section_size = compute_code_section_size(&self.function_bodies);
 
         Ok(())
     }
+
+    fn add_code_section_size(
+        &self,
+        sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
+    ) {
+        if self.code_section_size > 0 {
+            sizes.increment(crate::part_id::WASM_CODE, self.code_section_size);
+        }
+    }
+}
+
+fn compute_code_section_size(bodies: &[WasmFunctionBody<'_>]) -> u64 {
+    if bodies.is_empty() {
+        return 0;
+    }
+    let count = bodies.len() as u32;
+    let count_leb_size = uleb128_size(count) as u64;
+    let bodies_with_prefix_total: u64 = bodies
+        .iter()
+        .map(|b| {
+            let body_len = b.bytes.len() as u32;
+            uleb128_size(body_len) as u64 + b.bytes.len() as u64
+        })
+        .sum();
+    let payload_size = count_leb_size + bodies_with_prefix_total;
+    let payload_size_leb_size = uleb128_size(payload_size as u32) as u64;
+
+    // section id (1 byte) + payload size LEB + payload
+    1 + payload_size_leb_size + payload_size
 }
 
 #[derive(Debug, Default)]
@@ -2337,6 +2387,7 @@ impl platform::Platform for Wasm {
         _symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
     ) {
         properties.encoded_sections.add_sizes_to(mem_sizes);
+        properties.add_code_section_size(mem_sizes);
     }
 
     fn finalise_sizes_all<'data>(
@@ -2365,6 +2416,7 @@ impl platform::Platform for Wasm {
         _dynamic_symbol_defs: &[crate::layout::DynamicSymbolDefinition<Self>],
     ) -> crate::error::Result {
         common_state.encoded_sections.add_sizes_to(memory_offsets);
+        common_state.add_code_section_size(memory_offsets);
         Ok(())
     }
 

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -399,7 +399,9 @@ pub(crate) struct WasmDataSegment<'data> {
 
 #[derive(Debug, Clone)]
 pub(crate) struct WasmFunctionBody<'data> {
-    pub(crate) bytes: &'data [u8],
+    /// Raw body bytes including the size prefix. Borrowed when no relocations are applied;
+    /// owned when the body has been patched.
+    pub(crate) bytes: std::borrow::Cow<'data, [u8]>,
     /// Byte offset of this body (starting at its size prefix) within the code section payload.
     pub(crate) code_offset: u32,
 }
@@ -553,8 +555,7 @@ impl<'data> File<'data> {
         let Some(reader) = self.code_section_reader()? else {
             return Ok(Vec::new());
         };
-        let code_payload_start = self
-            .standard_section_index[section_id::CODE as usize]
+        let code_payload_start = self.standard_section_index[section_id::CODE as usize]
             .and_then(|i| self.sections.get(i as usize))
             .map_or(0, |h| h.payload_range.start);
         reader
@@ -563,7 +564,7 @@ impl<'data> File<'data> {
                 res.map(|body| {
                     let range = body.range();
                     WasmFunctionBody {
-                        bytes: &self.data[range.clone()],
+                        bytes: std::borrow::Cow::Borrowed(&self.data[range.clone()]),
                         code_offset: range.start as u32 - code_payload_start,
                     }
                 })
@@ -1526,7 +1527,7 @@ impl<'data> WasmLayout<'data> {
         }
 
         let code_section = crate::wasm_writer::build_code_section(
-            self.function_bodies.iter().map(|body| body.bytes),
+            self.function_bodies.iter().map(|body| body.bytes.as_ref()),
         );
         if !code_section.is_empty() {
             self.encoded_sections.code = Some(encode_wasm_section(&code_section));
@@ -1589,8 +1590,7 @@ impl WasmObjectIndexMap {
             | reloc_type::MEMORY_ADDR_I32 => {
                 bail!("memory address relocations are not supported yet");
             }
-            reloc_type::TABLE_INDEX_SLEB
-            | reloc_type::TABLE_INDEX_I32 => {
+            reloc_type::TABLE_INDEX_SLEB | reloc_type::TABLE_INDEX_I32 => {
                 bail!("table index relocations are not supported yet");
             }
             reloc_type::EVENT_INDEX_LEB => {
@@ -1626,6 +1626,8 @@ struct WasmObjectLayoutInput<'data> {
     function_bodies: Vec<WasmFunctionBody<'data>>,
     memories: Vec<MemoryType>,
     unsupported_output: Vec<&'static str>,
+    code_relocations: Vec<WasmRelocation>,
+    symbols: Vec<WasmSymbol>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1692,9 +1694,24 @@ impl<'data> WasmObjectLayoutInput<'data> {
             }
         }
 
+        let code_section_index = file.standard_section_index[section_id::CODE as usize];
+        let code_relocations: Vec<WasmRelocation> = code_section_index
+            .and_then(|code_idx| {
+                file.reloc_sections
+                    .iter()
+                    .find(|s| s.target_section_index == code_idx)
+            })
+            .map(|s| s.entries.clone())
+            .unwrap_or_default();
+
+        let has_non_code_relocs = file
+            .reloc_sections
+            .iter()
+            .any(|s| code_section_index != Some(s.target_section_index));
+
         let mut unsupported_output = Vec::new();
-        if !file.reloc_sections.is_empty() {
-            unsupported_output.push("relocation");
+        if has_non_code_relocs {
+            unsupported_output.push("non-code relocation");
         }
         if file.standard_section_index[section_id::TABLE as usize].is_some() {
             unsupported_output.push("table");
@@ -1757,6 +1774,8 @@ impl<'data> WasmObjectLayoutInput<'data> {
             function_bodies,
             memories,
             unsupported_output,
+            code_relocations,
+            symbols: file.symbols.clone(),
         })
     }
 
@@ -1853,13 +1872,20 @@ impl<'data> WasmObjectLayoutInput<'data> {
             })
             .collect::<Result<Vec<_>>>()?;
 
+        let function_bodies = apply_code_relocations(
+            self.function_bodies,
+            &self.code_relocations,
+            &self.symbols,
+            &index_map,
+        )?;
+
         Ok(WasmObjectOutputLayout {
             types: self.types,
             imports,
             function_type_indices,
             globals: self.globals,
             exports,
-            function_bodies: self.function_bodies,
+            function_bodies,
             memories: self.memories,
             unsupported_output: self.unsupported_output,
             index_map,
@@ -1959,6 +1985,55 @@ fn allocate_wasm_object_index_bases(
     }
 
     Ok(index_bases)
+}
+
+/// Apply code relocations to function bodies. Bodies with relocations get an owned copy;
+/// bodies without relocations remain borrowed from the input.
+fn apply_code_relocations<'data>(
+    mut bodies: Vec<WasmFunctionBody<'data>>,
+    relocs: &[WasmRelocation],
+    symbols: &[WasmSymbol],
+    index_map: &WasmObjectIndexMap,
+) -> Result<Vec<WasmFunctionBody<'data>>> {
+    if relocs.is_empty() {
+        return Ok(bodies);
+    }
+
+    // Group relocations by body. Both relocs (by offset) and bodies (by code_offset) are ordered.
+    let mut reloc_iter = relocs.iter().peekable();
+    for body in &mut bodies {
+        let body_start = body.code_offset;
+        let body_end = body_start + body.bytes.len() as u32;
+
+        // Collect relocations that fall within this body's range.
+        let mut body_relocs: Vec<WasmRelocation> = Vec::new();
+        while let Some(reloc) = reloc_iter.peek().copied() {
+            if reloc.offset >= body_end {
+                break;
+            }
+            reloc_iter.next();
+            if reloc.offset >= body_start {
+                body_relocs.push(*reloc);
+            }
+        }
+
+        if body_relocs.is_empty() {
+            continue;
+        }
+
+        let mut patched = body.bytes.to_vec();
+        for reloc in &body_relocs {
+            let value = index_map.resolve_reloc(reloc, symbols)?;
+            let local_reloc = WasmRelocation {
+                offset: reloc.offset - body_start,
+                ..*reloc
+            };
+            apply_relocation(&mut patched, &local_reloc, value)?;
+        }
+        body.bytes = std::borrow::Cow::Owned(patched);
+    }
+
+    Ok(bodies)
 }
 
 fn remap_wasm_index(indices: &[u32], index: u32, kind: &str) -> Result<u32> {

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -1544,6 +1544,69 @@ pub(crate) struct WasmObjectIndexMap {
     pub(crate) memory_indices: Vec<u32>,
 }
 
+impl WasmObjectIndexMap {
+    /// Resolve a code relocation to its output value using the symbol table from the same object.
+    pub(crate) fn resolve_reloc(
+        &self,
+        reloc: &WasmRelocation,
+        symbols: &[WasmSymbol],
+    ) -> Result<u32> {
+        if reloc.ty == R_WASM_TYPE_INDEX_LEB {
+            return self
+                .type_index_base
+                .checked_add(reloc.index)
+                .ok_or_else(|| crate::error!("Wasm type index overflow"));
+        }
+
+        let sym = symbols
+            .get(reloc.index as usize)
+            .ok_or_else(|| crate::error!("relocation symbol index {} out of range", reloc.index))?;
+
+        match reloc.ty {
+            reloc_type::FUNCTION_INDEX_LEB | reloc_type::FUNCTION_INDEX_I32 => {
+                ensure!(
+                    sym.kind == WasmSymbolKind::Func,
+                    "R_WASM_FUNCTION_INDEX_* references non-function symbol"
+                );
+                remap_wasm_index(&self.function_indices, sym.index, "function")
+            }
+            reloc_type::GLOBAL_INDEX_LEB | reloc_type::GLOBAL_INDEX_I32 => {
+                ensure!(
+                    sym.kind == WasmSymbolKind::Global,
+                    "R_WASM_GLOBAL_INDEX_* references non-global symbol"
+                );
+                remap_wasm_index(&self.global_indices, sym.index, "global")
+            }
+            reloc_type::TABLE_NUMBER_LEB => {
+                ensure!(
+                    sym.kind == WasmSymbolKind::Table,
+                    "R_WASM_TABLE_NUMBER_LEB references non-table symbol"
+                );
+                bail!("table relocations are not supported yet");
+            }
+            reloc_type::MEMORY_ADDR_LEB
+            | reloc_type::MEMORY_ADDR_SLEB
+            | reloc_type::MEMORY_ADDR_I32 => {
+                bail!("memory address relocations are not supported yet");
+            }
+            reloc_type::TABLE_INDEX_SLEB
+            | reloc_type::TABLE_INDEX_I32 => {
+                bail!("table index relocations are not supported yet");
+            }
+            reloc_type::EVENT_INDEX_LEB => {
+                bail!("event index relocations are not supported yet");
+            }
+            reloc_type::FUNCTION_OFFSET_I32 => {
+                bail!("function offset relocations are not supported yet");
+            }
+            reloc_type::SECTION_OFFSET_I32 => {
+                bail!("section offset relocations are not supported yet");
+            }
+            other => bail!("unsupported Wasm relocation type {other}"),
+        }
+    }
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct WasmObjectLayout<'data> {
     pub(crate) type_index_base: u32,

--- a/libwild/src/wasm_writer.rs
+++ b/libwild/src/wasm_writer.rs
@@ -1,4 +1,5 @@
 use crate::bail;
+use crate::ensure;
 use crate::error::Result;
 use crate::file_writer::SizedOutput;
 use crate::file_writer::split_output_into_sections;
@@ -12,8 +13,8 @@ use crate::wasm::WasmLayout;
 use crate::wasm::WasmRelocation;
 use crate::wasm::apply_relocation;
 use crate::wasm::section_id;
-use crate::wasm::uleb128_size;
 use crate::wasm::write_uleb128;
+use linker_utils::utils::uleb128_size;
 use wasm_encoder::ExportSection;
 use wasm_encoder::FunctionSection;
 use wasm_encoder::GlobalSection;
@@ -84,22 +85,20 @@ fn copy_metadata_sections(
 fn copy_encoded_section(encoded: Option<&Vec<u8>>, out: &mut [u8]) -> Result<()> {
     match encoded {
         Some(encoded) => {
-            if out.len() != encoded.len() {
-                bail!(
-                    "Wasm metadata section size mismatch: allocated {}, encoded {}",
-                    out.len(),
-                    encoded.len()
-                );
-            }
+            ensure!(
+                out.len() == encoded.len(),
+                "Wasm metadata section size allocated {}, encoded {}",
+                out.len(),
+                encoded.len()
+            );
             out.copy_from_slice(encoded);
         }
         None => {
-            if !out.is_empty() {
-                bail!(
-                    "Wasm metadata section unexpectedly allocated {} bytes",
-                    out.len()
-                );
-            }
+            ensure!(
+                out.is_empty(),
+                "Wasm metadata section unexpectedly allocated {} bytes",
+                out.len()
+            );
         }
     }
     Ok(())
@@ -109,12 +108,11 @@ fn copy_encoded_section(encoded: Option<&Vec<u8>>, out: &mut [u8]) -> Result<()>
 // This function writes the LEB128 size prefix for each body.
 fn write_code_section(bodies: &[WasmFunctionBody<'_>], out: &mut [u8]) -> Result<()> {
     if bodies.is_empty() {
-        if !out.is_empty() {
-            bail!(
-                "Wasm code section: buffer is {} bytes but no bodies to write",
-                out.len()
-            );
-        }
+        ensure!(
+            out.is_empty(),
+            "Wasm code section buffer is {} bytes but no bodies to write",
+            out.len()
+        );
         return Ok(());
     }
 
@@ -124,17 +122,17 @@ fn write_code_section(bodies: &[WasmFunctionBody<'_>], out: &mut [u8]) -> Result
     out[pos] = section_id::CODE;
     pos += 1;
 
-    let count = bodies.len() as u32;
+    let count = bodies.len() as u64;
     // Compute payload size: count LEB + sum(body_size_leb + body_bytes) for each body.
     let count_leb_size = uleb128_size(count);
     let bodies_with_prefix_total: usize = bodies
         .iter()
         .map(|b| {
-            let body_len = b.bytes.len() as u32;
+            let body_len = b.bytes.len() as u64;
             uleb128_size(body_len) + b.bytes.len()
         })
         .sum();
-    let payload_size = (count_leb_size + bodies_with_prefix_total) as u32;
+    let payload_size = (count_leb_size + bodies_with_prefix_total) as u64;
 
     pos += write_uleb128(&mut out[pos..], payload_size);
 
@@ -143,7 +141,7 @@ fn write_code_section(bodies: &[WasmFunctionBody<'_>], out: &mut [u8]) -> Result
 
     // Function bodies: size prefix + body bytes.
     for body in bodies {
-        let body_len = body.bytes.len() as u32;
+        let body_len = body.bytes.len() as u64;
         pos += write_uleb128(&mut out[pos..], body_len);
         let body_start = pos;
         let len = body.bytes.len();
@@ -155,18 +153,21 @@ fn write_code_section(bodies: &[WasmFunctionBody<'_>], out: &mut [u8]) -> Result
                 index: 0,
                 addend: 0,
             };
-            apply_relocation(&mut out[body_start..body_start + len], &reloc, resolved.value)?;
+            apply_relocation(
+                &mut out[body_start..body_start + len],
+                &reloc,
+                resolved.value,
+            )?;
         }
         pos += len;
     }
 
-    if pos != out.len() {
-        bail!(
-            "Wasm code section: wrote {} bytes but buffer is {} bytes",
-            pos,
-            out.len()
-        );
-    }
+    ensure!(
+        pos == out.len(),
+        "Wasm code section wrote {} bytes but buffer is {} bytes",
+        pos,
+        out.len()
+    );
 
     Ok(())
 }

--- a/libwild/src/wasm_writer.rs
+++ b/libwild/src/wasm_writer.rs
@@ -9,6 +9,7 @@ use crate::platform::Arch;
 use crate::wasm::WASM_MAGIC;
 use crate::wasm::WASM_VERSION;
 use crate::wasm::Wasm;
+use crate::wasm::WasmFunctionBody;
 use crate::wasm::WasmLayout;
 use wasm_encoder::CodeSection;
 use wasm_encoder::ExportSection;

--- a/libwild/src/wasm_writer.rs
+++ b/libwild/src/wasm_writer.rs
@@ -9,6 +9,8 @@ use crate::wasm::WASM_VERSION;
 use crate::wasm::Wasm;
 use crate::wasm::WasmFunctionBody;
 use crate::wasm::WasmLayout;
+use crate::wasm::WasmRelocation;
+use crate::wasm::apply_relocation;
 use crate::wasm::section_id;
 use crate::wasm::uleb128_size;
 use crate::wasm::write_uleb128;
@@ -143,8 +145,18 @@ fn write_code_section(bodies: &[WasmFunctionBody<'_>], out: &mut [u8]) -> Result
     for body in bodies {
         let body_len = body.bytes.len() as u32;
         pos += write_uleb128(&mut out[pos..], body_len);
+        let body_start = pos;
         let len = body.bytes.len();
-        out[pos..pos + len].copy_from_slice(&body.bytes);
+        out[pos..pos + len].copy_from_slice(body.bytes);
+        for resolved in &body.relocations {
+            let reloc = WasmRelocation {
+                ty: resolved.ty,
+                offset: resolved.offset,
+                index: 0,
+                addend: 0,
+            };
+            apply_relocation(&mut out[body_start..body_start + len], &reloc, resolved.value)?;
+        }
         pos += len;
     }
 

--- a/libwild/src/wasm_writer.rs
+++ b/libwild/src/wasm_writer.rs
@@ -9,7 +9,9 @@ use crate::wasm::WASM_VERSION;
 use crate::wasm::Wasm;
 use crate::wasm::WasmFunctionBody;
 use crate::wasm::WasmLayout;
-use wasm_encoder::CodeSection;
+use crate::wasm::section_id;
+use crate::wasm::uleb128_size;
+use crate::wasm::write_uleb128;
 use wasm_encoder::ExportSection;
 use wasm_encoder::FunctionSection;
 use wasm_encoder::GlobalSection;
@@ -33,6 +35,10 @@ pub(crate) fn write<'data, A: Arch<Platform = Wasm>>(
     preamble[4..8].copy_from_slice(&WASM_VERSION.to_le_bytes());
 
     copy_metadata_sections(&layout.properties_and_attributes, &mut section_buffers)?;
+    write_code_section(
+        &layout.properties_and_attributes.function_bodies,
+        section_buffers.get_mut(crate::output_section_id::WASM_CODE),
+    )?;
 
     if let Some(unsupported) = layout.properties_and_attributes.unsupported_output.first() {
         bail!("Wasm {unsupported} emission is not implemented yet");
@@ -67,10 +73,6 @@ fn copy_metadata_sections(
         section_buffers.get_mut(crate::output_section_id::WASM_EXPORT),
     )?;
     copy_encoded_section(
-        encoded.code.as_ref(),
-        section_buffers.get_mut(crate::output_section_id::WASM_CODE),
-    )?;
-    copy_encoded_section(
         encoded.memory.as_ref(),
         section_buffers.get_mut(crate::output_section_id::WASM_MEMORY),
     )?;
@@ -98,6 +100,62 @@ fn copy_encoded_section(encoded: Option<&Vec<u8>>, out: &mut [u8]) -> Result<()>
             }
         }
     }
+    Ok(())
+}
+
+// Each `WasmFunctionBody.bytes` is the raw body content (locals + operators) without a size prefix.
+// This function writes the LEB128 size prefix for each body.
+fn write_code_section(bodies: &[WasmFunctionBody<'_>], out: &mut [u8]) -> Result<()> {
+    if bodies.is_empty() {
+        if !out.is_empty() {
+            bail!(
+                "Wasm code section: buffer is {} bytes but no bodies to write",
+                out.len()
+            );
+        }
+        return Ok(());
+    }
+
+    let mut pos = 0;
+
+    // Section id.
+    out[pos] = section_id::CODE;
+    pos += 1;
+
+    let count = bodies.len() as u32;
+    // Compute payload size: count LEB + sum(body_size_leb + body_bytes) for each body.
+    let count_leb_size = uleb128_size(count);
+    let bodies_with_prefix_total: usize = bodies
+        .iter()
+        .map(|b| {
+            let body_len = b.bytes.len() as u32;
+            uleb128_size(body_len) + b.bytes.len()
+        })
+        .sum();
+    let payload_size = (count_leb_size + bodies_with_prefix_total) as u32;
+
+    pos += write_uleb128(&mut out[pos..], payload_size);
+
+    // Body count as LEB128.
+    pos += write_uleb128(&mut out[pos..], count);
+
+    // Function bodies: size prefix + body bytes.
+    for body in bodies {
+        let body_len = body.bytes.len() as u32;
+        pos += write_uleb128(&mut out[pos..], body_len);
+        let len = body.bytes.len();
+        out[pos..pos + len].copy_from_slice(&body.bytes);
+        pos += len;
+    }
+
+    if pos != out.len() {
+        bail!(
+            "Wasm code section: wrote {} bytes but buffer is {} bytes",
+            pos,
+            out.len()
+        );
+    }
+
     Ok(())
 }
 
@@ -166,16 +224,6 @@ pub(crate) fn build_memory_section(memories: &[wasmparser::MemoryType]) -> Memor
     let mut section = MemorySection::new();
     for &memory in memories {
         section.memory(convert_memory_type(memory));
-    }
-    section
-}
-
-pub(crate) fn build_code_section<'a>(
-    function_bodies: impl IntoIterator<Item = &'a [u8]>,
-) -> CodeSection {
-    let mut section = CodeSection::new();
-    for body in function_bodies {
-        section.raw(body);
     }
     section
 }

--- a/libwild/src/wasm_writer.rs
+++ b/libwild/src/wasm_writer.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::bail;
 use crate::error::Result;
 use crate::file_writer::SizedOutput;

--- a/linker-utils/src/utils.rs
+++ b/linker-utils/src/utils.rs
@@ -63,3 +63,11 @@ pub fn read_uleb128(content: &mut &[u8]) -> Result<u64> {
     leb128::read::unsigned(content)
         .map_err(|e| anyhow::anyhow!("Failed to read ULEB128 value: {e}"))
 }
+
+/// Number of bytes needed to encode `value` as an unsigned LEB128.
+// TODO: Replace with `leb128::write::unsigned_len` once https://github.com/gimli-rs/leb128/pull/32
+// is merged and released.
+#[must_use]
+pub fn uleb128_size(value: u64) -> usize {
+    leb128::write::unsigned(&mut std::io::sink(), value).unwrap()
+}


### PR DESCRIPTION
This patch enables the application of code index relocations (`R_WASM_TYPE_INDEX_LEB`, `R_WASM_FUNCTION_INDEX_LEB`, `R_WASM_FUNCTION_INDEX_I32`, `R_WASM_GLOBAL_INDEX_LEB`, `R_WASM_GLOBAL_INDEX_I32`). The byte-level encoding primitives (`apply_relocation()`) were already implemented in a prior patch and this patch adds the symbol-to-output-index resolution, per-body relocation grouping, and replaces the `wasm_encoder::CodeSection` builder with direct emission into the output buffer.

Part of #1431