### PR TITLE
port(wasm): Add per-object data segment layout and emission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,6 +2342,7 @@ dependencies = [
  "tempfile",
  "toml",
  "wait-timeout",
+ "wasmparser 0.252.0",
  "which",
 ]
 

--- a/libwild/src/args/wasm.rs
+++ b/libwild/src/args/wasm.rs
@@ -138,6 +138,16 @@ fn setup_argument_parser() -> ArgumentParser<WasmArgs> {
             Ok(())
         });
 
+    parser
+        .declare_with_param()
+        .long("no-gc-sections")
+        .help("Disable removal of unused sections")
+        .execute(|_args, _modifier_stack, _value| {
+            // TODO
+
+            Ok(())
+        });
+
     super::declare_common_args(&mut parser);
 
     parser

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -404,6 +404,34 @@ pub(crate) struct WasmModuleGlobal<'data> {
 pub(crate) struct WasmDataSegment<'data> {
     pub(crate) kind: DataKind<'data>,
     pub(crate) data: &'data [u8],
+    /// Byte offset of this segment's encoding within the input data section payload.
+    pub(crate) section_offset: u32,
+}
+
+/// Layout for one data segment within an input object.
+#[derive(Debug)]
+pub(crate) struct WasmDataSegmentLayout<'data> {
+    /// Index of this segment within the object's data section.
+    pub(crate) segment_index: u32,
+    pub(crate) kind: DataKind<'data>,
+    pub(crate) data: &'data [u8],
+    /// Relocations targeting this segment's payload bytes (segment-local offsets).
+    pub(crate) relocations: Vec<WasmRelocation>,
+    /// Output memory index after index remapping.
+    pub(crate) output_memory_index: u32,
+    /// Byte offset within the output module's linear memory where the payload is placed.
+    pub(crate) output_memory_offset: u32,
+    /// Byte offset of this segment's encoding within the output data section payload.
+    pub(crate) output_section_offset: u32,
+    /// Encoded size of this segment within the output data section payload.
+    pub(crate) encoded_output_size: u32,
+}
+
+/// Per-object data segment layout.
+#[derive(Debug, Default)]
+pub(crate) struct WasmObjectDataLayout<'data> {
+    pub(crate) file_id: crate::input_data::FileId,
+    pub(crate) segments: Vec<WasmDataSegmentLayout<'data>>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -599,16 +627,20 @@ impl<'data> File<'data> {
             return Ok(Vec::new());
         };
 
-        reader
-            .into_iter()
-            .map(|res| {
-                res.map(|d| WasmDataSegment {
-                    kind: d.kind,
-                    data: d.data,
-                })
-                .map_err(Into::into)
-            })
-            .collect()
+        let mut segments = Vec::new();
+        let mut section_offset = 0u32;
+        for res in reader {
+            let d = res?;
+            segments.push(WasmDataSegment {
+                kind: d.kind.clone(),
+                data: d.data,
+                section_offset,
+            });
+            section_offset = section_offset
+                .checked_add(wasm_data_segment_encoded_size(&d.kind, d.data.len())?)
+                .ok_or_else(|| crate::error!("Wasm data section offset overflow"))?;
+        }
+        Ok(segments)
     }
 
     /// Number of imported entries in the `function` index space.
@@ -1471,8 +1503,10 @@ pub(crate) struct WasmLayout<'data> {
     pub(crate) memories: Vec<MemoryType>,
     pub(crate) unsupported_output: Vec<&'static str>,
     pub(crate) object_index_maps: Vec<WasmObjectIndexMap>,
+    pub(crate) object_data_layouts: Vec<WasmObjectDataLayout<'data>>,
     pub(crate) encoded_sections: WasmEncodedSections,
     pub(crate) code_section_size: u64,
+    pub(crate) data_section_size: u64,
 }
 
 #[derive(Debug, Default)]
@@ -1546,6 +1580,7 @@ impl<'data> WasmLayout<'data> {
         }
 
         self.code_section_size = compute_code_section_size(&self.function_bodies);
+        self.data_section_size = compute_data_section_size(&self.object_data_layouts);
 
         Ok(())
     }
