### PR TITLE
port(wasm): Apply data relocations

### DIFF
--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -431,7 +431,6 @@ pub(crate) struct WasmDataSegmentLayout<'data> {
 #[derive(Debug, Default)]
 pub(crate) struct WasmObjectDataLayout<'data> {
     pub(crate) file_id: crate::input_data::FileId,
-    pub(crate) symbol_id_range: crate::symbol_db::SymbolIdRange,
     pub(crate) segments: Vec<WasmDataSegmentLayout<'data>>,
 }
 
@@ -1748,7 +1747,6 @@ fn layout_object_data<'data>(
     }
     Ok(WasmObjectDataLayout {
         file_id: input.file_id,
-        symbol_id_range: input.symbol_id_range,
         segments,
     })
 }
@@ -1800,6 +1798,7 @@ pub(crate) struct WasmObjectIndexMap {
     pub(crate) function_indices: Vec<u32>,
     pub(crate) global_indices: Vec<u32>,
     pub(crate) memory_indices: Vec<u32>,
+    pub(crate) data_addresses: Vec<u32>,
 }
 
 impl WasmObjectIndexMap {
@@ -1845,7 +1844,16 @@ impl WasmObjectIndexMap {
             reloc_type::MEMORY_ADDR_LEB
             | reloc_type::MEMORY_ADDR_SLEB
             | reloc_type::MEMORY_ADDR_I32 => {
-                bail!("memory address relocations are not supported yet");
+                ensure!(
+                    sym.kind == WasmSymbolKind::Data,
+                    "R_WASM_MEMORY_ADDR_* references non-data symbol"
+                );
+                self.data_addresses
+                    .get(reloc.index as usize)
+                    .copied()
+                    .ok_or_else(|| {
+                        crate::error!("data address for symbol index {} out of range", reloc.index)
+                    })
             }
             reloc_type::TABLE_INDEX_SLEB | reloc_type::TABLE_INDEX_I32 => {
                 bail!("table index relocations are not supported yet");
@@ -2087,6 +2095,7 @@ impl<'data> WasmObjectLayoutInput<'data> {
             ),
             global_indices: Vec::with_capacity(self.global_imports.len() + self.globals.len()),
             memory_indices: Vec::with_capacity(self.memories.len()),
+            data_addresses: Vec::new(),
         };
 
         let mut imports =
@@ -2459,6 +2468,13 @@ where
             &mut section_cursor,
         )?);
     }
+    compute_data_addresses(
+        &mut layout.object_index_maps,
+        &layout.per_object_symbols,
+        &layout.object_data_layouts,
+        &layout_inputs,
+        symbol_db,
+    )?;
     layout.encode_metadata_sections()?;
     Ok(layout)
 }
@@ -2486,7 +2502,7 @@ pub(crate) fn reloc_value_with_addend(base: u32, addend: i64) -> Result<u32> {
     u32::try_from(value).map_err(|_| crate::error!("Wasm relocation value out of range"))
 }
 
