### PR TITLE
fix: Add RWX LOAD segment for sections with writable+executable flags

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -4430,6 +4430,10 @@ const PROGRAM_SEGMENT_DEFS: &[ProgramSegmentDef] = &[
         segment_flags: pf::READABLE.with(pf::WRITABLE),
     },
     ProgramSegmentDef {
+        segment_type: pt::LOAD,
+        segment_flags: pf::READABLE.with(pf::WRITABLE).with(pf::EXECUTABLE),
+    },
+    ProgramSegmentDef {
         segment_type: pt::TLS,
         segment_flags: pf::READABLE,
     },

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -4102,6 +4102,16 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
     ) -> Result {
         let part_id = self.section_part_id(section_index, &resources.symbol_db.section_part_ids);
         let header = self.object.section(section_index)?;
+
+        // Warn about RWX sections like GNU ld does, as they pose a security risk.
+        if header.is_alloc() && header.is_writable() && header.is_executable() {
+            resources.symbol_db.warning(format!(
+                "{}: section `{}` has RWX (read+write+execute) permissions",
+                self.input,
+                self.object.section_display_name(section_index),
+            ));
+        }
+
         let section = Section::create(header, self, part_id)?;
 
         <A::Platform as Platform>::load_object_section_relocations::<A>(

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -468,7 +468,7 @@ impl platform::SectionHeader for SectionHeader {
     }
 
     fn is_writable(&self) -> bool {
-        todo!()
+        false
     }
 
     fn is_executable(&self) -> bool {

--- a/wild/tests/sources/elf/rwx-section/rwx-section.s
+++ b/wild/tests/sources/elf/rwx-section/rwx-section.s
@@ -1,0 +1,11 @@
+// Test that sections with writable+executable (awx) flags are placed in an RWX LOAD segment.
+// Wild should warn about RWX permissions like GNU ld does.
+//#Arch:x86_64
+//#Mode:static
+//#RunEnabled:false
+//#ExpectWarningWild:has RWX \(read\+write\+execute\) permissions
+
+.section .wtext,"awx"
+.globl _start
+_start:
+    ret


### PR DESCRIPTION
Sections with SHF_ALLOC|SHF_WRITE|SHF_EXECINSTR flags (e.g. .section foo,"awx") failed to link because Wild had no RWX LOAD segment defined. Both GNU ld and lld handle such sections by placing them in a LOAD segment with read+write+execute permissions.

Add an RWX LOAD segment to PROGRAM_SEGMENT_DEFS and emit a warning like GNU ld does, since RWX memory regions pose a security risk.

Fixes #2106