### PR TITLE
feat: Add `--compress-debug-section=zlib-gabi` as an alias for `--compress-debug-section=zlib`

### DIFF
--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -1112,7 +1112,7 @@ fn setup_argument_parser() -> ArgumentParser<ElfArgs> {
         .execute(|args, _modifier_stack, value| {
             match value {
                 "none" => args.debug_compression_kind = None,
-                "zlib" => args.debug_compression_kind = Some(CompressionKind::Zlib),
+                "zlib" | "zlib-gabi" => args.debug_compression_kind = Some(CompressionKind::Zlib),
                 "zstd" => args.debug_compression_kind = Some(CompressionKind::Zstd),
                 value => bail!("--compress-debug-sections={value}"),
             }

--- a/wild/tests/external_tests/mold_skip_tests.toml
+++ b/wild/tests/external_tests/mold_skip_tests.toml
@@ -16,7 +16,6 @@ tests = [
   "execute-only.sh",
   "fatal-warnings.sh",                     # `-warn-common` and `-fatal-warnings`
   "filter.sh",
-  "gdb-index-compress-output.sh",          # --compress-debug-sections=zlib-gabi
   "global-offset-table.sh",                # `-defsym=foo=_GLOBAL_OFFSET_TABLE_`
   "icf-gcc-except-table.sh",               # `--icf`
   "icf.sh",                                # `--icf`


### PR DESCRIPTION
GNU ld and mold support this.