### PR TITLE
test: Add basic Wasm integration test infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,27 @@ jobs:
       # spawning processes, which isn't supported on wasi.
       - run: cargo test --profile ci -p libwild --target wasm32-wasip1
 
+  wasm-test:
+    name: Test Wasm
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+        id: rust-toolchain
+      - uses: Swatinem/rust-cache@v2
+      - run: sudo apt-get update && sudo apt-get install -y wabt lld
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-tools
+      - name: Setup Wasmtime
+        uses: bytecodealliance/actions/wasmtime/setup@v1
+        with:
+          version: '43.0.0'
+      - run: cargo test --features wasm -- wasm
+
   macho-build:
     name: Test Mach-O (AArch64)
     runs-on: macos-latest

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -330,6 +330,8 @@ fn collect_tests(tests: &mut Vec<Trial>, filter: &Filter) -> Result {
 
     let host_arch = get_host_architecture();
 
+    collect_wasm_tests(tests, filter)?;
+
     for platform in [PlatformKind::Elf, PlatformKind::MachO] {
         // Right now, the Mach-O provided Clang and the ld linker do not support the ELF format.
         if platform == PlatformKind::Elf && cfg!(target_os = "macos") {
@@ -417,6 +419,210 @@ fn collect_tests(tests: &mut Vec<Trial>, filter: &Filter) -> Result {
         }
     }
 
+    Ok(())
+}
+
+fn collect_wasm_tests(tests: &mut Vec<Trial>, filter: &Filter) -> Result {
+    if !cfg!(feature = "wasm") {
+        return Ok(());
+    }
+
+    let platform_name = "wasm";
+    if filter.excludes(platform_name) {
+        return Ok(());
+    }
+
+    let root = src_path(platform_name);
+    if !root.exists() {
+        return Ok(());
+    }
+
+    let dir = std::fs::read_dir(&root)
+        .with_context(|| format!("Failed to read directory {}", root.display()))?;
+
+    for entry in dir {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        let test_name = path
+            .file_name()
+            .context("Missing filename")?
+            .to_str()
+            .context("Non-UTF-8 path")?
+            .to_owned();
+
+        let full_name = format!("{platform_name}/wasm32/{test_name}/default");
+        if filter.excludes(&full_name) {
+            continue;
+        }
+
+        let wat_file = path.join(format!("{test_name}.wat"));
+        if !wat_file.exists() {
+            continue;
+        }
+
+        tests.push(libtest_mimic::Trial::test(full_name, move || {
+            run_wasm_test(&wat_file).map_err(|e| libtest_mimic::Failed::from(e.to_string()))
+        }));
+    }
+
+    Ok(())
+}
+
+fn run_wasm_test(wat_file: &Path) -> Result {
+    let test_name = wat_file
+        .parent()
+        .and_then(|p| p.file_name())
+        .context("Bad test path")?
+        .to_str()
+        .context("Non-UTF-8 path")?;
+
+    let build_dir = build_dir().join("wasm").join("wasm32").join(test_name);
+    std::fs::create_dir_all(&build_dir)?;
+
+    // Parse directives from .wat file (;;# prefix)
+    let source = std::fs::read_to_string(wat_file)?;
+    let mut extra_objects = Vec::new();
+    let mut expect_error = false;
+    let mut skip_run = false;
+    for line in source.lines() {
+        if let Some(rest) = line.trim().strip_prefix(";;#") {
+            if let Some(obj_name) = rest.strip_prefix("Object:") {
+                extra_objects.push(obj_name.trim().to_owned());
+            } else if rest.starts_with("ExpectError") {
+                expect_error = true;
+            } else if rest.starts_with("SkipRun") {
+                skip_run = true;
+            }
+        }
+    }
+
+    let obj_file = build_dir.join(format!("{test_name}.o"));
+    let status = Command::new("wat2wasm")
+        .arg(wat_file)
+        .arg("--relocatable")
+        .arg("-o")
+        .arg(&obj_file)
+        .status()
+        .context("Failed to run wat2wasm")?;
+    ensure!(
+        status.success(),
+        "wat2wasm failed for {}",
+        wat_file.display()
+    );
+
+    // Compile any extra .wat objects
+    let mut all_objects = vec![obj_file];
+    for extra in &extra_objects {
+        let extra_wat = wat_file.parent().unwrap().join(extra);
+        let extra_obj = build_dir.join(extra.replace(".wat", ".o"));
+        let status = Command::new("wat2wasm")
+            .arg(&extra_wat)
+            .arg("--relocatable")
+            .arg("-o")
+            .arg(&extra_obj)
+            .status()
+            .with_context(|| format!("Failed to run wat2wasm for {}", extra_wat.display()))?;
+        ensure!(
+            status.success(),
+            "wat2wasm failed for {}",
+            extra_wat.display()
+        );
+        all_objects.push(extra_obj);
+    }
+
+    let wasm_ld_output = build_dir.join(format!("{test_name}.wasm-ld.wasm"));
+    let wasm_wild_output = build_dir.join(format!("{test_name}.wild.wasm"));
+    let mut wasm_ld_cmd = Command::new("wasm-ld");
+    for obj in &all_objects {
+        wasm_ld_cmd.arg(obj);
+    }
+    wasm_ld_cmd
+        .arg("-o")
+        .arg(&wasm_ld_output)
+        .arg("--no-entry")
+        .arg("--export-all")
+        .arg("--no-check-features");
+
+    let wasm_ld_result = wasm_ld_cmd.output().context("Failed to run wasm-ld")?;
+
+    if !expect_error {
+        ensure!(
+            wasm_ld_result.status.success(),
+            "wasm-ld linking failed:\n{}",
+            String::from_utf8_lossy(&wasm_ld_result.stderr)
+        );
+        validate_wasm(&wasm_ld_output, "wasm-ld")?;
+        if !skip_run {
+            run_wasm_with_wasmtime(&wasm_ld_output, "wasm-ld")?;
+        }
+    }
+
+    // Link with wild and verify the result.
+    let mut link_cmd = Command::new(wild_path());
+    link_cmd.arg("-flavor").arg("wasm");
+    for obj in &all_objects {
+        link_cmd.arg(obj);
+    }
+    link_cmd.arg("-o").arg(&wasm_wild_output);
+
+    let link_result = link_cmd.output().context("Failed to run wild")?;
+
+    if expect_error {
+        ensure!(
+            !link_result.status.success(),
+            "Expected link error but wild succeeded"
+        );
+        return Ok(());
+    }
+
+    ensure!(
+        link_result.status.success(),
+        "wild linking failed:\n{}",
+        String::from_utf8_lossy(&link_result.stderr)
+    );
+
+    validate_wasm(&wasm_wild_output, "wild")?;
+    if !skip_run {
+        run_wasm_with_wasmtime(&wasm_wild_output, "wild")?;
+    }
+
+    Ok(())
+}
+
+fn validate_wasm(wasm_file: &Path, linker_name: &str) -> Result {
+    let output = Command::new("wasm-tools")
+        .arg("validate")
+        .arg(wasm_file)
+        .output()
+        .context("Failed to run wasm-tools validate")?;
+    ensure!(
+        output.status.success(),
+        "wasm-tools validate failed for {} output ({}):\n{}",
+        linker_name,
+        wasm_file.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(())
+}
+
+fn run_wasm_with_wasmtime(wasm_file: &Path, linker_name: &str) -> Result {
+    let output = Command::new("wasmtime")
+        .arg("run")
+        .arg(wasm_file)
+        .output()
+        .context("Failed to run wasmtime")?;
+    ensure!(
+        output.status.success(),
+        "wasmtime execution of {} output failed (exit={:?}):\nstdout: {}\nstderr: {}",
+        linker_name,
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
     Ok(())
 }
 

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -350,25 +350,12 @@ fn collect_tests(tests: &mut Vec<Trial>, filter: &Filter) -> Result {
             continue;
         }
 
-        let root = src_path(platform_name);
-        let dir = std::fs::read_dir(&root)
-            .with_context(|| format!("Failed to read directory {}", root.display()))?;
-
         let is_nextest = std::env::var("NEXTEST").is_ok();
 
-        for entry in dir {
-            let entry = entry?;
-            let path = entry.path();
+        for_each_test_dir(platform_name, filter, |base_name, path| {
             if path.ends_with("common") {
-                continue;
+                return Ok(());
             }
-
-            let base_name = path
-                .file_name()
-                .context("Missing filename")?
-                .to_str()
-                .context("Non-UTF-8 path")?
-                .to_owned();
 
             for &arch in platform.supported_architectures() {
                 let name_prefix = format!("{platform_name}/{arch}/{base_name}");
@@ -376,12 +363,12 @@ fn collect_tests(tests: &mut Vec<Trial>, filter: &Filter) -> Result {
                     continue;
                 }
 
-                let primary_source_file = identify_primary_source(&path, &base_name)?;
+                let primary_source_file = identify_primary_source(&path, base_name)?;
 
                 let configs = parse_configs(
                     &primary_source_file,
                     &Config::new(
-                        base_name.clone(),
+                        base_name.to_owned(),
                         platform,
                         arch,
                         path.clone(),
@@ -416,22 +403,20 @@ fn collect_tests(tests: &mut Vec<Trial>, filter: &Filter) -> Result {
                     }));
                 }
             }
-        }
+            Ok(())
+        })?;
     }
 
     Ok(())
 }
 