-pub(crate) fn data_symbol_memory_address(
+fn data_symbol_memory_address(
     object_data_layouts: &[WasmObjectDataLayout<'_>],
     obj_idx: usize,
     sym: &WasmSymbol,
@@ -2505,6 +2521,54 @@ pub(crate) fn data_symbol_memory_address(
         .output_memory_offset
         .checked_add(sym.offset)
         .ok_or_else(|| crate::error!("Wasm data symbol address overflow"))
+}
+
+fn compute_data_addresses(
+    object_index_maps: &mut [WasmObjectIndexMap],
+    per_object_symbols: &[Vec<WasmSymbol>],
+    object_data_layouts: &[WasmObjectDataLayout<'_>],
+    layout_inputs: &[WasmObjectLayoutInput<'_>],
+    symbol_db: &SymbolDb<'_, Wasm>,
+) -> Result<()> {
+    let file_id_to_index: HashMap<crate::input_data::FileId, usize> = layout_inputs
+        .iter()
+        .enumerate()
+        .map(|(i, input)| (input.file_id, i))
+        .collect();
+
+    for (obj_idx, (index_map, symbols)) in object_index_maps
+        .iter_mut()
+        .zip(per_object_symbols.iter())
+        .enumerate()
+    {
+        let mut data_addresses = vec![0u32; symbols.len()];
+        for (sym_idx, sym) in symbols.iter().enumerate() {
+            if sym.kind != WasmSymbolKind::Data {
+                continue;
+            }
+            let (def_obj_idx, def_sym) = if sym.is_undefined() {
+                let symbol_id = layout_inputs[obj_idx].symbol_id_range.offset_to_id(sym_idx);
+                let def_id = symbol_db.definition(symbol_id);
+                if def_id == symbol_id {
+                    continue;
+                }
+                let def_file_id = symbol_db.file_id_for_symbol(def_id);
+                let Some(&def_obj_idx) = file_id_to_index.get(&def_file_id) else {
+                    continue;
+                };
+                let def_input = &layout_inputs[def_obj_idx];
+                let def_sym_offset = def_id.to_offset(def_input.symbol_id_range);
+                (def_obj_idx, per_object_symbols[def_obj_idx][def_sym_offset])
+            } else {
+                (obj_idx, *sym)
+            };
+            data_addresses[sym_idx] =
+                data_symbol_memory_address(object_data_layouts, def_obj_idx, &def_sym)?;
+        }
+        index_map.data_addresses = data_addresses;
+    }
+
+    Ok(())
 }
 
 fn allocate_wasm_object_index_bases(

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -431,17 +431,8 @@ pub(crate) struct WasmDataSegmentLayout<'data> {
 #[derive(Debug, Default)]
 pub(crate) struct WasmObjectDataLayout<'data> {
     pub(crate) file_id: crate::input_data::FileId,
+    pub(crate) symbol_id_range: crate::symbol_db::SymbolIdRange,
     pub(crate) segments: Vec<WasmDataSegmentLayout<'data>>,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct ResolvedCodeReloc {
-    /// Byte offset within the body's bytes where the relocation should be applied.
-    pub(crate) offset: u32,
-    /// Wasm relocation type code.
-    pub(crate) ty: u8,
-    /// Resolved output value to write at the relocation site.
-    pub(crate) value: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -450,7 +441,10 @@ pub(crate) struct WasmFunctionBody<'data> {
     pub(crate) bytes: &'data [u8],
     /// Byte offset of this body (starting at its size prefix) within the code section payload.
     pub(crate) code_offset: u32,
-    pub(crate) relocations: Vec<ResolvedCodeReloc>,
+    /// Relocations targeting this body, with offsets relative to the body start.
+    pub(crate) relocations: Vec<WasmRelocation>,
+    /// Index of the object this body belongs to.
+    pub(crate) object_index: usize,
 }
 
 impl<'data> File<'data> {
@@ -614,6 +608,7 @@ impl<'data> File<'data> {
                         bytes: &self.data[range.clone()],
                         code_offset: range.start as u32 - code_payload_start,
                         relocations: Vec::new(),
+                        object_index: 0,
                     }
                 })
                 .map_err(Into::into)
@@ -628,7 +623,8 @@ impl<'data> File<'data> {
         };
 
         let mut segments = Vec::new();
-        let mut section_offset = 0u32;
+        let mut section_offset = u32::try_from(uleb128_size(u64::from(reader.count())))
+            .context("Wasm data count LEB")?;
         for res in reader {
             let d = res?;
             segments.push(WasmDataSegment {
@@ -1504,6 +1500,7 @@ pub(crate) struct WasmLayout<'data> {
     pub(crate) unsupported_output: Vec<&'static str>,
     pub(crate) object_index_maps: Vec<WasmObjectIndexMap>,
     pub(crate) object_data_layouts: Vec<WasmObjectDataLayout<'data>>,
+    pub(crate) per_object_symbols: Vec<Vec<WasmSymbol>>,
     pub(crate) encoded_sections: WasmEncodedSections,
     pub(crate) code_section_size: u64,
     pub(crate) data_section_size: u64,
@@ -1669,9 +1666,8 @@ fn output_data_segment_encoded_size(
 fn data_segment_payload_offset_in_section(kind: &DataKind<'_>, data_len: usize) -> Result<u32> {
     let encoded = wasm_data_segment_encoded_size(kind, data_len)?;
     let data_len = u32::try_from(data_len).context("Wasm data segment too large")?;
-    let payload_len = uleb128_size(u64::from(data_len)) as u32 + data_len;
     encoded
-        .checked_sub(payload_len)
+        .checked_sub(data_len)
         .ok_or_else(|| crate::error!("Wasm data segment payload offset underflow"))
 }
 
@@ -1752,6 +1748,7 @@ fn layout_object_data<'data>(
     }
     Ok(WasmObjectDataLayout {
         file_id: input.file_id,
+        symbol_id_range: input.symbol_id_range,
         segments,
     })
 }
@@ -1990,7 +1987,7 @@ impl<'data> WasmObjectLayoutInput<'data> {
         if has_other_non_code_relocs {
             unsupported_output.push("non-code relocation");
         }
-        if !data_relocations.is_empty() {
+        if !data_relocations.is_empty() && !data_relocations_are_supported(&data_relocations) {
             unsupported_output.push("data relocation");
         }
         if file.standard_section_index[section_id::TABLE as usize].is_some() {
@@ -2223,12 +2220,7 @@ impl<'data> WasmObjectLayoutInput<'data> {
             .collect::<Result<Vec<_>>>()?;
 
         let mut function_bodies = self.function_bodies.clone();
-        resolve_code_relocations(
-            &mut function_bodies,
-            &self.code_relocations,
-            &self.symbols,
-            &index_map,
-        )?;
+        classify_code_relocations(&mut function_bodies, &self.code_relocations);
 
         Ok(WasmObjectOutputLayout {
             types: self.types.clone(),
@@ -2441,7 +2433,7 @@ where
     let mut layout = WasmLayout::default();
     let mut memory_cursor = 0u32;
     let mut section_cursor = 0u32;
-    for (input, object_layout) in layout_inputs.iter().zip(object_layouts) {
+    for (obj_idx, (input, object_layout)) in layout_inputs.iter().zip(object_layouts).enumerate() {
         layout.output_types.extend(object_layout.types);
         layout.imports.extend(object_layout.imports);
         layout
@@ -2449,12 +2441,17 @@ where
             .extend(object_layout.function_type_indices);
         layout.globals.extend(object_layout.globals);
         layout.exports.extend(object_layout.exports);
-        layout.function_bodies.extend(object_layout.function_bodies);
+        let mut bodies = object_layout.function_bodies;
+        for body in &mut bodies {
+            body.object_index = obj_idx;
+        }
+        layout.function_bodies.extend(bodies);
         layout.memories.extend(object_layout.memories);
         layout
             .unsupported_output
             .extend(object_layout.unsupported_output);
         layout.object_index_maps.push(object_layout.index_map);
+        layout.per_object_symbols.push(input.symbols.clone());
         layout.object_data_layouts.push(layout_object_data(
             input,
             layout.object_index_maps.last().expect("index map pushed"),
@@ -2464,6 +2461,50 @@ where
     }
     layout.encode_metadata_sections()?;
     Ok(layout)
+}
+
+fn is_supported_data_relocation(ty: u8) -> bool {
+    matches!(
+        ty,
+        reloc_type::MEMORY_ADDR_LEB
+            | reloc_type::MEMORY_ADDR_SLEB
+            | reloc_type::MEMORY_ADDR_I32
+            | reloc_type::FUNCTION_INDEX_I32
+    )
+}
+
+fn data_relocations_are_supported(relocs: &[WasmRelocation]) -> bool {
+    relocs
+        .iter()
+        .all(|reloc| is_supported_data_relocation(reloc.ty))
+}
+
+pub(crate) fn reloc_value_with_addend(base: u32, addend: i64) -> Result<u32> {
+    let value = i64::from(base)
+        .checked_add(addend)
+        .ok_or_else(|| crate::error!("Wasm relocation value overflow"))?;
+    u32::try_from(value).map_err(|_| crate::error!("Wasm relocation value out of range"))
+}
+
+pub(crate) fn data_symbol_memory_address(
+    object_data_layouts: &[WasmObjectDataLayout<'_>],
+    obj_idx: usize,
+    sym: &WasmSymbol,
+) -> Result<u32> {
+    ensure!(
+        sym.kind == WasmSymbolKind::Data,
+        "memory address relocation references non-data symbol"
+    );
+    let object_layout = &object_data_layouts[obj_idx];
+    let segment = object_layout
+        .segments
+        .iter()
+        .find(|segment| segment.segment_index == sym.index)
+        .ok_or_else(|| crate::error!("Wasm data symbol segment {} not found", sym.index))?;
+    segment
+        .output_memory_offset
+        .checked_add(sym.offset)
+        .ok_or_else(|| crate::error!("Wasm data symbol address overflow"))
 }
 
 fn allocate_wasm_object_index_bases(
@@ -2517,14 +2558,13 @@ fn allocate_wasm_object_index_bases(
     Ok(index_bases)
 }
 
-fn resolve_code_relocations<'data>(
+/// Classify code relocations into per-body groups with body-local offsets.
+fn classify_code_relocations<'data>(
     bodies: &mut [WasmFunctionBody<'data>],
     relocs: &[WasmRelocation],
-    symbols: &[WasmSymbol],
-    index_map: &WasmObjectIndexMap,
-) -> Result {
+) {
     if relocs.is_empty() {
-        return Ok(());
+        return;
     }
 
     let mut reloc_iter = relocs.iter().peekable();
@@ -2538,17 +2578,13 @@ fn resolve_code_relocations<'data>(
             }
             reloc_iter.next();
             if reloc.offset >= body_start {
-                let value = index_map.resolve_reloc(reloc, symbols)?;
-                body.relocations.push(ResolvedCodeReloc {
+                body.relocations.push(WasmRelocation {
                     offset: reloc.offset - body_start,
-                    ty: reloc.ty,
-                    value,
+                    ..*reloc
                 });
             }
         }
     }
-
-    Ok(())
 }
 
 fn remap_wasm_index(indices: &[u32], index: u32, kind: &str) -> Result<u32> {

--- a/libwild/src/wasm_writer.rs
+++ b/libwild/src/wasm_writer.rs
@@ -6,16 +6,23 @@ use crate::file_writer::SizedOutput;
 use crate::file_writer::split_output_into_sections;
 use crate::layout::Layout;
 use crate::platform::Arch;
+use crate::symbol_db::SymbolDb;
 use crate::wasm::WASM_MAGIC;
 use crate::wasm::WASM_VERSION;
 use crate::wasm::Wasm;
 use crate::wasm::WasmFunctionBody;
 use crate::wasm::WasmLayout;
-use crate::wasm::WasmObjectDataLayout;
+use crate::wasm::WasmObjectIndexMap;
 use crate::wasm::WasmRelocation;
+use crate::wasm::WasmSymbol;
+use crate::wasm::WasmSymbolKind;
 use crate::wasm::apply_relocation;
+use crate::wasm::data_symbol_memory_address;
+use crate::wasm::reloc_type;
+use crate::wasm::reloc_value_with_addend;
 use crate::wasm::section_id;
 use crate::wasm::write_uleb128;
+use hashbrown::HashMap;
 use leb128::write::unsigned_len as uleb128_size;
 use wasm_encoder::ConstExpr;
 use wasm_encoder::DataSection;
@@ -49,10 +56,13 @@ pub(crate) fn write<'data, A: Arch<Platform = Wasm>>(
     copy_metadata_sections(&layout.format_specific, &mut section_buffers)?;
     write_code_section(
         &layout.format_specific.function_bodies,
+        &layout.format_specific.object_index_maps,
+        &layout.format_specific.per_object_symbols,
         section_buffers.get_mut(crate::output_section_id::WASM_CODE),
     )?;
     write_data_section(
-        &layout.format_specific.object_data_layouts,
+        &layout.format_specific,
+        &layout.symbol_db,
         section_buffers.get_mut(crate::output_section_id::WASM_DATA),
     )?;
 
@@ -114,8 +124,13 @@ fn copy_encoded_section(encoded: Option<&Vec<u8>>, out: &mut [u8]) -> Result<()>
 }
 
 // Each `WasmFunctionBody.bytes` is the raw body content (locals + operators) without a size prefix.
-// This function writes the LEB128 size prefix for each body.
-fn write_code_section(bodies: &[WasmFunctionBody<'_>], out: &mut [u8]) -> Result<()> {
+// This function writes the LEB128 size prefix for each body, then resolves and applies relocations.
+fn write_code_section(
+    bodies: &[WasmFunctionBody<'_>],
+    object_index_maps: &[WasmObjectIndexMap],
+    per_object_symbols: &[Vec<WasmSymbol>],
+    out: &mut [u8],
+) -> Result<()> {
     if bodies.is_empty() {
         ensure!(
             out.is_empty(),
@@ -148,25 +163,17 @@ fn write_code_section(bodies: &[WasmFunctionBody<'_>], out: &mut [u8]) -> Result
     // Body count as LEB128.
     pos += write_uleb128(&mut out[pos..], count);
 
-    // Function bodies: size prefix + body bytes.
     for body in bodies {
         let body_len = body.bytes.len() as u64;
         pos += write_uleb128(&mut out[pos..], body_len);
         let body_start = pos;
         let len = body.bytes.len();
         out[pos..pos + len].copy_from_slice(body.bytes);
-        for resolved in &body.relocations {
-            let reloc = WasmRelocation {
-                ty: resolved.ty,
-                offset: resolved.offset,
-                index: 0,
-                addend: 0,
-            };
-            apply_relocation(
-                &mut out[body_start..body_start + len],
-                &reloc,
-                resolved.value,
-            )?;
+        let index_map = &object_index_maps[body.object_index];
+        let symbols = &per_object_symbols[body.object_index];
+        for reloc in &body.relocations {
+            let value = index_map.resolve_reloc(reloc, symbols)?;
+            apply_relocation(&mut out[body_start..body_start + len], reloc, value)?;
         }
         pos += len;
     }
@@ -182,9 +189,11 @@ fn write_code_section(bodies: &[WasmFunctionBody<'_>], out: &mut [u8]) -> Result
 }
 
 fn write_data_section(
-    object_data_layouts: &[WasmObjectDataLayout<'_>],
+    wasm_layout: &WasmLayout<'_>,
+    symbol_db: &SymbolDb<'_, Wasm>,
     out: &mut [u8],
 ) -> Result<()> {
+    let object_data_layouts = &wasm_layout.object_data_layouts;
     let has_segments = object_data_layouts
         .iter()
         .any(|object| !object.segments.is_empty());
@@ -197,7 +206,7 @@ fn write_data_section(
         return Ok(());
     }
 
-    let section = build_data_section(object_data_layouts)?;
+    let section = build_data_section(wasm_layout, symbol_db)?;
     let mut encoded = Vec::new();
     section.append_to(&mut encoded);
     ensure!(
@@ -272,11 +281,30 @@ pub(crate) fn build_global_section(globals: &[OutputGlobal<'_>]) -> Result<Globa
 }
 
 pub(crate) fn build_data_section(
-    object_data_layouts: &[WasmObjectDataLayout<'_>],
+    wasm_layout: &WasmLayout<'_>,
+    symbol_db: &SymbolDb<'_, Wasm>,
 ) -> Result<DataSection> {
+    let object_data_layouts = &wasm_layout.object_data_layouts;
+    let file_id_to_index: HashMap<crate::input_data::FileId, usize> = object_data_layouts
+        .iter()
+        .enumerate()
+        .map(|(i, obj)| (obj.file_id, i))
+        .collect();
+
     let mut section = DataSection::new();
-    for object_layout in object_data_layouts {
+    for (obj_idx, object_layout) in object_data_layouts.iter().enumerate() {
         for segment in &object_layout.segments {
+            let mut payload = segment.data.to_vec();
+            for reloc in &segment.relocations {
+                let value = resolve_data_relocation_value(
+                    reloc,
+                    obj_idx,
+                    wasm_layout,
+                    symbol_db,
+                    &file_id_to_index,
+                )?;
+                apply_relocation(&mut payload, reloc, value)?;
+            }
             let offset = ConstExpr::i32_const(
                 i32::try_from(segment.output_memory_offset).with_context(|| {
                     format!(
@@ -288,11 +316,72 @@ pub(crate) fn build_data_section(
             section.active(
                 segment.output_memory_index,
                 &offset,
-                segment.data.iter().copied(),
+                payload.iter().copied(),
             );
         }
     }
     Ok(section)
+}
+
+/// Resolve a data relocation to its output value.
+fn resolve_data_relocation_value(
+    reloc: &WasmRelocation,
+    obj_idx: usize,
+    wasm_layout: &WasmLayout<'_>,
+    symbol_db: &SymbolDb<'_, Wasm>,
+    file_id_to_index: &HashMap<crate::input_data::FileId, usize>,
+) -> Result<u32> {
+    ensure!(
+        reloc.refers_to_symbol(),
+        "type-index relocations are not expected in data"
+    );
+    let symbols = &wasm_layout.per_object_symbols[obj_idx];
+    let sym = symbols
+        .get(reloc.index as usize)
+        .ok_or_else(|| crate::error!("relocation symbol index {} out of range", reloc.index))?;
+
+    let (def_obj_idx, def_sym) = if sym.is_undefined() {
+        let symbol_id_range = wasm_layout.object_data_layouts[obj_idx].symbol_id_range;
+        let symbol_id = symbol_id_range.offset_to_id(reloc.index as usize);
+        let def_id = symbol_db.definition(symbol_id);
+        if def_id == symbol_id {
+            bail!("undefined Wasm data relocation symbol");
+        }
+        let def_file_id = symbol_db.file_id_for_symbol(def_id);
+        let &def_obj_idx = file_id_to_index
+            .get(&def_file_id)
+            .ok_or_else(|| crate::error!("Wasm data relocation definition file not in link"))?;
+        let def_symbol_id_range = wasm_layout.object_data_layouts[def_obj_idx].symbol_id_range;
+        let def_sym_offset = def_id.to_offset(def_symbol_id_range);
+        let def_sym = wasm_layout.per_object_symbols[def_obj_idx][def_sym_offset];
+        (def_obj_idx, def_sym)
+    } else {
+        (obj_idx, *sym)
+    };
+
+    match reloc.ty {
+        reloc_type::MEMORY_ADDR_LEB
+        | reloc_type::MEMORY_ADDR_SLEB
+        | reloc_type::MEMORY_ADDR_I32 => {
+            let base = data_symbol_memory_address(
+                &wasm_layout.object_data_layouts,
+                def_obj_idx,
+                &def_sym,
+            )?;
+            reloc_value_with_addend(base, reloc.addend)
+        }
+        reloc_type::FUNCTION_INDEX_I32 => {
+            ensure!(
+                def_sym.kind == WasmSymbolKind::Func,
+                "R_WASM_FUNCTION_INDEX_I32 references non-function symbol"
+            );
+            let index_map = &wasm_layout.object_index_maps[def_obj_idx];
+            let def_symbols = &wasm_layout.per_object_symbols[def_obj_idx];
+            let base = index_map.resolve_reloc(reloc, def_symbols)?;
+            reloc_value_with_addend(base, reloc.addend)
+        }
+        other => bail!("unsupported Wasm data relocation type {other}"),
+    }
 }
 
 pub(crate) fn build_memory_section(memories: &[wasmparser::MemoryType]) -> MemorySection {

--- a/libwild/src/wasm_writer.rs
+++ b/libwild/src/wasm_writer.rs
@@ -6,23 +6,17 @@ use crate::file_writer::SizedOutput;
 use crate::file_writer::split_output_into_sections;
 use crate::layout::Layout;
 use crate::platform::Arch;
-use crate::symbol_db::SymbolDb;
 use crate::wasm::WASM_MAGIC;
 use crate::wasm::WASM_VERSION;
 use crate::wasm::Wasm;
 use crate::wasm::WasmFunctionBody;
 use crate::wasm::WasmLayout;
 use crate::wasm::WasmObjectIndexMap;
-use crate::wasm::WasmRelocation;
 use crate::wasm::WasmSymbol;
-use crate::wasm::WasmSymbolKind;
 use crate::wasm::apply_relocation;
-use crate::wasm::data_symbol_memory_address;
-use crate::wasm::reloc_type;
 use crate::wasm::reloc_value_with_addend;
 use crate::wasm::section_id;
 use crate::wasm::write_uleb128;
-use hashbrown::HashMap;
 use leb128::write::unsigned_len as uleb128_size;
 use wasm_encoder::ConstExpr;
 use wasm_encoder::DataSection;
@@ -62,7 +56,6 @@ pub(crate) fn write<'data, A: Arch<Platform = Wasm>>(
     )?;
     write_data_section(
         &layout.format_specific,
-        &layout.symbol_db,
         section_buffers.get_mut(crate::output_section_id::WASM_DATA),
     )?;
 
@@ -172,7 +165,8 @@ fn write_code_section(
         let index_map = &object_index_maps[body.object_index];
         let symbols = &per_object_symbols[body.object_index];
         for reloc in &body.relocations {
-            let value = index_map.resolve_reloc(reloc, symbols)?;
+            let base = index_map.resolve_reloc(reloc, symbols)?;
+            let value = reloc_value_with_addend(base, reloc.addend)?;
             apply_relocation(&mut out[body_start..body_start + len], reloc, value)?;
         }
         pos += len;
@@ -188,11 +182,7 @@ fn write_code_section(
     Ok(())
 }
 
-fn write_data_section(
-    wasm_layout: &WasmLayout<'_>,
-    symbol_db: &SymbolDb<'_, Wasm>,
-    out: &mut [u8],
-) -> Result<()> {
+fn write_data_section(wasm_layout: &WasmLayout<'_>, out: &mut [u8]) -> Result<()> {
     let object_data_layouts = &wasm_layout.object_data_layouts;
     let has_segments = object_data_layouts
         .iter()
@@ -206,7 +196,7 @@ fn write_data_section(
         return Ok(());
     }
 
-    let section = build_data_section(wasm_layout, symbol_db)?;
+    let section = build_data_section(wasm_layout)?;
     let mut encoded = Vec::new();
     section.append_to(&mut encoded);
     ensure!(
@@ -280,29 +270,16 @@ pub(crate) fn build_global_section(globals: &[OutputGlobal<'_>]) -> Result<Globa
     Ok(section)
 }
 
-pub(crate) fn build_data_section(
-    wasm_layout: &WasmLayout<'_>,
-    symbol_db: &SymbolDb<'_, Wasm>,
-) -> Result<DataSection> {
-    let object_data_layouts = &wasm_layout.object_data_layouts;
-    let file_id_to_index: HashMap<crate::input_data::FileId, usize> = object_data_layouts
-        .iter()
-        .enumerate()
-        .map(|(i, obj)| (obj.file_id, i))
-        .collect();
-
+pub(crate) fn build_data_section(wasm_layout: &WasmLayout<'_>) -> Result<DataSection> {
     let mut section = DataSection::new();
-    for (obj_idx, object_layout) in object_data_layouts.iter().enumerate() {
+    for (obj_idx, object_layout) in wasm_layout.object_data_layouts.iter().enumerate() {
+        let index_map = &wasm_layout.object_index_maps[obj_idx];
+        let symbols = &wasm_layout.per_object_symbols[obj_idx];
         for segment in &object_layout.segments {
             let mut payload = segment.data.to_vec();
             for reloc in &segment.relocations {
-                let value = resolve_data_relocation_value(
-                    reloc,
-                    obj_idx,
-                    wasm_layout,
-                    symbol_db,
-                    &file_id_to_index,
-                )?;
+                let base = index_map.resolve_reloc(reloc, symbols)?;
+                let value = reloc_value_with_addend(base, reloc.addend)?;
                 apply_relocation(&mut payload, reloc, value)?;
             }
             let offset = ConstExpr::i32_const(
@@ -321,67 +298,6 @@ pub(crate) fn build_data_section(
         }
     }
     Ok(section)
-}
-
-/// Resolve a data relocation to its output value.
-fn resolve_data_relocation_value(
-    reloc: &WasmRelocation,
-    obj_idx: usize,
-    wasm_layout: &WasmLayout<'_>,
-    symbol_db: &SymbolDb<'_, Wasm>,
-    file_id_to_index: &HashMap<crate::input_data::FileId, usize>,
-) -> Result<u32> {
-    ensure!(
-        reloc.refers_to_symbol(),
-        "type-index relocations are not expected in data"
-    );
-    let symbols = &wasm_layout.per_object_symbols[obj_idx];
-    let sym = symbols
-        .get(reloc.index as usize)
-        .ok_or_else(|| crate::error!("relocation symbol index {} out of range", reloc.index))?;
-
-    let (def_obj_idx, def_sym) = if sym.is_undefined() {
-        let symbol_id_range = wasm_layout.object_data_layouts[obj_idx].symbol_id_range;
-        let symbol_id = symbol_id_range.offset_to_id(reloc.index as usize);
-        let def_id = symbol_db.definition(symbol_id);
-        if def_id == symbol_id {
-            bail!("undefined Wasm data relocation symbol");
-        }
-        let def_file_id = symbol_db.file_id_for_symbol(def_id);
-        let &def_obj_idx = file_id_to_index
-            .get(&def_file_id)
-            .ok_or_else(|| crate::error!("Wasm data relocation definition file not in link"))?;
-        let def_symbol_id_range = wasm_layout.object_data_layouts[def_obj_idx].symbol_id_range;
-        let def_sym_offset = def_id.to_offset(def_symbol_id_range);
-        let def_sym = wasm_layout.per_object_symbols[def_obj_idx][def_sym_offset];
-        (def_obj_idx, def_sym)
-    } else {
-        (obj_idx, *sym)
-    };
-
-    match reloc.ty {
-        reloc_type::MEMORY_ADDR_LEB
-        | reloc_type::MEMORY_ADDR_SLEB
-        | reloc_type::MEMORY_ADDR_I32 => {
-            let base = data_symbol_memory_address(
-                &wasm_layout.object_data_layouts,
-                def_obj_idx,
-                &def_sym,
-            )?;
-            reloc_value_with_addend(base, reloc.addend)
-        }
-        reloc_type::FUNCTION_INDEX_I32 => {
-            ensure!(
-                def_sym.kind == WasmSymbolKind::Func,
-                "R_WASM_FUNCTION_INDEX_I32 references non-function symbol"
-            );
-            let index_map = &wasm_layout.object_index_maps[def_obj_idx];
-            let def_symbols = &wasm_layout.per_object_symbols[def_obj_idx];
-            let base = index_map.resolve_reloc(reloc, def_symbols)?;
-            reloc_value_with_addend(base, reloc.addend)
-        }
-        other => bail!("unsupported Wasm data relocation type {other}"),
-    }
 }
 
 pub(crate) fn build_memory_section(memories: &[wasmparser::MemoryType]) -> MemorySection {


### PR DESCRIPTION
Resolve `MEMORY_ADDR_*` and `FUNCTION_INDEX_I32` relocations in data segment payloads after per-object layout.

Part of #1431