### PR TITLE
feat: use location counters within output sections in linker scripts

### DIFF
--- a/LINKER_SCRIPT_SUPPORT.md
+++ b/LINKER_SCRIPT_SUPPORT.md
@@ -43,7 +43,7 @@ end lists the features required to link the Linux kernel.
 | `PROVIDE(sym = expr)` inside sections | ✅ | |
 | `PROVIDE_HIDDEN(sym = expr)` inside sections | ✅ | |
 | Symbol assignment inside sections (`sym = .`) | ✅ | |
-| Location counter assignment (`. = expr`) | 🧪 | constant expressions (e.g. `. = 0x1000 * 2`) supported between output sections only; not inside section contents |
+| Location counter assignment (`. = expr`) | 🧪 | constant expressions (e.g. `. = 0x1000 * 2`) are supported |
 | `ALIGN(n)` on the location counter (`. = ALIGN(n)`) | ✅ | |
 | Per-section `ALIGN(n)` specifier | ✅ | |
 | `ASSERT(expr, "msg")` inside `SECTIONS` | ✅ | |

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -3904,6 +3904,12 @@ impl platform::SectionAttributes for SectionAttributes {
         info.section_attributes.entsize = self.entsize;
 
         info.section_attributes.ty = info.section_attributes.ty.max(self.ty);
+
+        if let SectionKind::Secondary(primary_id) = info.kind
+            && info.location.is_some()
+        {
+            self.apply(output_sections, primary_id);
+        }
     }
 
     fn is_null(&self) -> bool {

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -4484,7 +4484,9 @@ fn get_defsym_attributes(
         }
     } else {
         let shndx = match redirect.loc {
-            SymbolLoc::SectionStart(os) | SymbolLoc::SectionEnd(os) => {
+            SymbolLoc::SectionStart(os)
+            | SymbolLoc::SectionEnd(os)
+            | SymbolLoc::RelativeExpression(_, os) => {
                 let os = layout.output_sections.primary_output_section(os);
                 layout
                     .output_sections

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -118,6 +118,9 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
             }
             SymbolLoc::FirstSection | SymbolLoc::None => Ok(0),
             SymbolLoc::Expression(expr, _) => eval!(expr),
+            SymbolLoc::RelativeExpression(expr, id) => {
+                eval!(expr).map(|x| x + section_layouts.get(*id).mem_offset)
+            }
         },
 
         Expression::Symbol(name) => symbol_resolution_callback(name),

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -410,7 +410,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
     // Evaluate ASSERT commands from all linker scripts now that layout is complete.
     crate::expression_eval::evaluate_assertions(
         &symbol_db,
-        &section_layouts,
+        &merged_section_layouts,
         &output_sections,
         &symbol_resolutions.resolutions,
         sizeof_headers,
@@ -1737,7 +1737,18 @@ pub(crate) fn merge_secondary_parts<P: Platform>(
     for (id, info) in output_sections.ids_with_info() {
         if let SectionKind::Secondary(primary_id) = info.kind {
             let secondary_layout = take(section_layouts.get_mut(id));
-            section_layouts.get_mut(primary_id).merge(&secondary_layout);
+            let primary = section_layouts.get_mut(primary_id);
+            if info.location.is_some() {
+                let mem_end = secondary_layout.mem_offset + secondary_layout.mem_size;
+                if mem_end > primary.mem_offset + primary.mem_size {
+                    primary.mem_size = mem_end - primary.mem_offset;
+                }
+                let file_end = secondary_layout.file_offset + secondary_layout.file_size;
+                if file_end > primary.file_offset + primary.file_size {
+                    primary.file_size = file_end - primary.file_offset;
+                }
+            }
+            primary.merge(&secondary_layout);
         }
     }
 }
@@ -5126,6 +5137,8 @@ fn layout_section<'data, P: Platform>(
                 let section_info = output_sections.output_info(section_id);
                 let part_id_range = section_id.part_id_range();
                 let max_alignment = sizes.max_alignment(part_id_range.clone(), output_sections);
+                let merge_target = output_sections.primary_output_section(section_id);
+                let section_flags = output_sections.section_flags(merge_target);
                 let region = section_info
                     .region_name
                     .map(|region_name| {
@@ -5151,6 +5164,12 @@ fn layout_section<'data, P: Platform>(
                             String::from_utf8_lossy(section_info.region_name.unwrap()),
                         );
                     }
+                    if section_flags.is_alloc() && output_sections.has_data_in_file(merge_target) {
+                        let new_offset = offset
+                            .checked_sub(mem_offset)
+                            .with_context(|| format!("Cannot move location counter backwards (from 0x{mem_offset:x} to 0x{offset:x})"))?;
+                        file_offset += new_offset as usize;
+                    }
                     mem_offset = offset;
                 }
                 lma_offset = mem_offset;
@@ -5162,8 +5181,6 @@ fn layout_section<'data, P: Platform>(
                     .try_for_each(|(offset, (part_layout, &part_size))| -> Result {
                         let part_id = part_id_range.start.offset(offset);
                         let alignment = part_id.alignment(output_sections).min(max_alignment);
-                        let merge_target = output_sections.primary_output_section(section_id);
-                        let section_flags = output_sections.section_flags(merge_target);
                         let mem_size = if section_id == output_section_id::RELRO_PADDING {
                             let page_alignment = args.loadable_segment_alignment();
                             let aligned_offset = page_alignment.align_up(mem_offset);

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -5137,8 +5137,6 @@ fn layout_section<'data, P: Platform>(
                 let section_info = output_sections.output_info(section_id);
                 let part_id_range = section_id.part_id_range();
                 let max_alignment = sizes.max_alignment(part_id_range.clone(), output_sections);
-                let merge_target = output_sections.primary_output_section(section_id);
-                let section_flags = output_sections.section_flags(merge_target);
                 let region = section_info
                     .region_name
                     .map(|region_name| {
@@ -5164,6 +5162,8 @@ fn layout_section<'data, P: Platform>(
                             String::from_utf8_lossy(section_info.region_name.unwrap()),
                         );
                     }
+                    let merge_target = output_sections.primary_output_section(section_id);
+                    let section_flags = output_sections.section_flags(merge_target);
                     if section_flags.is_alloc() && output_sections.has_data_in_file(merge_target) {
                         let new_offset = offset
                             .checked_sub(mem_offset)
@@ -5181,6 +5181,8 @@ fn layout_section<'data, P: Platform>(
                     .try_for_each(|(offset, (part_layout, &part_size))| -> Result {
                         let part_id = part_id_range.start.offset(offset);
                         let alignment = part_id.alignment(output_sections).min(max_alignment);
+                        let merge_target = output_sections.primary_output_section(section_id);
+                        let section_flags = output_sections.section_flags(merge_target);
                         let mem_size = if section_id == output_section_id::RELRO_PADDING {
                             let page_alignment = args.loadable_segment_alignment();
                             let aligned_offset = page_alignment.align_up(mem_offset);

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -302,6 +302,10 @@ impl<'data> LayoutRulesBuilder<'data> {
                                             )),
                                             Box::new(location.address.clone()),
                                         ));
+                                        last_symbol_loc = SymbolLoc::RelativeExpression(
+                                            location.address.clone(),
+                                            primary_section_id,
+                                        );
                                     }
                                 }
                             }
@@ -318,7 +322,8 @@ impl<'data> LayoutRulesBuilder<'data> {
                             let section_id = match loc {
                                 SymbolLoc::Expression(_, section_id) => section_id,
                                 SymbolLoc::SectionStart(section_id)
-                                | SymbolLoc::SectionEnd(section_id) => Some(section_id),
+                                | SymbolLoc::SectionEnd(section_id)
+                                | SymbolLoc::RelativeExpression(_, section_id) => Some(section_id),
                                 _ => None,
                             };
                             loc = SymbolLoc::Expression(new_location.address.clone(), section_id);

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -237,18 +237,22 @@ impl<'data> LayoutRulesBuilder<'data> {
                             loc = SymbolLoc::SectionEnd(primary_section_id);
 
                             let mut last_section_id = None;
-                            let mut last_loc = SymbolLoc::SectionStart(primary_section_id);
+                            let mut last_symbol_loc = SymbolLoc::SectionStart(primary_section_id);
+                            let mut last_location = None;
 
                             for contents_cmd in &sec.commands {
                                 match contents_cmd {
                                     ContentsCommand::Matcher(matcher) => {
-                                        let section_id = if last_section_id.is_none() {
+                                        let section_id = if last_section_id.is_none()
+                                            && last_location.is_none()
+                                        {
                                             primary_section_id
                                         } else {
                                             output_sections.add_secondary_section(
                                                 primary_section_id,
                                                 replace(&mut extra_min_alignment, alignment::MIN),
                                                 None,
+                                                last_location.take(),
                                             )
                                         };
 
@@ -266,13 +270,13 @@ impl<'data> LayoutRulesBuilder<'data> {
                                         }
 
                                         last_section_id = Some(section_id);
-                                        last_loc = SymbolLoc::SectionEnd(section_id);
+                                        last_symbol_loc = SymbolLoc::SectionEnd(section_id);
                                     }
                                     ContentsCommand::SymbolAssignment(assignment) => {
                                         let placement = SymbolPlacement::Redirect(Redirect {
                                             kind: RedirectKind::Script,
                                             expression: assignment.expr.clone(),
-                                            loc: last_loc.clone(),
+                                            loc: last_symbol_loc.clone(),
                                         });
                                         symbol_defs.push(InternalSymDefInfo::new(
                                             placement,
@@ -284,14 +288,30 @@ impl<'data> LayoutRulesBuilder<'data> {
                                         let placement = SymbolPlacement::Redirect(Redirect {
                                             kind: RedirectKind::Script,
                                             expression: provide.value.clone(),
-                                            loc: last_loc.clone(),
+                                            loc: last_symbol_loc.clone(),
                                         });
                                         symbol_defs.push(
                                             InternalSymDefInfo::new(placement, provide.name)
                                                 .with_hidden(provide.hidden),
                                         );
                                     }
+                                    ContentsCommand::SetLocation(location) => {
+                                        last_location = Some(linker_script::Expression::Add(
+                                            Box::new(linker_script::Expression::Addr(
+                                                sec.output_section_name,
+                                            )),
+                                            Box::new(location.address.clone()),
+                                        ));
+                                    }
                                 }
+                            }
+                            if let Some(location) = last_location.take() {
+                                output_sections.add_secondary_section(
+                                    primary_section_id,
+                                    alignment::MIN,
+                                    None,
+                                    Some(location),
+                                );
                             }
                         }
                         SectionCommand::SetLocation(new_location) => {

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -122,6 +122,7 @@ pub(crate) enum ContentsCommand<'a> {
     SymbolAssignment(SymbolAssignment<'a>),
     Align(Alignment),
     Provide(ProvideSymbolDefinition<'a>),
+    SetLocation(Location<'a>),
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -1172,7 +1173,7 @@ fn parse_assignment<'input>(input: &mut &'input BStr) -> winnow::Result<Contents
                 return Err(ContextError::default());
             }
         } else {
-            return Err(ContextError::default());
+            ContentsCommand::SetLocation(Location { address: (expr) })
         }
     } else {
         ContentsCommand::SymbolAssignment(SymbolAssignment { name, expr })

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -711,6 +711,7 @@ impl<'data, P: Platform> OutputSections<'data, P> {
         primary_id: OutputSectionId,
         min_alignment: Alignment,
         secondary_order: Option<SecondaryOrder>,
+        location: Option<linker_script::Expression<'data>>,
     ) -> OutputSectionId {
         let primary_info = self.section_infos.get(primary_id);
         let section_attributes = primary_info.section_attributes;
@@ -719,7 +720,7 @@ impl<'data, P: Platform> OutputSections<'data, P> {
             kind: SectionKind::Secondary(primary_id),
             section_attributes,
             min_alignment,
-            location: None,
+            location,
             load_location,
             secondary_order,
             phdr_name: None,
@@ -766,6 +767,7 @@ impl<'data, P: Platform> OutputSections<'data, P> {
             primary,
             min_alignment,
             Some(SecondaryOrder::InitFini { priority }),
+            None,
         );
 
         self.init_fini_by_priority.insert(key, sid);

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -103,6 +103,7 @@ pub(crate) enum SymbolLoc<'data> {
     SectionEnd(OutputSectionId),
     FirstSection,
     Expression(Expression<'data>, Option<OutputSectionId>),
+    RelativeExpression(Expression<'data>, OutputSectionId),
     None,
 }
 

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter-underflow.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter-underflow.ld
@@ -1,0 +1,11 @@
+ENTRY(begin_here)
+
+SECTIONS
+{
+    .text : {
+        . = 0x10;
+        *(.text)
+        . = 0x11;
+    }
+}
+

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
@@ -1,0 +1,19 @@
+//#Config:default
+//#LinkerScript:linker-script-location-counter.ld
+//#Object:runtime.c
+// RISC-V: BFD complains about missing __global_pointer$ (defined in the default linker script)
+//#SkipArch:riscv64
+
+//#Config:no_gc_sections:default
+//#LinkArgs:--no-gc-sections
+
+//#Config:underflow
+//#Object:runtime.c
+//#LinkerScript:linker-script-location-counter-underflow.ld
+//#ExpectError:(?i)cannot move location counter backwards
+
+#include <stddef.h>
+
+#include "../common/runtime.h"
+
+void begin_here(void) { exit_syscall(42); }

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.ld
@@ -1,0 +1,21 @@
+ENTRY(begin_here)
+
+SECTIONS
+{
+    . = 0x300000 * 2;
+	start_of_sections = .;
+    .text : {
+        . = 0x10;
+        *(.text)
+        . = 0x1000;
+    }
+    . = 0x800000;
+	start_of_data = .;
+    .data : {
+        *(.data)
+    }
+}
+
+ASSERT(start_of_sections == 0x600000, "start_of_sections should be 0x600000");
+ASSERT(start_of_data == 0x800000, "start_of_data should be 0x800000");
+ASSERT(SIZEOF(.text) == 0x1000, "text section should be 0x1000 bytes");

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.ld
@@ -5,9 +5,12 @@ SECTIONS
     . = 0x300000 * 2;
 	start_of_sections = .;
     .text : {
+		start_of_text = .;
         . = 0x10;
+		text1 = .;
         *(.text)
         . = 0x1000;
+		text2 = .;
     }
     . = 0x800000;
 	start_of_data = .;
@@ -19,3 +22,5 @@ SECTIONS
 ASSERT(start_of_sections == 0x600000, "start_of_sections should be 0x600000");
 ASSERT(start_of_data == 0x800000, "start_of_data should be 0x800000");
 ASSERT(SIZEOF(.text) == 0x1000, "text section should be 0x1000 bytes");
+ASSERT(text1 == start_of_text + 0x10, "text1 should be 0x10 bytes after start_of_sections");
+ASSERT(text2 == start_of_text + 0x1000, "text2 should be 0x1000 bytes after start_of_sections");


### PR DESCRIPTION
This PR adds support for setting the location counter using the `.` keyword within an output section.