### PR TITLE
fix: Accept full byte range for R_X86_64_8 and R_X86_64_16 relocations

### DIFF
--- a/linker-utils/src/x86_64.rs
+++ b/linker-utils/src/x86_64.rs
@@ -306,6 +306,14 @@ const RELOC_1_BYTE_SIGNED: RelocSizeAndRange = (
     RelocationSize::ByteSize(1),
     AllowedRange::from_byte_size(1, Sign::Signed),
 );
+const RELOC_2_BYTE_MIXED: RelocSizeAndRange = (
+    RelocationSize::ByteSize(2),
+    AllowedRange::new(i16::MIN as i64, u16::MAX as i64 + 1),
+);
+const RELOC_1_BYTE_MIXED: RelocSizeAndRange = (
+    RelocationSize::ByteSize(1),
+    AllowedRange::new(i8::MIN as i64, u8::MAX as i64 + 1),
+);
 const RELOC_NONE: RelocSizeAndRange = (RelocationSize::ByteSize(0), AllowedRange::no_check());
 
 /// Returns the supplied x86-64 relocation as RelocationKindType. Returns `None` if the r_type isn't
@@ -332,9 +340,9 @@ pub const fn relocation_from_raw(r_type: u32) -> Option<RelocationKindInfo> {
 
         object::elf::R_X86_64_32 => (RelocationKind::Absolute, RELOC_4_BYTE_UNSIGNED),
         object::elf::R_X86_64_32S => (RelocationKind::Absolute, RELOC_4_BYTE_SIGNED),
-        object::elf::R_X86_64_16 => (RelocationKind::Absolute, RELOC_2_BYTE_SIGNED),
+        object::elf::R_X86_64_16 => (RelocationKind::Absolute, RELOC_2_BYTE_MIXED),
         object::elf::R_X86_64_PC16 => (RelocationKind::Relative, RELOC_2_BYTE_SIGNED),
-        object::elf::R_X86_64_8 => (RelocationKind::Absolute, RELOC_1_BYTE_SIGNED),
+        object::elf::R_X86_64_8 => (RelocationKind::Absolute, RELOC_1_BYTE_MIXED),
         object::elf::R_X86_64_PC8 => (RelocationKind::Relative, RELOC_1_BYTE_SIGNED),
         object::elf::R_X86_64_TLSGD => (RelocationKind::TlsGd, RELOC_4_BYTE_SIGNED),
         object::elf::R_X86_64_TLSLD => (RelocationKind::TlsLd, RELOC_4_BYTE_SIGNED),

--- a/wild/tests/sources/elf/reloc-8-16-range/reloc-8-16-range.s
+++ b/wild/tests/sources/elf/reloc-8-16-range/reloc-8-16-range.s
@@ -1,0 +1,37 @@
+// Test that R_X86_64_8 and R_X86_64_16 accept the full mixed range [-128, 255] and
+// [-32768, 65535] respectively, not just the signed range.
+//#Arch:x86_64
+//#LinkArgs:-nostdlib --no-gc-sections
+//#Mode:static
+//#RunEnabled:false
+
+.globl _start
+_start:
+    ret
+
+.data
+.byte foo8_max - 1
+.byte foo8_mid - 1
+.byte foo8_base - 129
+
+.short foo16_max - 1
+.short foo16_mid - 1
+.short foo16_base - 32769
+
+.globl foo8_max
+foo8_max = 256
+
+.globl foo8_mid
+foo8_mid = 128
+
+.globl foo8_base
+foo8_base = 1
+
+.globl foo16_max
+foo16_max = 65536
+
+.globl foo16_mid
+foo16_mid = 32768
+
+.globl foo16_base
+foo16_base = 1


### PR DESCRIPTION
R_X86_64_8 and R_X86_64_16 are absolute relocations that should accept the full mixed range (signed minimum, unsigned maximum): [-128, 255] for 8-bit and [-32768, 65535] for 16-bit. Wild was incorrectly using signed-only ranges, rejecting valid values like 255 for R_X86_64_8.

GNU ld and lld both accept the full mixed range.

Fixes #2101