### PR TITLE
refactor: Make late-stage layout phase platform interface more flexible

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -31,6 +31,7 @@ use crate::layout::ObjectLayoutState;
 use crate::layout::OutputRecordLayout;
 use crate::layout::Resolution;
 use crate::layout::SymbolCopyInfo;
+use crate::layout::objects_iter;
 use crate::layout_rules::SectionKind;
 use crate::layout_rules::SectionRule;
 use crate::layout_rules::SectionRuleOutcome;
@@ -975,14 +976,13 @@ impl platform::Platform for Elf {
 
     fn create_finalise_sizes_ext<'data, 'states, 'files, A: Arch<Platform = Self>>(
         args: &ElfArgs,
-        objects: impl Iterator<Item = &'files Self::File<'data>>,
-        states: impl Iterator<Item = &'states Self::ObjectLayoutStateExt<'data>> + Clone,
+        groups: &'files [layout::GroupState<'data, Self>],
     ) -> Result<LayoutExt>
     where
         'data: 'files,
         'data: 'states,
     {
-        LayoutExt::new::<A>(objects, states, args)
+        LayoutExt::new::<A>(groups, args)
     }
 
     fn create_layout_ext<'data>(
@@ -3475,13 +3475,13 @@ pub(crate) struct LayoutExt {
 
 impl LayoutExt {
     pub(crate) fn new<'files, 'states, 'data: 'files + 'states, A: Arch<Platform = Elf>>(
-        objects: impl Iterator<Item = &'files File<'data>>,
-        states: impl Iterator<Item = &'states ObjectLayoutStateExt<'data>> + Clone,
+        groups: &'files [layout::GroupState<'data, Elf>],
         args: &ElfArgs,
     ) -> Result<Self> {
+        let states = objects_iter(groups).map(|o| &o.format_specific);
         let gnu_property_notes = merge_gnu_property_notes::<A>(states.clone(), args.z_isa)?;
         let riscv_attributes = merge_riscv_attributes::<A>(states)?;
-        let eflags = merge_eflags::<A>(objects)?;
+        let eflags = merge_eflags::<A>(objects_iter(groups).map(|o| o.object))?;
 
         Ok(Self {
             gnu_property_notes,

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -310,6 +310,7 @@ impl platform::Platform for Elf {
     type DynamicEntry = DynamicEntry;
     type DynamicSymbolDefinitionExt = DynamicSymbolDefinitionExt;
     type RelocationInfo = u32;
+    type FinaliseSizesExt<'data> = LayoutExt;
     type LayoutExt<'data> = LayoutExt;
     type SymbolVersionIndex = Versym;
     type NonAddressableCounts = NonAddressableCounts;
@@ -972,7 +973,7 @@ impl platform::Platform for Elf {
             .collect()
     }
 
-    fn create_layout_properties<'data, 'states, 'files, A: Arch<Platform = Self>>(
+    fn create_finalise_sizes_ext<'data, 'states, 'files, A: Arch<Platform = Self>>(
         args: &ElfArgs,
         objects: impl Iterator<Item = &'files Self::File<'data>>,
         states: impl Iterator<Item = &'states Self::ObjectLayoutStateExt<'data>> + Clone,
@@ -982,6 +983,12 @@ impl platform::Platform for Elf {
         'data: 'states,
     {
         LayoutExt::new::<A>(objects, states, args)
+    }
+
+    fn create_layout_ext<'data>(
+        finalise_sizes_ext: Self::FinaliseSizesExt<'data>,
+    ) -> Result<Self::LayoutExt<'data>> {
+        Ok(finalise_sizes_ext)
     }
 
     fn load_exception_frame_data<'data, 'scope, A: Arch<Platform = Elf>>(

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -462,9 +462,7 @@ fn populate_file_header<A: Arch<Platform = Elf>>(
         e,
         u64::from(elf::FILE_HEADER_SIZE) + crate::elf::program_headers_size(header_info),
     );
-    header
-        .e_flags
-        .set(e, layout.properties_and_attributes.eflags);
+    header.e_flags.set(e, layout.format_specific.eflags);
     header.e_ehsize.set(e, elf::FILE_HEADER_SIZE);
     header.e_phentsize.set(
         e,
@@ -4005,19 +4003,10 @@ fn write_epilogue<A: Arch<Platform = Elf>>(
 
     write_dynamic_symbol_definitions(table_writer, layout)?;
 
-    if !layout
-        .properties_and_attributes
-        .gnu_property_notes
-        .is_empty()
-    {
+    if !layout.format_specific.gnu_property_notes.is_empty() {
         write_gnu_property_notes(layout, buffers)?;
     }
-    if layout
-        .properties_and_attributes
-        .riscv_attributes
-        .section_size
-        != 0
-    {
+    if layout.format_specific.riscv_attributes.section_size != 0 {
         write_riscv_attributes(layout, buffers)?;
     }
 
@@ -4077,15 +4066,14 @@ fn write_gnu_property_notes(
     note_header.n_namesz.set(e, GNU_NOTE_NAME.len() as u32);
     note_header.n_descsz.set(
         e,
-        (layout.properties_and_attributes.gnu_property_notes.len() * GNU_NOTE_PROPERTY_ENTRY_SIZE)
-            as u32,
+        (layout.format_specific.gnu_property_notes.len() * GNU_NOTE_PROPERTY_ENTRY_SIZE) as u32,
     );
     note_header.n_type.set(e, NT_GNU_PROPERTY_TYPE_0);
 
     let name_out = rest.split_off_mut(..GNU_NOTE_NAME.len()).unwrap();
     name_out.copy_from_slice(GNU_NOTE_NAME);
 
-    for note in &layout.properties_and_attributes.gnu_property_notes {
+    for note in &layout.format_specific.gnu_property_notes {
         let entry_bytes = rest.split_off_mut(..size_of::<NoteProperty>()).unwrap();
         let property = NoteProperty::mut_from_bytes(entry_bytes).unwrap();
         property.pr_type = note.ptype.0;
@@ -4104,10 +4092,7 @@ fn write_riscv_attributes(
     let mut writer = Cursor::new(&mut **buffers.get_mut(part_id::RISCV_ATTRIBUTES));
     writer.write_all(b"A")?;
 
-    let riscv_attributes_length = layout
-        .properties_and_attributes
-        .riscv_attributes
-        .section_size as u32;
+    let riscv_attributes_length = layout.format_specific.riscv_attributes.section_size as u32;
 
     writer.write_all((riscv_attributes_length - 1).to_le_bytes().as_slice())?;
     writer.write_all(RISCV_ATTRIBUTE_VENDOR_NAME.as_bytes())?;
@@ -4118,7 +4103,7 @@ fn write_riscv_attributes(
             .to_le_bytes()
             .as_slice(),
     )?;
-    for tag in &layout.properties_and_attributes.riscv_attributes.attributes {
+    for tag in &layout.format_specific.riscv_attributes.attributes {
         match tag {
             &RiscVAttribute::StackAlign(align) => {
                 leb128::write::unsigned(&mut writer, TAG_RISCV_STACK_ALIGN)?;

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -407,11 +407,14 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
     let relocation_statistics = OutputSectionMap::with_size(section_layouts.len());
 
     let num_sections = output_sections.num_sections();
+
     P::set_imported_symbols(
         &mut finalise_sizes_ext,
         &symbol_resolutions,
         imported_symbols,
     )?;
+
+    let format_specific = P::create_layout_ext(finalise_sizes_ext)?;
 
     let mut layout = Layout {
         symbol_db,
@@ -432,7 +435,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         relocation_statistics,
         per_symbol_flags,
         dynamic_symbol_definitions,
-        properties_and_attributes: P::create_layout_ext(finalise_sizes_ext)?,
+        format_specific,
         thunk_block_addresses,
         compressed_debug_sections: OutputSectionMap::with_size(num_sections),
         gdb_index_data,
@@ -710,7 +713,7 @@ pub struct Layout<'data, P: Platform> {
     pub(crate) has_variant_pcs: bool,
     pub(crate) per_symbol_flags: PerSymbolFlags,
     pub(crate) dynamic_symbol_definitions: Vec<DynamicSymbolDefinition<'data, P>>,
-    pub(crate) properties_and_attributes: P::LayoutExt<'data>,
+    pub(crate) format_specific: P::LayoutExt<'data>,
     /// Thunk address maps indexed by ThunkBlockId. Each entry maps SymbolId to the memory address
     /// of the thunk for that symbol within the block.
     pub(crate) thunk_block_addresses: Vec<BTreeMap<SymbolId, u64>>,

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -170,7 +170,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         num_symbols: 0,
     });
 
-    let mut properties_and_attributes = P::create_layout_properties::<A>(
+    let mut finalise_sizes_ext = P::create_finalise_sizes_ext::<A>(
         symbol_db.args,
         objects_iter(&group_states).map(|obj| obj.object),
         objects_iter(&group_states).map(|obj| &obj.format_specific),
@@ -182,7 +182,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         imported_libraries: &[],
         symbol_db: &symbol_db,
         merged_strings: &merged_strings,
-        format_specific: &properties_and_attributes,
+        format_specific: &finalise_sizes_ext,
     };
 
     finalise_all_sizes(
@@ -362,7 +362,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         dynamic_symbol_definitions: &dynamic_symbol_definitions,
         segment_layouts: &segment_layouts,
         program_segments: &program_segments,
-        format_specific: &properties_and_attributes,
+        format_specific: &finalise_sizes_ext,
         thunk_blocks: &thunk_blocks,
         thunk_block_addresses: &thunk_block_addresses_out,
     };
@@ -412,7 +412,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
 
     let num_sections = output_sections.num_sections();
     P::set_imported_symbols(
-        &mut properties_and_attributes,
+        &mut finalise_sizes_ext,
         &symbol_resolutions,
         imported_symbols,
     )?;
@@ -436,7 +436,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         relocation_statistics,
         per_symbol_flags,
         dynamic_symbol_definitions,
-        properties_and_attributes,
+        properties_and_attributes: P::create_layout_ext(finalise_sizes_ext)?,
         thunk_block_addresses,
         compressed_debug_sections: OutputSectionMap::with_size(num_sections),
         gdb_index_data,
@@ -455,7 +455,7 @@ struct FinaliseSizesResources<'data, 'scope, P: Platform> {
     imported_libraries: &'scope [ImportedLibrary<'data>],
     symbol_db: &'scope SymbolDb<'data, P>,
     merged_strings: &'scope OutputSectionMap<MergedStringsSection<'data>>,
-    format_specific: &'scope P::LayoutExt<'data>,
+    format_specific: &'scope P::FinaliseSizesExt<'data>,
 }
 
 /// Update resolutions for symbol redirects.
@@ -1479,7 +1479,7 @@ pub(crate) struct FinaliseLayoutResources<'scope, 'data, P: Platform> {
     dynamic_symbol_definitions: &'scope Vec<DynamicSymbolDefinition<'data, P>>,
     segment_layouts: &'scope SegmentLayouts,
     program_segments: &'scope ProgramSegments<P::ProgramSegmentDef>,
-    format_specific: &'scope P::LayoutExt<'data>,
+    format_specific: &'scope P::FinaliseSizesExt<'data>,
 
     pub(crate) thunk_blocks: &'scope [crate::thunks::ThunkBlock],
 

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -170,11 +170,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         num_symbols: 0,
     });
 
-    let mut finalise_sizes_ext = P::create_finalise_sizes_ext::<A>(
-        symbol_db.args,
-        objects_iter(&group_states).map(|obj| obj.object),
-        objects_iter(&group_states).map(|obj| &obj.format_specific),
-    )?;
+    let mut finalise_sizes_ext = P::create_finalise_sizes_ext::<A>(symbol_db.args, &group_states)?;
 
     let mut finalise_sizes_resources = FinaliseSizesResources {
         dynamic_symbol_definitions: &dynamic_symbol_definitions,
@@ -670,7 +666,7 @@ fn append_prelude_defsym_dynamic_symbols<'data, P: Platform>(
     Ok(())
 }
 
-fn objects_iter<'groups, 'data, P: Platform>(
+pub(crate) fn objects_iter<'groups, 'data, P: Platform>(
     group_states: &'groups [GroupState<'data, P>],
 ) -> impl Iterator<Item = &'groups ObjectLayoutState<'data, P>> + Clone {
     group_states.iter().flat_map(|group| {

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -1089,8 +1089,7 @@ impl platform::Platform for MachO {
 
     fn create_finalise_sizes_ext<'data, 'states, 'files, A: platform::Arch<Platform = Self>>(
         _args: &Self::Args,
-        _objects: impl Iterator<Item = &'files Self::File<'data>>,
-        _states: impl Iterator<Item = &'states Self::ObjectLayoutStateExt<'data>> + Clone,
+        _groups: &'files [layout::GroupState<'data, Self>],
     ) -> crate::error::Result<Self::FinaliseSizesExt<'data>>
     where
         'data: 'files,

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -893,6 +893,7 @@ impl platform::Platform for MachO {
     type ResolutionExt = ResolutionExt;
     type SymtabShndxEntry = ();
     type SymbolVersionIndex = ();
+    type FinaliseSizesExt<'data> = LayoutExt<'data>;
     type LayoutExt<'data> = LayoutExt<'data>;
     type GdbIndexScanResult<'data> = ();
     type SectionIterator<'a> = core::slice::Iter<'a, SectionHeader>;
@@ -1086,16 +1087,22 @@ impl platform::Platform for MachO {
             .collect()
     }
 
-    fn create_layout_properties<'data, 'states, 'files, A: platform::Arch<Platform = Self>>(
+    fn create_finalise_sizes_ext<'data, 'states, 'files, A: platform::Arch<Platform = Self>>(
         _args: &Self::Args,
         _objects: impl Iterator<Item = &'files Self::File<'data>>,
         _states: impl Iterator<Item = &'states Self::ObjectLayoutStateExt<'data>> + Clone,
-    ) -> crate::error::Result<Self::LayoutExt<'data>>
+    ) -> crate::error::Result<Self::FinaliseSizesExt<'data>>
     where
         'data: 'files,
         'data: 'states,
     {
         Ok(LayoutExt::default())
+    }
+
+    fn create_layout_ext<'data>(
+        finalise_sizes_ext: Self::FinaliseSizesExt<'data>,
+    ) -> Result<Self::LayoutExt<'data>> {
+        Ok(finalise_sizes_ext)
     }
 
     fn set_imported_symbols<'data>(

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -260,7 +260,7 @@ fn write_epilogue<A: Arch<Platform = MachO>>(
 fn write_got_entries(layout: &MachOLayout<'_>, got: &mut [u8]) -> Result {
     let got_layout = layout.section_layouts.get(output_section_id::GOT);
 
-    let sorted_symbols = &layout.properties_and_attributes.imported_symbols;
+    let sorted_symbols = &layout.format_specific.imported_symbols;
     for (i, imported_symbol) in sorted_symbols.iter().enumerate() {
         let offset = imported_symbol
             .got_address
@@ -295,7 +295,7 @@ fn write_plt_entries<A: Arch<Platform = MachO>>(
 ) -> Result {
     let plt_layout = layout.section_layouts.get(output_section_id::PLT_GOT);
 
-    for imported_symbol in &layout.properties_and_attributes.imported_symbols {
+    for imported_symbol in &layout.format_specific.imported_symbols {
         let Some(stub_address) = imported_symbol.plt_address else {
             continue;
         };
@@ -840,7 +840,7 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
     layout: &MachOLayout,
     chained_fixup_table: &mut [u8],
 ) -> Result {
-    let symbols = &layout.properties_and_attributes.imported_symbols;
+    let symbols = &layout.format_specific.imported_symbols;
 
     let active_segments = PROGRAM_SEGMENT_DEFS
         .iter()
@@ -925,7 +925,7 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
     // TODO: support more pages
     assert!(symbols.len() < MACHO_PAGE_ALIGNMENT.value() as usize / size_of::<u32>());
 
-    let sorted_symbols = &layout.properties_and_attributes.imported_symbols;
+    let sorted_symbols = &layout.format_specific.imported_symbols;
     let mut symbol_offsets = Vec::with_capacity(sorted_symbols.len());
     let mut str_offset = 0;
     for imported_symbol in sorted_symbols {

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -498,8 +498,7 @@ pub(crate) trait Platform:
 
     fn create_finalise_sizes_ext<'data, 'states, 'files, A: Arch<Platform = Self>>(
         args: &Self::Args,
-        objects: impl Iterator<Item = &'files Self::File<'data>>,
-        states: impl Iterator<Item = &'states Self::ObjectLayoutStateExt<'data>> + Clone,
+        groups: &'files [layout::GroupState<'data, Self>],
     ) -> Result<Self::FinaliseSizesExt<'data>>
     where
         'data: 'files,

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -255,6 +255,7 @@ pub(crate) trait Platform:
     type ResolutionExt: Default + std::fmt::Debug + Copy + Send + Sync + 'static;
     type SymtabShndxEntry: std::fmt::Debug + Default + Send + Sync + 'static;
     type ResolvedObjectExt<'data>: Default + std::fmt::Debug + Send + Sync;
+    type FinaliseSizesExt<'data>: Send + Sync;
 
     /// An index into the local object's symbol versions.
     type SymbolVersionIndex: Send + Sync + Copy;
@@ -495,17 +496,21 @@ pub(crate) trait Platform:
     fn built_in_section_infos<'data>()
     -> Vec<crate::output_section_id::SectionOutputInfo<'data, Self>>;
 
-    fn create_layout_properties<'data, 'states, 'files, A: Arch<Platform = Self>>(
+    fn create_finalise_sizes_ext<'data, 'states, 'files, A: Arch<Platform = Self>>(
         args: &Self::Args,
         objects: impl Iterator<Item = &'files Self::File<'data>>,
         states: impl Iterator<Item = &'states Self::ObjectLayoutStateExt<'data>> + Clone,
-    ) -> Result<Self::LayoutExt<'data>>
+    ) -> Result<Self::FinaliseSizesExt<'data>>
     where
         'data: 'files,
         'data: 'states;
 
+    fn create_layout_ext<'data>(
+        finalise_sizes_ext: Self::FinaliseSizesExt<'data>,
+    ) -> Result<Self::LayoutExt<'data>>;
+
     fn set_imported_symbols<'data>(
-        _properties: &mut Self::LayoutExt<'data>,
+        _format_specific: &mut Self::FinaliseSizesExt<'data>,
         _resolutions: &SymbolResolutions<Self>,
         _imported_symbols: Vec<ImportedSymbol<'data>>,
     ) -> Result {
@@ -553,7 +558,7 @@ pub(crate) trait Platform:
         state: &mut Self::EpilogueLayoutExt,
         mem_sizes: &mut OutputSectionPartMap<u64>,
         dynamic_symbol_definitions: &[DynamicSymbolDefinition<'data, Self>],
-        properties: &Self::LayoutExt<'data>,
+        properties: &Self::FinaliseSizesExt<'data>,
         symbol_db: &SymbolDb<'data, Self>,
     );
 
@@ -584,7 +589,7 @@ pub(crate) trait Platform:
         epilogue_state: &mut Self::EpilogueLayoutExt,
         memory_offsets: &mut OutputSectionPartMap<u64>,
         symbol_db: &SymbolDb<'data, Self>,
-        common_state: &Self::LayoutExt<'data>,
+        common_state: &Self::FinaliseSizesExt<'data>,
         dynsym_start_index: u32,
         dynamic_symbol_defs: &[DynamicSymbolDefinition<Self>],
     ) -> Result;

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -2103,6 +2103,7 @@ impl platform::Platform for Wasm {
     type ResolutionExt = ();
     type SymtabShndxEntry = ();
     type SymbolVersionIndex = ();
+    type FinaliseSizesExt<'data> = WasmLayout<'data>;
     type LayoutExt<'data> = WasmLayout<'data>;
     type GdbIndexScanResult<'data> = ();
     type SectionIterator<'a> = core::slice::Iter<'a, SectionHeader>;
@@ -2298,16 +2299,22 @@ impl platform::Platform for Wasm {
             .collect()
     }
 
-    fn create_layout_properties<'data, 'states, 'files, A: platform::Arch<Platform = Self>>(
+    fn create_finalise_sizes_ext<'data, 'states, 'files, A: platform::Arch<Platform = Self>>(
         _args: &Self::Args,
         objects: impl Iterator<Item = &'files Self::File<'data>>,
         _states: impl Iterator<Item = &'states Self::ObjectLayoutStateExt<'data>> + Clone,
-    ) -> crate::error::Result<Self::LayoutExt<'data>>
+    ) -> crate::error::Result<Self::FinaliseSizesExt<'data>>
     where
         'data: 'files,
         'data: 'states,
     {
         build_output_module_layout(objects)
+    }
+
+    fn create_layout_ext<'data>(
+        finalise_sizes_ext: Self::FinaliseSizesExt<'data>,
+    ) -> Result<Self::LayoutExt<'data>> {
+        Ok(finalise_sizes_ext)
     }
 
     fn load_exception_frame_data<'data, 'scope, A: platform::Arch<Platform = Self>>(

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -7,6 +7,7 @@ use crate::bail;
 use crate::ensure;
 use crate::error::Context as _;
 use crate::error::Result;
+use crate::layout;
 use crate::layout::ImportedSymbol;
 use crate::layout_rules::SectionKind;
 use crate::output_section_id::SectionName;
@@ -1936,12 +1937,14 @@ impl<'data> WasmObjectLayoutInput<'data> {
 }
 
 fn build_output_module_layout<'data, 'files>(
-    objects: impl Iterator<Item = &'files File<'data>>,
+    groups: &'files [layout::GroupState<'data, Wasm>],
 ) -> Result<WasmLayout<'data>>
 where
     'data: 'files,
 {
-    let objects = objects.collect::<Vec<_>>();
+    let objects = layout::objects_iter(groups)
+        .map(|o| o.object)
+        .collect::<Vec<_>>();
     let layout_inputs = objects
         .par_iter()
         .map(|object| WasmObjectLayoutInput::from_file(object))
@@ -2301,14 +2304,13 @@ impl platform::Platform for Wasm {
 
     fn create_finalise_sizes_ext<'data, 'states, 'files, A: platform::Arch<Platform = Self>>(
         _args: &Self::Args,
-        objects: impl Iterator<Item = &'files Self::File<'data>>,
-        _states: impl Iterator<Item = &'states Self::ObjectLayoutStateExt<'data>> + Clone,
+        groups: &'files [layout::GroupState<'data, Self>],
     ) -> crate::error::Result<Self::FinaliseSizesExt<'data>>
     where
         'data: 'files,
         'data: 'states,
     {
-        build_output_module_layout(objects)
+        build_output_module_layout(groups)
     }
 
     fn create_layout_ext<'data>(

--- a/libwild/src/wasm_writer.rs
+++ b/libwild/src/wasm_writer.rs
@@ -37,13 +37,13 @@ pub(crate) fn write<'data, A: Arch<Platform = Wasm>>(
     preamble[..4].copy_from_slice(&WASM_MAGIC);
     preamble[4..8].copy_from_slice(&WASM_VERSION.to_le_bytes());
 
-    copy_metadata_sections(&layout.properties_and_attributes, &mut section_buffers)?;
+    copy_metadata_sections(&layout.format_specific, &mut section_buffers)?;
     write_code_section(
-        &layout.properties_and_attributes.function_bodies,
+        &layout.format_specific.function_bodies,
         section_buffers.get_mut(crate::output_section_id::WASM_CODE),
     )?;
 
-    if let Some(unsupported) = layout.properties_and_attributes.unsupported_output.first() {
+    if let Some(unsupported) = layout.format_specific.unsupported_output.first() {
         bail!("Wasm {unsupported} emission is not implemented yet");
     }
 


### PR DESCRIPTION
Three commits. One creates FinaliseSizesExt, where previously we just uses LayoutExt. For now all `Platform` implementations use the same type for both `FinaliseSizesExt` and `LayoutExt`, but that will likely change later. The second commit passes Groups states directly to `create_finalise_sizes_ext`, where previously we passed an iterator over objects. The last commit is just a rename to a more general and more consistent name.