### PR TITLE
fix: Reject R_X86_64_8/16/PC8/PC16 against preemptible symbols in shared objects

### DIFF
--- a/libwild/src/elf_x86_64.rs
+++ b/libwild/src/elf_x86_64.rs
@@ -70,7 +70,13 @@ impl crate::platform::Arch for ElfX86_64 {
     fn is_illegal_in_shared_object(r_type: u32) -> bool {
         matches!(
             r_type,
-            object::elf::R_X86_64_32 | object::elf::R_X86_64_32S | object::elf::R_X86_64_PC32
+            object::elf::R_X86_64_32
+                | object::elf::R_X86_64_32S
+                | object::elf::R_X86_64_PC32
+                | object::elf::R_X86_64_8
+                | object::elf::R_X86_64_16
+                | object::elf::R_X86_64_PC8
+                | object::elf::R_X86_64_PC16
         )
     }
 

--- a/wild/tests/sources/elf/shared-sub-ptr-reloc/shared-sub-ptr-reloc.s
+++ b/wild/tests/sources/elf/shared-sub-ptr-reloc/shared-sub-ptr-reloc.s
@@ -1,0 +1,10 @@
+//#Arch:x86_64
+//#Mode:dynamic
+//#LinkArgs:-shared --no-gc-sections
+//#ExpectError:R_X86_64_8
+.global foo
+.data
+.byte foo
+.short foo
+.byte foo - .
+.short foo - .


### PR DESCRIPTION
R_X86_64_8, R_X86_64_16, R_X86_64_PC8 and R_X86_64_PC16 relocations cannot be used against preemptible symbols in shared objects because the dynamic linker has no way to patch sub-pointer-size values at runtime. Wild was silently succeeding and producing a broken binary.

Both GNU ld and lld error with "recompile with -fPIC".

Fixes #2115