@@ -1558,6 +1593,188 @@ impl<'data> WasmLayout<'data> {
             sizes.increment(crate::part_id::WASM_CODE, self.code_section_size);
         }
     }
+
+    fn add_data_section_size(
+        &self,
+        sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
+    ) {
+        if self.data_section_size > 0 {
+            sizes.increment(crate::part_id::WASM_DATA, self.data_section_size);
+        }
+    }
+}
+
+fn const_expr_encoded_size(expr: &ConstExpr<'_>) -> Result<u32> {
+    let body = crate::wasm_writer::const_expr_body(expr)
+        .ok_or_else(|| crate::error!("Wasm const expression is missing end opcode"))?;
+    // instruction bytes plus the trailing `end` (0x0B) opcode
+    u32::try_from(body.len() + 1).context("Wasm const expression too large")
+}
+
+/// Encoded size of one segment in the data section payload. See `data` in
+/// <https://webassembly.github.io/spec/core/binary/modules.html#data-section>.
+fn wasm_data_segment_encoded_size(kind: &DataKind<'_>, data_len: usize) -> Result<u32> {
+    let data_len = u32::try_from(data_len).context("Wasm data segment too large")?;
+    let payload_len = uleb128_size(u64::from(data_len)) as u32 + data_len;
+    match kind {
+        DataKind::Passive => Ok(1 + payload_len),
+        DataKind::Active {
+            memory_index,
+            offset_expr,
+        } => {
+            let init_len = const_expr_encoded_size(offset_expr)?;
+            let header = if *memory_index == 0 {
+                1
+            } else {
+                1 + uleb128_size(u64::from(*memory_index)) as u32
+            };
+            Ok(header
+                .checked_add(init_len)
+                .and_then(|n| n.checked_add(payload_len))
+                .ok_or_else(|| crate::error!("Wasm data segment size overflow"))?)
+        }
+    }
+}
+
+/// Byte length of the offset `expr` we emit (`i32.const` + LEB + `end`).
+fn output_i32_const_init_expr_size(offset: u32) -> u32 {
+    1 + uleb128_size(u64::from(offset)) as u32 + 1
+}
+
+fn output_data_segment_encoded_size(
+    kind: &DataKind<'_>,
+    data_len: usize,
+    output_memory_offset: u32,
+    output_memory_index: u32,
+) -> Result<u32> {
+    let data_len = u32::try_from(data_len).context("Wasm data segment too large")?;
+    let payload_len = uleb128_size(u64::from(data_len)) as u32 + data_len;
+    match kind {
+        DataKind::Passive => bail!("passive data segments are not emitted"),
+        DataKind::Active { .. } => {
+            let init_len = output_i32_const_init_expr_size(output_memory_offset);
+            let header = if output_memory_index == 0 {
+                1
+            } else {
+                1 + uleb128_size(u64::from(output_memory_index)) as u32
+            };
+            Ok(header
+                .checked_add(init_len)
+                .and_then(|n| n.checked_add(payload_len))
+                .ok_or_else(|| crate::error!("Wasm data segment size overflow"))?)
+        }
+    }
+}
+
+fn data_segment_payload_offset_in_section(kind: &DataKind<'_>, data_len: usize) -> Result<u32> {
+    let encoded = wasm_data_segment_encoded_size(kind, data_len)?;
+    let data_len = u32::try_from(data_len).context("Wasm data segment too large")?;
+    let payload_len = uleb128_size(u64::from(data_len)) as u32 + data_len;
+    encoded
+        .checked_sub(payload_len)
+        .ok_or_else(|| crate::error!("Wasm data segment payload offset underflow"))
+}
+
+fn classify_data_relocations(
+    segments: &[WasmDataSegment<'_>],
+    relocs: &[WasmRelocation],
+) -> Vec<Vec<WasmRelocation>> {
+    let mut per_segment = vec![Vec::new(); segments.len()];
+    for &reloc in relocs {
+        let Some(segment_idx) = segments.iter().position(|segment| {
+            let Ok(encoded) = wasm_data_segment_encoded_size(&segment.kind, segment.data.len())
+            else {
+                return false;
+            };
+            let start = segment.section_offset;
+            let end = start.saturating_add(encoded);
+            reloc.offset >= start && reloc.offset < end
+        }) else {
+            continue;
+        };
+        let segment = &segments[segment_idx];
+        let Ok(payload_start) =
+            data_segment_payload_offset_in_section(&segment.kind, segment.data.len())
+        else {
+            continue;
+        };
+        let segment_payload_start = segment.section_offset.saturating_add(payload_start);
+        if reloc.offset < segment_payload_start {
+            continue;
+        }
+        per_segment[segment_idx].push(WasmRelocation {
+            offset: reloc.offset - segment_payload_start,
+            ..reloc
+        });
+    }
+    per_segment
+}
+
+fn layout_object_data<'data>(
+    input: &WasmObjectLayoutInput<'data>,
+    index_map: &WasmObjectIndexMap,
+    memory_cursor: &mut u32,
+    section_cursor: &mut u32,
+) -> Result<WasmObjectDataLayout<'data>> {
+    let mut segment_relocations =
+        classify_data_relocations(&input.data_segments, &input.data_relocations);
+    let mut segments = Vec::with_capacity(input.data_segments.len());
+    for (segment_index, segment) in input.data_segments.iter().enumerate() {
+        let DataKind::Active { memory_index, .. } = segment.kind else {
+            bail!("passive data segments are not emitted");
+        };
+        let output_memory_index =
+            remap_wasm_index(&index_map.memory_indices, memory_index, "memory")?;
+        let output_memory_offset = *memory_cursor;
+        let output_section_offset = *section_cursor;
+        let encoded_output_size = output_data_segment_encoded_size(
+            &segment.kind,
+            segment.data.len(),
+            output_memory_offset,
+            output_memory_index,
+        )?;
+        *memory_cursor = memory_cursor
+            .checked_add(u32::try_from(segment.data.len()).context("Wasm data segment too large")?)
+            .ok_or_else(|| crate::error!("Wasm output memory offset overflow"))?;
+        *section_cursor = section_cursor
+            .checked_add(encoded_output_size)
+            .ok_or_else(|| crate::error!("Wasm data section offset overflow"))?;
+        segments.push(WasmDataSegmentLayout {
+            segment_index: u32::try_from(segment_index).context("too many Wasm data segments")?,
+            kind: segment.kind.clone(),
+            data: segment.data,
+            relocations: std::mem::take(&mut segment_relocations[segment_index]),
+            output_memory_index,
+            output_memory_offset,
+            output_section_offset,
+            encoded_output_size,
+        });
+    }
+    Ok(WasmObjectDataLayout {
+        file_id: input.file_id,
+        segments,
+    })
+}
+
+fn compute_data_section_size(object_data_layouts: &[WasmObjectDataLayout<'_>]) -> u64 {
+    let segment_count: u32 = object_data_layouts
+        .iter()
+        .map(|obj| u32::try_from(obj.segments.len()).unwrap_or(u32::MAX))
+        .sum();
+    if segment_count == 0 {
+        return 0;
+    }
+    let count_leb_size = uleb128_size(u64::from(segment_count)) as u64;
+    let segments_total: u64 = object_data_layouts
+        .iter()
+        .flat_map(|obj| obj.segments.iter())
+        .map(|segment| u64::from(segment.encoded_output_size))
+        .sum();
+    let payload_size = count_leb_size + segments_total;
+    let payload_size_leb_size = uleb128_size(payload_size) as u64;
+
+    // `section` envelope. See <https://webassembly.github.io/spec/core/binary/modules.html#binary-section>
+    1 + payload_size_leb_size + payload_size
 }
 
 fn compute_code_section_size(bodies: &[WasmFunctionBody<'_>]) -> u64 {
@@ -1669,6 +1886,8 @@ struct WasmObjectLayoutInput<'data> {
     memories: Vec<MemoryType>,
     unsupported_output: Vec<&'static str>,
     code_relocations: Vec<WasmRelocation>,
+    data_segments: Vec<WasmDataSegment<'data>>,
+    data_relocations: Vec<WasmRelocation>,
     symbols: Vec<WasmSymbol>,
     symbol_id_range: crate::symbol_db::SymbolIdRange,
     file_id: crate::input_data::FileId,
@@ -1752,14 +1971,27 @@ impl<'data> WasmObjectLayoutInput<'data> {
             .map(|s| s.entries.clone())
             .unwrap_or_default();
 
-        let has_non_code_relocs = file
-            .reloc_sections
-            .iter()
-            .any(|s| code_section_index != Some(s.target_section_index));
+        let data_section_index = file.standard_section_index[section_id::DATA as usize];
+        let data_relocations: Vec<WasmRelocation> = data_section_index
+            .and_then(|data_idx| {
+                file.reloc_sections
+                    .iter()
+                    .find(|s| s.target_section_index == data_idx)
+            })
+            .map(|s| s.entries.clone())
+            .unwrap_or_default();
+
+        let has_other_non_code_relocs = file.reloc_sections.iter().any(|s| {
+            let target = Some(s.target_section_index);
+            target != code_section_index && target != data_section_index
+        });
 
         let mut unsupported_output = Vec::new();
-        if has_non_code_relocs {
+        if has_other_non_code_relocs {
             unsupported_output.push("non-code relocation");
+        }
+        if !data_relocations.is_empty() {
+            unsupported_output.push("data relocation");
         }
         if file.standard_section_index[section_id::TABLE as usize].is_some() {
             unsupported_output.push("table");
@@ -1773,8 +2005,13 @@ impl<'data> WasmObjectLayoutInput<'data> {
         if file.standard_section_index[section_id::DATA_COUNT as usize].is_some() {
             unsupported_output.push("data_count");
         }
-        if file.standard_section_index[section_id::DATA as usize].is_some() {
-            unsupported_output.push("data");
+
+        let data_segments = file.data_segments()?;
+        for segment in &data_segments {
+            if let DataKind::Passive = segment.kind {
+                unsupported_output.push("passive data segment");
+                break;
+            }
         }
 
         let module_functions = file.module_functions()?;
@@ -1823,14 +2060,16 @@ impl<'data> WasmObjectLayoutInput<'data> {
             memories,
             unsupported_output,
             code_relocations,
+            data_segments,
+            data_relocations,
             symbols: file.symbols.clone(),
             symbol_id_range,
             file_id,
         })
     }
 
-    fn into_output_layout(
-        self,
+    fn build_object_output_layout(
+        &self,
         index_bases: WasmObjectIndexBases,
         resolutions: &ObjectImportResolutions,
         all_index_bases: &[WasmObjectIndexBases],
@@ -1964,7 +2203,7 @@ impl<'data> WasmObjectLayoutInput<'data> {
 
         let exports = self
             .exports
-            .into_iter()
+            .iter()
             .map(|export| {
                 let index = match export.kind {
                     wasmparser::ExternalKind::Func | wasmparser::ExternalKind::FuncExact => {
@@ -1979,11 +2218,11 @@ impl<'data> WasmObjectLayoutInput<'data> {
                     wasmparser::ExternalKind::Table => bail!("Wasm table exports are not emitted"),
                     wasmparser::ExternalKind::Tag => bail!("Wasm tag exports are not emitted"),
                 };
-                Ok(OutputExport { index, ..export })
+                Ok(OutputExport { index, ..*export })
             })
             .collect::<Result<Vec<_>>>()?;
 
-        let mut function_bodies = self.function_bodies;
+        let mut function_bodies = self.function_bodies.clone();
         resolve_code_relocations(
             &mut function_bodies,
             &self.code_relocations,
@@ -1992,14 +2231,14 @@ impl<'data> WasmObjectLayoutInput<'data> {
         )?;
 
         Ok(WasmObjectOutputLayout {
-            types: self.types,
+            types: self.types.clone(),
             imports,
             function_type_indices,
-            globals: self.globals,
+            globals: self.globals.clone(),
             exports,
             function_bodies,
-            memories: self.memories,
-            unsupported_output: self.unsupported_output,
+            memories: self.memories.clone(),
+            unsupported_output: self.unsupported_output.clone(),
             index_map,
         })
     }
@@ -2191,16 +2430,18 @@ where
     let import_resolutions = resolve_cross_object_imports(&layout_inputs, symbol_db)?;
     let index_bases = allocate_wasm_object_index_bases(&layout_inputs, &import_resolutions)?;
     let object_layouts = layout_inputs
-        .into_par_iter()
+        .par_iter()
         .zip(import_resolutions.par_iter())
         .enumerate()
         .map(|(obj_idx, (input, resolutions))| {
-            input.into_output_layout(index_bases[obj_idx], resolutions, &index_bases)
+            input.build_object_output_layout(index_bases[obj_idx], resolutions, &index_bases)
         })
         .collect::<Result<Vec<_>>>()?;
 
     let mut layout = WasmLayout::default();
-    for object_layout in object_layouts {
+    let mut memory_cursor = 0u32;
+    let mut section_cursor = 0u32;
+    for (input, object_layout) in layout_inputs.iter().zip(object_layouts) {
         layout.output_types.extend(object_layout.types);
         layout.imports.extend(object_layout.imports);
         layout
@@ -2214,6 +2455,12 @@ where
             .unsupported_output
             .extend(object_layout.unsupported_output);
         layout.object_index_maps.push(object_layout.index_map);
+        layout.object_data_layouts.push(layout_object_data(
+            input,
+            layout.object_index_maps.last().expect("index map pushed"),
+            &mut memory_cursor,
+            &mut section_cursor,
+        )?);
     }
     layout.encode_metadata_sections()?;
     Ok(layout)
@@ -2632,6 +2879,7 @@ impl platform::Platform for Wasm {
     ) {
         properties.encoded_sections.add_sizes_to(mem_sizes);
         properties.add_code_section_size(mem_sizes);
+        properties.add_data_section_size(mem_sizes);
     }
 
     fn finalise_sizes_all<'data>(
@@ -2661,6 +2909,7 @@ impl platform::Platform for Wasm {
     ) -> crate::error::Result {
         common_state.encoded_sections.add_sizes_to(memory_offsets);
         common_state.add_code_section_size(memory_offsets);
+        common_state.add_data_section_size(memory_offsets);
         Ok(())
     }
 

--- a/libwild/src/wasm_writer.rs
+++ b/libwild/src/wasm_writer.rs
@@ -1,5 +1,6 @@
 use crate::bail;
 use crate::ensure;
+use crate::error::Context as _;
 use crate::error::Result;
 use crate::file_writer::SizedOutput;
 use crate::file_writer::split_output_into_sections;
@@ -10,16 +11,20 @@ use crate::wasm::WASM_VERSION;
 use crate::wasm::Wasm;
 use crate::wasm::WasmFunctionBody;
 use crate::wasm::WasmLayout;
+use crate::wasm::WasmObjectDataLayout;
 use crate::wasm::WasmRelocation;
 use crate::wasm::apply_relocation;
 use crate::wasm::section_id;
 use crate::wasm::write_uleb128;
 use leb128::write::unsigned_len as uleb128_size;
+use wasm_encoder::ConstExpr;
+use wasm_encoder::DataSection;
 use wasm_encoder::ExportSection;
 use wasm_encoder::FunctionSection;
 use wasm_encoder::GlobalSection;
 use wasm_encoder::ImportSection;
 use wasm_encoder::MemorySection;
+use wasm_encoder::Section;
 use wasm_encoder::TypeSection;
 
 pub(crate) fn write<'data, A: Arch<Platform = Wasm>>(
@@ -37,15 +42,19 @@ pub(crate) fn write<'data, A: Arch<Platform = Wasm>>(
     preamble[..4].copy_from_slice(&WASM_MAGIC);
     preamble[4..8].copy_from_slice(&WASM_VERSION.to_le_bytes());
 
+    if let Some(unsupported) = layout.format_specific.unsupported_output.first() {
+        bail!("Wasm {unsupported} emission is not implemented yet");
+    }
+
     copy_metadata_sections(&layout.format_specific, &mut section_buffers)?;
     write_code_section(
         &layout.format_specific.function_bodies,
         section_buffers.get_mut(crate::output_section_id::WASM_CODE),
     )?;
-
-    if let Some(unsupported) = layout.format_specific.unsupported_output.first() {
-        bail!("Wasm {unsupported} emission is not implemented yet");
-    }
+    write_data_section(
+        &layout.format_specific.object_data_layouts,
+        section_buffers.get_mut(crate::output_section_id::WASM_DATA),
+    )?;
 
     Ok(())
 }
@@ -172,6 +181,35 @@ fn write_code_section(bodies: &[WasmFunctionBody<'_>], out: &mut [u8]) -> Result
     Ok(())
 }
 
+fn write_data_section(
+    object_data_layouts: &[WasmObjectDataLayout<'_>],
+    out: &mut [u8],
+) -> Result<()> {
+    let has_segments = object_data_layouts
+        .iter()
+        .any(|object| !object.segments.is_empty());
+    if !has_segments {
+        ensure!(
+            out.is_empty(),
+            "Wasm data section buffer is {} bytes but no segments to write",
+            out.len()
+        );
+        return Ok(());
+    }
+
+    let section = build_data_section(object_data_layouts)?;
+    let mut encoded = Vec::new();
+    section.append_to(&mut encoded);
+    ensure!(
+        out.len() == encoded.len(),
+        "Wasm data section wrote {} bytes but buffer is {} bytes",
+        encoded.len(),
+        out.len()
+    );
+    out.copy_from_slice(&encoded);
+    Ok(())
+}
+
 /// Build a `type` section from a list of function types in output order. Callers must have
 /// already done dedup across input modules.
 pub(crate) fn build_type_section(types: &[wasmparser::FuncType]) -> Result<TypeSection> {
@@ -229,6 +267,30 @@ pub(crate) fn build_global_section(globals: &[OutputGlobal<'_>]) -> Result<Globa
     for global in globals {
         let init_expr = wasm_encoder::ConstExpr::raw(global.init_expr_body.iter().copied());
         section.global(convert_global_type(global.ty)?, &init_expr);
+    }
+    Ok(section)
+}
+
+pub(crate) fn build_data_section(
+    object_data_layouts: &[WasmObjectDataLayout<'_>],
+) -> Result<DataSection> {
+    let mut section = DataSection::new();
+    for object_layout in object_data_layouts {
+        for segment in &object_layout.segments {
+            let offset = ConstExpr::i32_const(
+                i32::try_from(segment.output_memory_offset).with_context(|| {
+                    format!(
+                        "Wasm data segment memory offset {}",
+                        segment.output_memory_offset
+                    )
+                })?,
+            );
+            section.active(
+                segment.output_memory_index,
+                &offset,
+                segment.data.iter().copied(),
+            );
+        }
     }
     Ok(section)
 }

--- a/wild/Cargo.toml
+++ b/wild/Cargo.toml
@@ -40,6 +40,7 @@ linker-layout.path = "../linker-layout"
 libloading.workspace = true
 libtest-mimic = { workspace = true }
 object.workspace = true
+wasmparser.workspace = true
 os_info.workspace = true
 regex.workspace = true
 serde.workspace = true

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -486,6 +486,7 @@ fn run_wasm_test(wat_file: &Path) -> Result {
     let mut extra_objects = Vec::new();
     let mut expect_error = false;
     let mut should_run = true;
+    let mut expected_sections = Vec::new();
     for line in source.lines() {
         if let Some(rest) = line.trim().strip_prefix(";;#") {
             if let Some(obj_name) = rest.strip_prefix("Object:") {
@@ -494,6 +495,8 @@ fn run_wasm_test(wat_file: &Path) -> Result {
                 expect_error = true;
             } else if let Some(val) = rest.strip_prefix("RunEnabled:") {
                 should_run = val.trim().parse().context("Invalid bool for RunEnabled")?;
+            } else if let Some(section) = rest.strip_prefix("ExpectSection:") {
+                expected_sections.push(section.trim().to_owned());
             }
         }
     }
@@ -584,10 +587,44 @@ fn run_wasm_test(wat_file: &Path) -> Result {
     );
 
     validate_wasm(&wasm_wild_output, "wild")?;
+    for section in &expected_sections {
+        ensure_wasm_section(&wasm_wild_output, section, "wild")?;
+    }
     if should_run {
         run_wasm_with_wasmtime(&wasm_wild_output, "wild")?;
     }
 
+    Ok(())
+}
+
+fn ensure_wasm_section(wasm_file: &Path, section_name: &str, linker_name: &str) -> Result {
+    let output = Command::new("wasm-objdump")
+        .arg("-x")
+        .arg(wasm_file)
+        .output()
+        .with_context(|| {
+            format!(
+                "Failed to run wasm-objdump on {linker_name} output ({})",
+                wasm_file.display()
+            )
+        })?;
+    ensure!(
+        output.status.success(),
+        "wasm-objdump failed for {linker_name} output ({}):\n{}",
+        wasm_file.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let found = stdout.lines().any(|line| {
+        let trimmed = line.trim_start();
+        trimmed.starts_with(section_name)
+            && trimmed.as_bytes().get(section_name.len()) == Some(&b'[')
+    });
+    ensure!(
+        found,
+        "Expected section `{section_name}` in {linker_name} output ({}), wasm-objdump -x:\n{stdout}",
+        wasm_file.display()
+    );
     Ok(())
 }
 

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -487,6 +487,8 @@ fn run_wasm_test(wat_file: &Path) -> Result {
     let mut expect_error = false;
     let mut should_run = true;
     let mut expected_sections = Vec::new();
+    let mut link_args = ArgumentSet::empty();
+    let mut wild_extra_link_args = ArgumentSet::empty();
     for line in source.lines() {
         if let Some(rest) = line.trim().strip_prefix(";;#") {
             if let Some(obj_name) = rest.strip_prefix("Object:") {
@@ -495,6 +497,13 @@ fn run_wasm_test(wat_file: &Path) -> Result {
                 expect_error = true;
             } else if let Some(val) = rest.strip_prefix("RunEnabled:") {
                 should_run = val.trim().parse().context("Invalid bool for RunEnabled")?;
+            } else if let Some(args) = rest.strip_prefix("LinkArgs:") {
+                let args = args
+                    .trim()
+                    .replace("$OUT_DIR", &build_dir.display().to_string());
+                link_args = ArgumentSet::parse(&args)?;
+            } else if let Some(args) = rest.strip_prefix("WildExtraLinkArgs:") {
+                wild_extra_link_args = ArgumentSet::parse(args.trim())?;
             } else if let Some(section) = rest.strip_prefix("ExpectSection:") {
                 expected_sections.push(section.trim().to_owned());
             }
@@ -546,7 +555,8 @@ fn run_wasm_test(wat_file: &Path) -> Result {
         .arg(&wasm_ld_output)
         .arg("--no-entry")
         .arg("--export-all")
-        .arg("--no-check-features");
+        .arg("--no-check-features")
+        .args(&link_args.args);
 
     let wasm_ld_result = wasm_ld_cmd.output().context("Failed to run wasm-ld")?;
 
@@ -568,7 +578,10 @@ fn run_wasm_test(wat_file: &Path) -> Result {
     for obj in &all_objects {
         link_cmd.arg(obj);
     }
-    link_cmd.arg("-o").arg(&wasm_wild_output);
+    link_cmd
+        .arg("-o")
+        .arg(&wasm_wild_output)
+        .args(&wild_extra_link_args.args);
 
     let link_result = link_cmd.output().context("Failed to run wild")?;
 
@@ -587,8 +600,11 @@ fn run_wasm_test(wat_file: &Path) -> Result {
     );
 
     validate_wasm(&wasm_wild_output, "wild")?;
-    for section in &expected_sections {
-        ensure_wasm_section(&wasm_wild_output, section, "wild")?;
+    if !expected_sections.is_empty() {
+        ensure_wasm_sections_for_linkers(
+            &expected_sections,
+            &[(&wasm_ld_output, "wasm-ld"), (&wasm_wild_output, "wild")],
+        )?;
     }
     if should_run {
         run_wasm_with_wasmtime(&wasm_wild_output, "wild")?;
@@ -597,34 +613,63 @@ fn run_wasm_test(wat_file: &Path) -> Result {
     Ok(())
 }
 
-fn ensure_wasm_section(wasm_file: &Path, section_name: &str, linker_name: &str) -> Result {
-    let output = Command::new("wasm-objdump")
-        .arg("-x")
-        .arg(wasm_file)
-        .output()
-        .with_context(|| {
-            format!(
-                "Failed to run wasm-objdump on {linker_name} output ({})",
-                wasm_file.display()
-            )
-        })?;
-    ensure!(
-        output.status.success(),
-        "wasm-objdump failed for {linker_name} output ({}):\n{}",
-        wasm_file.display(),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let found = stdout.lines().any(|line| {
-        let trimmed = line.trim_start();
-        trimmed.starts_with(section_name)
-            && trimmed.as_bytes().get(section_name.len()) == Some(&b'[')
-    });
-    ensure!(
-        found,
-        "Expected section `{section_name}` in {linker_name} output ({}), wasm-objdump -x:\n{stdout}",
-        wasm_file.display()
-    );
+fn ensure_wasm_sections_for_linkers(
+    section_names: &[String],
+    outputs: &[(&Path, &str)],
+) -> Result<()> {
+    for (wasm_file, linker_name) in outputs {
+        ensure_wasm_sections(wasm_file, section_names, linker_name)?;
+    }
+    Ok(())
+}
+
+fn wasm_standard_sections(wasm_file: &Path) -> Result<std::collections::HashSet<String>> {
+    use wasmparser::Parser;
+    use wasmparser::Payload;
+
+    let bytes = std::fs::read(wasm_file)
+        .with_context(|| format!("Failed to read wasm file {}", wasm_file.display()))?;
+    let mut sections = std::collections::HashSet::new();
+    for payload in Parser::new(0).parse_all(&bytes) {
+        if let Some(name) = match payload? {
+            Payload::TypeSection(_) => Some("Type"),
+            Payload::ImportSection(_) => Some("Import"),
+            Payload::FunctionSection(_) => Some("Function"),
+            Payload::TableSection(_) => Some("Table"),
+            Payload::MemorySection(_) => Some("Memory"),
+            Payload::GlobalSection(_) => Some("Global"),
+            Payload::ExportSection(_) => Some("Export"),
+            Payload::StartSection { .. } => Some("Start"),
+            Payload::ElementSection(_) => Some("Element"),
+            Payload::CodeSectionStart { .. } => Some("Code"),
+            Payload::DataSection(_) => Some("Data"),
+            Payload::DataCountSection { .. } => Some("DataCount"),
+            _ => None,
+        } {
+            sections.insert(name.to_owned());
+        }
+    }
+    Ok(sections)
+}
+
+fn ensure_wasm_sections(
+    wasm_file: &Path,
+    section_names: &[String],
+    linker_name: &str,
+) -> Result<()> {
+    let sections = wasm_standard_sections(wasm_file)?;
+    for section_name in section_names {
+        ensure!(
+            sections.contains(section_name),
+            "Expected section `{section_name}` in {linker_name} output ({}), found: {}",
+            wasm_file.display(),
+            {
+                let mut names: Vec<_> = sections.iter().cloned().collect();
+                names.sort();
+                names.join(", ")
+            }
+        );
+    }
     Ok(())
 }
 

--- a/wild/tests/sources/wasm/data-segment/data-segment.wat
+++ b/wild/tests/sources/wasm/data-segment/data-segment.wat
@@ -1,4 +1,5 @@
 ;;#RunEnabled:false
+;;#LinkArgs:--no-gc-sections
 ;;#ExpectSection:Data
 
 (module

--- a/wild/tests/sources/wasm/data-segment/data-segment.wat
+++ b/wild/tests/sources/wasm/data-segment/data-segment.wat
@@ -1,0 +1,10 @@
+;;#RunEnabled:false
+;;#ExpectSection:Data
+
+(module
+  (memory (export "memory") 1)
+  (data (i32.const 0) "\2A\00\00\00")
+  (func $start (export "_start")
+    nop
+  )
+)


### PR DESCRIPTION
This PR implements the data segment layout and emission. Features like applying data relocations (such as `R_WASM_MEMORY_ADDR_*`) and handling passive segments are not included in this PR.

Part of #1431