### PR TITLE
port(MachO): refactor how imported_symbols and imported_libraries work

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -25,7 +25,6 @@ use crate::layout;
 use crate::layout::CommonGroupState;
 use crate::layout::DynamicSymbolDefinition;
 use crate::layout::HandlerData as _;
-use crate::layout::ImportedSymbol;
 use crate::layout::ObjectLayout;
 use crate::layout::ObjectLayoutState;
 use crate::layout::OutputRecordLayout;
@@ -321,6 +320,7 @@ impl platform::Platform for Elf {
     type EpilogueLayoutExt = EpilogueLayoutExt;
     type GroupLayoutExt = GroupLayoutExt;
     type CommonGroupStateExt = CommonGroupStateExt;
+    type StubLibraryLayoutStateExt = ();
     type PreludeLayoutStateExt = PreludeLayoutStateExt;
     type PreludeLayoutExt = PreludeLayoutExt;
     type ArchIdentifier = object::elf::Machine;
@@ -991,6 +991,7 @@ impl platform::Platform for Elf {
 
     fn create_layout_ext<'data>(
         finalise_sizes_ext: Self::FinaliseSizesExt<'data>,
+        _resolutions: &layout::SymbolResolutions<Self>,
     ) -> Result<Self::LayoutExt<'data>> {
         Ok(finalise_sizes_ext)
     }
@@ -1085,10 +1086,11 @@ impl platform::Platform for Elf {
         Ok(())
     }
 
-    fn new_epilogue_layout(
+    fn new_epilogue_layout<'data>(
         args: &ElfArgs,
         output_kind: OutputKind,
-        dynamic_symbol_definitions: &mut [DynamicSymbolDefinition<'_, Self>],
+        dynamic_symbol_definitions: &mut [DynamicSymbolDefinition<'data, Self>],
+        _group_states: &[layout::GroupState<'data, Self>],
     ) -> EpilogueLayoutExt {
         let gnu_hash_layout = create_gnu_hash_layout(args, output_kind, dynamic_symbol_definitions);
 
@@ -1304,7 +1306,6 @@ impl platform::Platform for Elf {
         current_sizes: &OutputSectionPartMap<u64>,
         extra_sizes: &mut OutputSectionPartMap<u64>,
         dynamic_symbol_defs: &[DynamicSymbolDefinition<Self>],
-        _imported_symbols: &[ImportedSymbol],
         args: &ElfArgs,
     ) -> Result {
         if args.hash_style.includes_sysv() {
@@ -1781,11 +1782,12 @@ impl platform::Platform for Elf {
         Ok(())
     }
 
-    fn allocate_header_sizes(
-        prelude: &mut layout::PreludeLayoutState<Self>,
+    fn allocate_header_sizes<'data>(
+        prelude: &mut layout::PreludeLayoutState<'data, Self>,
         sizes: &mut OutputSectionPartMap<u64>,
         header_info: &layout::HeaderInfo,
         output_sections: &OutputSections<Self>,
+        _resources: &layout::FinaliseSizesResources<'data, '_, Self>,
     ) {
         sizes.increment(part_id::FILE_HEADER, u64::from(elf::FILE_HEADER_SIZE));
         sizes.increment(part_id::PROGRAM_HEADERS, program_headers_size(header_info));

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -76,7 +76,6 @@ use crate::verbose_timing_phase;
 use crossbeam_queue::ArrayQueue;
 use crossbeam_queue::SegQueue;
 use hashbrown::HashMap;
-use hashbrown::HashSet;
 use itertools::Itertools;
 use linker_utils::elf::RelocationKind;
 use linker_utils::relaxation::RelaxDeltaMap;
@@ -165,19 +164,18 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
             symbol_db.args,
             symbol_db.output_kind,
             &mut dynamic_symbol_definitions,
+            &group_states,
         ))],
         queue: LocalWorkQueue::new(epilogue_file_id.group()),
         common: CommonGroupState::new(&output_sections),
         num_symbols: 0,
     });
 
-    let mut finalise_sizes_ext =
+    let finalise_sizes_ext =
         P::create_finalise_sizes_ext::<A>(symbol_db.args, &group_states, &symbol_db)?;
 
-    let mut finalise_sizes_resources = FinaliseSizesResources {
+    let finalise_sizes_resources = FinaliseSizesResources {
         dynamic_symbol_definitions: &dynamic_symbol_definitions,
-        imported_symbols: &[],
-        imported_libraries: &[],
         symbol_db: &symbol_db,
         merged_strings: &merged_strings,
         format_specific: &finalise_sizes_ext,
@@ -189,11 +187,6 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         &atomic_per_symbol_flags,
         &finalise_sizes_resources,
     )?;
-
-    let imported_symbols = collect_imported_symbols(&group_states);
-    let imported_libraries = collect_imported_libraries(&group_states);
-    finalise_sizes_resources.imported_symbols = &imported_symbols;
-    finalise_sizes_resources.imported_libraries = &imported_libraries;
 
     // Dropping `symbol_info_printer` will cause it to print. So we'll either print now, or, if we
     // got an error or panic, then we'll have printed at that point.
@@ -433,13 +426,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
 
     let num_sections = output_sections.num_sections();
 
-    P::set_imported_symbols(
-        &mut finalise_sizes_ext,
-        &symbol_resolutions,
-        imported_symbols,
-    )?;
-
-    let format_specific = P::create_layout_ext(finalise_sizes_ext)?;
+    let format_specific = P::create_layout_ext(finalise_sizes_ext, &symbol_resolutions)?;
 
     let mut layout = Layout {
         symbol_db,
@@ -473,13 +460,11 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
     Ok(layout)
 }
 
-struct FinaliseSizesResources<'data, 'scope, P: Platform> {
+pub(crate) struct FinaliseSizesResources<'data, 'scope, P: Platform> {
     dynamic_symbol_definitions: &'scope [DynamicSymbolDefinition<'data, P>],
-    imported_symbols: &'scope [ImportedSymbol<'data>],
-    imported_libraries: &'scope [ImportedLibrary<'data>],
-    symbol_db: &'scope SymbolDb<'data, P>,
+    pub(crate) symbol_db: &'scope SymbolDb<'data, P>,
     merged_strings: &'scope OutputSectionMap<MergedStringsSection<'data>>,
-    format_specific: &'scope P::FinaliseSizesExt<'data>,
+    pub(crate) format_specific: &'scope P::FinaliseSizesExt<'data>,
 }
 
 /// Update resolutions for symbol redirects.
@@ -637,25 +622,6 @@ fn merge_dynamic_symbol_definitions<'data, P: Platform>(
     )?;
 
     Ok(dynamic_symbol_definitions)
