### PR TITLE
fix: Error on R_X86_64_PC32 to DSO symbols in non-executable sections in PIE

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2889,6 +2889,7 @@ fn apply_relocation<
     let flags = layout.flags_for_symbol(local_symbol_id);
     if layout.symbol_db.output_kind.is_position_independent()
         && (flags.is_interposable() || flags.is_dynamic())
+        && !flags.needs_copy_relocation()
         && A::is_illegal_in_shared_object(r_type)
     {
         bail!(

--- a/libwild/src/elf_x86_64.rs
+++ b/libwild/src/elf_x86_64.rs
@@ -68,7 +68,10 @@ impl crate::platform::Arch for ElfX86_64 {
     }
 
     fn is_illegal_in_shared_object(r_type: u32) -> bool {
-        matches!(r_type, object::elf::R_X86_64_32 | object::elf::R_X86_64_32S)
+        matches!(
+            r_type,
+            object::elf::R_X86_64_32 | object::elf::R_X86_64_32S | object::elf::R_X86_64_PC32
+        )
     }
 
     fn get_dynamic_relocation_type(relocation: DynamicRelocationKind) -> u32 {

--- a/wild/tests/sources/elf/pie-pc32-dso-code-ref-code/pie-pc32-dso-code-ref-code.s
+++ b/wild/tests/sources/elf/pie-pc32-dso-code-ref-code/pie-pc32-dso-code-ref-code.s
@@ -1,0 +1,17 @@
+// Scenario: code references DSO function via PLT call - valid in PIE
+//#Arch:x86_64
+//#Mode:dynamic
+//#Shared:pie-pc32-dso-shared-fn.s
+//#SoSingleLinker:wild
+//#LinkArgs:-pie
+//#RunEnabled:false
+//#EnableLinker:lld
+//#SkipLinker:ld
+//#DiffIgnore:.dynamic.DT_FLAGS_1.NOW
+//#DiffIgnore:.dynamic.DT_RELA
+//#DiffIgnore:.dynamic.DT_RELAENT
+//#DiffIgnore:section.got.plt.entsize
+.global _start
+_start:
+    call zed_fn
+    ret

--- a/wild/tests/sources/elf/pie-pc32-dso-code-ref-code/pie-pc32-dso-shared-fn.s
+++ b/wild/tests/sources/elf/pie-pc32-dso-code-ref-code/pie-pc32-dso-shared-fn.s
@@ -1,0 +1,3 @@
+.global zed_fn
+zed_fn:
+    ret

--- a/wild/tests/sources/elf/pie-pc32-dso-code-ref-data/pie-pc32-dso-code-ref-data.s
+++ b/wild/tests/sources/elf/pie-pc32-dso-code-ref-data/pie-pc32-dso-code-ref-data.s
@@ -1,0 +1,16 @@
+// Scenario: code references DSO data symbol via R_X86_64_PC32 - invalid in PIE.
+// SkipLinker:lld because lld creates a canonical PLT entry for R_X86_64_PC32 to
+// STT_FUNC DSO symbols and succeeds, while Wild doesn't support canonical PLT and errors.
+// This case will be revisited when canonical PLT support is added to Wild.
+//#Arch:x86_64
+//#Mode:dynamic
+//#Shared:pie-pc32-dso-shared.s
+//#SoSingleLinker:wild
+//#LinkArgs:-pie --no-gc-sections
+//#ExpectErrorWild:R_X86_64_PC32
+//#SkipLinker:ld
+//#SkipLinker:lld
+.global _start
+_start:
+    mov zed_fn - ., %eax
+    ret

--- a/wild/tests/sources/elf/pie-pc32-dso-code-ref-data/pie-pc32-dso-shared.s
+++ b/wild/tests/sources/elf/pie-pc32-dso-code-ref-data/pie-pc32-dso-shared.s
@@ -1,0 +1,6 @@
+.global zed_fn
+.text
+.type zed_fn, @function
+zed_fn:
+    ret
+.size zed_fn, .-zed_fn

--- a/wild/tests/sources/elf/pie-pc32-dso-data-ref-code/pie-pc32-dso-data-ref-code.s
+++ b/wild/tests/sources/elf/pie-pc32-dso-data-ref-code/pie-pc32-dso-data-ref-code.s
@@ -1,0 +1,14 @@
+// Scenario: data section references DSO function via R_X86_64_PC32 - invalid in PIE
+//#Arch:x86_64
+//#Mode:dynamic
+//#Shared:pie-pc32-dso-shared-fn.s
+//#SoSingleLinker:wild
+//#LinkArgs:-pie --no-gc-sections
+//#EnableLinker:lld
+//#ExpectError:R_X86_64_PC32
+//#SkipLinker:ld
+.global _start
+_start:
+    ret
+.data
+.long zed_fn - .

--- a/wild/tests/sources/elf/pie-pc32-dso-data-ref-code/pie-pc32-dso-shared-fn.s
+++ b/wild/tests/sources/elf/pie-pc32-dso-data-ref-code/pie-pc32-dso-shared-fn.s
@@ -1,0 +1,3 @@
+.global zed_fn
+zed_fn:
+    ret

--- a/wild/tests/sources/elf/pie-pc32-dso-data-ref-data/pie-pc32-dso-data-ref-data.s
+++ b/wild/tests/sources/elf/pie-pc32-dso-data-ref-data/pie-pc32-dso-data-ref-data.s
@@ -1,0 +1,14 @@
+// Scenario: data section references DSO data symbol via R_X86_64_PC32 - invalid in PIE
+//#Arch:x86_64
+//#Mode:dynamic
+//#Shared:pie-pc32-dso-shared.s
+//#SoSingleLinker:wild
+//#LinkArgs:-pie --no-gc-sections
+//#EnableLinker:lld
+//#ExpectError:R_X86_64_PC32
+//#SkipLinker:ld
+.global _start
+_start:
+    ret
+.data
+.long zed - .

--- a/wild/tests/sources/elf/pie-pc32-dso-data-ref-data/pie-pc32-dso-shared.s
+++ b/wild/tests/sources/elf/pie-pc32-dso-data-ref-data/pie-pc32-dso-shared.s
@@ -1,0 +1,3 @@
+.global zed
+zed:
+    .long 0

--- a/wild/tests/sources/elf/pie-pc32-dso/pie-pc32-dso-shared-fn.s
+++ b/wild/tests/sources/elf/pie-pc32-dso/pie-pc32-dso-shared-fn.s
@@ -1,0 +1,3 @@
+.global zed_fn
+zed_fn:
+    ret

--- a/wild/tests/sources/elf/pie-pc32-dso/pie-pc32-dso-shared.s
+++ b/wild/tests/sources/elf/pie-pc32-dso/pie-pc32-dso-shared.s
@@ -1,0 +1,3 @@
+.global zed
+zed:
+    .long 0

--- a/wild/tests/sources/elf/pie-pc32-dso/pie-pc32-dso.s
+++ b/wild/tests/sources/elf/pie-pc32-dso/pie-pc32-dso.s
@@ -1,0 +1,15 @@
+// Test that R_X86_64_PC32 to a DSO symbol in a non-executable section errors in PIE output.
+// lld errors with "recompile with -fPIC". Valid in .text (PLT call) but not in .data.
+//#Arch:x86_64
+//#Mode:dynamic
+//#Shared:pie-pc32-dso-shared.s
+//#LinkArgs:-pie --no-gc-sections
+//#ExpectErrorWild:R_X86_64_PC32
+//#SkipLinker:ld
+
+.global _start
+_start:
+    ret
+
+.data
+.long zed - .


### PR DESCRIPTION
R_X86_64_PC32 to a DSO symbol in a non-executable section (e.g. .data) is invalid in PIE output. Wild was silently producing a broken binary. R_X86_64_PC32 in executable sections (.text) remains valid as it goes via PLT.

lld errors in this case; GNU ld only warns.

Issue #2114