### PR TITLE
chore(gdb-index): rely more on `gimli` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,6 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 [[package]]
 name = "gimli"
 version = "0.33.1"
-source = "git+https://github.com/gimli-rs/gimli#ae567b983020cbfc125a4813400f15e37038af6d"
 dependencies = [
  "fnv",
  "hashbrown 0.17.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,12 +668,11 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gimli"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+version = "0.33.1"
+source = "git+https://github.com/gimli-rs/gimli#ae567b983020cbfc125a4813400f15e37038af6d"
 dependencies = [
  "fnv",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "stable_deref_trait",
 ]
@@ -701,12 +700,6 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash 0.1.5",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashbrown"
@@ -911,7 +904,7 @@ dependencies = [
  "derive_more",
  "flate2",
  "foldhash 0.2.0",
- "gimli 0.33.0",
+ "gimli 0.33.1",
  "glob",
  "hashbrown 0.17.1",
  "hex",
@@ -958,7 +951,7 @@ dependencies = [
  "anstyle",
  "anyhow",
  "clap",
- "gimli 0.33.0",
+ "gimli 0.33.1",
  "hashbrown 0.17.1",
  "iced-x86",
  "itertools",
@@ -2322,7 +2315,7 @@ dependencies = [
  "dhat",
  "diff",
  "foldhash 0.2.0",
- "gimli 0.33.0",
+ "gimli 0.33.1",
  "hex",
  "itertools",
  "libloading",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,6 +669,7 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 [[package]]
 name = "gimli"
 version = "0.33.1"
+source = "git+https://github.com/gimli-rs/gimli.git?rev=9dcce498dd3d90a98a16eb27c5229bba02603050#9dcce498dd3d90a98a16eb27c5229bba02603050"
 dependencies = [
  "fnv",
  "hashbrown 0.17.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ dhat = { version = "0.3.3" }
 diff = "0.1.13"
 flate2 = { version = "1.1.0", features = ["zlib-rs"] }
 foldhash = "0.2.0"
-gimli = { git = "https://github.com/gimli-rs/gimli" }
+gimli = { path = "../gimli" }
 glob = "0.3.2"
 hashbrown = "0.17.1"
 hex = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ dhat = { version = "0.3.3" }
 diff = "0.1.13"
 flate2 = { version = "1.1.0", features = ["zlib-rs"] }
 foldhash = "0.2.0"
-gimli = "0.33.0"
+gimli = { git = "https://github.com/gimli-rs/gimli" }
 glob = "0.3.2"
 hashbrown = "0.17.1"
 hex = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ dhat = { version = "0.3.3" }
 diff = "0.1.13"
 flate2 = { version = "1.1.0", features = ["zlib-rs"] }
 foldhash = "0.2.0"
-gimli = { path = "../gimli" }
+gimli = { git = "https://github.com/gimli-rs/gimli.git", rev = "9dcce498dd3d90a98a16eb27c5229bba02603050" }
 glob = "0.3.2"
 hashbrown = "0.17.1"
 hex = "0.4.0"

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -159,18 +159,18 @@ struct PubnamesSet<'data> {
 }
 
 /// Parse `.debug_gnu_pubnames` / `.debug_gnu_pubtypes` section data.
-fn parse_pubnames_sets<'data>(data: &'data [u8]) -> Result<Vec<PubnamesSet<'data>>> {
+fn parse_pubnames_sets<'data>(
+    data: &'data [u8],
+    section_name: &str,
+) -> Result<Vec<PubnamesSet<'data>>> {
     let mut sets = Vec::new();
+    // Both gimli::DebugGnuPubNames and gimli::DebugGnuPubTypes have an equal data representation!
     for set in gimli::DebugGnuPubNames::new(data, gimli::LittleEndian).sets() {
-        let set = set.context("Failed to parse .debug_gnu_pubnames set")?;
+        let set = set.context(format!("Failed to parse {section_name} set"))?;
         let mut entries = Vec::new();
         for item in set.items() {
-            let item = item.context("Failed to parse .debug_gnu_pubnames entry")?;
-            let mut attrs = item.kind().0 << 4;
-            if item.is_static() {
-                attrs |= 0x80;
-            }
-            entries.push((item.name().slice(), attrs));
+            let item = item.context(format!("Failed to parse {section_name} entry"))?;
+            entries.push((item.name().slice(), item.flags()));
         }
         sets.push(PubnamesSet {
             debug_info_offset: set.unit_header_offset().0 as u64,
@@ -407,7 +407,7 @@ fn scan_one_object(
         let Some(data) = section_by_name(object, section_name)? else {
             continue;
         };
-        for set in parse_pubnames_sets(&data)? {
+        for set in parse_pubnames_sets(&data, section_name)? {
             let Some(&local_cu_idx) = offset_to_idx.get(&set.debug_info_offset) else {
                 continue;
             };

--- a/libwild/src/gdb_index.rs
+++ b/libwild/src/gdb_index.rs
@@ -159,86 +159,23 @@ struct PubnamesSet<'data> {
 }
 
 /// Parse `.debug_gnu_pubnames` / `.debug_gnu_pubtypes` section data.
-///
-/// Each set has a header pointing to a CU in `.debug_info`, followed by
-/// (die_offset, attrs_byte, NUL-terminated name) entries terminated by a zero die_offset.
-fn parse_pubnames_sets<'data>(
-    data: &'data [u8],
-    section_name: &str,
-) -> Result<Vec<PubnamesSet<'data>>> {
+fn parse_pubnames_sets<'data>(data: &'data [u8]) -> Result<Vec<PubnamesSet<'data>>> {
     let mut sets = Vec::new();
-    let mut pos = 0;
-    while pos + 4 <= data.len() {
-        let init_len = u32_from_slice(&data[pos..]);
-
-        let (header_size, set_end, debug_info_offset) = if init_len == 0xFFFF_FFFF {
-            // DWARF64: 4 + 8(len) + 2(ver) + 8(offset) + 8(size) = 30
-            crate::ensure!(
-                pos + 30 <= data.len(),
-                "Truncated DWARF64 header in {section_name} at offset {pos}"
-            );
-            let len = u64_from_slice(&data[pos + 4..]);
-            let dio = u64_from_slice(&data[pos + 14..]);
-            (30, pos + 12 + len as usize, dio)
-        } else {
-            // DWARF32: 4(len) + 2(ver) + 4(offset) + 4(size) = 14
-            crate::ensure!(
-                pos + 14 <= data.len(),
-                "Truncated DWARF32 header in {section_name} at offset {pos}"
-            );
-            let dio = u64::from(u32_from_slice(&data[pos + 6..]));
-            (14, pos + 4 + init_len as usize, dio)
-        };
-
-        let set_end = set_end.min(data.len());
-        let mut ep = pos + header_size;
+    for set in gimli::DebugGnuPubNames::new(data, gimli::LittleEndian).sets() {
+        let set = set.context("Failed to parse .debug_gnu_pubnames set")?;
         let mut entries = Vec::new();
-        let is_64 = init_len == 0xFFFF_FFFF;
-
-        while ep < set_end {
-            let die_offset = if is_64 {
-                crate::ensure!(
-                    ep + 8 <= set_end,
-                    "Truncated die offset in {section_name} at offset {ep}"
-                );
-                let v = u64_from_slice(&data[ep..]);
-                ep += 8;
-                v
-            } else {
-                crate::ensure!(
-                    ep + 4 <= set_end,
-                    "Truncated die offset in {section_name} at offset {ep}"
-                );
-                let v = u64::from(u32_from_slice(&data[ep..]));
-                ep += 4;
-                v
-            };
-            if die_offset == 0 {
-                break;
+        for item in set.items() {
+            let item = item.context("Failed to parse .debug_gnu_pubnames entry")?;
+            let mut attrs = item.kind().0 << 4;
+            if item.is_static() {
+                attrs |= 0x80;
             }
-            crate::ensure!(
-                ep < set_end,
-                "Missing attrs byte in {section_name} at offset {ep}"
-            );
-            let attrs = data[ep];
-            ep += 1;
-            let name_start = ep;
-            while ep < set_end && data[ep] != 0 {
-                ep += 1;
-            }
-            crate::ensure!(
-                ep < set_end,
-                "Unterminated name in {section_name} at offset {name_start}"
-            );
-            entries.push((&data[name_start..ep], attrs));
-            ep += 1;
+            entries.push((item.name().slice(), attrs));
         }
-
         sets.push(PubnamesSet {
-            debug_info_offset,
+            debug_info_offset: set.unit_header_offset().0 as u64,
             entries,
         });
-        pos = set_end;
     }
     Ok(sets)
 }
@@ -470,7 +407,7 @@ fn scan_one_object(
         let Some(data) = section_by_name(object, section_name)? else {
             continue;
         };
-        for set in parse_pubnames_sets(&data, section_name)? {
+        for set in parse_pubnames_sets(&data)? {
             let Some(&local_cu_idx) = offset_to_idx.get(&set.debug_info_offset) else {
                 continue;
             };


### PR DESCRIPTION
We can use the library parser for `.debug_gnu_pubnames` / `.debug_gnu_pubtypes` directly, the binary is practically identical:
```
❯ bloaty ld -- ld-after
    FILE SIZE        VM SIZE
 --------------  --------------
  +0.1% +1.23Ki  [ = ]       0    .strtab
  +0.0%    +800  +0.0%    +800    .text
  +0.1%    +336  +0.1%    +336    .rodata
  +0.1%    +144  [ = ]       0    .symtab
  +139%     +32  +139%     +32    [LOAD #5 [RW]]
  +0.0%     +16  +0.0%     +16    .eh_frame
 -58.2%     -32 -58.2%     -32    [LOAD #3 [RX]]
  [ = ]       0 -33.8% -1.09Ki    .relro_padding
  +0.0% +2.50Ki  +0.0%     +32    TOTAL
```

and haven't noticed any performance difference.