### PR TITLE
fix: Error on R_X86_64_32/32S against DSO symbols in PIE output

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2887,6 +2887,15 @@ fn apply_relocation<
     }
     let (resolution, symbol_index, local_symbol_id) = get_resolution(rel, object_layout, layout)?;
     let flags = layout.flags_for_symbol(local_symbol_id);
+    if layout.symbol_db.output_kind.is_position_independent()
+        && (flags.is_interposable() || flags.is_dynamic())
+        && A::is_illegal_in_shared_object(r_type)
+    {
+        bail!(
+            "relocation {} cannot be used against symbol; recompile with -fPIC",
+            A::rel_type_to_string(r_type)
+        );
+    }
     let mut next_modifier = RelocationModifier::Normal;
     let rel_info;
     let output_kind = layout.symbol_db.output_kind;

--- a/libwild/src/output_kind.rs
+++ b/libwild/src/output_kind.rs
@@ -72,7 +72,7 @@ impl OutputKind {
                 | OutputKind::StaticExecutable(RelocationModel::Relocatable)
         )
     }
-    
+
     pub(crate) fn needs_dynsym(self) -> bool {
         matches!(
             self,

--- a/libwild/src/output_kind.rs
+++ b/libwild/src/output_kind.rs
@@ -88,4 +88,13 @@ impl OutputKind {
             OutputKind::DynamicExecutable(_) | OutputKind::SharedObject
         )
     }
+
+    pub(crate) fn is_position_independent(self) -> bool {
+        matches!(
+            self,
+            OutputKind::SharedObject
+                | OutputKind::DynamicExecutable(RelocationModel::Relocatable)
+                | OutputKind::StaticExecutable(RelocationModel::Relocatable)
+        )
+    }
 }

--- a/libwild/src/output_kind.rs
+++ b/libwild/src/output_kind.rs
@@ -64,6 +64,15 @@ impl OutputKind {
         )
     }
 
+    pub(crate) fn is_position_independent(self) -> bool {
+        matches!(
+            self,
+            OutputKind::SharedObject
+                | OutputKind::DynamicExecutable(RelocationModel::Relocatable)
+                | OutputKind::StaticExecutable(RelocationModel::Relocatable)
+        )
+    }
+    
     pub(crate) fn needs_dynsym(self) -> bool {
         matches!(
             self,
@@ -86,15 +95,6 @@ impl OutputKind {
         matches!(
             self,
             OutputKind::DynamicExecutable(_) | OutputKind::SharedObject
-        )
-    }
-
-    pub(crate) fn is_position_independent(self) -> bool {
-        matches!(
-            self,
-            OutputKind::SharedObject
-                | OutputKind::DynamicExecutable(RelocationModel::Relocatable)
-                | OutputKind::StaticExecutable(RelocationModel::Relocatable)
         )
     }
 }

--- a/wild/tests/sources/elf/pie-invalid-reloc/pie-invalid-reloc-dso.s
+++ b/wild/tests/sources/elf/pie-invalid-reloc/pie-invalid-reloc-dso.s
@@ -1,0 +1,3 @@
+.globl dso_sym
+dso_sym:
+  .long 0

--- a/wild/tests/sources/elf/pie-invalid-reloc/pie-invalid-reloc.s
+++ b/wild/tests/sources/elf/pie-invalid-reloc/pie-invalid-reloc.s
@@ -1,0 +1,12 @@
+// Test that R_X86_64_32 to a DSO symbol errors in PIE/shared output.
+// Both GNU ld and lld error with "recompile with -fPIC".
+//#Arch:x86_64
+//#Mode:dynamic
+//#Shared:pie-invalid-reloc-dso.s
+//#LinkArgs:-pie --no-gc-sections
+//#ExpectError:R_X86_64_32
+.globl _start
+_start:
+  ret
+.data
+.long dso_sym


### PR DESCRIPTION
Wild was silently succeeding when R_X86_64_32 or R_X86_64_32S relocations were used against DSO symbols in PIE output. Both GNU ld and lld correctly error with "recompile with -fPIC".

Issue #2114