### PR TITLE
chore: bump memmap2 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,9 +1046,9 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
Doesn't look like a problem for us, but bumping the version shouldn't hurt.

As per cargo-deny:
```
error[unsound]: Unchecked pointer offset in crate `memmap2`
    ┌─ /home/mateusz/Projects/wild/Cargo.lock:104:1
    │
104 │ memmap2 0.9.10 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unsound advisory detected
    │
    ├ ID: RUSTSEC-2026-0186
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0186
    ├ Affected versionf of `memmap2` did not perform enough validation on the `offset` and `len` parameters of
      `Mmap::[unchecked_]advise_range()`,
      `MmapMut::[unchecked_]advise_ranage()`
      and `MmapMut::flush[_async]_range()`.

      This can cause undefined behavior due to invalid values being passed to [`pointer::offset()`] and [`pointer::add()`]
      when passing an out-of-bounds range to any of the affected functions.

      The flaw was corrected in commit [`cee7cf0`] and released in version `0.9.11`.

      The invalid pointer is not dereferenced,
      but it is passed to the `madvise` and `msync` syscalls and their Windows equivalents.

      [`pointer::offset()`]: https://doc.rust-lang.org/stable/std/primitive.pointer.html#method.offset-1
      [`pointer::add()`]: https://doc.rust-lang.org/stable/std/primitive.pointer.html#method.add-1
      [`cee7cf0`] [RazrFalcon/memmap2-rs@`cee7cf0` (#170)](https://github.com/RazrFalcon/memmap2-rs/pull/170/changes/cee7cf03a9ee095982a3c37b7aac8e3f68f1a00c)
    ├ Announcement: https://github.com/RazrFalcon/memmap2-rs/issues/169
    ├ Solution: Upgrade to >=0.9.11 (try `cargo update -p memmap2`)
    ├ memmap2 v0.9.10
      ├── libwild v0.9.0
      │   └── wild-linker v0.9.0
      ├── linker-diff v0.9.0
      │   └── (dev) wild-linker v0.9.0 (*)
      └── symbolic-common v13.3.1
          ├── libwild v0.9.0 (*)
          └── symbolic-demangle v13.3.1
              ├── libwild v0.9.0 (*)
              └── linker-diff v0.9.0 (*)
```