-}
-
-fn collect_imported_symbols<'data, P: Platform>(
-    group_states: &[GroupState<'data, P>],
-) -> Vec<ImportedSymbol<'data>> {
-    group_states
-        .iter()
-        .flat_map(|group| group.common.imported_symbols.iter().copied())
-        .collect()
-}
-
-fn collect_imported_libraries<'data, P: Platform>(
-    group_states: &[GroupState<'data, P>],
-) -> Vec<ImportedLibrary<'data>> {
-    group_states
-        .iter()
-        .flat_map(|group| group.common.imported_libraries.iter().copied())
-        .sorted_by_key(|library| library.index)
-        .collect()
 }
 
 fn append_prelude_defsym_dynamic_symbols<'data, P: Platform>(
@@ -834,7 +800,7 @@ pub(crate) enum FileLayoutState<'data, P: Platform> {
     Prelude(PreludeLayoutState<'data, P>),
     Object(ObjectLayoutState<'data, P>),
     Dynamic(DynamicLayoutState<'data, P>),
-    StubLibrary(StubLibraryLayoutState<'data>),
+    StubLibrary(StubLibraryLayoutState<'data, P>),
     NotLoaded(NotLoaded),
     SyntheticSymbols(SyntheticSymbolsLayoutState<'data, P>),
     Epilogue(EpilogueLayoutState<P>),
@@ -850,7 +816,6 @@ pub(crate) struct PreludeLayoutState<'data, P: Platform> {
     identity: String,
     header_info: Option<HeaderInfo>,
     dynamic_linker: Option<CString>,
-    pub(crate) imported_library_paths: Vec<String>,
     pub(crate) format_specific: P::PreludeLayoutStateExt,
 }
 
@@ -865,10 +830,11 @@ pub(crate) struct EpilogueLayoutState<P: Platform> {
 }
 
 #[derive(Debug)]
-pub(crate) struct StubLibraryLayoutState<'data> {
+pub(crate) struct StubLibraryLayoutState<'data, P: Platform> {
     input: InputRef<'data>,
     file_id: FileId,
     symbol_id_range: SymbolIdRange,
+    pub(crate) format_specific: P::StubLibraryLayoutStateExt,
 }
 
 #[derive(Debug)]
@@ -922,7 +888,6 @@ pub(crate) struct PreludeLayout<'data, P: Platform> {
     pub(crate) header_info: HeaderInfo,
     pub(crate) internal_symbols: InternalSymbols<'data, P>,
     pub(crate) dynamic_linker: Option<CString>,
-    pub(crate) imported_library_paths: Vec<String>,
     pub(crate) format_specific: P::PreludeLayoutExt,
 }
 
@@ -1153,7 +1118,7 @@ impl<'data, P: Platform> SymbolRequestHandler<'data, P> for LinkerScriptLayoutSt
     }
 }
 
-impl HandlerData for StubLibraryLayoutState<'_> {
+impl<P: Platform> HandlerData for StubLibraryLayoutState<'_, P> {
     fn file_id(&self) -> FileId {
         self.file_id
     }
@@ -1163,7 +1128,7 @@ impl HandlerData for StubLibraryLayoutState<'_> {
     }
 }
 
-impl<'data, P: Platform> SymbolRequestHandler<'data, P> for StubLibraryLayoutState<'data> {
+impl<'data, P: Platform> SymbolRequestHandler<'data, P> for StubLibraryLayoutState<'data, P> {
     fn load_symbol<'scope, A: Arch<Platform = P>>(
         &mut self,
         _common: &mut CommonGroupState<'data, P>,
@@ -1228,10 +1193,6 @@ pub(crate) struct CommonGroupState<'data, P: Platform> {
     /// symbol. That's OK though because the epilogue will sort all dynamic symbols.
     dynamic_symbol_definitions: Vec<DynamicSymbolDefinition<'data, P>>,
 
-    /// A list of imported STUB library symbols (Mach-O specific).
-    imported_symbols: Vec<ImportedSymbol<'data>>,
-    imported_libraries: HashSet<ImportedLibrary<'data>>,
-
     pub(crate) format_specific: P::CommonGroupStateExt,
 }
 
@@ -1241,8 +1202,6 @@ impl<'data, P: Platform> CommonGroupState<'data, P> {
             mem_sizes: output_sections.new_part_map(),
             section_attributes: output_sections.new_section_map(),
             dynamic_symbol_definitions: Default::default(),
-            imported_symbols: Default::default(),
-            imported_libraries: Default::default(),
             format_specific: Default::default(),
         }
     }
