### PR TITLE
refactor: Remove an unused field

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -1474,7 +1474,7 @@ fn write_object<'data, A: Arch<Platform = Elf>>(
                 write_object_section::<A>(
                     object,
                     layout,
-                    sec,
+                    *sec,
                     section_index,
                     buffers,
                     table_writer,
@@ -1482,7 +1482,7 @@ fn write_object<'data, A: Arch<Platform = Elf>>(
                 )?;
             }
             SectionSlot::LoadedDebugInfo(sec) => {
-                write_debug_section::<A>(object, layout, sec, section_index, buffers)?;
+                write_debug_section::<A>(object, layout, *sec, section_index, buffers)?;
             }
             SectionSlot::FrameData(section_index) => {
                 write_eh_frame_data::<A>(object, *section_index, layout, table_writer, trace)?;
@@ -1834,7 +1834,7 @@ fn write_rela_sections<'data>(
 fn write_object_section<'data, A: Arch<Platform = Elf>>(
     object: &ObjectLayout<'data, Elf>,
     layout: &ElfLayout<'data>,
-    section: &Section,
+    section: Section,
     section_index: object::SectionIndex,
     buffers: &mut OutputSectionPartMap<&mut [u8]>,
     table_writer: &mut TableWriter,
@@ -1865,7 +1865,6 @@ fn write_object_section<'data, A: Arch<Platform = Elf>>(
         return write_section_reversed::<A>(
             object,
             layout,
-            section,
             section_index,
             table_writer,
             trace,
@@ -1905,16 +1904,12 @@ fn write_object_section<'data, A: Arch<Platform = Elf>>(
             object.input
         )
     })?;
-    if section.flags.needs_got() || section.flags.needs_plt() {
-        bail!("Section has GOT or PLT");
-    }
     Ok(())
 }
 
 fn write_section_reversed<'data, A: Arch<Platform = Elf>>(
     object: &ObjectLayout<'data, Elf>,
     layout: &ElfLayout<'data>,
-    section: &Section,
     section_index: object::SectionIndex,
     table_writer: &mut TableWriter<'_, '_>,
     trace: &TraceOutput,
@@ -1976,17 +1971,13 @@ fn write_section_reversed<'data, A: Arch<Platform = Elf>>(
         )
     })?;
 
-    if section.flags.needs_got() || section.flags.needs_plt() {
-        bail!("Section has GOT or PLT");
-    }
-
     Ok(())
 }
 
 fn write_debug_section<'data, A: Arch<Platform = Elf>>(
     object: &ObjectLayout<'data, Elf>,
     layout: &ElfLayout<'data>,
-    section: &Section,
+    section: Section,
     section_index: object::SectionIndex,
     buffers: &mut OutputSectionPartMap<&mut [u8]>,
 ) -> Result {
@@ -2025,7 +2016,7 @@ fn write_debug_section<'data, A: Arch<Platform = Elf>>(
 fn write_section_raw<'out, 'data>(
     object: &ObjectLayout<'data, Elf>,
     layout: &ElfLayout,
-    sec: &Section,
+    sec: Section,
     section_index: object::SectionIndex,
     buffers: &'out mut OutputSectionPartMap<&mut [u8]>,
 ) -> Result<&'out mut [u8]> {

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -1345,7 +1345,6 @@ pub(crate) struct Section {
     /// Size in the output. This starts as the input section size, then may be reduced by
     /// relaxation-induced byte deletions during `scan_relaxations`.
     pub(crate) size: u64,
-    pub(crate) flags: ValueFlags,
 }
 
 #[derive(Debug)]
@@ -2919,17 +2918,14 @@ impl Section {
         _part_id: PartId,
     ) -> Result<Section> {
         let size = object_state.object.section_size(header)?;
-        let section = Section {
-            size,
-            flags: ValueFlags::empty(),
-        };
+        let section = Section { size };
         Ok(section)
     }
 
     // How much space we take up. This is our size rounded up to the next multiple of our
     // alignment, unless we're in a packed section, in which case it's just our size.
     pub(crate) fn capacity<P: Platform>(
-        &self,
+        self,
         part_id: PartId,
         output_sections: &OutputSections<P>,
     ) -> u64 {
@@ -4136,9 +4132,9 @@ impl<'data, P: Platform> ObjectLayoutState<'data, P> {
         }
         let output_kind = resources.symbol_db.output_kind;
         for slot in &mut self.sections {
-            if let SectionSlot::Loaded(section) = slot {
+            if let SectionSlot::Loaded(_) = slot {
                 P::allocate_resolution(
-                    section.flags,
+                    ValueFlags::empty(),
                     &mut common.mem_sizes,
                     output_kind,
                     resources.symbol_db.args,

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -597,7 +597,7 @@ fn write_object<'data, A: Arch<Platform = MachO>>(
     for (i, sec) in object.sections.iter().enumerate() {
         match sec {
             SectionSlot::Loaded(sec) => {
-                write_object_section::<A>(object, layout, sec, object::SectionIndex(i), buffers)?;
+                write_object_section::<A>(object, layout, *sec, object::SectionIndex(i), buffers)?;
             }
             _ => (),
         }
@@ -611,7 +611,7 @@ fn write_object<'data, A: Arch<Platform = MachO>>(
 fn write_object_section<'data, A: Arch<Platform = MachO>>(
     object_layout: &ObjectLayout<'data, MachO>,
     layout: &MachOLayout<'data>,
-    section: &Section,
+    section: Section,
     section_index: object::SectionIndex,
     buffers: &mut OutputSectionPartMap<&mut [u8]>,
 ) -> Result {
@@ -683,7 +683,7 @@ fn apply_relocation<'data, A: Arch<Platform = MachO>>(
 fn write_section_raw<'out, 'data>(
     object: &ObjectLayout<'data, MachO>,
     layout: &MachOLayout,
-    sec: &Section,
+    sec: Section,
     section_index: object::SectionIndex,
     buffers: &'out mut OutputSectionPartMap<&mut [u8]>,
 ) -> Result<&'out mut [u8]> {


### PR DESCRIPTION
The `flags` field on `layout::Section` was never set to anything other than empty. Once removed, the size of `Section` then reduced, which meant that there were some warnings that passing it by value would be better than passing it by reference, so I fixed those.