### PR TITLE
fix: Reject absolute R_X86_64_8/16 against non-preemptible symbols in shared objects

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2868,7 +2868,13 @@ fn apply_relocation<
         }
         RelocationKind::Absolute
             if layout.symbol_db.output_kind.is_shared_object()
-                && matches!(r_type, object::elf::R_X86_64_32 | object::elf::R_X86_64_32S) =>
+                && matches!(
+                    r_type,
+                    object::elf::R_X86_64_32
+                        | object::elf::R_X86_64_32S
+                        | object::elf::R_X86_64_8
+                        | object::elf::R_X86_64_16
+                ) =>
         {
             bail!(
                 "relocation type {} cannot be used when making a shared object; \

--- a/wild/tests/sources/elf/shared-local-sub-ptr-reloc/shared-local-sub-ptr-reloc.s
+++ b/wild/tests/sources/elf/shared-local-sub-ptr-reloc/shared-local-sub-ptr-reloc.s
@@ -1,0 +1,11 @@
+//#Arch:x86_64
+//#Mode:dynamic
+//#LinkArgs:-shared --no-gc-sections
+//#ExpectError:R_X86_64_8
+//#ExpectErrorWild:R_X86_64_8.*cannot be used when making a shared object
+
+.data
+local_byte:
+  .byte 0
+  .byte local_byte
+  .short local_byte


### PR DESCRIPTION
Extend the existing Absolute immediate-reject path so local, non-preemptible references are rejected too. Without this, Wild emitted `R_X86_64_RELATIVE` on 1- and 2-byte slots and produced a broken shared object.

Inspired by #2146 