### PR TITLE
feat: calculate section layouts and part layouts at the same time

### DIFF
--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -279,7 +279,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         unreachable!();
     };
 
-    let (mut section_part_layouts, mut section_layouts) = layout_section_parts::<A::Platform>(
+    let (mut section_part_layouts, mut section_layouts) = layout_section::<A::Platform>(
         &section_part_sizes,
         &output_sections,
         &program_segments,
@@ -305,20 +305,25 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         )?;
     }
 
-    if let Some((record, last_part_id)) = section_part_layouts
-        .parts
+    if let Some((last_section_id, _)) = section_layouts
         .iter()
-        .enumerate()
-        .map(|(index, rec)| (rec, PartId::from_usize(index)))
-        .max_by_key(|(record, _)| record.file_offset + record.file_size)
+        .max_by_key(|(_, record)| record.file_end())
     {
-        let extra_file_size = A::Platform::last_part_size_to_extend(record, last_part_id)?;
+        let last_part_id = PartId::from_usize(last_section_id.part_id_range().end.as_usize() - 1);
+        let extra_file_size = A::Platform::last_part_size_to_extend(
+            section_part_layouts.get(last_part_id),
+            last_part_id,
+        )?;
         if extra_file_size > 0 {
             section_part_sizes.increment(last_part_id, extra_file_size as u64);
 
-            let rec = section_part_layouts.get_mut(last_part_id);
-            rec.file_size += extra_file_size;
-            rec.mem_size += extra_file_size as u64;
+            let part_layout = section_part_layouts.get_mut(last_part_id);
+            part_layout.file_size += extra_file_size;
+            part_layout.mem_size += extra_file_size as u64;
+
+            let section_layout = section_layouts.get_mut(last_section_id);
+            section_layout.file_size += extra_file_size;
+            section_layout.mem_size += extra_file_size as u64;
         }
     }
 
@@ -5054,7 +5059,7 @@ fn perform_iterative_relaxation<'data, A: Arch>(
                 .collect(),
         );
 