@@ -1291,24 +1250,6 @@ impl<'data, P: Platform> CommonGroupState<'data, P> {
 
     pub(crate) fn allocate(&mut self, part_id: PartId, size: u64) {
         self.mem_sizes.increment(part_id, size);
-    }
-
-    pub(crate) fn add_imported_symbol(
-        &mut self,
-        symbol_id: SymbolId,
-        name: &'data [u8],
-        library_index: u8,
-        library_path: &'data str,
-    ) {
-        self.imported_symbols.push(ImportedSymbol {
-            symbol_id,
-            name,
-            library_index,
-        });
-        self.imported_libraries.insert(ImportedLibrary {
-            index: library_index,
-            path: library_path,
-        });
     }
 
     /// Allocate resources and update attributes based on a section having been loaded.
@@ -1391,22 +1332,6 @@ pub(crate) struct DynamicSymbolDefinition<'data, P: Platform> {
     #[debug("{:?}", String::from_utf8_lossy(name))]
     pub(crate) name: &'data [u8],
     pub(crate) format_specific: P::DynamicSymbolDefinitionExt,
-}
-
-#[derive(derive_more::Debug, Clone, Copy)]
-pub(crate) struct ImportedSymbol<'data> {
-    pub(crate) symbol_id: SymbolId,
-    #[debug("{:?}", String::from_utf8_lossy(name))]
-    pub(crate) name: &'data [u8],
-    // One-based index of the stub library that defines the symbol.
-    pub(crate) library_index: u8,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) struct ImportedLibrary<'data> {
-    // One-based index of the stub library.
-    pub(crate) index: u8,
-    pub(crate) path: &'data str,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -2757,7 +2682,9 @@ impl<'data, P: Platform> FileLayoutState<'data, P> {
                 )?;
             }
             FileLayoutState::LinkerScript(_) => {}
-            FileLayoutState::StubLibrary(_) => {}
+            FileLayoutState::StubLibrary(state) => {
+                P::load_stub_library_symbol(state, symbol_id)?;
+            }
             FileLayoutState::NotLoaded(_) => {}
             FileLayoutState::SyntheticSymbols(state) => {
                 SymbolRequestHandler::load_symbol::<A>(
@@ -2863,7 +2790,7 @@ impl<P: Platform> std::fmt::Display for LinkerScriptLayoutState<'_, P> {
     }
 }
 
-impl std::fmt::Display for StubLibraryLayoutState<'_> {
+impl<P: Platform> std::fmt::Display for StubLibraryLayoutState<'_, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(&self.input, f)
     }
@@ -3052,7 +2979,6 @@ impl<'data, P: Platform> PreludeLayoutState<'data, P> {
             identity: format!("Linker: {}\0", args.common().linker_identity()),
             header_info: None,
             dynamic_linker: None,
-            imported_library_paths: Vec::new(),
             format_specific: Default::default(),
         }
     }
@@ -3185,12 +3111,6 @@ impl<'data, P: Platform> PreludeLayoutState<'data, P> {
         per_symbol_flags: &mut PerSymbolFlags,
         resources: &FinaliseSizesResources<'data, '_, P>,
     ) -> Result {
-        self.imported_library_paths = resources
-            .imported_libraries
-            .iter()
-            .map(|library| library.path.to_string())
-            .collect();
-
         // Total section  sizes have already been computed. So any allocations we do need to update
         // both `total_sizes` and the size records in `common`. We track the extra sizes in
         // `extra_sizes` which we can then later add to both.
@@ -3440,7 +3360,7 @@ impl<'data, P: Platform> PreludeLayoutState<'data, P> {
         };
 
         // Allocate space for headers based on segment and section counts.
-        P::allocate_header_sizes(self, extra_sizes, &header_info, output_sections);
+        P::allocate_header_sizes(self, extra_sizes, &header_info, output_sections, resources);
 
         self.header_info = Some(header_info);
     }
@@ -3485,7 +3405,6 @@ impl<'data, P: Platform> PreludeLayoutState<'data, P> {
             header_info: self
                 .header_info
                 .expect("we should have computed header info by now"),
-            imported_library_paths: self.imported_library_paths,
             format_specific,
         })
     }
@@ -3824,10 +3743,16 @@ impl<'data, P: Platform> EpilogueLayoutState<P> {
     fn new(
         args: &P::Args,
         output_kind: OutputKind,
-        dynamic_symbol_definitions: &mut [DynamicSymbolDefinition<P>],
+        dynamic_symbol_definitions: &mut [DynamicSymbolDefinition<'data, P>],
+        group_states: &[GroupState<'data, P>],
     ) -> Self {
         EpilogueLayoutState {
-            format_specific: P::new_epilogue_layout(args, output_kind, dynamic_symbol_definitions),
+            format_specific: P::new_epilogue_layout(
+                args,
+                output_kind,
+                dynamic_symbol_definitions,
+                group_states,
+            ),
         }
     }
 
@@ -3843,7 +3768,6 @@ impl<'data, P: Platform> EpilogueLayoutState<P> {
             total_sizes,
             &mut extra_sizes,
             resources.dynamic_symbol_definitions,
-            resources.imported_symbols,
             resources.symbol_db.args,
         )?;
 
@@ -4603,16 +4527,17 @@ impl<P: Platform> ResolutionWriter<'_, '_, P> {
     }
 }
 
