### PR TITLE
fix(loongarch64): Treat R_LARCH_CALL36 as PLT-generating

### DIFF
--- a/libwild/src/elf_loongarch64.rs
+++ b/libwild/src/elf_loongarch64.rs
@@ -128,6 +128,15 @@ impl crate::platform::Arch for ElfLoongArch64 {
         let offset = offset_in_section as usize;
 
         match relocation_kind {
+            object::elf::R_LARCH_CALL36 if !interposable => {
+                relocation.kind = RelocationKind::Relative;
+                return Some(Relaxation {
+                    kind: RelaxationKind::NoOp,
+                    rel_info: relocation,
+                    mandatory: true,
+                });
+            }
+
             object::elf::R_LARCH_B26 if !interposable => {
                 relocation.kind = RelocationKind::Relative;
                 return Some(Relaxation {

--- a/linker-utils/src/loongarch64.rs
+++ b/linker-utils/src/loongarch64.rs
@@ -354,7 +354,7 @@ pub const fn relocation_type_from_raw(r_type: u32) -> Option<RelocationKindInfo>
             0,
         ),
         object::elf::R_LARCH_CALL36 => (
-            RelocationKind::Relative,
+            RelocationKind::PltRelative,
             RelocationSize::bit_mask_loongarch64(2, 38, LoongArch64Instruction::Call36),
             None,
             // with check 38-bit signed overflow and a multiple of 4

--- a/wild/tests/sources/elf/larch-call36-shared/larch-call36-shared.s
+++ b/wild/tests/sources/elf/larch-call36-shared/larch-call36-shared.s
@@ -1,0 +1,25 @@
+/*
+//#Config:default
+//#Arch:loongarch64
+//#Mode:dynamic
+//#LinkArgs:-shared -z now
+//#DiffIgnore:.dynamic.DT_RELA
+//#DiffIgnore:.dynamic.DT_RELAENT
+//#RunEnabled:false
+*/
+
+.section .text, "ax", @progbits
+
+.globl call_target
+.type call_target, @function
+call_target:
+    addi.w  $r4, $r0, 42
+    jirl    $r0, $r1, 0
+.size call_target, .-call_target
+
+.globl do_call
+.type do_call, @function
+do_call:
+    pcaddu18i $r1, %call36(call_target)
+    jirl      $r1, $r1, 0
+.size do_call, .-do_call


### PR DESCRIPTION
## Problem

Run wild with `-mcmodel=medium`:

```
Direct relocation (R_LARCH_CALL36) to dynamic symbol from non-writable
section, but copy relocations are disabled because output is a shared
object.
```

`R_LARCH_CALL36` was mapped to `RelocationKind::Relative`, so the linker tried to resolve it directly. For interposable symbols in non-writable sections, the only fallback is a copy relocation, which is disallowed for shared objects.

## Fix

Treats CALL36 like R_LARCH_B26 and call relocations on other architectures.

This matches the behavior of ld.lld, which routes R_LARCH_CALL36 through processR_PLT_PC.

## Test

Ran the integration tests on Arch Linux for Loong64 (this distro defaults to `-mcmodel=medium` so it uses R_LARCH_CALL36 instead of R_LARCH_B26):

- Before: 13 failures in `elf/loongarch64/*` with the CALL36 error.
- After: 275 passed, 0 failed, 859 ignored.