### PR TITLE
fix: error on sub-pointer-size absolute relocations in shared objects

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -5018,6 +5018,13 @@ fn process_relocation<'data, 'scope, A: Arch<Platform = Elf>, R: Relocation>(
                     .store(true, atomic::Ordering::Relaxed);
             }
         } else if flags_to_add.needs_direct() && flags.is_interposable() {
+            if symbol_db.output_kind.is_shared_object() && A::is_illegal_in_shared_object(r_type) {
+                bail!(
+                    "relocation {} cannot be used when making a shared object; \
+                    recompile with -fPIC",
+                    A::rel_type_to_string(r_type),
+                );
+            }
             if section_is_writable {
                 common.allocate(part_id::RELA_DYN_GENERAL, elf::RELA_ENTRY_SIZE);
             } else if flags.is_function() {

--- a/libwild/src/elf_aarch64.rs
+++ b/libwild/src/elf_aarch64.rs
@@ -72,6 +72,13 @@ impl crate::platform::Arch for ElfAArch64 {
         })
     }
 
+    fn is_illegal_in_shared_object(r_type: u32) -> bool {
+        matches!(
+            r_type,
+            object::elf::R_AARCH64_ABS32 | object::elf::R_AARCH64_ABS16
+        )
+    }
+
     fn get_dynamic_relocation_type(relocation: DynamicRelocationKind) -> u32 {
         relocation.aarch64_r_type()
     }

--- a/libwild/src/elf_loongarch64.rs
+++ b/libwild/src/elf_loongarch64.rs
@@ -46,6 +46,10 @@ impl crate::platform::Arch for ElfLoongArch64 {
         })
     }
 
+    fn is_illegal_in_shared_object(r_type: u32) -> bool {
+        matches!(r_type, object::elf::R_LARCH_32)
+    }
+
     fn get_dynamic_relocation_type(relocation: DynamicRelocationKind) -> u32 {
         relocation.loongarch64_r_type()
     }

--- a/libwild/src/elf_ppc64.rs
+++ b/libwild/src/elf_ppc64.rs
@@ -30,6 +30,10 @@ impl crate::platform::Arch for ElfPpc64 {
         })
     }
 
+    fn is_illegal_in_shared_object(r_type: u32) -> bool {
+        matches!(r_type, object::elf::R_PPC64_ADDR32)
+    }
+
     fn get_dynamic_relocation_type(relocation: DynamicRelocationKind) -> u32 {
         relocation.ppc64_r_type()
     }

--- a/libwild/src/elf_riscv64.rs
+++ b/libwild/src/elf_riscv64.rs
@@ -65,6 +65,10 @@ impl crate::platform::Arch for ElfRiscV64 {
         })
     }
 
+    fn is_illegal_in_shared_object(r_type: u32) -> bool {
+        matches!(r_type, object::elf::R_RISCV_32)
+    }
+
     fn get_dynamic_relocation_type(relocation: DynamicRelocationKind) -> u32 {
         relocation.riscv64_r_type()
     }

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2899,6 +2899,16 @@ fn apply_relocation<
                 .write_to_buffer(value, &mut out[offset_in_section as usize..])?;
             return Ok(RelocationModifier::Normal);
         }
+        RelocationKind::Absolute
+            if layout.symbol_db.output_kind.is_shared_object()
+                && matches!(r_type, object::elf::R_X86_64_32 | object::elf::R_X86_64_32S) =>
+        {
+            bail!(
+                "relocation type {} cannot be used when making a shared object; \
+                 recompile with -fPIC",
+                A::rel_type_to_string(r_type)
+            );
+        }
         _ => {}
     }
     let (resolution, symbol_index, local_symbol_id) = get_resolution(rel, object_layout, layout)?;

--- a/libwild/src/elf_x86_64.rs
+++ b/libwild/src/elf_x86_64.rs
@@ -67,6 +67,10 @@ impl crate::platform::Arch for ElfX86_64 {
         })
     }
 
+    fn is_illegal_in_shared_object(r_type: u32) -> bool {
+        matches!(r_type, object::elf::R_X86_64_32 | object::elf::R_X86_64_32S)
+    }
+
     fn get_dynamic_relocation_type(relocation: DynamicRelocationKind) -> u32 {
         relocation.x86_64_r_type()
     }

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -124,6 +124,13 @@ pub(crate) trait Arch: Send + Sync + 'static {
         false
     }
 
+    /// Returns true if the given relocation type cannot be used when making a shared object.
+    /// On 64-bit architectures, sub-pointer-size absolute relocations cannot be represented
+    /// as dynamic relocations and must be rejected. Default is false (allow).
+    fn is_illegal_in_shared_object(_r_type: u32) -> bool {
+        false
+    }
+
     /// Uses debug info, if available, to get information about where in the source code a
     /// particular offset in a particular section came from.
     fn get_source_info<'data>(

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -120,6 +120,8 @@
 //!
 //! ExpectWarningWild:{message regex} As for ExpectWarning, but only checks Wild's warning output.
 //!
+//! ExpectErrorWild:{error regex} As for ExpectError, but only checks Wild's error output.
+//!
 //! Malfunction:{malfunction-id} Run with the specified malfunction enabled. Linking should still
 //! succeed, but linker-diff should report a diff. That diff will be snapshot tested.
 //!
@@ -1751,6 +1753,13 @@ fn process_directive(
         "Cross" => config.cross_enabled = parse_bool(arg, "Cross")?,
         "ExpectError" => {
             config.expect_stderr.push(ErrorMatcher::new(arg)?);
+            config.should_error = true;
+            // If there are errors, then there's nothing to run and nothing to diff.
+            config.should_run = false;
+            config.should_diff = false;
+        }
+        "ExpectErrorWild" => {
+            config.expect_stderr.push(ErrorMatcher::wild_only(arg)?);
             config.should_error = true;
             // If there are errors, then there's nothing to run and nothing to diff.
             config.should_run = false;

--- a/wild/tests/sources/elf/pic-required/pic-required.s
+++ b/wild/tests/sources/elf/pic-required/pic-required.s
@@ -1,0 +1,10 @@
+// Test that R_X86_64_32 cannot be used when making a shared object.
+// .long _shared generates R_X86_64_32 which is illegal in shared objects.
+// Both GNU ld and lld error: recompile with -fPIC
+//#Arch:x86_64
+//#LinkArgs:--no-gc-sections -shared
+//#ExpectError:recompile with -fPIC
+//#ExpectErrorWild:R_X86_64_32.*cannot be used when making a shared object
+
+.data
+.long _shared


### PR DESCRIPTION
R_X86_64_32 and R_X86_64_32S cannot be used when making a shared object because the dynamic linker has no way to patch 32-bit absolute relocations at runtime. Wild was silently emitting R_X86_64_64 instead of erroring, producing a broken shared object.

Add an early check in apply_relocation to error when these relocation types are encountered while building a shared object, matching the behavior of GNU ld and lld.

Fixes #2074