-impl<'data> StubLibraryLayoutState<'data> {
+impl<'data, P: Platform> StubLibraryLayoutState<'data, P> {
     fn new(stub: &resolution::ResolvedStubLibrary<'data>) -> Self {
         Self {
             input: stub.input,
             file_id: stub.file_id,
             symbol_id_range: stub.symbol_id_range,
+            format_specific: Default::default(),
         }
     }
 
-    fn finalise_layout<P: Platform>(
+    fn finalise_layout(
         &self,
         memory_offsets: &mut OutputSectionPartMap<u64>,
         resolutions_out: &mut ResolutionWriter<P>,

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -9,11 +9,13 @@ use crate::error;
 use crate::error::Result;
 use crate::file_writer::copy_section_data;
 use crate::grouping::SequencedInput;
+use crate::input_data::FileId;
 use crate::layout;
-use crate::layout::ImportedSymbol;
+use crate::layout::HandlerData as _;
 use crate::layout::Layout;
 use crate::layout::OutputRecordLayout;
 use crate::layout::Resolution;
+use crate::layout::StubLibraryLayoutState;
 use crate::layout::SymbolCopyInfo;
 use crate::layout::SymbolResolutions;
 use crate::layout_rules::SectionKind;
@@ -35,8 +37,10 @@ use crate::part_id;
 use crate::platform;
 use crate::platform::Args;
 use crate::platform::ObjectFile;
+use crate::symbol_db::SymbolId;
 use crate::symbol_db::Visibility;
 use crate::value_flags::ValueFlags;
+use crate::verbose_timing_phase;
 use anyhow::Context;
 use itertools::Itertools;
 use object::Endianness;
@@ -49,6 +53,7 @@ use object::macho::N_SECT;
 use object::macho::N_WEAK_DEF;
 use object::macho::SEG_LINKEDIT;
 use object::macho::Section64;
+pub use object::macho::SectionFlags;
 use object::read::macho::MachHeader;
 use object::read::macho::Nlist;
 use object::read::macho::Section;
@@ -133,20 +138,27 @@ pub(crate) fn load_dylib_command_size(path: &[u8]) -> usize {
 }
 
 #[derive(Debug, Default)]
-pub(crate) struct LayoutExt<'data> {
+pub(crate) struct LayoutExt {
     /// Imported STUB library symbols, sorted by GOT.
-    pub(crate) imported_symbols: Vec<ImportedSymbolWithResolution<'data>>,
+    pub(crate) imported_symbols: Vec<ImportedSymbolWithResolution>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct FinaliseSizesExt {
+    imported_libraries: Vec<FileId>,
+    imported_symbols: Vec<SymbolId>,
 }
 
 #[derive(Debug, Default, Clone)]
 pub(crate) struct PreludeLayoutExt {
+    pub(crate) imported_library_file_ids: Vec<FileId>,
     pub(crate) load_dylib_command_sizes: Vec<usize>,
     pub(crate) load_command_count: usize,
 }
 
 #[derive(derive_more::Debug, Clone, Copy)]
-pub(crate) struct ImportedSymbolWithResolution<'data> {
-    pub(crate) symbol: ImportedSymbol<'data>,
+pub(crate) struct ImportedSymbolWithResolution {
+    pub(crate) symbol_id: SymbolId,
     pub(crate) got_address: NonZeroU64,
     pub(crate) plt_address: Option<NonZeroU64>,
 }
@@ -536,8 +548,6 @@ impl platform::SectionType for SectionType {
     }
 }
 
-pub use object::macho::SectionFlags;
-
 impl platform::SectionFlags for SectionFlags {
     fn is_alloc(self) -> bool {
         true
@@ -885,16 +895,17 @@ impl platform::Platform for MachO {
     type RelocationInfo = object::macho::RelocationInfo;
     type NonAddressableIndexes = NonAddressableIndexes;
     type NonAddressableCounts = ();
-    type EpilogueLayoutExt = ();
+    type EpilogueLayoutExt = EpilogueLayoutExt;
     type GroupLayoutExt = ();
     type CommonGroupStateExt = ();
+    type StubLibraryLayoutStateExt = StubLibraryLayoutStateExt;
     type ArchIdentifier = ();
     type Args = MachOArgs;
     type ResolutionExt = ResolutionExt;
     type SymtabShndxEntry = ();
     type SymbolVersionIndex = ();
-    type FinaliseSizesExt<'data> = LayoutExt<'data>;
-    type LayoutExt<'data> = LayoutExt<'data>;
+    type FinaliseSizesExt<'data> = FinaliseSizesExt;
+    type LayoutExt<'data> = LayoutExt;
     type GdbIndexScanResult<'data> = ();
     type SectionIterator<'a> = core::slice::Iter<'a, SectionHeader>;
     type DynamicTagValues<'data> = DynamicTagValues<'data>;
@@ -1092,52 +1103,70 @@ impl platform::Platform for MachO {
 
     fn create_finalise_sizes_ext<'data, 'states, 'files, A: platform::Arch<Platform = Self>>(
         _args: &Self::Args,
-        _groups: &'files [layout::GroupState<'data, Self>],
+        groups: &'files [layout::GroupState<'data, Self>],
         _symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
     ) -> crate::error::Result<Self::FinaliseSizesExt<'data>>
     where
         'data: 'files,
         'data: 'states,
     {
-        Ok(LayoutExt::default())
+        let mut imported_libraries = Vec::new();
+        let mut imported_symbols = Vec::new();
+
+        for group in groups {
+            for file in &group.files {
+                match file {
+                    layout::FileLayoutState::StubLibrary(state) => {
+                        if state.format_specific.loaded {
+                            imported_libraries.push(state.file_id());
+                        }
+                        imported_symbols
+                            .extend_from_slice(state.format_specific.imported_symbols.as_slice());
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        Ok(FinaliseSizesExt {
+            imported_libraries,
+            imported_symbols,
+        })
     }
 
     fn create_layout_ext<'data>(
         finalise_sizes_ext: Self::FinaliseSizesExt<'data>,
-    ) -> Result<Self::LayoutExt<'data>> {
-        Ok(finalise_sizes_ext)
-    }
-
-    fn set_imported_symbols<'data>(
-        properties: &mut Self::LayoutExt<'data>,
         resolutions: &SymbolResolutions<Self>,
-        imported_symbols: Vec<ImportedSymbol<'data>>,
-    ) -> Result {
-        let imported_symbols = imported_symbols
+    ) -> Result<Self::LayoutExt<'data>> {
+        let mut layout_ext = LayoutExt::default();
+
+        let imported_symbols = finalise_sizes_ext
+            .imported_symbols
             .iter()
-            .map(|symbol| {
+            .map(|&symbol_id| {
                 let resolution = resolutions
-                    .get(symbol.symbol_id)
+                    .get(symbol_id)
                     .with_context(|| "missing resolution for a stub library symbol".to_string())?;
+
                 let got_address = resolution
                     .format_specific
                     .got_address
                     .ok_or_else(|| error!("missing GOT entry for a stub library symbol"))?;
 
                 Ok(ImportedSymbolWithResolution {
-                    symbol: *symbol,
+                    symbol_id,
                     got_address,
                     plt_address: resolution.format_specific.plt_address,
                 })
             })
             .collect::<Result<Vec<_>>>()?;
 
-        properties.imported_symbols = imported_symbols
+        layout_ext.imported_symbols = imported_symbols
             .into_iter()
             .sorted_by_key(|symbol| symbol.got_address)
             .collect();
 
-        Ok(())
+        Ok(layout_ext)
     }
 
     fn load_exception_frame_data<'data, 'scope, A: platform::Arch<Platform = Self>>(
@@ -1162,11 +1191,28 @@ impl platform::Platform for MachO {
         Ok(())
     }
 
-    fn new_epilogue_layout(
+    fn new_epilogue_layout<'data>(
         _args: &Self::Args,
         _output_kind: crate::output_kind::OutputKind,
-        _dynamic_symbol_definitions: &mut [crate::layout::DynamicSymbolDefinition<'_, Self>],
+        _dynamic_symbol_definitions: &mut [crate::layout::DynamicSymbolDefinition<'data, Self>],
+        group_states: &[layout::GroupState<'data, Self>],
     ) -> Self::EpilogueLayoutExt {
+        verbose_timing_phase!("Gather imported symbol IDs");
+
+        let imported_symbols = group_states
+            .iter()
+            .flat_map(|group| {
+                group.files.iter().flat_map(|file| match file {
+                    layout::FileLayoutState::StubLibrary(stub_state) => {
+                        stub_state.format_specific.imported_symbols.as_slice()
+                    }
+                    _ => &[],
+                })
+            })
+            .copied()
+            .collect();
+
+        EpilogueLayoutExt { imported_symbols }
     }
 
     fn apply_non_addressable_indexes_epilogue(
@@ -1185,13 +1231,30 @@ impl platform::Platform for MachO {
     }
 
     fn finalise_sizes_epilogue<'data>(
-        _state: &mut Self::EpilogueLayoutExt,
+        state: &mut Self::EpilogueLayoutExt,
         mem_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         _dynamic_symbol_definitions: &[crate::layout::DynamicSymbolDefinition<'data, Self>],
-        _properties: &Self::LayoutExt<'data>,
-        _symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
+        _format_specific: &Self::FinaliseSizesExt<'data>,
+        symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
     ) {
-        mem_sizes.increment(part_id::CHAINED_FIXUP_TABLE, CHAINED_FIXUP_TABLE_BASE_SIZE);
+        let mut fixup_table_size = CHAINED_FIXUP_TABLE_BASE_SIZE;
+
+        fixup_table_size += state
+            .imported_symbols
+            .iter()
+            .map(|&s| {
+                CHAINED_FIXUP_IMPORT_SIZE
+                    + symbol_db.symbol_name(s).unwrap().bytes().len() as u64
+                    + 1
+            })
+            .sum::<u64>();
+
+        // Chained fixups record start information per page. At this point the final GOT size is
+        // known, so reserve the fixup table entries needed to describe the GOT pages.
+        fixup_table_size += CHAINED_FIXUP_PAGE_START_SIZE
+            * (state.imported_symbols.len() as u64).div_ceil(MACHO_PAGE_ALIGNMENT.value());
+
+        mem_sizes.increment(part_id::CHAINED_FIXUP_TABLE, fixup_table_size);
     }
 
     fn finalise_sizes_all<'data>(
@@ -1200,37 +1263,11 @@ impl platform::Platform for MachO {
     ) {
     }
 
-    fn apply_late_size_adjustments_epilogue(
-        _state: &mut Self::EpilogueLayoutExt,
-        _current_sizes: &crate::output_section_part_map::OutputSectionPartMap<u64>,
-        extra_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
-        _dynamic_symbol_defs: &[crate::layout::DynamicSymbolDefinition<Self>],
-        imported_symbols: &[ImportedSymbol],
-        _args: &Self::Args,
-    ) -> crate::error::Result {
-        extra_sizes.increment(
-            part_id::CHAINED_FIXUP_TABLE,
-            imported_symbols
-                .iter()
-                .map(|s| CHAINED_FIXUP_IMPORT_SIZE + s.name.len() as u64 + 1)
-                .sum(),
-        );
-        // Chained fixups record start information per page. At this point the final GOT size is
-        // known, so reserve the fixup table entries needed to describe the GOT pages.
-        extra_sizes.increment(
-            part_id::CHAINED_FIXUP_TABLE,
-            CHAINED_FIXUP_PAGE_START_SIZE
-                * (imported_symbols.len() as u64).div_ceil(MACHO_PAGE_ALIGNMENT.value()),
-        );
-
-        Ok(())
-    }
-
     fn finalise_layout_epilogue<'data>(
         _epilogue_state: &mut Self::EpilogueLayoutExt,
         _memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         _symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
-        _common_state: &Self::LayoutExt<'data>,
+        _format_specific: &Self::FinaliseSizesExt<'data>,
         _dynsym_start_index: u32,
         _dynamic_symbol_defs: &[crate::layout::DynamicSymbolDefinition<Self>],
     ) -> crate::error::Result {
@@ -1251,11 +1288,12 @@ impl platform::Platform for MachO {
         true
     }
 
-    fn allocate_header_sizes(
-        prelude: &mut crate::layout::PreludeLayoutState<Self>,
+    fn allocate_header_sizes<'data>(
+        prelude: &mut crate::layout::PreludeLayoutState<'data, Self>,
         sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         header_info: &crate::layout::HeaderInfo,
         output_sections: &crate::output_section_id::OutputSections<Self>,
+        resources: &layout::FinaliseSizesResources<'data, '_, Self>,
     ) {
         sizes.increment(part_id::FILE_HEADER, size_of::<FileHeader>() as u64);
 
@@ -1296,10 +1334,20 @@ impl platform::Platform for MachO {
             (size_of::<DylinkerCommand>() + DYLINKER_PATH.len())
                 .next_multiple_of(MACHO_COMMAND_ALIGNMENT),
         );
+
+        prelude.format_specific.imported_library_file_ids =
+            resources.format_specific.imported_libraries.clone();
+
         prelude.format_specific.load_dylib_command_sizes = prelude
-            .imported_library_paths
+            .format_specific
+            .imported_library_file_ids
             .iter()
-            .map(|imported_lib| load_dylib_command_size(imported_lib.as_bytes()))
+            .map(|&file_id| {
+                let SequencedInput::StubLibrary(stub) = resources.symbol_db.file(file_id) else {
+                    panic!("Internal error: Expected StubLibrary");
+                };
+                load_dylib_command_size(stub.defined_symbols.install_name.as_bytes())
+            })
             .collect();
         let load_dylib_command_sizes = prelude.format_specific.load_dylib_command_sizes.clone();
         for command_size in load_dylib_command_sizes {
@@ -1311,26 +1359,22 @@ impl platform::Platform for MachO {
         allocate_load_cmd(size_of::<CodeSignatureCommand>());
     }
 
+    fn load_stub_library_symbol<'data>(
+        state: &mut StubLibraryLayoutState<Self>,
+        symbol_id: SymbolId,
+    ) -> Result {
+        state.format_specific.loaded = true;
+        state.format_specific.imported_symbols.push(symbol_id);
+
+        Ok(())
+    }
+
     fn finalise_sizes_for_symbol<'data>(
-        common: &mut crate::layout::CommonGroupState<'data, Self>,
-        symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
-        symbol_id: crate::symbol_db::SymbolId,
-        flags: crate::value_flags::ValueFlags,
+        _common: &mut crate::layout::CommonGroupState<'data, Self>,
+        _symbol_db: &crate::symbol_db::SymbolDb<'data, Self>,
+        _symbol_id: crate::symbol_db::SymbolId,
+        _flags: crate::value_flags::ValueFlags,
     ) -> crate::error::Result {
-        if flags.has_resolution() && symbol_db.is_stub_library_symbol(symbol_id) {
-            let symbol_name = symbol_db.symbol_name(symbol_id)?;
-            let SequencedInput::StubLibrary(stub) =
-                symbol_db.file(symbol_db.file_id_for_symbol(symbol_id))
-            else {
-                bail!("stub library expected");
-            };
-            common.add_imported_symbol(
-                symbol_id,
-                symbol_name.bytes(),
-                u8::try_from(stub.file_id.file() + 1).with_context(|| "too many stub libraries")?,
-                stub.defined_symbols.install_name,
-            );
-        }
         Ok(())
     }
 
@@ -1599,6 +1643,17 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
 
     defs
 };
+
+#[derive(Debug, Default)]
+pub(crate) struct EpilogueLayoutExt {
+    imported_symbols: Vec<SymbolId>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct StubLibraryLayoutStateExt {
+    imported_symbols: Vec<SymbolId>,
+    loaded: bool,
+}
 
 #[derive(Debug, Default, Clone, Copy)]
 pub(crate) struct ResolutionExt {

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -9,6 +9,7 @@ use crate::file_writer::SizedOutput;
 use crate::file_writer::split_buffers_by_alignment;
 use crate::file_writer::split_output_by_group;
 use crate::file_writer::split_output_into_sections;
+use crate::grouping::SequencedInput;
 use crate::layout::EpilogueLayout;
 use crate::layout::FileLayout;
 use crate::layout::Layout;
@@ -189,7 +190,7 @@ fn write_prelude<'data, A: Arch<Platform = MachO>>(
 ) -> Result {
     verbose_timing_phase!("Write prelude");
     debug_assert_eq!(
-        prelude.imported_library_paths.len(),
+        prelude.format_specific.imported_library_file_ids.len(),
         prelude.format_specific.load_dylib_command_sizes.len()
     );
 
@@ -213,14 +214,20 @@ fn write_prelude<'data, A: Arch<Platform = MachO>>(
         from_bytes_mut(command_buffer).map_err(|_| error!("Invalid INTERP command allocation"))?;
     write_dylinker_command::<A>(dylinker_command, dylinker_path_buffer);
 
-    for (path, &command_size) in prelude
-        .imported_library_paths
+    for (&file_id, &command_size) in prelude
+        .format_specific
+        .imported_library_file_ids
         .iter()
         .zip(&prelude.format_specific.load_dylib_command_sizes)
     {
         let command_buffer = load_command_buffer.split_off_mut(..command_size).unwrap();
         let (dylib_command, dylib_path_buffer) =
             from_bytes_mut(command_buffer).map_err(load_cmd_err)?;
+        let SequencedInput::StubLibrary(stub) = layout.symbol_db.file(file_id) else {
+            bail!("Internal error: All imported libraries must be StubLibraries");
+        };
+        let path = stub.defined_symbols.install_name;
+
         write_dylib_command::<A>(dylib_command, dylib_path_buffer, path.as_bytes());
     }
 
@@ -929,11 +936,15 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
     let mut symbol_offsets = Vec::with_capacity(sorted_symbols.len());
     let mut str_offset = 0;
     for imported_symbol in sorted_symbols {
-        let symbol = &imported_symbol.symbol;
-        string_pool[str_offset..str_offset + symbol.name.len()].copy_from_slice(symbol.name);
-        string_pool[str_offset + symbol.name.len()] = b'\0';
+        let symbol_name = layout
+            .symbol_db
+            .symbol_name(imported_symbol.symbol_id)
+            .unwrap()
+            .bytes();
+        string_pool[str_offset..str_offset + symbol_name.len()].copy_from_slice(symbol_name);
+        string_pool[str_offset + symbol_name.len()] = b'\0';
         symbol_offsets.push(str_offset);
-        str_offset += symbol.name.len() + 1;
+        str_offset += symbol_name.len() + 1;
     }
 
     // Emit `dyld_chained_import` that is built by 3 pieces:
@@ -941,9 +952,20 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
     // weak_import: 1
     // name_offset: 23
     for (i, imported_symbol) in sorted_symbols.iter().enumerate() {
+        // TODO: Does it matter that some stub libraries aren't used, so the file indexes may have
+        // gaps?
+        let lib_ordinal = u8::try_from(
+            layout
+                .symbol_db
+                .file_id_for_symbol(imported_symbol.symbol_id)
+                .file()
+                + 1,
+        )
+        .context("too many stub libraries")?;
+
         imports[i].set(
             Endianness::Little,
-            u32::from(imported_symbol.symbol.library_index) | ((symbol_offsets[i] as u32) << 9),
+            u32::from(lib_ordinal) | ((symbol_offsets[i] as u32) << 9),
         );
     }
 

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -11,7 +11,6 @@ use crate::input_data::InputRef;
 use crate::layout;
 use crate::layout::CommonGroupState;
 use crate::layout::DynamicSymbolDefinition;
-use crate::layout::ImportedSymbol;
 use crate::layout::Layout;
 use crate::layout::ObjectLayoutState;
 use crate::layout::OutputRecordLayout;
@@ -257,6 +256,7 @@ pub(crate) trait Platform:
     type EpilogueLayoutExt: Send + Sync + 'static;
     type GroupLayoutExt: std::fmt::Debug + Send + Sync + 'static;
     type CommonGroupStateExt: Default + std::fmt::Debug + Send + Sync + 'static;
+    type StubLibraryLayoutStateExt: Default + std::fmt::Debug + Send + Sync + 'static;
     type ArchIdentifier: Send + Sync + 'static;
     type Args: Args;
     type ResolutionExt: Default + std::fmt::Debug + Copy + Send + Sync + 'static;
@@ -514,15 +514,8 @@ pub(crate) trait Platform:
 
     fn create_layout_ext<'data>(
         finalise_sizes_ext: Self::FinaliseSizesExt<'data>,
-    ) -> Result<Self::LayoutExt<'data>>;
-
-    fn set_imported_symbols<'data>(
-        _format_specific: &mut Self::FinaliseSizesExt<'data>,
         _resolutions: &SymbolResolutions<Self>,
-        _imported_symbols: Vec<ImportedSymbol<'data>>,
-    ) -> Result {
-        Ok(())
-    }
+    ) -> Result<Self::LayoutExt<'data>>;
 
     fn load_exception_frame_data<'data, 'scope, A: Arch<Platform = Self>>(
         object: &mut ObjectLayoutState<'data, Self>,
@@ -544,10 +537,11 @@ pub(crate) trait Platform:
         scope: &Scope<'scope>,
     ) -> Result;
 
-    fn new_epilogue_layout(
+    fn new_epilogue_layout<'data>(
         args: &Self::Args,
         output_kind: OutputKind,
-        dynamic_symbol_definitions: &mut [DynamicSymbolDefinition<'_, Self>],
+        dynamic_symbol_definitions: &mut [DynamicSymbolDefinition<'data, Self>],
+        group_states: &[layout::GroupState<'data, Self>],
     ) -> Self::EpilogueLayoutExt;
 
     fn apply_non_addressable_indexes_epilogue(
@@ -565,7 +559,7 @@ pub(crate) trait Platform:
         state: &mut Self::EpilogueLayoutExt,
         mem_sizes: &mut OutputSectionPartMap<u64>,
         dynamic_symbol_definitions: &[DynamicSymbolDefinition<'data, Self>],
-        properties: &Self::FinaliseSizesExt<'data>,
+        format_specific: &Self::FinaliseSizesExt<'data>,
         symbol_db: &SymbolDb<'data, Self>,
     );
 
@@ -575,13 +569,14 @@ pub(crate) trait Platform:
     );
 
     fn apply_late_size_adjustments_epilogue(
-        state: &mut Self::EpilogueLayoutExt,
-        current_sizes: &OutputSectionPartMap<u64>,
-        extra_sizes: &mut OutputSectionPartMap<u64>,
-        dynamic_symbol_defs: &[DynamicSymbolDefinition<Self>],
-        imported_symbols: &[ImportedSymbol],
-        args: &Self::Args,
-    ) -> Result;
+        _state: &mut Self::EpilogueLayoutExt,
+        _current_sizes: &OutputSectionPartMap<u64>,
+        _extra_sizes: &mut OutputSectionPartMap<u64>,
+        _dynamic_symbol_defs: &[DynamicSymbolDefinition<Self>],
+        _args: &Self::Args,
+    ) -> Result {
+        Ok(())
+    }
 
     /// Returns any extra size needed for the part that currently ends last in
     /// the output file, once its file offset and provisional size are known.
@@ -624,11 +619,12 @@ pub(crate) trait Platform:
     }
 
     /// Allocate space for headers based on segment and section counts.
-    fn allocate_header_sizes(
-        prelude: &mut PreludeLayoutState<Self>,
+    fn allocate_header_sizes<'data>(
+        prelude: &mut PreludeLayoutState<'data, Self>,
         sizes: &mut OutputSectionPartMap<u64>,
         header_info: &layout::HeaderInfo,
         output_sections: &OutputSections<Self>,
+        resources: &layout::FinaliseSizesResources<'data, '_, Self>,
     );
 
     /// Gives the platform an opportunity to error out if an input stack section is requesting an
@@ -637,6 +633,13 @@ pub(crate) trait Platform:
         _section: &Self::SectionHeader,
         _object: &impl std::fmt::Display,
         _args: &Self::Args,
+    ) -> Result {
+        Ok(())
+    }
+
+    fn load_stub_library_symbol(
+        _state: &mut layout::StubLibraryLayoutState<Self>,
+        _symbol_id: SymbolId,
     ) -> Result {
         Ok(())
     }

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -787,11 +787,6 @@ impl<'data, P: Platform> SymbolDb<'data, P> {
         resolution == symbol_id
     }
 
-    pub(crate) fn is_stub_library_symbol(&self, symbol_id: SymbolId) -> bool {
-        let file_id = self.file_id_for_symbol(symbol_id);
-        matches!(self.groups[file_id.group()], Group::StubLibraries(_))
-    }
-
     pub(crate) fn definition(&self, symbol_id: SymbolId) -> SymbolId {
         // We need to do two steps when finding the definition for a symbol, since the definition
         // may have changed since we did the original name lookup. It would be possible to avoid

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -8,10 +8,10 @@ use crate::ensure;
 use crate::error::Context as _;
 use crate::error::Result;
 use crate::layout;
-use crate::layout::ImportedSymbol;
 use crate::layout_rules::SectionKind;
 use crate::output_section_id::SectionName;
 use crate::platform;
+use crate::symbol_db::SymbolDb;
 use crate::wasm_writer::OutputExport;
 use crate::wasm_writer::OutputGlobal;
 use crate::wasm_writer::OutputImport;
@@ -2339,6 +2339,7 @@ impl platform::Platform for Wasm {
     type EpilogueLayoutExt = ();
     type GroupLayoutExt = ();
     type CommonGroupStateExt = ();
+    type StubLibraryLayoutStateExt = ();
     type ArchIdentifier = ();
     type Args = WasmArgs;
     type ResolutionExt = ();
@@ -2572,6 +2573,7 @@ impl platform::Platform for Wasm {
 
     fn create_layout_ext<'data>(
         finalise_sizes_ext: Self::FinaliseSizesExt<'data>,
+        _resolutions: &layout::SymbolResolutions<Self>,
     ) -> Result<Self::LayoutExt<'data>> {
         Ok(finalise_sizes_ext)
     }
@@ -2599,10 +2601,11 @@ impl platform::Platform for Wasm {
         Ok(())
     }
 
-    fn new_epilogue_layout(
+    fn new_epilogue_layout<'data>(
         args: &Self::Args,
         output_kind: crate::output_kind::OutputKind,
-        dynamic_symbol_definitions: &mut [crate::layout::DynamicSymbolDefinition<'_, Self>],
+        dynamic_symbol_definitions: &mut [crate::layout::DynamicSymbolDefinition<'data, Self>],
+        group_states: &[layout::GroupState<'data, Self>],
     ) -> Self::EpilogueLayoutExt {
     }
 
@@ -2640,17 +2643,6 @@ impl platform::Platform for Wasm {
     ) {
     }
 
-    fn apply_late_size_adjustments_epilogue(
-        state: &mut Self::EpilogueLayoutExt,
-        current_sizes: &crate::output_section_part_map::OutputSectionPartMap<u64>,
-        extra_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
-        dynamic_symbol_defs: &[crate::layout::DynamicSymbolDefinition<Self>],
-        imported_symbols: &[ImportedSymbol],
-        args: &Self::Args,
-    ) -> crate::error::Result {
-        Ok(())
-    }
-
     fn finalise_layout_epilogue<'data>(
         _epilogue_state: &mut Self::EpilogueLayoutExt,
         memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
@@ -2678,11 +2670,12 @@ impl platform::Platform for Wasm {
         true
     }
 
-    fn allocate_header_sizes(
-        _prelude: &mut crate::layout::PreludeLayoutState<Self>,
+    fn allocate_header_sizes<'data>(
+        _prelude: &mut crate::layout::PreludeLayoutState<'data, Self>,
         sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         _header_info: &crate::layout::HeaderInfo,
         _output_sections: &crate::output_section_id::OutputSections<Self>,
+        _resources: &layout::FinaliseSizesResources<'data, '_, Self>,
     ) {
         sizes.increment(crate::part_id::FILE_HEADER, (WASM_MAGIC.len() + 4) as u64);
     }


### PR DESCRIPTION
`ImportedSymbol` and `ImportedLibrary` are both gone. Rather than creating `ImportedLibrary` instances when we import a library, we now just set a bool on the layout state for the stub. When we import symbols, we now record just the `SymbolId`, since we can get everything else that we need from that. All the state related to this is moved to format-specific extensions.

Fixes #2075