### PR TITLE
feat: Add built-in symbol `__bss_start`

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -900,6 +900,10 @@ impl platform::Platform for Elf {
             .set_hidden(hidden);
 
         symbols
+            .section_start(output_section_id::BSS, "__bss_start")
+            .set_hidden(hidden);
+
+        symbols
             .section_end(output_section_id::BSS, "end")
             .set_hidden(hidden);
         symbols

--- a/wild/tests/sources/elf/segment-end-syms/segment-end-syms.c
+++ b/wild/tests/sources/elf/segment-end-syms/segment-end-syms.c
@@ -13,6 +13,7 @@
 extern char _etext;
 extern char __etext;
 extern char _edata;
+extern char __bss_start;
 extern char _end;
 
 int data_var = 123;
@@ -46,6 +47,10 @@ void _start(void) {
 
   if (ptr_to_int(&_end) == 0) {
     exit_syscall(16);
+  }
+
+  if (ptr_to_int(&_end) < ptr_to_int(&__bss_start)) {
+    exit_syscall(18);
   }
 
   // _end (end of .bss) should be >= _edata (end of .data). They can be equal


### PR DESCRIPTION
This PR adds the built-in symbol `__bss_start` that points to the start of the `.bss` section. I found that this was missing during the development of the [elf-symbols](https://crates.io/crates/elf-symbols) Rust crate (see https://github.com/mkroening/elf-symbols/pull/1).

This is already defined by:
- BFD: [binutils-gdb@`252b513`]
- gold: [binutils-gdb@`f6ce93d`]
- LLD: [llvm/llvm-project@`e6c5d38`]
- mold: [rui314/mold@`ccc7f83`]

[binutils-gdb@`252b513`]: https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=ld/scripttempl/elf.sc;h=e1fea97d791a692b267a267a9a70463289eeb998;hb=252b5132c753830d5fd56823373aed85f2a0db63
[binutils-gdb@`f6ce93d`]: https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff;h=f6ce93d6e999d1a0c450c5e71c5b3468e6217f0a#patch4
[llvm/llvm-project@`e6c5d38`]: https://github.com/llvm/llvm-project/commit/e6c5d3862d123f84bf400078172fd93680e15c5b
[rui314/mold@`ccc7f83`]: https://github.com/rui314/mold/commit/ccc7f83cde954048424fa488464be41f210e60d1

Note that https://github.com/wild-linker/wild/commit/2bf38ca17804bbaf0fa7e28bdf9be8efb7f8fe30 mentions the symbol three times, but does not define or use it.

Please let me know whether the segment-end-syms test is appropriate for this or whether I should create a new test.