-        (*section_part_layouts, *section_layouts) = layout_section_parts::<A::Platform>(
+        (*section_part_layouts, *section_layouts) = layout_section::<A::Platform>(
             section_part_sizes,
             output_sections,
             program_segments,
@@ -5067,7 +5072,7 @@ fn perform_iterative_relaxation<'data, A: Arch>(
     Ok(())
 }
 
-fn layout_section_parts<'data, P: Platform>(
+fn layout_section<'data, P: Platform>(
     sizes: &OutputSectionPartMap<u64>,
     output_sections: &OutputSections<'data, P>,
     program_segments: &ProgramSegments<P::ProgramSegmentDef>,
@@ -5626,7 +5631,7 @@ fn test_no_disallowed_overlaps() {
     let symbol_db =
         crate::symbol_db::SymbolDb::<Elf>::new(&args, output_kind, &auxiliary, &herd).unwrap();
 
-    let (_, section_layouts) = layout_section_parts::<Elf>(
+    let (_, section_layouts) = layout_section::<Elf>(
         &section_part_sizes,
         &output_sections,
         &program_segments,

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -279,7 +279,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         unreachable!();
     };
 
-    let mut section_part_layouts = layout_section_parts::<A::Platform>(
+    let (mut section_part_layouts, mut section_layouts) = layout_section_parts::<A::Platform>(
         &section_part_sizes,
         &output_sections,
         &program_segments,
@@ -294,6 +294,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
             &mut group_states,
             &mut section_part_sizes,
             &mut section_part_layouts,
+            &mut section_layouts,
             &output_sections,
             &program_segments,
             &output_order,
@@ -321,7 +322,6 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         }
     }
 
-    let section_layouts = layout_sections(&output_sections, &section_part_layouts);
     let mut merged_section_layouts = section_layouts.clone();
     merge_secondary_parts(&output_sections, &mut merged_section_layouts);
 
@@ -1755,40 +1755,42 @@ impl<'data, P: Platform> Layout<'data, P> {
     }
 }
 
-fn layout_sections<P: Platform>(
-    output_sections: &OutputSections<P>,
-    section_part_layouts: &OutputSectionPartMap<OutputRecordLayout>,
-) -> OutputSectionMap<OutputRecordLayout> {
-    section_part_layouts.merge_parts(|section_id, layouts| {
-        let info = output_sections.section_infos.get(section_id);
-        let mut file_offset = usize::MAX;
-        let mut mem_offset = u64::MAX;
-        let mut lma_offset = u64::MAX;
-        let mut file_end = 0;
-        let mut mem_end = 0;
-        let mut lma_end = 0;
-        let mut alignment = info.min_alignment;
+fn layout_section_from_part_layouts<'data, P: Platform>(
+    part: &OutputRecordLayout,
+    section_layout: &mut OutputRecordLayout,
+    section_info: &output_section_id::SectionOutputInfo<'data, P>,
+    is_first_part: bool,
+) {
+    if is_first_part {
+        *section_layout = *part;
+        section_layout.alignment = section_info.min_alignment;
+        if part.mem_size > 0 {
+            section_layout.alignment = section_layout.alignment.max(part.alignment);
+        }
+        return;
+    }
 
-        for part in layouts {
-            file_offset = file_offset.min(part.file_offset);
-            mem_offset = mem_offset.min(part.mem_offset);
-            lma_offset = lma_offset.min(part.lma_offset);
-            file_end = file_end.max(part.file_offset + part.file_size);
-            mem_end = mem_end.max(part.mem_offset + part.mem_size);
-            lma_end = lma_end.max(part.lma_offset + part.mem_size);
-            if part.mem_size > 0 {
-                alignment = alignment.max(part.alignment);
-            }
-        }
-        OutputRecordLayout {
-            file_size: file_end - file_offset,
-            mem_size: mem_end - mem_offset,
-            alignment,
-            file_offset,
-            mem_offset,
-            lma_offset,
-        }
-    })
+    let file_offset = section_layout.file_offset.min(part.file_offset);
+    let mem_offset = section_layout.mem_offset.min(part.mem_offset);
+    let lma_offset = section_layout.lma_offset.min(part.lma_offset);
+
+    let file_size = section_layout.file_end().max(part.file_end()) - file_offset;
+    let mem_size = section_layout.mem_end().max(part.mem_end()) - mem_offset;
+
+    let alignment = if part.mem_size > 0 {
+        section_layout.alignment.max(part.alignment)
+    } else {
+        section_layout.alignment
+    };
+
+    *section_layout = OutputRecordLayout {
+        file_size,
+        mem_size,
+        alignment,
+        file_offset,
+        mem_offset,
+        lma_offset,
+    };
 }
 
 pub(crate) fn merge_secondary_parts<P: Platform>(
@@ -4995,6 +4997,7 @@ fn perform_iterative_relaxation<'data, A: Arch>(
     group_states: &mut [GroupState<'data, A::Platform>],
     section_part_sizes: &mut OutputSectionPartMap<u64>,
     section_part_layouts: &mut OutputSectionPartMap<OutputRecordLayout>,
+    section_layouts: &mut OutputSectionMap<OutputRecordLayout>,
     output_sections: &OutputSections<'data, A::Platform>,
     program_segments: &ProgramSegments<<A::Platform as Platform>::ProgramSegmentDef>,
     output_order: &OutputOrder<'data>,
@@ -5051,7 +5054,7 @@ fn perform_iterative_relaxation<'data, A: Arch>(
                 .collect(),
         );
 
-        *section_part_layouts = layout_section_parts::<A::Platform>(
+        (*section_part_layouts, *section_layouts) = layout_section_parts::<A::Platform>(
             section_part_sizes,
             output_sections,
             program_segments,
@@ -5072,7 +5075,10 @@ fn layout_section_parts<'data, P: Platform>(
     symbol_db: &SymbolDb<'data, P>,
     memory_regions: &mut HashMap<&[u8], MemoryRegion>,
     sizeof_headers: u64,
-) -> Result<OutputSectionPartMap<OutputRecordLayout>> {
+) -> Result<(
+    OutputSectionPartMap<OutputRecordLayout>,
+    OutputSectionMap<OutputRecordLayout>,
+)> {
     let args = symbol_db.args;
     let segment_alignments = compute_segment_alignments::<P>(
         sizes,
@@ -5082,16 +5088,16 @@ fn layout_section_parts<'data, P: Platform>(
         output_sections,
     );
 
-    // Create an empty section layout for now, until we can support using linker script
-    // commands.
-    let empty_section_layouts = OutputSectionMap::with_size(output_sections.num_sections());
+    let mut section_layouts = OutputSectionMap::with_size(output_sections.num_sections());
 
     let expression_eval =
-        |expr: &Expression<'data>, memory_regions: &HashMap<&[u8], MemoryRegion>| {
+        |expr: &Expression<'data>,
+         memory_regions: &HashMap<&[u8], MemoryRegion>,
+         section_layouts: &OutputSectionMap<OutputRecordLayout>| {
             crate::expression_eval::evaluate_expression(
                 expr,
                 &crate::parsing::SymbolLoc::None,
-                &empty_section_layouts,
+                section_layouts,
                 output_sections,
                 memory_regions,
                 symbol_db,
@@ -5103,7 +5109,11 @@ fn layout_section_parts<'data, P: Platform>(
         };
 
     let mut file_offset = 0;
-    let mut mem_offset = expression_eval(&output_sections.base_address, memory_regions)?;
+    let mut mem_offset = expression_eval(
+        &output_sections.base_address,
+        memory_regions,
+        &section_layouts,
+    )?;
     let mut lma_offset = mem_offset;
     let mut nonalloc_mem_offsets: OutputSectionMap<u64> =
         OutputSectionMap::with_size(output_sections.num_sections());
@@ -5127,7 +5137,7 @@ fn layout_section_parts<'data, P: Platform>(
                         .unwrap_or_else(|| args.loadable_segment_alignment());
                     if let Some(expr) = pending_location.take() {
                         // The OrderEvent::SetLocation is ELF-specific only.
-                        mem_offset = expression_eval(&expr, memory_regions)?;
+                        mem_offset = expression_eval(&expr, memory_regions, &section_layouts)?;
                         lma_offset = mem_offset;
                         file_offset =
                             segment_alignment.align_modulo(mem_offset, file_offset as u64) as usize;
@@ -5172,7 +5182,7 @@ fn layout_section_parts<'data, P: Platform>(
                     mem_offset = region.origin + region.used;
                 }
                 if let Some(ref expr) = section_info.location {
-                    let offset = expression_eval(expr, memory_regions)?;
+                    let offset = expression_eval(expr, memory_regions, &section_layouts)?;
                     if let Some(region) = region
                         && (offset < mem_offset || offset > mem_offset + region.length)
                     {
@@ -5184,17 +5194,13 @@ fn layout_section_parts<'data, P: Platform>(
                     }
                     mem_offset = offset;
                 }
-                if let Some(ref expr) = section_info.load_location {
-                    lma_offset = expression_eval(expr, memory_regions)?;
-                } else {
-                    lma_offset = mem_offset;
-                }
+                lma_offset = mem_offset;
 
                 records_out[part_id_range.clone()]
                     .iter_mut()
                     .zip(&sizes[part_id_range.clone()])
                     .enumerate()
-                    .for_each(|(offset, (part_layout, &part_size))| {
+                    .try_for_each(|(offset, (part_layout, &part_size))| -> Result {
                         let part_id = part_id_range.start.offset(offset);
                         let alignment = part_id.alignment(output_sections).min(max_alignment);
                         let merge_target = output_sections.primary_output_section(section_id);
@@ -5275,7 +5281,21 @@ fn layout_section_parts<'data, P: Platform>(
                             };
                             file_offset += mem_size as usize;
                         }
-                    });
+                        layout_section_from_part_layouts(
+                            part_layout,
+                            section_layouts.get_mut(section_id),
+                            section_info,
+                            offset == 0,
+                        );
+
+                        if let Some(ref expr) = section_info.load_location {
+                            lma_offset = expression_eval(expr, memory_regions, &section_layouts)?;
+                            part_layout.lma_offset = lma_offset;
+                            let section_layout = section_layouts.get_mut(section_id);
+                            section_layout.lma_offset = lma_offset;
+                        }
+                        Ok(())
+                    })?;
 
                 if let Some(region_name) = section_info.region_name
                     && let Some(region) = memory_regions.get_mut(region_name)
@@ -5294,7 +5314,7 @@ fn layout_section_parts<'data, P: Platform>(
         }
     }
 
-    Ok(records_out)
+    Ok((records_out, section_layouts))
 }
 
 /// Computes the maximum alignment for each LOAD segment by examining the alignments of all sections
@@ -5606,7 +5626,7 @@ fn test_no_disallowed_overlaps() {
     let symbol_db =
         crate::symbol_db::SymbolDb::<Elf>::new(&args, output_kind, &auxiliary, &herd).unwrap();
 
-    let section_part_layouts = layout_section_parts::<Elf>(
+    let (_, section_layouts) = layout_section_parts::<Elf>(
         &section_part_sizes,
         &output_sections,
         &program_segments,
@@ -5616,8 +5636,6 @@ fn test_no_disallowed_overlaps() {
         0,
     )
     .unwrap();
-
-    let section_layouts = layout_sections(&output_sections, &section_part_layouts);
 
     // Make sure no alloc sections overlap
     let mut last_file_start = 0;
@@ -5760,6 +5778,14 @@ impl<'scope, 'data, P: Platform> FinaliseLayoutResources<'scope, 'data, P> {
 }
 
 impl OutputRecordLayout {
+    pub(crate) fn file_end(&self) -> usize {
+        self.file_offset + self.file_size
+    }
+
+    pub(crate) fn mem_end(&self) -> u64 {
+        self.mem_offset + self.mem_size
+    }
+
     fn merge(&mut self, other: &OutputRecordLayout) {
         debug_assert!(other.mem_offset >= self.mem_offset);
         debug_assert!(other.file_offset >= self.file_offset);

--- a/libwild/src/output_section_part_map.rs
+++ b/libwild/src/output_section_part_map.rs
@@ -2,9 +2,7 @@ use crate::alignment;
 use crate::alignment::Alignment;
 use crate::output_section_id::OrderEvent;
 use crate::output_section_id::OutputOrder;
-use crate::output_section_id::OutputSectionId;
 use crate::output_section_id::OutputSections;
-use crate::output_section_map::OutputSectionMap;
 use crate::part_id::PartId;
 use crate::platform::Platform;
 use std::mem::take;
@@ -182,28 +180,6 @@ impl<T: Default> OutputSectionPartMap<T> {
     }
 }
 
-impl<T: Copy> OutputSectionPartMap<T> {
-    /// Merges the parts of each section together.
-    pub(crate) fn merge_parts<U: Default + Copy>(
-        &self,
-        mut cb: impl FnMut(OutputSectionId, &[T]) -> U,
-    ) -> OutputSectionMap<U> {
-        let num_sections = PartId::from_usize(self.parts.len())
-            .output_section_id()
-            .as_usize();
-        let mut parts = self.parts.as_slice();
-        let values_out = (0..num_sections)
-            .map(|i| {
-                let num_parts = OutputSectionId::from_usize(i).num_parts();
-                let (section_parts, rest) = parts.split_at(num_parts);
-                parts = rest;
-                cb(OutputSectionId::from_usize(i), section_parts)
-            })
-            .collect();
-        OutputSectionMap::from_values(values_out)
-    }
-}
-
 impl<T: AddAssign + Copy + Default> OutputSectionPartMap<T> {
     pub(crate) fn merge(&mut self, rhs: &Self) {
         if self.num_parts() < rhs.num_parts() {
@@ -227,6 +203,7 @@ impl<'out> OutputSectionPartMap<&'out mut [u8]> {
 #[test]
 fn test_merge_parts() {
     use crate::output_section_id;
+    use crate::output_section_id::OutputSectionId;
 
     let output_sections =
         crate::output_section_id::OutputSections::<crate::elf::Elf>::for_testing();
@@ -251,7 +228,12 @@ fn test_merge_parts() {
     // Subtract the Mach-O specific sections.
     let num_regular_sections = output_sections.num_regular_sections() - 1;
     let mut num_sections_with_17 = 0;
-    let sum_of_1s: OutputSectionMap<u32> = all_1.merge_parts(|_, values| values.iter().sum());
+
+    let mut sum_of_1s = output_sections.new_section_map::<u32>();
+    sum_of_1s.for_each_mut(|section_id, sum| {
+        let range = section_id.part_id_range();
+        *sum = all_1[range].iter().sum();
+    });
 
     const SKIP_SECTIONS: &[OutputSectionId] = &[
         crate::part_id::UNMAPPED.output_section_id(),
@@ -291,7 +273,13 @@ fn test_merge_parts() {
 
     let mut headers_only = output_sections.new_part_map::<u32>();
     *headers_only.get_mut(crate::part_id::FILE_HEADER) += 42;
-    let merged: OutputSectionMap<u32> = headers_only.merge_parts(|_, values| values.iter().sum());
+
+    let mut merged = output_sections.new_section_map::<u32>();
+    merged.for_each_mut(|section_id, sum| {
+        let range = section_id.part_id_range();
+        *sum = headers_only[range].iter().sum();
+    });
+
     assert_eq!(*merged.get(crate::output_section_id::FILE_HEADER), 42);
     assert_eq!(*merged.get(crate::output_section_id::TEXT), 0);
     assert_eq!(*merged.get(crate::output_section_id::BSS), 0);

--- a/wild/tests/sources/elf/linker-script-at/linker-script-at.ld
+++ b/wild/tests/sources/elf/linker-script-at/linker-script-at.ld
@@ -4,7 +4,8 @@ SECTIONS {
     .text 0x100000 : AT(0x200000) {
         *(.text .text.*)
     }
-    .data 0x200000 : AT(0x300000) {
+
+    .data ADDR(.text) + 0x100000 : AT(ADDR(.data) + 0x100000) {
         *(.data)
     }
 }


### PR DESCRIPTION
By computing both at the same time, linker scripts can use the values of previously computed sections within expressions defined for the current output section.