### PR TITLE
test: Add runtime test for GOTPCRELX access to hidden absolute symbol in shared object

### DIFF
--- a/wild/tests/sources/elf/gotpcrelx-abs-no-relax-pic/gotpcrelx-abs-no-relax-pic.s
+++ b/wild/tests/sources/elf/gotpcrelx-abs-no-relax-pic/gotpcrelx-abs-no-relax-pic.s
@@ -1,0 +1,21 @@
+// Test that GOTPCRELX access to a hidden absolute symbol in a shared object
+// produces correct runtime behavior. Wild relaxes to a direct immediate
+// (matching GNU ld), while lld keeps the GOT access. Both are correct.
+// lld is used as reference linker since GNU ld uses different relaxation.
+//#Arch:x86_64
+//#LinkArgs:--no-gc-sections -shared
+//#ReferenceLinkers:lld
+//#RunDynSym:get_bar
+//#DiffIgnore:.dynamic.DT_FLAGS_1.NOW
+//#DiffIgnore:section.got
+//#DiffIgnore:rel.extra-opt.R_X86_64_REX_GOTPCRELX.RexMovIndirectToAbsolute*
+.text
+.globl get_bar
+.type get_bar, @function
+get_bar:
+    movq bar@GOTPCREL(%rip), %rax
+    ret
+.data
+.global bar
+.hidden bar
+bar = 42


### PR DESCRIPTION
When an absolute symbol is accessed via GOTPCRELX or REX_GOTPCRELX in a shared object or PIE, Wild was incorrectly relaxing the GOT-indirect load to a direct immediate (`mov $42, %rax`). This puts the symbol's value instead of its address into the register.

The GOT access must be preserved in position-independent output so that the symbol's address can be loaded at runtime. lld keeps the GOT access correctly. GNU ld has the same bug as the old Wild behavior.

Fixes #2147