### PR TITLE
fix: --compress-debug-sections drops merged-string offset map

### DIFF
--- a/libwild/src/compression.rs
+++ b/libwild/src/compression.rs
@@ -326,7 +326,15 @@ fn update_allocation_sizes<P: Platform>(layout: &mut Layout<P>) {
             }
         }
 
-        *layout.merged_strings.get_mut(section_id) = Default::default();
+        // Free the merged string data now that it's been written into the compressed buffer, but
+        // keep the offset maps: a compressed merge-string section (e.g. `.debug_str`) can still be
+        // the target of relocations from other debug sections (e.g. `.debug_str_offsets`) that are
+        // resolved later when those sections are written. Clearing the whole `MergedStringsSection`
+        // here dropped `string_offsets`, leaving those lookups hitting an empty map ("Failed to
+        // find merge-string"). Clearing only `buckets` frees the bulk of the memory and makes
+        // `len()` zero so `write_merged_strings` skips re-emitting this (already compressed)
+        // section, while preserving the offset maps that relocation resolution needs. See #2113.
+        layout.merged_strings.get_mut(section_id).buckets = Vec::new();
     }
 }
 

--- a/libwild/src/compression.rs
+++ b/libwild/src/compression.rs
@@ -333,7 +333,8 @@ fn update_allocation_sizes<P: Platform>(layout: &mut Layout<P>) {
         // here dropped `string_offsets`, leaving those lookups hitting an empty map ("Failed to
         // find merge-string"). Clearing only `buckets` frees the bulk of the memory and makes
         // `len()` zero so `write_merged_strings` skips re-emitting this (already compressed)
-        // section, while preserving the offset maps that relocation resolution needs. See #2113.
+        // section, while preserving the offset maps that relocation resolution needs. See
+        // https://github.com/wild-linker/wild/issues/2113.
         layout.merged_strings.get_mut(section_id).buckets = Vec::new();
     }
 }

--- a/libwild/src/compression.rs
+++ b/libwild/src/compression.rs
@@ -326,15 +326,9 @@ fn update_allocation_sizes<P: Platform>(layout: &mut Layout<P>) {
             }
         }
 
-        // Free the merged string data now that it's been written into the compressed buffer, but
-        // keep the offset maps: a compressed merge-string section (e.g. `.debug_str`) can still be
-        // the target of relocations from other debug sections (e.g. `.debug_str_offsets`) that are
-        // resolved later when those sections are written. Clearing the whole `MergedStringsSection`
-        // here dropped `string_offsets`, leaving those lookups hitting an empty map ("Failed to
-        // find merge-string"). Clearing only `buckets` frees the bulk of the memory and makes
-        // `len()` zero so `write_merged_strings` skips re-emitting this (already compressed)
-        // section, while preserving the offset maps that relocation resolution needs. See
-        // https://github.com/wild-linker/wild/issues/2113.
+        // Free only `buckets`; the offset maps are still needed to resolve relocations from other
+        // debug sections (e.g. `.debug_str_offsets`) that are written later.
+        // https://github.com/wild-linker/wild/issues/2113
         layout.merged_strings.get_mut(section_id).buckets = Vec::new();
     }
 }

--- a/wild/tests/sources/elf/compressed-debug-merge/compressed-debug-merge.c
+++ b/wild/tests/sources/elf/compressed-debug-merge/compressed-debug-merge.c
@@ -1,22 +1,23 @@
 //#AbstractConfig:default
-// clang + DWARF5 so the compiler emits `.debug_str_offsets` (gcc keeps string offsets inline);
-// the bug is a relocation from `.debug_str_offsets` into a compressed `.debug_str`.
+// clang + DWARF5 emits `.debug_str_offsets`; gcc keeps the string offsets inline.
 //#Compiler:clang
 //#CompArgs:-g -gdwarf-5
 //#Object:runtime.c
 //#DiffIgnore:section.debug_*
-// `debug_info`: at this scale wild and GNU ld compress `.debug_info` to different sizes; that
-// cross-linker difference is unrelated to the merge-string bug under test.
+// wild and GNU ld compress `.debug_info` to different sizes; same underlying cause as #2119.
 //#DiffIgnore:debug_info
-// wild types `.eh_frame` as SHT_PROGBITS where GNU ld uses SHT_X86_64_UNWIND; a pre-existing
-// cosmetic difference, unrelated to this bug.
+// wild types `.eh_frame` as SHT_PROGBITS, GNU ld as SHT_X86_64_UNWIND.
 //#DiffIgnore:section.eh_frame.type
-// Link-only: this reproduces a link-time failure (#2113), and a statically linked test binary
-// can't be executed in every CI environment.
-//#RunEnabled:false
 
 //#Config:zlib:default
-//#LinkArgs:--no-gc-sections --compress-debug-sections=zlib
+//#LinkArgs:--compress-debug-sections=zlib
+
+//#Config:zstd:default
+//#RequiresLinkerFlags:--compress-debug-sections=zstd
+//#LinkArgs:--compress-debug-sections=zstd
+
+//#Config:none:default
+//#LinkArgs:--compress-debug-sections=none
 
 #include "../common/runtime.h"
 

