### PR TITLE
test: Add test for R_X86_64_64 to local symbols in read-only sections in PIE

### DIFF
--- a/wild/tests/sources/elf/pie-r64-local-rodata/pie-r64-local-rodata.s
+++ b/wild/tests/sources/elf/pie-r64-local-rodata/pie-r64-local-rodata.s
@@ -1,0 +1,16 @@
+//#Arch:x86_64
+//#Mode:dynamic
+//#LinkArgs:-pie
+//#EnableLinker:lld
+//#ExpectError:R_X86_64_64
+//#SkipLinker:ld
+.global _start, foo, rodata_ref
+_start:
+    lea rodata_ref(%rip), %rax
+    ret
+foo:
+    ret
+.section .rodata
+rodata_ref:
+.quad _start
+.quad foo


### PR DESCRIPTION
While investigating #2114, discovered Wild already correctly errors on R_X86_64_64 to local symbols in non-writable sections in PIE. Add a test to document and prevent regression.

Issue #2114