### PR TITLE
chore: Fix `TRIPLE` env value used in external tests

### DIFF
--- a/wild/tests/external_tests/mold_tests.rs
+++ b/wild/tests/external_tests/mold_tests.rs
@@ -44,7 +44,7 @@ fn run_mold_test(mold_test: &Path) -> Result<Output> {
         && let Ok(arch) = Architecture::from_str(arch_name)
         && arch != get_host_architecture()
     {
-        Some(format!("{}-linux-gnu", arch))
+        Some(arch.cross_triplet())
     } else {
         None
     };


### PR DESCRIPTION
When trying cross tests for powerpc64le, I noticed that a mold test marked for skipping would fail with an error indicating that `ppc64le-linux-gnu-gcc` could not be found. This occurs because the `TRIPLE` environment variable is being constructed using `format!("{}-linux-gnu", arch)`, which incorrectly sets the GCC command.