### PR TITLE
fix: Support `--wrap` combined with linker plugin LTO

### DIFF
--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -303,8 +303,6 @@ impl Linker {
             loaded,
         )?;
 
-        // TODO: Doing this here means that we can't wrap symbols produced by the linker plugin.
-        // Moving it earlier or later however requires some rethought as to how this works.
         symbol_db.apply_wrapped_symbol_overrides();
 
         let mut resolver = resolution::Resolver::default();

--- a/libwild/src/linker_plugins.rs
+++ b/libwild/src/linker_plugins.rs
@@ -25,6 +25,7 @@ use crate::input_data::FileLoader;
 use crate::input_data::InputRef;
 use crate::layout_rules::LayoutRulesBuilder;
 use crate::output_section_id::OutputSections;
+use crate::platform::Args as _;
 use crate::platform::Platform;
 use crate::platform::RawSymbolName as _;
 use crate::resolution::ResolutionResources;
@@ -211,6 +212,11 @@ impl<'data> LinkerPlugin<'data> {
 
         timing_phase!("Linker plugin codegen");
 
+        // Mark wrapped symbol names and their __wrap_/__real_ variants as referenced by non-IR
+        // code. This ensures the plugin keeps them in the LTO output rather than
+        // internalising/removing them.
+        mark_wrap_symbols_as_non_ir_ref(symbol_db, per_symbol_flags);
+
         let plugin_outputs = self.store.loaded()?.with_callbacks(|callbacks| {
             if let Some(cb) = callbacks.all_symbols_read {
                 let ctx = AllSymbolsReadContext {
@@ -237,6 +243,10 @@ impl<'data> LinkerPlugin<'data> {
             layout_rules_builder,
             plugin_loaded,
         )?;
+
+        // Re-apply --wrap overrides so that wrapped names now map to definitions from the LTO
+        // output rather than the LTO input objects.
+        symbol_db.apply_wrapped_symbol_overrides();
 
         resolver.resolve_symbols_and_select_archive_entries(symbol_db, per_symbol_flags)?;
 
@@ -922,6 +932,20 @@ fn get_symbol_resolution<'data>(
     if !sym.version.is_null() {
         raw_name.version_name = Some(unsafe { CStr::from_ptr(sym.version) }.to_bytes());
     }
+
+    // If the symbol was wrapped via --wrap, the name table has been modified to map the original
+    // name to __wrap_<name>. We must not report the wrapped resolution to the plugin, since the
+    // plugin needs to know the pre-wrap state.
+    let wrap_names = symbol_db.args.symbol_names_to_wrap();
+    let is_wrapped = wrap_names.iter().any(|w| w.as_bytes() == raw_name.name);
+    if is_wrapped {
+        return if sym.is_undefined() {
+            PluginSymbolResolution::ResolvedExec
+        } else {
+            PluginSymbolResolution::PreemptedReg
+        };
+    }
+
     let symbol_id = symbol_db
         .get(&PreHashedSymbolName::from_raw(&raw_name), true)
         .map(|id| symbol_db.definition(id));
@@ -1417,4 +1441,25 @@ pub(crate) fn resolve_lto_symbols<'data, 'scope>(
                 Ok(())
             },
         )
+}
+
+/// Marks symbols related to --wrap as having non-IR references. This ensures that the linker
+/// plugin preserves these symbols in its output rather than internalising them.
+fn mark_wrap_symbols_as_non_ir_ref<'data, P: Platform>(
+    symbol_db: &SymbolDb<'data, P>,
+    per_symbol_flags: &mut PerSymbolFlags,
+) {
+    for name in symbol_db.args.symbol_names_to_wrap() {
+        for lookup_name in [
+            name.clone(),
+            format!("__wrap_{name}"),
+            format!("__real_{name}"),
+        ] {
+            if let Some(symbol_id) =
+                symbol_db.get_unversioned(&UnversionedSymbolName::prehashed(lookup_name.as_bytes()))
+            {
+                per_symbol_flags.set_flag(symbol_id, ValueFlags::HAS_NON_IR_REF);
+            }
+        }
+    }
 }

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -586,7 +586,16 @@ impl<'data, P: Platform> SymbolDb<'data, P> {
 
         for name in wrap {
             let name_bytes = allocator.alloc_slice_copy(name.as_bytes());
-            let orig_id = self.get_unversioned(&UnversionedSymbolName::prehashed(name_bytes));
+            let real_name = allocator.alloc_slice_copy(format!("__real_{name}").as_bytes());
+
+            // When this function is called a second time (after LTO), the name table already has
+            // "foo" mapped to __wrap_foo's symbol ID from the first call. To get the ORIGINAL foo
+            // symbol ID, we first check if __real_foo already has a mapping (set by the first
+            // call), and fall back to looking up "foo" only on the first call.
+            let orig_id = self
+                .get_unversioned(&UnversionedSymbolName::prehashed(real_name))
+                .or_else(|| self.get_unversioned(&UnversionedSymbolName::prehashed(name_bytes)));
+
             let wrap_name = format!("__wrap_{name}");
             if let Some(wrap_id) =
                 self.get_unversioned(&UnversionedSymbolName::prehashed(wrap_name.as_bytes()))
@@ -595,7 +604,6 @@ impl<'data, P: Platform> SymbolDb<'data, P> {
             }
 
             if let Some(orig_id) = orig_id {
-                let real_name = allocator.alloc_slice_copy(format!("__real_{name}").as_bytes());
                 self.override_name(UnversionedSymbolName::prehashed(real_name), orig_id);
             }
         }

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -183,7 +183,6 @@ tests = [
   "lto-llvm2.sh",           # -m llvm is not yet supported
   "duplicate-error-lto.sh", # Wild deduplicates inputs
   "lto-comdat.sh",          # We don't support COMDAT
-  "wrap-lto.sh",            # We don't yet support --wrap with LTO
   "lto-archive4.sh",
   "lto-mixed-gcc-fat.sh",
 ]

--- a/wild/tests/sources/elf/wrap-lto/wrap-lto-2.c
+++ b/wild/tests/sources/elf/wrap-lto/wrap-lto-2.c
@@ -1,0 +1,1 @@
+int foo(void) { return 10; }

--- a/wild/tests/sources/elf/wrap-lto/wrap-lto.c
+++ b/wild/tests/sources/elf/wrap-lto/wrap-lto.c
@@ -1,0 +1,30 @@
+//#AbstractConfig:default
+//#RequiresLinkerPlugin:true
+//#Object:runtime.c
+//#Object:wrap-lto-2.c:-fno-lto
+//#SkipLinker:ld
+//#CompArgs:-flto
+//#LinkArgs:-flto -nostdlib -z now -Wl,-wrap,foo
+
+//#Config:gcc:default
+//#LinkerDriver:gcc
+
+//#Config:clang:default
+//#Compiler:clang
+//#LinkerDriver:clang
+//#EnableLinker:lld
+
+#include "../common/runtime.h"
+
+int foo(void);
+int __real_foo(void);
+
+int __wrap_foo(void) { return __real_foo() + 32; }
+
+void _start(void) {
+  runtime_init();
+  if (foo() != 42) {
+    exit_syscall(100);
+  }
+  exit_syscall(42);
+}


### PR DESCRIPTION
When `--wrap` and `-flto` were used together, the LTO plugin would internalize/remove `__wrap_*` symbols because it didn't know they were needed. This caused link failures.

Three changes fix this:

- In `get_symbol_resolution` (`get_symbols_v3`), report wrapped symbols as resolved to a regular (non-IR) object rather than letting the name-table override mislead the plugin into thinking they resolved to IR.
- Before calling the plugin's `all_symbols_read`, mark the wrapped symbol, `__wrap_*`, and `__real_*` variants with `HAS_NON_IR_REF` so the plugin emits them in its output instead of internalizing them.
- After loading the plugin's output objects, re-apply wrap overrides so the name table points to the new definitions rather than the LTO input objects.

Fixes #1903