--- a/wild/tests/sources/elf/compressed-debug-merge/compressed-debug-merge.c
+++ b/wild/tests/sources/elf/compressed-debug-merge/compressed-debug-merge.c
@@ -1,0 +1,98 @@
+//#AbstractConfig:default
+// clang + DWARF5 so the compiler emits `.debug_str_offsets` (gcc keeps string offsets inline);
+// the bug is a relocation from `.debug_str_offsets` into a compressed `.debug_str`.
+//#Compiler:clang
+//#CompArgs:-g -gdwarf-5
+//#Object:runtime.c
+//#DiffIgnore:section.debug_*
+// `debug_info`: at this scale wild and GNU ld compress `.debug_info` to different sizes; that
+// cross-linker difference is unrelated to the merge-string bug under test.
+//#DiffIgnore:debug_info
+// wild types `.eh_frame` as SHT_PROGBITS where GNU ld uses SHT_X86_64_UNWIND; a pre-existing
+// cosmetic difference, unrelated to this bug.
+//#DiffIgnore:section.eh_frame.type
+// Link-only: this reproduces a link-time failure (#2113), and a statically linked test binary
+// can't be executed in every CI environment.
+//#RunEnabled:false
+
+//#Config:zlib:default
+//#LinkArgs:--no-gc-sections --compress-debug-sections=zlib
+
+#include "../common/runtime.h"
+
+// Regression test for #2113. With `--compress-debug-sections`, a merge-string debug section
+// (`.debug_str`) that actually compresses had its merged-strings map freed after compression,
+// before `.debug_str_offsets` relocations into it were resolved, causing "Failed to find
+// merge-string at offset 0". We need *enough* distinct, compressible debug strings that
+// `.debug_str` compresses (and so is freed); a narrow program doesn't trigger it. Each instance
+// contributes distinct type/member/function names to `.debug_str`.
+#define GENERATE_DEBUG_STUFF(id)                          \
+  struct data_blob_##id {                                 \
+    int field_a_##id;                                     \
+    char field_b_##id[32];                                \
+    double field_c_##id;                                  \
+    float field_d_##id;                                   \
+  };                                                      \
+  void function_for_id_##id(struct data_blob_##id* ptr) { \
+    if (ptr) ptr->field_a_##id = id;                      \
+  }
+
+#define EXPAND_10(base)         \
+  GENERATE_DEBUG_STUFF(base##0) \
+  GENERATE_DEBUG_STUFF(base##1) \
+  GENERATE_DEBUG_STUFF(base##2) \
+  GENERATE_DEBUG_STUFF(base##3) \
+  GENERATE_DEBUG_STUFF(base##4) \
+  GENERATE_DEBUG_STUFF(base##5) \
+  GENERATE_DEBUG_STUFF(base##6) \
+  GENERATE_DEBUG_STUFF(base##7) \
+  GENERATE_DEBUG_STUFF(base##8) \
+  GENERATE_DEBUG_STUFF(base##9)
+
+#define EXPAND_100(base) \
+  EXPAND_10(base##0)     \
+  EXPAND_10(base##1)     \
+  EXPAND_10(base##2)     \
+  EXPAND_10(base##3)     \
+  EXPAND_10(base##4)     \
+  EXPAND_10(base##5)     \
+  EXPAND_10(base##6)     \
+  EXPAND_10(base##7)     \
+  EXPAND_10(base##8)     \
+  EXPAND_10(base##9)
+
+EXPAND_100(1)
+EXPAND_100(2)
+EXPAND_100(3)
+EXPAND_100(4)
+EXPAND_100(5)
+EXPAND_100(6)
+EXPAND_100(7)
+EXPAND_100(8)
+EXPAND_100(9)
+EXPAND_100(10)
+EXPAND_100(11)
+EXPAND_100(12)
+EXPAND_100(13)
+EXPAND_100(14)
+EXPAND_100(15)
+EXPAND_100(16)
+EXPAND_100(17)
+EXPAND_100(18)
+EXPAND_100(19)
+EXPAND_100(20)
+EXPAND_100(21)
+EXPAND_100(22)
+EXPAND_100(23)
+EXPAND_100(24)
+EXPAND_100(25)
+EXPAND_100(26)
+EXPAND_100(27)
+EXPAND_100(28)
+EXPAND_100(29)
+EXPAND_100(30)
+
+void _start(void) {
+  runtime_init();
+  exit_syscall(42);
+}


### PR DESCRIPTION
I've been developing some agent tooling to improve solution generalization, and Wild just happened to be welcoming of going out to look for these types of bugs. To be up front, I actually don't understand the specifics of the code being proposed here. However, I did read your contributing.md and made sure to look over past PRs for what counts as a general fix. Here, I directed my agent to use a custom tool to go beyond passing tests. I can provide reasoning traces, demos, and further explanation on how this tool works if you're curious. I hope that better tooling will push the project forward faster. Thanks for review.

---

*Generated change summary (agent):*

Fixes #2113 ("Failed to find merge-string at offset 0" with `--compress-debug-sections` on large `-g` objects).

- **Cause:** after compressing a debug section, `update_allocation_sizes` reset the whole `MergedStringsSection`. For a compressed `.debug_str`, that dropped `string_offsets`, still needed to resolve `.debug_str_offsets` → `.debug_str` relocations applied later. Only hits objects where `.debug_str` is large enough to compress (and so gets cleared).
- **Fix:** clear only `buckets`, not the whole struct. `len()` still goes to 0 (so the compressed section isn't re-emitted) while the offset maps survive for relocation resolution.
- **Test:** `compressed-debug-merge` (clang + DWARF5) — fails on `main`, passes here.