-fn collect_wasm_tests(tests: &mut Vec<Trial>, filter: &Filter) -> Result {
-    if !cfg!(feature = "wasm") {
-        return Ok(());
-    }
-
-    let platform_name = "wasm";
-    if filter.excludes(platform_name) {
-        return Ok(());
-    }
-
+/// Iterates over subdirectories under `tests/sources/{platform_name}/`, calling `cb` with the
+/// directory name and path for each entry.
+fn for_each_test_dir(
+    platform_name: &str,
+    filter: &Filter,
+    mut cb: impl FnMut(&str, PathBuf) -> Result,
+) -> Result {
     let root = src_path(platform_name);
     if !root.exists() {
         return Ok(());
@@ -447,29 +432,45 @@ fn collect_wasm_tests(tests: &mut Vec<Trial>, filter: &Filter) -> Result {
             continue;
         }
 
-        let test_name = path
+        let name = path
             .file_name()
             .context("Missing filename")?
             .to_str()
             .context("Non-UTF-8 path")?
             .to_owned();
 
-        let full_name = format!("{platform_name}/wasm32/{test_name}/default");
-        if filter.excludes(&full_name) {
+        if filter.excludes(&format!("{platform_name}/{name}")) {
             continue;
         }
 
-        let wat_file = path.join(format!("{test_name}.wat"));
-        if !wat_file.exists() {
-            continue;
-        }
-
-        tests.push(libtest_mimic::Trial::test(full_name, move || {
-            run_wasm_test(&wat_file).map_err(|e| libtest_mimic::Failed::from(e.to_string()))
-        }));
+        cb(&name, path)?;
     }
 
     Ok(())
+}
+
+fn collect_wasm_tests(tests: &mut Vec<Trial>, filter: &Filter) -> Result {
+    if !cfg!(feature = "wasm") {
+        return Ok(());
+    }
+
+    let platform_name = "wasm";
+    if filter.excludes(platform_name) {
+        return Ok(());
+    }
+
+    for_each_test_dir(platform_name, filter, |test_name, path| {
+        let wat_file = path.join(format!("{test_name}.wat"));
+        if !wat_file.exists() {
+            return Ok(());
+        }
+
+        let full_name = format!("{platform_name}/wasm32/{test_name}/default");
+        tests.push(libtest_mimic::Trial::test(full_name, move || {
+            run_wasm_test(&wat_file).map_err(|e| libtest_mimic::Failed::from(e.to_string()))
+        }));
+        Ok(())
+    })
 }
 
 fn run_wasm_test(wat_file: &Path) -> Result {
@@ -487,15 +488,15 @@ fn run_wasm_test(wat_file: &Path) -> Result {
     let source = std::fs::read_to_string(wat_file)?;
     let mut extra_objects = Vec::new();
     let mut expect_error = false;
-    let mut skip_run = false;
+    let mut should_run = true;
     for line in source.lines() {
         if let Some(rest) = line.trim().strip_prefix(";;#") {
             if let Some(obj_name) = rest.strip_prefix("Object:") {
                 extra_objects.push(obj_name.trim().to_owned());
             } else if rest.starts_with("ExpectError") {
                 expect_error = true;
-            } else if rest.starts_with("SkipRun") {
-                skip_run = true;
+            } else if let Some(val) = rest.strip_prefix("RunEnabled:") {
+                should_run = val.trim().parse().context("Invalid bool for RunEnabled")?;
             }
         }
     }
@@ -556,7 +557,7 @@ fn run_wasm_test(wat_file: &Path) -> Result {
             String::from_utf8_lossy(&wasm_ld_result.stderr)
         );
         validate_wasm(&wasm_ld_output, "wasm-ld")?;
-        if !skip_run {
+        if should_run {
             run_wasm_with_wasmtime(&wasm_ld_output, "wasm-ld")?;
         }
     }
@@ -586,7 +587,7 @@ fn run_wasm_test(wat_file: &Path) -> Result {
     );
 
     validate_wasm(&wasm_wild_output, "wild")?;
-    if !skip_run {
+    if should_run {
         run_wasm_with_wasmtime(&wasm_wild_output, "wild")?;
     }
 

--- a/wild/tests/sources/wasm/call/call.wat
+++ b/wild/tests/sources/wasm/call/call.wat
@@ -1,0 +1,11 @@
+(module
+  (func $callee (result i32)
+    i32.const 42
+  )
+  (func $start (export "_start")
+    call $callee
+    i32.const 42
+    i32.ne
+    if unreachable end
+  )
+)

--- a/wild/tests/sources/wasm/global/global.wat
+++ b/wild/tests/sources/wasm/global/global.wat
@@ -1,0 +1,15 @@
+(module
+  (global $counter (mut i32) (i32.const 0))
+  (func $start (export "_start")
+    ;; Increment counter: 0 -> 1
+    global.get $counter
+    i32.const 1
+    i32.add
+    global.set $counter
+    ;; Verify counter == 1
+    global.get $counter
+    i32.const 1
+    i32.ne
+    if unreachable end
+  )
+)

--- a/wild/tests/sources/wasm/memory/memory.wat
+++ b/wild/tests/sources/wasm/memory/memory.wat
@@ -1,0 +1,15 @@
+(module
+  (memory (export "memory") 1)
+  (func $start (export "_start")
+    ;; Store 42 at address 0
+    i32.const 0
+    i32.const 42
+    i32.store
+    ;; Load back and verify
+    i32.const 0
+    i32.load
+    i32.const 42
+    i32.ne
+    if unreachable end
+  )
+)

--- a/wild/tests/sources/wasm/multi-object/multi-object.wat
+++ b/wild/tests/sources/wasm/multi-object/multi-object.wat
@@ -1,5 +1,5 @@
 ;;#Object:multi-object2.wat
-;;#SkipRun
+;;#RunEnabled:false
 (module
   (type $void_to_void (func))
   (import "env" "helper" (func $helper (type $void_to_void)))

--- a/wild/tests/sources/wasm/multi-object/multi-object.wat
+++ b/wild/tests/sources/wasm/multi-object/multi-object.wat
@@ -1,0 +1,9 @@
+;;#Object:multi-object2.wat
+;;#SkipRun
+(module
+  (type $void_to_void (func))
+  (import "env" "helper" (func $helper (type $void_to_void)))
+  (func $start (export "_start")
+    call $helper
+  )
+)

--- a/wild/tests/sources/wasm/multi-object/multi-object2.wat
+++ b/wild/tests/sources/wasm/multi-object/multi-object2.wat
@@ -1,0 +1,5 @@
+(module
+  (func $helper (export "helper")
+    nop
+  )
+)

--- a/wild/tests/sources/wasm/multiple-types/multiple-types.wat
+++ b/wild/tests/sources/wasm/multiple-types/multiple-types.wat
@@ -1,0 +1,15 @@
+(module
+  (func $add (param i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    i32.add
+  )
+  (func $start (export "_start")
+    i32.const 40
+    i32.const 2
+    call $add
+    i32.const 42
+    i32.ne
+    if unreachable end
+  )
+)

--- a/wild/tests/sources/wasm/trivial/trivial.wat
+++ b/wild/tests/sources/wasm/trivial/trivial.wat
@@ -1,0 +1,5 @@
+(module
+  (func $start (export "_start")
+    nop
+  )
+)


### PR DESCRIPTION
This patch adds an integration test infrastructure for WebAssembly. Since Wild currently lacks support for features required to link C code targeting Wasm, such as memory imports, data section emission, and symbols like `__stack_pointer`, the added tests are based on `.wat` files instead.

For each test case, the input is first linked with wasm-ld as a reference. If linking succeeds, the same input is linked with Wild, and the resulting output is validated using `wasm-tools validate` to verify that it is a well-formed Wasm binary. The binary produced by Wild is then executed with wasmtime to verify its runtime behavior.

Part of #1431