### PR TITLE
fix: Apply linker-managed section rules when using linker scripts

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -1728,7 +1728,9 @@ impl platform::Platform for Elf {
             ))
         };
 
-        let mut rules = Vec::with_capacity(DEFAULT_SECTION_RULES.len() + 1);
+        let mut rules = Vec::with_capacity(
+            DEFAULT_SECTION_PLACEMENT_RULES.len() + LINKER_MANAGED_SECTION_RULES.len() + 1,
+        );
 
         if args.gdb_index {
             rules.push(SectionRule::exact(
@@ -1741,7 +1743,8 @@ impl platform::Platform for Elf {
             ));
         }
 
-        rules.extend(DEFAULT_SECTION_RULES.iter().cloned());
+        rules.extend(DEFAULT_SECTION_PLACEMENT_RULES.iter().cloned());
+        rules.extend(LINKER_MANAGED_SECTION_RULES.iter().cloned());
 
         rules.push(SectionRule::exact(
             secnames::SFRAME_SECTION_NAME,
@@ -1760,10 +1763,9 @@ impl platform::Platform for Elf {
             secnames::COMMENT_SECTION_NAME,
             output_section_id::COMMENT,
         ));
-        rule_builder.add_section_rule(SectionRule::exact(
-            secnames::RISCV_ATTRIBUTES_SECTION_NAME,
-            SectionRuleOutcome::RiscVAttribute,
-        ));
+        for rule in LINKER_MANAGED_SECTION_RULES {
+            rule_builder.add_section_rule(rule.clone());
+        }
     }
 
     fn init_section_priority(name: &[u8]) -> Option<u16> {
@@ -5292,7 +5294,8 @@ pub(crate) struct ResolvedObjectExt<'data> {
     debug_index_sections: Vec<InputDebugIndexSection<'data>>,
 }
 
-const DEFAULT_SECTION_RULES: &[SectionRule<'static>] = &[
+/// Rules that map input sections to built-in output sections when no linker script is in use.
+const DEFAULT_SECTION_PLACEMENT_RULES: &[SectionRule<'static>] = &[
     SectionRule::exact_section_keep(secnames::INIT_SECTION_NAME, output_section_id::INIT),
     SectionRule::exact_section_keep(secnames::FINI_SECTION_NAME, output_section_id::FINI),
     SectionRule::exact_section_keep(
@@ -5332,6 +5335,11 @@ const DEFAULT_SECTION_RULES: &[SectionRule<'static>] = &[
         secnames::GCC_EXCEPT_TABLE_SECTION_NAME,
         output_section_id::GCC_EXCEPT_TABLE,
     ),
+];
+
+/// Rules for input sections that the linker processes itself instead of copying them into an output
+/// section.
+const LINKER_MANAGED_SECTION_RULES: &[SectionRule<'static>] = &[
     SectionRule::prefix(secnames::RELA_SECTION_NAME, SectionRuleOutcome::Discard),
     SectionRule::prefix(secnames::CREL_SECTION_NAME, SectionRuleOutcome::Discard),
     SectionRule::exact(

--- a/wild/tests/sources/elf/linker-script-executable/linker-script-executable.c
+++ b/wild/tests/sources/elf/linker-script-executable/linker-script-executable.c
@@ -5,6 +5,9 @@
 // RISC-V: BFD complains about missing __global_pointer$ (defined in the default linker script)
 //#SkipArch:riscv64
 
+//#Config:no_gc_sections:default
+//#LinkArgs:--no-gc-sections
+
 //#Config:check_start
 //#LinkerScript:linker-script-executable.ld
 //#LinkerScript:linker-script-check-start.ld


### PR DESCRIPTION
When a linker script was present, Wild used [only the rules derived from the linker script](https://github.com/wild-linker/wild/blob/71b609badf3f7b56d1ea54ce4b03123458d6047e/libwild/src/layout_rules.rs#L359-L364), replacing all built-in section rules including those that discard input metadata sections such as `.symtab` and `.strtab`. As a result, when linking with `--no-gc-sections`, these metadata sections could be copied into the output ELF. This produced duplicate symbol tables (as shown below) and could result in a corrupt `.symtab`.

(after adding `//#LinkArgs:--no-gc-sections` to `wild/tests/sources/elf/linker-script-executable/linker-script-executable.c`)

```
（▰╹◡╹）❯  readelf -S wild/tests/build/elf/x86_64/linker-script-executable/default/linker-script-executable.c.wild
There are 17 section headers, starting at offset 0x200:

Section Headers:
  [Nr] Name              Type             Address           Offset
       Size              EntSize          Flags  Link  Info  Align
  [ 0]                   NULL             0000000000600000  00000000
       0000000000000000  0000000000000000   A       0     0     0
...
readelf: Warning: [10]: Link field (0) should index a string section.
  [10] .symtab           SYMTAB           0000000000000000  00001308
       0000000000000150  0000000000000018           0     0     8
  [11] .strtab           STRTAB           0000000000000000  00001458
       000000000000008c  0000000000000000           0     0     1
  [12] .shstrtab         STRTAB           0000000000000000  000014e4
       00000000000000d3  0000000000000000           0     0     1
  [13] .comment          PROGBITS         0000000000000000  000015b7
       0000000000000063  0000000000000001  MS       0     0     1
  [14] .shstrtab         STRTAB           0000000000000000  0000161a
       00000000000000a5  0000000000000000           0     0     1
  [15] .symtab           SYMTAB           0000000000000000  000016c0
       0000000000000108  0000000000000018          16     4     8
  [16] .strtab           STRTAB           0000000000000000  000017c8
       000000000000008b  0000000000000000           0     0     1
...
```

Fixes #2108