### PR TITLE
feat: define multiple location counters that are relative to each other

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -972,8 +972,7 @@ impl platform::Platform for Elf {
                 },
                 kind: d.kind,
                 min_alignment: d.min_alignment,
-                location: None,
-                load_location: None,
+                location_info: None,
                 secondary_order: None,
                 phdr_name: None,
                 region_name: None,
@@ -1875,9 +1874,15 @@ impl platform::Platform for Elf {
         output_kind: OutputKind,
         output_sections: &OutputSections<'data, Self>,
         secondary: &OutputSectionMap<Vec<OutputSectionId>>,
+        location_counters: &[crate::layout_rules::LocationCounter<'data>],
     ) -> (OutputOrder<'data>, ProgramSegments<Self::ProgramSegmentDef>) {
-        let mut builder =
-            OutputOrderBuilder::<Self>::new(output_kind, output_sections, secondary, false);
+        let mut builder = OutputOrderBuilder::<Self>::new(
+            output_kind,
+            output_sections,
+            secondary,
+            false,
+            location_counters,
+        );
 
         builder.add_section(output_section_id::FILE_HEADER);
         builder.add_section(output_section_id::PROGRAM_HEADERS);
@@ -1946,9 +1951,15 @@ impl platform::Platform for Elf {
         secondary: &OutputSectionMap<Vec<OutputSectionId>>,
         linker_scripts: &[&SequencedLinkerScript<'data, Self>],
         phdr_map: &mut hashbrown::HashMap<&[u8], Vec<OutputSectionId>>,
+        location_counters: &[crate::layout_rules::LocationCounter<'data>],
     ) -> Result<(OutputOrder<'data>, ProgramSegments<Self::ProgramSegmentDef>)> {
-        let mut builder =
-            OutputOrderBuilder::<Self>::new(output_kind, output_sections, secondary, true);
+        let mut builder = OutputOrderBuilder::<Self>::new(
+            output_kind,
+            output_sections,
+            secondary,
+            true,
+            location_counters,
+        );
 
         let mut insert_re = false;
         let mut insert_rw = false;
@@ -3913,7 +3924,7 @@ impl platform::SectionAttributes for SectionAttributes {
         info.section_attributes.ty = info.section_attributes.ty.max(self.ty);
 
         if let SectionKind::Secondary(primary_id) = info.kind
-            && info.location.is_some()
+            && info.location_info.is_some()
         {
             self.apply(output_sections, primary_id);
         }

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -4504,7 +4504,9 @@ fn get_defsym_attributes(
         }
     } else {
         let shndx = match redirect.loc {
-            SymbolLoc::SectionStart(os) | SymbolLoc::SectionEnd(os) => {
+            SymbolLoc::SectionStartRelative(os)
+            | SymbolLoc::SectionEndRelative(os)
+            | SymbolLoc::SectionEnd(os) => {
                 let os = layout.output_sections.primary_output_section(os);
                 layout
                     .output_sections

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -4504,9 +4504,7 @@ fn get_defsym_attributes(
         }
     } else {
         let shndx = match redirect.loc {
-            SymbolLoc::SectionStart(os)
-            | SymbolLoc::SectionEnd(os)
-            | SymbolLoc::RelativeExpression(_, os) => {
+            SymbolLoc::SectionStart(os) | SymbolLoc::SectionEnd(os) => {
                 let os = layout.output_sections.primary_output_section(os);
                 layout
                     .output_sections
@@ -4514,8 +4512,7 @@ fn get_defsym_attributes(
                     .unwrap_or(0)
             }
             SymbolLoc::FirstSection => 1,
-            SymbolLoc::None => return Ok((object::elf::SHN_ABS.into(), object::elf::STT_NOTYPE)),
-            SymbolLoc::Expression(_, os) => {
+            SymbolLoc::LocationCounter(_, os) => {
                 if let Some(os) = os {
                     let os = layout.output_sections.primary_output_section(os);
                     layout
@@ -4526,6 +4523,7 @@ fn get_defsym_attributes(
                     1
                 }
             }
+            SymbolLoc::None => return Ok((object::elf::SHN_ABS.into(), object::elf::STT_NOTYPE)),
         };
         Ok((SymbolSection::Index(shndx), object::elf::STT_NOTYPE))
     }

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -84,6 +84,34 @@ pub(crate) fn evaluate_assertions<'data, P: Platform>(
     Ok(())
 }
 
+pub(crate) fn evaluate_location(
+    expr_loc: &SymbolLoc,
+    section_layouts: &OutputSectionMap<OutputRecordLayout>,
+    resolved_location_counters: &[(u64, Option<u64>)],
+) -> Result<u64> {
+    match expr_loc {
+        SymbolLoc::SectionStart(id) => Ok(section_layouts.get(*id).mem_offset),
+        SymbolLoc::SectionEnd(id) => {
+            let layout = section_layouts.get(*id);
+            Ok(layout.mem_offset + layout.mem_size)
+        }
+        SymbolLoc::FirstSection | SymbolLoc::None => Ok(0),
+        SymbolLoc::LocationCounter(idx, section_id) => {
+            let entry = resolved_location_counters.get(*idx).ok_or_else(|| {
+                crate::error!(
+                    "location counter index {idx} out of range (len: {})",
+                    resolved_location_counters.len()
+                )
+            })?;
+            if section_id.is_none() {
+                Ok(entry.1.unwrap_or(entry.0))
+            } else {
+                Ok(entry.0)
+            }
+        }
+    }
+}
+
 pub(crate) fn evaluate_expression<'data, P: Platform>(
     expr: &Expression<'data>,
     expr_loc: &SymbolLoc,
@@ -114,28 +142,9 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
     match expr {
         Expression::Number(n) => Ok(*n),
 
-        Expression::LocationCounter => match expr_loc {
-            SymbolLoc::SectionStart(id) => Ok(section_layouts.get(*id).mem_offset),
-            SymbolLoc::SectionEnd(id) => {
-                let layout = section_layouts.get(*id);
-                Ok(layout.mem_offset + layout.mem_size)
-            }
-            SymbolLoc::FirstSection | SymbolLoc::None => Ok(0),
-            SymbolLoc::LocationCounter(idx, section_id) => {
-                let idx = *idx as usize;
-                let entry = resolved_location_counters.get(idx).ok_or_else(|| {
-                    crate::error!(
-                        "location counter index {idx} out of range (len: {})",
-                        resolved_location_counters.len()
-                    )
-                })?;
-                if section_id.is_none() {
-                    Ok(entry.1.unwrap_or(entry.0))
-                } else {
-                    Ok(entry.0)
-                }
-            }
-        },
+        Expression::LocationCounter => {
+            evaluate_location(expr_loc, section_layouts, resolved_location_counters)
+        }
 
         Expression::Symbol(name) => symbol_resolution_callback(name),
 
@@ -171,13 +180,9 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
             if align == 0 {
                 bail!("ALIGN(0) is invalid");
             }
-            // NOTE: ALIGN(n) in a full linker script context means "align the current address
-            // to n". Here we always align 0 because the location counter is not threaded through
-            // expression evaluation. This gives correct results when used as a standalone value
-            // (e.g. ASSERT(ALIGN(4096) == 0, ...)) but not when combined with the location
-            // counter (e.g. ASSERT(. + ALIGN(4096) > x, ...)). Full support requires passing
-            // the current address into evaluate_expression.
-            Ok(0u64.wrapping_add(align - 1) & !(align - 1))
+            let location =
+                evaluate_location(expr_loc, section_layouts, resolved_location_counters)?;
+            Ok(location.wrapping_add(align - 1) & !(align - 1))
         }
 
         Expression::Min(l, r) => Ok(eval!(l)?.min(eval!(r)?)),

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -37,6 +37,7 @@ pub(crate) fn evaluate_assertions<'data, P: Platform>(
     resolutions: &[Option<Resolution<P>>],
     sizeof_headers: u64,
     memory_regions: &HashMap<&[u8], layout::MemoryRegion>,
+    resolved_location_counters: &[(u64, Option<u64>)],
 ) -> Result {
     for group in &symbol_db.groups {
         let Group::LinkerScripts(scripts) = group else {
@@ -54,6 +55,7 @@ pub(crate) fn evaluate_assertions<'data, P: Platform>(
                     memory_regions,
                     symbol_db,
                     sizeof_headers,
+                    resolved_location_counters,
                     &|name| {
                         let Some(target_symbol_id) =
                             symbol_db.get_unversioned(&UnversionedSymbolName::prehashed(name))
@@ -84,12 +86,13 @@ pub(crate) fn evaluate_assertions<'data, P: Platform>(
 
 pub(crate) fn evaluate_expression<'data, P: Platform>(
     expr: &Expression<'data>,
-    expr_loc: &SymbolLoc<'data>,
+    expr_loc: &SymbolLoc,
     section_layouts: &OutputSectionMap<OutputRecordLayout>,
     output_sections: &OutputSections<'data, P>,
     memory_regions: &HashMap<&[u8], layout::MemoryRegion>,
     symbol_db: &SymbolDb<'data, P>,
     sizeof_headers: u64,
+    resolved_location_counters: &[(u64, Option<u64>)],
     symbol_resolution_callback: &dyn Fn(&[u8]) -> Result<u64>,
 ) -> Result<u64> {
     macro_rules! eval {
@@ -102,6 +105,7 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
                 memory_regions,
                 symbol_db,
                 sizeof_headers,
+                resolved_location_counters,
                 symbol_resolution_callback,
             )
         };
@@ -117,9 +121,19 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
                 Ok(layout.mem_offset + layout.mem_size)
             }
             SymbolLoc::FirstSection | SymbolLoc::None => Ok(0),
-            SymbolLoc::Expression(expr, _) => eval!(expr),
-            SymbolLoc::RelativeExpression(expr, id) => {
-                eval!(expr).map(|x| x + section_layouts.get(*id).mem_offset)
+            SymbolLoc::LocationCounter(idx, section_id) => {
+                let idx = *idx as usize;
+                let entry = resolved_location_counters.get(idx).ok_or_else(|| {
+                    crate::error!(
+                        "location counter index {idx} out of range (len: {})",
+                        resolved_location_counters.len()
+                    )
+                })?;
+                if section_id.is_none() {
+                    Ok(entry.1.unwrap_or(entry.0))
+                } else {
+                    Ok(entry.0)
+                }
             }
         },
 
@@ -368,6 +382,7 @@ mod tests {
                 &HashMap::new(),
                 symbol_db,
                 0,
+                &[],
                 &|_| Ok(1),
             )
         })
@@ -689,6 +704,7 @@ mod tests {
                 file_bytes: b"",
                 memory_regions: Vec::new(),
                 program_headers: Vec::new(),
+                location_counters: Vec::new(),
             },
             symbol_id_range: SymbolIdRange::empty(),
             file_id: FileId::new(0, 0),
@@ -709,8 +725,16 @@ mod tests {
             }]);
             symbol_db.add_group(group);
             assert!(
-                evaluate_assertions::<Elf>(symbol_db, layouts, sections, &[], 0, &HashMap::new())
-                    .is_ok()
+                evaluate_assertions::<Elf>(
+                    symbol_db,
+                    layouts,
+                    sections,
+                    &[],
+                    0,
+                    &HashMap::new(),
+                    &[]
+                )
+                .is_ok()
             );
         });
     }
@@ -724,9 +748,16 @@ mod tests {
                 remainder: b"",
             }]);
             symbol_db.add_group(group);
-            let err =
-                evaluate_assertions::<Elf>(symbol_db, layouts, sections, &[], 0, &HashMap::new())
-                    .unwrap_err();
+            let err = evaluate_assertions::<Elf>(
+                symbol_db,
+                layouts,
+                sections,
+                &[],
+                0,
+                &HashMap::new(),
+                &[],
+            )
+            .unwrap_err();
             assert!(err.to_string().contains("intentional failure"));
         });
     }
@@ -761,6 +792,7 @@ mod tests {
                     &regions,
                     symbol_db,
                     0,
+                    &[],
                     &|_| Ok(0),
                 )
             };

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -37,7 +37,7 @@ pub(crate) fn evaluate_assertions<'data, P: Platform>(
     resolutions: &[Option<Resolution<P>>],
     sizeof_headers: u64,
     memory_regions: &HashMap<&[u8], layout::MemoryRegion>,
-    resolved_location_counters: &[(u64, Option<u64>)],
+    resolved_location_counters: &[ResolvedLocationCounter],
 ) -> Result {
     for group in &symbol_db.groups {
         let Group::LinkerScripts(scripts) = group else {
@@ -84,11 +84,17 @@ pub(crate) fn evaluate_assertions<'data, P: Platform>(
     Ok(())
 }
 
+#[derive(Clone, Default)]
+pub(crate) struct ResolvedLocationCounter {
+    pub(crate) value: u64,
+    pub(crate) section_offset: Option<u64>,
+}
+
 fn evaluate_location<'data, P: Platform>(
     expr_loc: &SymbolLoc,
     section_layouts: &OutputSectionMap<OutputRecordLayout>,
     output_sections: &OutputSections<'data, P>,
-    resolved_location_counters: &[(u64, Option<u64>)],
+    resolved_location_counters: &[ResolvedLocationCounter],
 ) -> Result<u64> {
     match expr_loc {
         SymbolLoc::SectionStartRelative(_) => Ok(0),
@@ -112,9 +118,9 @@ fn evaluate_location<'data, P: Platform>(
                 )
             })?;
             if section_id.is_none() {
-                Ok(entry.0)
+                Ok(entry.value)
             } else {
-                Ok(entry.1.unwrap_or(0))
+                Ok(entry.section_offset.unwrap_or(0))
             }
         }
     }
@@ -128,7 +134,7 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
     memory_regions: &HashMap<&[u8], layout::MemoryRegion>,
     symbol_db: &SymbolDb<'data, P>,
     sizeof_headers: u64,
-    resolved_location_counters: &[(u64, Option<u64>)],
+    resolved_location_counters: &[ResolvedLocationCounter],
     symbol_resolution_callback: &dyn Fn(&[u8]) -> Result<u64>,
 ) -> Result<u64> {
     let mut has_section_relative_offset = true;
@@ -174,7 +180,7 @@ fn evaluate_expression_value<'data, P: Platform>(
     memory_regions: &HashMap<&[u8], layout::MemoryRegion>,
     symbol_db: &SymbolDb<'data, P>,
     sizeof_headers: u64,
-    resolved_location_counters: &[(u64, Option<u64>)],
+    resolved_location_counters: &[ResolvedLocationCounter],
     has_section_relative_offset: &mut bool,
     symbol_resolution_callback: &dyn Fn(&[u8]) -> Result<u64>,
 ) -> Result<u64> {

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -84,13 +84,21 @@ pub(crate) fn evaluate_assertions<'data, P: Platform>(
     Ok(())
 }
 
-pub(crate) fn evaluate_location(
+fn evaluate_location<'data, P: Platform>(
     expr_loc: &SymbolLoc,
     section_layouts: &OutputSectionMap<OutputRecordLayout>,
+    output_sections: &OutputSections<'data, P>,
     resolved_location_counters: &[(u64, Option<u64>)],
 ) -> Result<u64> {
     match expr_loc {
-        SymbolLoc::SectionStart(id) => Ok(section_layouts.get(*id).mem_offset),
+        SymbolLoc::SectionStartRelative(_) => Ok(0),
+        SymbolLoc::SectionEndRelative(id) => {
+            let primary_id = output_sections.primary_output_section(*id);
+            let primary_start = section_layouts.get(primary_id).mem_offset;
+            let id_layout = section_layouts.get(*id);
+            let id_end = id_layout.mem_offset + id_layout.mem_size;
+            Ok(id_end - primary_start)
+        }
         SymbolLoc::SectionEnd(id) => {
             let layout = section_layouts.get(*id);
             Ok(layout.mem_offset + layout.mem_size)
@@ -104,9 +112,9 @@ pub(crate) fn evaluate_location(
                 )
             })?;
             if section_id.is_none() {
-                Ok(entry.1.unwrap_or(entry.0))
-            } else {
                 Ok(entry.0)
+            } else {
+                Ok(entry.1.unwrap_or(0))
             }
         }
     }
@@ -123,9 +131,56 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
     resolved_location_counters: &[(u64, Option<u64>)],
     symbol_resolution_callback: &dyn Fn(&[u8]) -> Result<u64>,
 ) -> Result<u64> {
+    let mut has_section_relative_offset = true;
+    let value = evaluate_expression_value(
+        expr,
+        expr_loc,
+        section_layouts,
+        output_sections,
+        memory_regions,
+        symbol_db,
+        sizeof_headers,
+        resolved_location_counters,
+        &mut has_section_relative_offset,
+        symbol_resolution_callback,
+    )?;
+
+    let offset = if has_section_relative_offset {
+        match expr_loc {
+            SymbolLoc::SectionStartRelative(id) | SymbolLoc::SectionEndRelative(id) => {
+                let primary_id = output_sections.primary_output_section(*id);
+                let section_layout = section_layouts.get(primary_id);
+                section_layout.mem_offset
+            }
+            SymbolLoc::LocationCounter(_, Some(id)) => {
+                let primary_id = output_sections.primary_output_section(*id);
+                let section_layout = section_layouts.get(primary_id);
+                section_layout.mem_offset
+            }
+            _ => 0,
+        }
+    } else {
+        0
+    };
+
+    Ok(value + offset)
+}
+
+fn evaluate_expression_value<'data, P: Platform>(
+    expr: &Expression<'data>,
+    expr_loc: &SymbolLoc,
+    section_layouts: &OutputSectionMap<OutputRecordLayout>,
+    output_sections: &OutputSections<'data, P>,
+    memory_regions: &HashMap<&[u8], layout::MemoryRegion>,
+    symbol_db: &SymbolDb<'data, P>,
+    sizeof_headers: u64,
+    resolved_location_counters: &[(u64, Option<u64>)],
+    has_section_relative_offset: &mut bool,
+    symbol_resolution_callback: &dyn Fn(&[u8]) -> Result<u64>,
+) -> Result<u64> {
     macro_rules! eval {
         ($e:expr) => {
-            evaluate_expression(
+            evaluate_expression_value(
                 $e,
                 expr_loc,
                 section_layouts,
@@ -134,6 +189,7 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
                 symbol_db,
                 sizeof_headers,
                 resolved_location_counters,
+                has_section_relative_offset,
                 symbol_resolution_callback,
             )
         };
@@ -142,9 +198,12 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
     match expr {
         Expression::Number(n) => Ok(*n),
 
-        Expression::LocationCounter => {
-            evaluate_location(expr_loc, section_layouts, resolved_location_counters)
-        }
+        Expression::LocationCounter => evaluate_location(
+            expr_loc,
+            section_layouts,
+            output_sections,
+            resolved_location_counters,
+        ),
 
         Expression::Symbol(name) => symbol_resolution_callback(name),
 
@@ -180,8 +239,12 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
             if align == 0 {
                 bail!("ALIGN(0) is invalid");
             }
-            let location =
-                evaluate_location(expr_loc, section_layouts, resolved_location_counters)?;
+            let location = evaluate_location(
+                expr_loc,
+                section_layouts,
+                output_sections,
+                resolved_location_counters,
+            )?;
             Ok(location.wrapping_add(align - 1) & !(align - 1))
         }
 
@@ -217,6 +280,7 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
             Ok(region.length)
         }
         Expression::SegmentStart(name, default_expr) => {
+            *has_section_relative_offset = false;
             if let Some(val) = symbol_db.args.segment_start_override(*name) {
                 Ok(val)
             } else {

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -215,8 +215,13 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         .flatten()
         .collect();
 
+    let mut location_counters = Vec::new();
+    for script in &linker_scripts {
+        location_counters.extend(script.parsed.location_counters.iter().cloned());
+    }
+
     let (output_order, program_segments) =
-        output_sections.output_order(symbol_db.output_kind, &linker_scripts)?;
+        output_sections.output_order(symbol_db.output_kind, &linker_scripts, &location_counters)?;
 
     tracing::trace!(
         "Output order:\n{}",
@@ -281,15 +286,16 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         unreachable!();
     };
 
-    let (mut section_part_layouts, mut section_layouts) = layout_section::<A::Platform>(
-        &section_part_sizes,
-        &output_sections,
-        &program_segments,
-        &output_order,
-        &symbol_db,
-        &mut memory_regions,
-        sizeof_headers,
-    )?;
+    let (mut section_part_layouts, mut section_layouts, mut resolved_location_counters) =
+        compute_layout_sections::<A::Platform>(
+            &section_part_sizes,
+            &output_sections,
+            &program_segments,
+            &output_order,
+            &symbol_db,
+            &mut memory_regions,
+            sizeof_headers,
+        )?;
 
     if symbol_db.args.should_relax() && A::supports_size_reduction_relaxations() {
         perform_iterative_relaxation::<A>(
@@ -304,6 +310,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
             &per_symbol_flags,
             &mut memory_regions,
             sizeof_headers,
+            &mut resolved_location_counters,
         )?;
     }
 
@@ -419,6 +426,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         &section_layouts,
         sizeof_headers,
         &memory_regions,
+        &resolved_location_counters,
     )?;
     crate::gc_stats::maybe_write_gc_stats(&group_layouts, &symbol_db)?;
 
@@ -430,6 +438,7 @@ pub fn compute<'data, P: Platform, A: Arch<Platform = P>>(
         &symbol_resolutions.resolutions,
         sizeof_headers,
         &memory_regions,
+        &resolved_location_counters,
     )?;
 
     let thunk_block_addresses = thunk_block_addresses_out
@@ -492,6 +501,7 @@ fn update_redirect_resolutions<'data, P: Platform>(
     section_layouts: &OutputSectionMap<OutputRecordLayout>,
     sizeof_headers: u64,
     memory_regions: &HashMap<&[u8], MemoryRegion>,
+    resolved_location_counters: &[(u64, Option<u64>)],
 ) -> Result {
     verbose_timing_phase!("Update symdef resolutions");
 
@@ -510,6 +520,7 @@ fn update_redirect_resolutions<'data, P: Platform>(
                         section_layouts,
                         memory_regions,
                         sizeof_headers,
+                        &[],
                     )?;
                     symbol_id = symbol_id.next();
                 }
@@ -526,6 +537,7 @@ fn update_redirect_resolutions<'data, P: Platform>(
                             section_layouts,
                             memory_regions,
                             sizeof_headers,
+                            resolved_location_counters,
                         )?;
                         symbol_id = symbol_id.next();
                     }
@@ -549,6 +561,7 @@ fn update_defsym_symbol_resolution<'data, P: Platform>(
     section_layouts: &OutputSectionMap<OutputRecordLayout>,
     memory_regions: &HashMap<&[u8], MemoryRegion>,
     sizeof_headers: u64,
+    resolved_location_counters: &[(u64, Option<u64>)],
 ) -> Result {
     if let SymbolPlacement::Redirect(redirect) = &def_info.placement {
         let value = crate::expression_eval::evaluate_expression(
@@ -559,6 +572,7 @@ fn update_defsym_symbol_resolution<'data, P: Platform>(
             memory_regions,
             symbol_db,
             sizeof_headers,
+            resolved_location_counters,
             &|name| {
                 let Some(target_symbol_id) =
                     symbol_db.get_unversioned(&UnversionedSymbolName::prehashed(name))
@@ -1751,7 +1765,7 @@ pub(crate) fn merge_secondary_parts<P: Platform>(
         if let SectionKind::Secondary(primary_id) = info.kind {
             let secondary_layout = take(section_layouts.get_mut(id));
             let primary = section_layouts.get_mut(primary_id);
-            if info.location.is_some() {
+            if info.location_info.is_some() {
                 let mem_end = secondary_layout.mem_offset + secondary_layout.mem_size;
                 if mem_end > primary.mem_offset + primary.mem_size {
                     primary.mem_size = mem_end - primary.mem_offset;
@@ -1943,7 +1957,9 @@ fn compute_segment_layout<'data, P: Platform>(
                     }
                 }
             }
-            OrderEvent::SetLocation(_) => {}
+            OrderEvent::SetLocation(_)
+            | OrderEvent::SetLocationRelative(_, _)
+            | OrderEvent::SetSectionAddress(_) => {}
         }
     }
 
@@ -3352,7 +3368,9 @@ impl<'data, P: Platform> PreludeLayoutState<'data, P> {
                         active_segments.clear();
                     }
                 }
-                OrderEvent::SetLocation(_) => {}
+                OrderEvent::SetLocation(_)
+                | OrderEvent::SetLocationRelative(_, _)
+                | OrderEvent::SetSectionAddress(_) => {}
             }
         }
 
@@ -5026,6 +5044,7 @@ fn perform_iterative_relaxation<'data, A: Arch>(
     per_symbol_flags: &PerSymbolFlags,
     memory_regions: &mut HashMap<&[u8], MemoryRegion>,
     sizeof_headers: u64,
+    resolved_location_counters: &mut Vec<(u64, Option<u64>)>,
 ) -> Result {
     timing_phase!("Iterative relaxation");
 
@@ -5075,7 +5094,11 @@ fn perform_iterative_relaxation<'data, A: Arch>(
                 .collect(),
         );
 
-        (*section_part_layouts, *section_layouts) = layout_section::<A::Platform>(
+        (
+            *section_part_layouts,
+            *section_layouts,
+            *resolved_location_counters,
+        ) = compute_layout_sections::<A::Platform>(
             section_part_sizes,
             output_sections,
             program_segments,
@@ -5088,7 +5111,8 @@ fn perform_iterative_relaxation<'data, A: Arch>(
     Ok(())
 }
 
-fn layout_section<'data, P: Platform>(
+#[allow(clippy::type_complexity)]
+fn compute_layout_sections<'data, P: Platform>(
     sizes: &OutputSectionPartMap<u64>,
     output_sections: &OutputSections<'data, P>,
     program_segments: &ProgramSegments<P::ProgramSegmentDef>,
@@ -5099,6 +5123,7 @@ fn layout_section<'data, P: Platform>(
 ) -> Result<(
     OutputSectionPartMap<OutputRecordLayout>,
     OutputSectionMap<OutputRecordLayout>,
+    Vec<(u64, Option<u64>)>,
 )> {
     let args = symbol_db.args;
     let segment_alignments = compute_segment_alignments::<P>(
@@ -5111,29 +5136,36 @@ fn layout_section<'data, P: Platform>(
 
     let mut section_layouts = OutputSectionMap::with_size(output_sections.num_sections());
 
-    let expression_eval =
-        |expr: &Expression<'data>,
-         memory_regions: &HashMap<&[u8], MemoryRegion>,
-         section_layouts: &OutputSectionMap<OutputRecordLayout>| {
-            crate::expression_eval::evaluate_expression(
-                expr,
-                &crate::parsing::SymbolLoc::None,
-                section_layouts,
-                output_sections,
-                memory_regions,
-                symbol_db,
-                sizeof_headers,
-                &|_| {
-                    bail!("Symbols with the set location operation are not yet supported.");
-                },
-            )
+    let expression_eval = |expr: &Expression<'data>,
+                           memory_regions: &HashMap<&[u8], MemoryRegion>,
+                           section_layouts: &OutputSectionMap<OutputRecordLayout>,
+                           resolved_lc: &[(u64, Option<u64>)]| {
+        let loc = if resolved_lc.is_empty() {
+            crate::parsing::SymbolLoc::None
+        } else {
+            crate::parsing::SymbolLoc::LocationCounter(resolved_lc.len() - 1, None)
         };
+        crate::expression_eval::evaluate_expression(
+            expr,
+            &loc,
+            section_layouts,
+            output_sections,
+            memory_regions,
+            symbol_db,
+            sizeof_headers,
+            resolved_lc,
+            &|_| {
+                bail!("Symbols with the set location operation are not yet supported.");
+            },
+        )
+    };
 
     let mut file_offset = 0;
     let mut mem_offset = expression_eval(
         &output_sections.base_address,
         memory_regions,
         &section_layouts,
+        &[],
     )?;
     let mut lma_offset = mem_offset;
     let mut nonalloc_mem_offsets: OutputSectionMap<u64> =
@@ -5142,13 +5174,33 @@ fn layout_section<'data, P: Platform>(
         OutputSectionMap::with_size(output_sections.num_sections());
 
     let mut pending_location = None;
+    let mut resolved_lc: Vec<(u64, Option<u64>)> = vec![(mem_offset, None)];
 
     let mut records_out = output_sections.new_part_map();
 
     for event in output_order {
         match event {
             OrderEvent::SetLocation(expr) => {
-                pending_location = Some(expr);
+                let value = expression_eval(&expr, memory_regions, &section_layouts, &resolved_lc)?;
+                if resolved_lc.len() > 1 {
+                    pending_location = Some(value);
+                }
+                resolved_lc.push((value, None));
+            }
+            OrderEvent::SetLocationRelative(expr, section_id) => {
+                let primary_id = output_sections.primary_output_section(section_id);
+                let section_base = section_layouts.get(primary_id).mem_offset;
+                let offset =
+                    expression_eval(&expr, memory_regions, &section_layouts, &resolved_lc)?;
+                let value = section_base + offset;
+                if resolved_lc.len() > 1 {
+                    pending_location = Some(value);
+                }
+                resolved_lc.push((value, Some(offset)));
+            }
+            OrderEvent::SetSectionAddress(expr) => {
+                let value = expression_eval(&expr, memory_regions, &section_layouts, &resolved_lc)?;
+                pending_location = Some(value);
             }
             OrderEvent::SegmentStart(segment_id) => {
                 if program_segments.is_load_segment(segment_id) {
@@ -5156,9 +5208,9 @@ fn layout_section<'data, P: Platform>(
                         .get(&segment_id)
                         .copied()
                         .unwrap_or_else(|| args.loadable_segment_alignment());
-                    if let Some(expr) = pending_location.take() {
+                    if let Some(addr) = pending_location.take() {
                         // The OrderEvent::SetLocation is ELF-specific only.
-                        mem_offset = expression_eval(&expr, memory_regions, &section_layouts)?;
+                        mem_offset = addr;
                         lma_offset = mem_offset;
                         file_offset =
                             segment_alignment.align_modulo(mem_offset, file_offset as u64) as usize;
@@ -5181,11 +5233,17 @@ fn layout_section<'data, P: Platform>(
             }
             OrderEvent::SegmentEnd(_) => {}
             OrderEvent::Section(section_id) => {
-                debug_assert!(
-                    pending_location.is_none(),
-                    "SetLocation, Section without SegmentStart"
-                );
                 let section_info = output_sections.output_info(section_id);
+                let loc_offset = section_info
+                    .location_info
+                    .as_ref()
+                    .and_then(|info| info.location.as_ref())
+                    .map(|expr| {
+                        expression_eval(expr, memory_regions, &section_layouts, &resolved_lc)
+                    })
+                    .transpose()?;
+                let lc_offset = pending_location.take();
+                let section_offset = loc_offset.or(lc_offset);
                 let part_id_range = section_id.part_id_range();
                 let max_alignment = sizes.max_alignment(part_id_range.clone(), output_sections);
                 let region = section_info
@@ -5202,8 +5260,8 @@ fn layout_section<'data, P: Platform>(
                 if let Some(region) = region {
                     mem_offset = region.origin + region.used;
                 }
-                if let Some(ref expr) = section_info.location {
-                    let offset = expression_eval(expr, memory_regions, &section_layouts)?;
+
+                if let Some(offset) = section_offset {
                     if let Some(region) = region
                         && (offset < mem_offset || offset > mem_offset + region.length)
                     {
@@ -5215,7 +5273,14 @@ fn layout_section<'data, P: Platform>(
                     }
                     let merge_target = output_sections.primary_output_section(section_id);
                     let section_flags = output_sections.section_flags(merge_target);
-                    if section_flags.is_alloc() && output_sections.has_data_in_file(merge_target) {
+                    let is_top_level = section_info
+                        .location_info
+                        .as_ref()
+                        .is_some_and(|info| info.is_top_level);
+                    if (section_id == merge_target || !is_top_level)
+                        && section_flags.is_alloc()
+                        && output_sections.has_data_in_file(merge_target)
+                    {
                         let new_offset = offset
                             .checked_sub(mem_offset)
                             .with_context(|| format!("Cannot move location counter backwards (from 0x{mem_offset:x} to 0x{offset:x})"))?;
@@ -5317,8 +5382,17 @@ fn layout_section<'data, P: Platform>(
                             offset == 0,
                         );
 
-                        if let Some(ref expr) = section_info.load_location {
-                            lma_offset = expression_eval(expr, memory_regions, &section_layouts)?;
+                        if let Some(expr) = section_info
+                            .location_info
+                            .as_ref()
+                            .and_then(|info| info.at_location.as_ref())
+                        {
+                            lma_offset = expression_eval(
+                                expr,
+                                memory_regions,
+                                &section_layouts,
+                                &resolved_lc,
+                            )?;
                             part_layout.lma_offset = lma_offset;
                             let section_layout = section_layouts.get_mut(section_id);
                             section_layout.lma_offset = lma_offset;
@@ -5345,7 +5419,7 @@ fn layout_section<'data, P: Platform>(
 
     validate_all_non_empty_sections_emitted(sizes, output_sections, output_order)?;
 
-    Ok((records_out, section_layouts))
+    Ok((records_out, section_layouts, resolved_lc))
 }
 
 /// Checks if we've allocated space to any sections which aren't listed in our output ordering.
@@ -5424,7 +5498,9 @@ fn compute_segment_alignments<'data, P: Platform>(
                         .and_modify(|a| *a = (*a).max(max_alignment));
                 }
             }
-            OrderEvent::SetLocation(_) => {}
+            OrderEvent::SetLocation(_)
+            | OrderEvent::SetLocationRelative(_, _)
+            | OrderEvent::SetSectionAddress(_) => {}
         }
     }
 
@@ -5680,6 +5756,7 @@ fn test_no_disallowed_overlaps() {
                 crate::args::RelocationModel::NonRelocatable,
             ),
             &[],
+            &[],
         )
         .unwrap();
     let mut args = crate::args::elf::ElfArgs::default();
@@ -5715,7 +5792,7 @@ fn test_no_disallowed_overlaps() {
     let symbol_db =
         crate::symbol_db::SymbolDb::<Elf>::new(&args, output_kind, &auxiliary, &herd).unwrap();
 
-    let (_, section_layouts) = layout_section::<Elf>(
+    let (_, section_layouts, _) = compute_layout_sections::<Elf>(
         &section_part_sizes,
         &output_sections,
         &program_segments,
@@ -5827,7 +5904,7 @@ fn verify_consistent_allocation_handling<P: Platform>(
     args: &P::Args,
 ) -> Result {
     let output_sections = OutputSections::with_base_address(0);
-    let (output_order, _program_segments) = output_sections.output_order(output_kind, &[])?;
+    let (output_order, _program_segments) = output_sections.output_order(output_kind, &[], &[])?;
     let mut mem_sizes = output_sections.new_part_map();
     P::allocate_resolution(flags, &mut mem_sizes, output_kind, args);
     let mut memory_offsets = output_sections.new_part_map();

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -5111,7 +5111,7 @@ fn perform_iterative_relaxation<'data, A: Arch>(
     Ok(())
 }
 
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 fn compute_layout_sections<'data, P: Platform>(
     sizes: &OutputSectionPartMap<u64>,
     output_sections: &OutputSections<'data, P>,

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -32,6 +32,7 @@ use crate::output_section_id::OutputSections;
 use crate::output_section_map::OutputSectionMap;
 use crate::output_section_part_map::OutputSectionPartMap;
 use crate::parsing::InternalSymDefInfo;
+use crate::parsing::SymbolLoc;
 use crate::parsing::SymbolPlacement;
 use crate::part_id;
 use crate::part_id::NUM_SINGLE_PART_SECTIONS;
@@ -1957,8 +1958,8 @@ fn compute_segment_layout<'data, P: Platform>(
                     }
                 }
             }
-            OrderEvent::SetLocation(_, _)
-            | OrderEvent::SetLocationRelative(_, _, _)
+            OrderEvent::SetLocation(..)
+            | OrderEvent::SetLocationRelative(..)
             | OrderEvent::SetSectionAddress(_) => {}
         }
     }
@@ -3368,8 +3369,8 @@ impl<'data, P: Platform> PreludeLayoutState<'data, P> {
                         active_segments.clear();
                     }
                 }
-                OrderEvent::SetLocation(_, _)
-                | OrderEvent::SetLocationRelative(_, _, _)
+                OrderEvent::SetLocation(..)
+                | OrderEvent::SetLocationRelative(..)
                 | OrderEvent::SetSectionAddress(_) => {}
             }
         }
@@ -5137,13 +5138,10 @@ fn compute_layout_sections<'data, P: Platform>(
     let mut section_layouts = OutputSectionMap::with_size(output_sections.num_sections());
 
     let expression_eval = |expr: &Expression<'data>,
+                           loc: &SymbolLoc,
                            memory_regions: &HashMap<&[u8], MemoryRegion>,
                            section_layouts: &OutputSectionMap<OutputRecordLayout>,
-                           resolved_lc: &[(u64, Option<u64>)],
-                           last_resolved_lc: Option<usize>| {
-        let loc = last_resolved_lc.map_or(crate::parsing::SymbolLoc::None, |idx| {
-            crate::parsing::SymbolLoc::LocationCounter(idx, None)
-        });
+                           resolved_lc: &[(u64, Option<u64>)]| {
         crate::expression_eval::evaluate_expression(
             expr,
             &loc,
@@ -5162,10 +5160,10 @@ fn compute_layout_sections<'data, P: Platform>(
     let mut file_offset = 0;
     let mut mem_offset = expression_eval(
         &output_sections.base_address,
+        &SymbolLoc::None,
         memory_regions,
         &section_layouts,
         &[],
-        None,
     )?;
     let mut lma_offset = mem_offset;
     let mut nonalloc_mem_offsets: OutputSectionMap<u64> =
@@ -5178,38 +5176,25 @@ fn compute_layout_sections<'data, P: Platform>(
     if !resolved_lc.is_empty() {
         resolved_lc[0] = (mem_offset, None);
     }
-    let mut last_resolved_lc = None;
 
     let mut records_out = output_sections.new_part_map();
 
     for event in output_order {
         match event {
-            OrderEvent::SetLocation(expr, idx) => {
-                let value = expression_eval(
-                    &expr,
-                    memory_regions,
-                    &section_layouts,
-                    &resolved_lc,
-                    last_resolved_lc,
-                )?;
-                last_resolved_lc = Some(idx);
+            OrderEvent::SetLocation(expr, loc, idx) => {
+                let value =
+                    expression_eval(&expr, &loc, memory_regions, &section_layouts, &resolved_lc)?;
                 if resolved_lc.len() > 1 {
                     pending_location = Some(value);
                 }
                 resolved_lc[idx] = (value, None);
             }
-            OrderEvent::SetLocationRelative(expr, section_id, idx) => {
+            OrderEvent::SetLocationRelative(expr, section_id, loc, idx) => {
                 let primary_id = output_sections.primary_output_section(section_id);
                 let section_base = section_layouts.get(primary_id).mem_offset;
-                let offset = expression_eval(
-                    &expr,
-                    memory_regions,
-                    &section_layouts,
-                    &resolved_lc,
-                    last_resolved_lc,
-                )?;
-                last_resolved_lc = Some(idx);
-                let value = section_base + offset;
+                let value =
+                    expression_eval(&expr, &loc, memory_regions, &section_layouts, &resolved_lc)?;
+                let offset = value - section_base;
                 if resolved_lc.len() > 1 {
                     pending_location = Some(value);
                 }
@@ -5218,10 +5203,10 @@ fn compute_layout_sections<'data, P: Platform>(
             OrderEvent::SetSectionAddress(expr) => {
                 let value = expression_eval(
                     &expr,
+                    &SymbolLoc::None,
                     memory_regions,
                     &section_layouts,
                     &resolved_lc,
-                    last_resolved_lc,
                 )?;
                 pending_location = Some(value);
             }
@@ -5403,10 +5388,10 @@ fn compute_layout_sections<'data, P: Platform>(
                         {
                             lma_offset = expression_eval(
                                 expr,
+                                &SymbolLoc::None,
                                 memory_regions,
                                 &section_layouts,
                                 &resolved_lc,
-                                last_resolved_lc,
                             )?;
                             part_layout.lma_offset = lma_offset;
                             let section_layout = section_layouts.get_mut(section_id);
@@ -5513,8 +5498,8 @@ fn compute_segment_alignments<'data, P: Platform>(
                         .and_modify(|a| *a = (*a).max(max_alignment));
                 }
             }
-            OrderEvent::SetLocation(_, _)
-            | OrderEvent::SetLocationRelative(_, _, _)
+            OrderEvent::SetLocation(..)
+            | OrderEvent::SetLocationRelative(..)
             | OrderEvent::SetSectionAddress(_) => {}
         }
     }

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -5208,7 +5208,7 @@ fn compute_layout_sections<'data, P: Platform>(
                         .get(&segment_id)
                         .copied()
                         .unwrap_or_else(|| args.loadable_segment_alignment());
-                    if let Some(addr) = pending_location.take() {
+                    if let Some(addr) = pending_location {
                         // The OrderEvent::SetLocation is ELF-specific only.
                         mem_offset = addr;
                         lma_offset = mem_offset;
@@ -5234,16 +5234,7 @@ fn compute_layout_sections<'data, P: Platform>(
             OrderEvent::SegmentEnd(_) => {}
             OrderEvent::Section(section_id) => {
                 let section_info = output_sections.output_info(section_id);
-                let loc_offset = section_info
-                    .location_info
-                    .as_ref()
-                    .and_then(|info| info.location.as_ref())
-                    .map(|expr| {
-                        expression_eval(expr, memory_regions, &section_layouts, &resolved_lc)
-                    })
-                    .transpose()?;
-                let lc_offset = pending_location.take();
-                let section_offset = loc_offset.or(lc_offset);
+                let section_offset = pending_location.take();
                 let part_id_range = section_id.part_id_range();
                 let max_alignment = sizes.max_alignment(part_id_range.clone(), output_sections);
                 let region = section_info

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -5113,7 +5113,6 @@ fn perform_iterative_relaxation<'data, A: Arch>(
     Ok(())
 }
 
-#[expect(clippy::type_complexity)]
 fn compute_layout_sections<'data, P: Platform>(
     sizes: &OutputSectionPartMap<u64>,
     output_sections: &OutputSections<'data, P>,
@@ -5145,7 +5144,7 @@ fn compute_layout_sections<'data, P: Platform>(
                            resolved_lc: &[ResolvedLocationCounter]| {
         crate::expression_eval::evaluate_expression(
             expr,
-            &loc,
+            loc,
             section_layouts,
             output_sections,
             memory_regions,

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -1957,8 +1957,8 @@ fn compute_segment_layout<'data, P: Platform>(
                     }
                 }
             }
-            OrderEvent::SetLocation(_)
-            | OrderEvent::SetLocationRelative(_, _)
+            OrderEvent::SetLocation(_, _)
+            | OrderEvent::SetLocationRelative(_, _, _)
             | OrderEvent::SetSectionAddress(_) => {}
         }
     }
@@ -3368,8 +3368,8 @@ impl<'data, P: Platform> PreludeLayoutState<'data, P> {
                         active_segments.clear();
                     }
                 }
-                OrderEvent::SetLocation(_)
-                | OrderEvent::SetLocationRelative(_, _)
+                OrderEvent::SetLocation(_, _)
+                | OrderEvent::SetLocationRelative(_, _, _)
                 | OrderEvent::SetSectionAddress(_) => {}
             }
         }
@@ -5139,12 +5139,11 @@ fn compute_layout_sections<'data, P: Platform>(
     let expression_eval = |expr: &Expression<'data>,
                            memory_regions: &HashMap<&[u8], MemoryRegion>,
                            section_layouts: &OutputSectionMap<OutputRecordLayout>,
-                           resolved_lc: &[(u64, Option<u64>)]| {
-        let loc = if resolved_lc.is_empty() {
-            crate::parsing::SymbolLoc::None
-        } else {
-            crate::parsing::SymbolLoc::LocationCounter(resolved_lc.len() - 1, None)
-        };
+                           resolved_lc: &[(u64, Option<u64>)],
+                           last_resolved_lc: Option<usize>| {
+        let loc = last_resolved_lc.map_or(crate::parsing::SymbolLoc::None, |idx| {
+            crate::parsing::SymbolLoc::LocationCounter(idx, None)
+        });
         crate::expression_eval::evaluate_expression(
             expr,
             &loc,
@@ -5166,6 +5165,7 @@ fn compute_layout_sections<'data, P: Platform>(
         memory_regions,
         &section_layouts,
         &[],
+        None,
     )?;
     let mut lma_offset = mem_offset;
     let mut nonalloc_mem_offsets: OutputSectionMap<u64> =
@@ -5174,32 +5174,55 @@ fn compute_layout_sections<'data, P: Platform>(
         OutputSectionMap::with_size(output_sections.num_sections());
 
     let mut pending_location = None;
-    let mut resolved_lc: Vec<(u64, Option<u64>)> = vec![(mem_offset, None)];
+    let mut resolved_lc = vec![Default::default(); output_order.num_location_counters()];
+    if !resolved_lc.is_empty() {
+        resolved_lc[0] = (mem_offset, None);
+    }
+    let mut last_resolved_lc = None;
 
     let mut records_out = output_sections.new_part_map();
 
     for event in output_order {
         match event {
-            OrderEvent::SetLocation(expr) => {
-                let value = expression_eval(&expr, memory_regions, &section_layouts, &resolved_lc)?;
+            OrderEvent::SetLocation(expr, idx) => {
+                let value = expression_eval(
+                    &expr,
+                    memory_regions,
+                    &section_layouts,
+                    &resolved_lc,
+                    last_resolved_lc,
+                )?;
+                last_resolved_lc = Some(idx);
                 if resolved_lc.len() > 1 {
                     pending_location = Some(value);
                 }
-                resolved_lc.push((value, None));
+                resolved_lc[idx] = (value, None);
             }
-            OrderEvent::SetLocationRelative(expr, section_id) => {
+            OrderEvent::SetLocationRelative(expr, section_id, idx) => {
                 let primary_id = output_sections.primary_output_section(section_id);
                 let section_base = section_layouts.get(primary_id).mem_offset;
-                let offset =
-                    expression_eval(&expr, memory_regions, &section_layouts, &resolved_lc)?;
+                let offset = expression_eval(
+                    &expr,
+                    memory_regions,
+                    &section_layouts,
+                    &resolved_lc,
+                    last_resolved_lc,
+                )?;
+                last_resolved_lc = Some(idx);
                 let value = section_base + offset;
                 if resolved_lc.len() > 1 {
                     pending_location = Some(value);
                 }
-                resolved_lc.push((value, Some(offset)));
+                resolved_lc[idx] = (value, Some(offset));
             }
             OrderEvent::SetSectionAddress(expr) => {
-                let value = expression_eval(&expr, memory_regions, &section_layouts, &resolved_lc)?;
+                let value = expression_eval(
+                    &expr,
+                    memory_regions,
+                    &section_layouts,
+                    &resolved_lc,
+                    last_resolved_lc,
+                )?;
                 pending_location = Some(value);
             }
             OrderEvent::SegmentStart(segment_id) => {
@@ -5383,6 +5406,7 @@ fn compute_layout_sections<'data, P: Platform>(
                                 memory_regions,
                                 &section_layouts,
                                 &resolved_lc,
+                                last_resolved_lc,
                             )?;
                             part_layout.lma_offset = lma_offset;
                             let section_layout = section_layouts.get_mut(section_id);
@@ -5489,8 +5513,8 @@ fn compute_segment_alignments<'data, P: Platform>(
                         .and_modify(|a| *a = (*a).max(max_alignment));
                 }
             }
-            OrderEvent::SetLocation(_)
-            | OrderEvent::SetLocationRelative(_, _)
+            OrderEvent::SetLocation(_, _)
+            | OrderEvent::SetLocationRelative(_, _, _)
             | OrderEvent::SetSectionAddress(_) => {}
         }
     }

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -14,6 +14,7 @@ use crate::error;
 use crate::error::Context;
 use crate::error::Error;
 use crate::error::Result;
+use crate::expression_eval::ResolvedLocationCounter;
 use crate::expression_eval::evaluate_const;
 use crate::file_writer;
 use crate::grouping::Group;
@@ -502,7 +503,7 @@ fn update_redirect_resolutions<'data, P: Platform>(
     section_layouts: &OutputSectionMap<OutputRecordLayout>,
     sizeof_headers: u64,
     memory_regions: &HashMap<&[u8], MemoryRegion>,
-    resolved_location_counters: &[(u64, Option<u64>)],
+    resolved_location_counters: &[ResolvedLocationCounter],
 ) -> Result {
     verbose_timing_phase!("Update symdef resolutions");
 
@@ -562,7 +563,7 @@ fn update_defsym_symbol_resolution<'data, P: Platform>(
     section_layouts: &OutputSectionMap<OutputRecordLayout>,
     memory_regions: &HashMap<&[u8], MemoryRegion>,
     sizeof_headers: u64,
-    resolved_location_counters: &[(u64, Option<u64>)],
+    resolved_location_counters: &[ResolvedLocationCounter],
 ) -> Result {
     if let SymbolPlacement::Redirect(redirect) = &def_info.placement {
         let value = crate::expression_eval::evaluate_expression(
@@ -5045,7 +5046,7 @@ fn perform_iterative_relaxation<'data, A: Arch>(
     per_symbol_flags: &PerSymbolFlags,
     memory_regions: &mut HashMap<&[u8], MemoryRegion>,
     sizeof_headers: u64,
-    resolved_location_counters: &mut Vec<(u64, Option<u64>)>,
+    resolved_location_counters: &mut Vec<ResolvedLocationCounter>,
 ) -> Result {
     timing_phase!("Iterative relaxation");
 
@@ -5124,7 +5125,7 @@ fn compute_layout_sections<'data, P: Platform>(
 ) -> Result<(
     OutputSectionPartMap<OutputRecordLayout>,
     OutputSectionMap<OutputRecordLayout>,
-    Vec<(u64, Option<u64>)>,
+    Vec<ResolvedLocationCounter>,
 )> {
     let args = symbol_db.args;
     let segment_alignments = compute_segment_alignments::<P>(
@@ -5141,7 +5142,7 @@ fn compute_layout_sections<'data, P: Platform>(
                            loc: &SymbolLoc,
                            memory_regions: &HashMap<&[u8], MemoryRegion>,
                            section_layouts: &OutputSectionMap<OutputRecordLayout>,
-                           resolved_lc: &[(u64, Option<u64>)]| {
+                           resolved_lc: &[ResolvedLocationCounter]| {
         crate::expression_eval::evaluate_expression(
             expr,
             &loc,
@@ -5174,7 +5175,10 @@ fn compute_layout_sections<'data, P: Platform>(
     let mut pending_location = None;
     let mut resolved_lc = vec![Default::default(); output_order.num_location_counters()];
     if !resolved_lc.is_empty() {
-        resolved_lc[0] = (mem_offset, None);
+        resolved_lc[0] = ResolvedLocationCounter {
+            value: mem_offset,
+            section_offset: None,
+        };
     }
 
     let mut records_out = output_sections.new_part_map();
@@ -5187,7 +5191,10 @@ fn compute_layout_sections<'data, P: Platform>(
                 if resolved_lc.len() > 1 {
                     pending_location = Some(value);
                 }
-                resolved_lc[idx] = (value, None);
+                resolved_lc[idx] = ResolvedLocationCounter {
+                    value,
+                    section_offset: None,
+                };
             }
             OrderEvent::SetLocationRelative(expr, section_id, loc, idx) => {
                 let primary_id = output_sections.primary_output_section(section_id);
@@ -5198,7 +5205,10 @@ fn compute_layout_sections<'data, P: Platform>(
                 if resolved_lc.len() > 1 {
                     pending_location = Some(value);
                 }
-                resolved_lc[idx] = (value, Some(offset));
+                resolved_lc[idx] = ResolvedLocationCounter {
+                    value,
+                    section_offset: Some(offset),
+                };
             }
             OrderEvent::SetSectionAddress(expr) => {
                 let value = expression_eval(

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -5187,9 +5187,7 @@ fn compute_layout_sections<'data, P: Platform>(
             OrderEvent::SetLocation(expr, loc, idx) => {
                 let value =
                     expression_eval(&expr, &loc, memory_regions, &section_layouts, &resolved_lc)?;
-                if resolved_lc.len() > 1 {
-                    pending_location = Some(value);
-                }
+                pending_location = Some(value);
                 resolved_lc[idx] = ResolvedLocationCounter {
                     value,
                     section_offset: None,
@@ -5201,9 +5199,7 @@ fn compute_layout_sections<'data, P: Platform>(
                 let value =
                     expression_eval(&expr, &loc, memory_regions, &section_layouts, &resolved_lc)?;
                 let offset = value - section_base;
-                if resolved_lc.len() > 1 {
-                    pending_location = Some(value);
-                }
+                pending_location = Some(value);
                 resolved_lc[idx] = ResolvedLocationCounter {
                     value,
                     section_offset: Some(offset),

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -28,7 +28,6 @@ use crate::platform::SectionHeader;
 use glob::Pattern;
 use hashbrown::HashTable;
 use std::borrow::Cow;
-use std::mem::replace;
 
 pub(crate) struct LayoutRules<'data> {
     pub(crate) section_rules: SectionRules<'data>,
@@ -197,15 +196,6 @@ impl<'data> LayoutRulesBuilder<'data> {
                 let mut location = None;
                 let mut section_start_lc_idx = last_lc_idx;
 
-                // "Extra alignment" is what we call it when a linker script sets alignment via a
-                // command like `. = ALIGN(8)`. We attach that to the subsequent section by
-                // adjusting its alignment. This doesn't exactly match what GNU ld does, since what
-                // we do can cause the alignment of the section in the section headers to increase,
-                // whereas GNU ld leaves the section header alignment alone in this case. For now,
-                // though, it doesn't seem worthwhile having two separate alignment properties on a
-                // section, one of which doesn't affect the header value.
-                let mut extra_min_alignment = alignment::MIN;
-
                 for sec_cmd in &sections.commands {
                     match sec_cmd {
                         SectionCommand::Section(sec) => {
@@ -225,10 +215,8 @@ impl<'data> LayoutRulesBuilder<'data> {
                                     }
                                 }
                             }
-                            let min_alignment = sec
-                                .alignment
-                                .unwrap_or(alignment::MIN)
-                                .max(replace(&mut extra_min_alignment, alignment::MIN));
+                            let min_alignment =
+                                sec.alignment.unwrap_or(alignment::MIN).max(alignment::MIN);
 
                             // Choose starting location for this output section.
                             let section_location = match &sec.start_address_expression {
@@ -282,7 +270,7 @@ impl<'data> LayoutRulesBuilder<'data> {
                                             inner_lc_start_idx = inner_lc_idx;
                                             output_sections.add_secondary_section(
                                                 primary_section_id,
-                                                replace(&mut extra_min_alignment, alignment::MIN),
+                                                alignment::MIN,
                                                 None,
                                                 Some(sec_location_info),
                                             )
@@ -321,7 +309,6 @@ impl<'data> LayoutRulesBuilder<'data> {
                                             assignment.name,
                                         ));
                                     }
-                                    ContentsCommand::Align(a) => extra_min_alignment = *a,
                                     ContentsCommand::Provide(provide) => {
                                         let placement = SymbolPlacement::Redirect(Redirect {
                                             kind: RedirectKind::Script,
@@ -374,7 +361,6 @@ impl<'data> LayoutRulesBuilder<'data> {
                             }
                             location = Some(new_location.address.clone());
                         }
-                        SectionCommand::Align(a) => extra_min_alignment = *a,
                         SectionCommand::Assert(assert_cmd) => {
                             assertions.push(assert_cmd.clone());
                         }

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -315,11 +315,11 @@ impl<'data> LayoutRulesBuilder<'data> {
                                             location.address.clone(),
                                             primary_section_id,
                                         ));
-                                        inner_lc_idx = location_counters.len();
                                         last_symbol_loc = SymbolLoc::LocationCounter(
-                                            inner_lc_idx - 1,
+                                            inner_lc_idx,
                                             Some(primary_section_id),
                                         );
+                                        inner_lc_idx += 1;
                                     }
                                 }
                             }
@@ -343,12 +343,12 @@ impl<'data> LayoutRulesBuilder<'data> {
                         SectionCommand::SetLocation(new_location) => {
                             location_counters
                                 .push(LocationCounter::Absolute(new_location.address.clone()));
-                            last_lc_idx = location_counters.len();
-                            loc = SymbolLoc::LocationCounter(last_lc_idx - 1, current_section_id);
-                            if current_section_id.is_none() {
+                            loc = SymbolLoc::LocationCounter(last_lc_idx, current_section_id);
+                            if current_section_id.is_none() && self.num_location_counters == 0 {
                                 output_sections.set_base_address(new_location.address.clone());
                                 section_start_lc_idx = location_counters.len();
                             }
+                            last_lc_idx += 1;
                         }
                         SectionCommand::Assert(assert_cmd) => {
                             assertions.push(assert_cmd.clone());

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -36,6 +36,7 @@ pub(crate) struct LayoutRules<'data> {
 #[derive(Default)]
 pub(crate) struct LayoutRulesBuilder<'data> {
     rules: Vec<SectionRule<'data>>,
+    num_location_counters: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -172,7 +173,7 @@ impl<'data> LayoutRulesBuilder<'data> {
 
         let mut current_section_id = None;
         let mut loc = SymbolLoc::FirstSection;
-        let mut last_lc_idx = 0;
+        let mut last_lc_idx = self.num_location_counters;
 
         for cmd in &input.script.commands {
             if let linker_script::Command::Provide(provide) = cmd {
@@ -193,7 +194,6 @@ impl<'data> LayoutRulesBuilder<'data> {
                 });
                 symbol_defs.push(crate::parsing::InternalSymDefInfo::new(placement, name));
             } else if let linker_script::Command::Sections(sections) = cmd {
-                let mut location = None;
                 let mut section_start_lc_idx = last_lc_idx;
 
                 for sec_cmd in &sections.commands {
@@ -218,19 +218,9 @@ impl<'data> LayoutRulesBuilder<'data> {
                             let min_alignment =
                                 sec.alignment.unwrap_or(alignment::MIN).max(alignment::MIN);
 
-                            // Choose starting location for this output section.
-                            let section_location = match &sec.start_address_expression {
-                                Some(address) => {
-                                    location.take();
-                                    Some(address.clone())
-                                }
-                                None => location.take(),
-                            };
-
-                            let section_lc_start = section_start_lc_idx;
                             let location_info = SectionLocationInfo {
-                                location_counters: (section_lc_start, last_lc_idx),
-                                location: section_location.clone(),
+                                location_counters: (section_start_lc_idx, last_lc_idx),
+                                location: sec.start_address_expression.clone(),
                                 at_location: sec.at_address.clone(),
                                 is_top_level: true,
                             };
@@ -327,7 +317,7 @@ impl<'data> LayoutRulesBuilder<'data> {
                                         ));
                                         inner_lc_idx = location_counters.len();
                                         last_symbol_loc = SymbolLoc::LocationCounter(
-                                            inner_lc_idx,
+                                            inner_lc_idx - 1,
                                             Some(primary_section_id),
                                         );
                                     }
@@ -354,12 +344,11 @@ impl<'data> LayoutRulesBuilder<'data> {
                             location_counters
                                 .push(LocationCounter::Absolute(new_location.address.clone()));
                             last_lc_idx = location_counters.len();
-                            loc = SymbolLoc::LocationCounter(last_lc_idx, current_section_id);
+                            loc = SymbolLoc::LocationCounter(last_lc_idx - 1, current_section_id);
                             if current_section_id.is_none() {
                                 output_sections.set_base_address(new_location.address.clone());
-                                continue;
+                                section_start_lc_idx = location_counters.len();
                             }
-                            location = Some(new_location.address.clone());
                         }
                         SectionCommand::Assert(assert_cmd) => {
                             assertions.push(assert_cmd.clone());
@@ -393,6 +382,8 @@ impl<'data> LayoutRulesBuilder<'data> {
                 program_headers = phdrs.clone();
             }
         }
+
+        self.num_location_counters += location_counters.len();
 
         Ok(ProcessedLinkerScript {
             symbol_defs,

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -15,6 +15,7 @@ use crate::linker_script::ContentsCommand;
 use crate::linker_script::SectionCommand;
 use crate::output_section_id;
 use crate::output_section_id::OutputSectionId;
+use crate::output_section_id::SectionLocationInfo;
 use crate::output_section_id::SectionName;
 use crate::parsing::InternalSymDefInfo;
 use crate::parsing::ProcessedLinkerScript;
@@ -132,10 +133,16 @@ impl SectionOutputInfo {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum LocationCounter<'data> {
+    Absolute(linker_script::Expression<'data>),
+    Relative(linker_script::Expression<'data>, OutputSectionId),
+}
+
 fn loc_for_global_expr<'data>(
     expr: &crate::linker_script::Expression<'data>,
     section_id: Option<OutputSectionId>,
-) -> SymbolLoc<'data> {
+) -> SymbolLoc {
     let mut loc = SymbolLoc::None;
     expr.visit_expressions(&mut |e| match e {
         crate::linker_script::Expression::SegmentStart(..) => {
@@ -162,9 +169,11 @@ impl<'data> LayoutRulesBuilder<'data> {
         let mut assertions = Vec::new();
         let mut memory_regions = Vec::new();
         let mut program_headers = Vec::new();
+        let mut location_counters = Vec::new();
 
         let mut current_section_id = None;
         let mut loc = SymbolLoc::FirstSection;
+        let mut last_lc_idx = 0;
 
         for cmd in &input.script.commands {
             if let linker_script::Command::Provide(provide) = cmd {
@@ -186,6 +195,7 @@ impl<'data> LayoutRulesBuilder<'data> {
                 symbol_defs.push(crate::parsing::InternalSymDefInfo::new(placement, name));
             } else if let linker_script::Command::Sections(sections) = cmd {
                 let mut location = None;
+                let mut section_start_lc_idx = last_lc_idx;
 
                 // "Extra alignment" is what we call it when a linker script sets alignment via a
                 // command like `. = ALIGN(8)`. We attach that to the subsequent section by
@@ -229,34 +239,52 @@ impl<'data> LayoutRulesBuilder<'data> {
                                 None => location.take(),
                             };
 
+                            let section_lc_start = section_start_lc_idx;
+                            let location_info = SectionLocationInfo {
+                                location_counters: (section_lc_start, last_lc_idx),
+                                location: section_location.clone(),
+                                at_location: sec.at_address.clone(),
+                                is_top_level: true,
+                            };
+
                             let primary_section_id = output_sections.add_named_section(
                                 SectionName(sec.output_section_name),
                                 min_alignment,
-                                section_location,
-                                sec.at_address.clone(),
                                 sec.phdr,
                                 sec.region,
+                                Some(location_info),
                             );
                             current_section_id = Some(primary_section_id);
                             loc = SymbolLoc::SectionEnd(primary_section_id);
 
                             let mut last_section_id = None;
                             let mut last_symbol_loc = SymbolLoc::SectionStart(primary_section_id);
-                            let mut last_location = None;
+                            let mut inner_lc_idx = last_lc_idx;
+                            let mut inner_lc_start_idx = last_lc_idx;
 
                             for contents_cmd in &sec.commands {
                                 match contents_cmd {
                                     ContentsCommand::Matcher(matcher) => {
                                         let section_id = if last_section_id.is_none()
-                                            && last_location.is_none()
+                                            && inner_lc_idx == inner_lc_start_idx
                                         {
                                             primary_section_id
                                         } else {
+                                            let sec_location_info = SectionLocationInfo {
+                                                location_counters: (
+                                                    inner_lc_start_idx,
+                                                    inner_lc_idx,
+                                                ),
+                                                location: None,
+                                                at_location: None,
+                                                is_top_level: false,
+                                            };
+                                            inner_lc_start_idx = inner_lc_idx;
                                             output_sections.add_secondary_section(
                                                 primary_section_id,
                                                 replace(&mut extra_min_alignment, alignment::MIN),
                                                 None,
-                                                last_location.take(),
+                                                Some(sec_location_info),
                                             )
                                         };
 
@@ -306,37 +334,40 @@ impl<'data> LayoutRulesBuilder<'data> {
                                         );
                                     }
                                     ContentsCommand::SetLocation(location) => {
-                                        last_location = Some(linker_script::Expression::Add(
-                                            Box::new(linker_script::Expression::Addr(
-                                                sec.output_section_name,
-                                            )),
-                                            Box::new(location.address.clone()),
-                                        ));
-                                        last_symbol_loc = SymbolLoc::RelativeExpression(
+                                        location_counters.push(LocationCounter::Relative(
                                             location.address.clone(),
                                             primary_section_id,
+                                        ));
+                                        inner_lc_idx = location_counters.len();
+                                        last_symbol_loc = SymbolLoc::LocationCounter(
+                                            inner_lc_idx,
+                                            Some(primary_section_id),
                                         );
                                     }
                                 }
                             }
-                            if let Some(location) = last_location.take() {
+                            if inner_lc_idx > inner_lc_start_idx {
+                                let trailing_lc_info = SectionLocationInfo {
+                                    location_counters: (inner_lc_start_idx, inner_lc_idx),
+                                    location: None,
+                                    at_location: None,
+                                    is_top_level: false,
+                                };
                                 output_sections.add_secondary_section(
                                     primary_section_id,
                                     alignment::MIN,
                                     None,
-                                    Some(location),
+                                    Some(trailing_lc_info),
                                 );
                             }
+                            last_lc_idx = inner_lc_idx;
+                            section_start_lc_idx = last_lc_idx;
                         }
                         SectionCommand::SetLocation(new_location) => {
-                            let section_id = match loc {
-                                SymbolLoc::Expression(_, section_id) => section_id,
-                                SymbolLoc::SectionStart(section_id)
-                                | SymbolLoc::SectionEnd(section_id)
-                                | SymbolLoc::RelativeExpression(_, section_id) => Some(section_id),
-                                _ => None,
-                            };
-                            loc = SymbolLoc::Expression(new_location.address.clone(), section_id);
+                            location_counters
+                                .push(LocationCounter::Absolute(new_location.address.clone()));
+                            last_lc_idx = location_counters.len();
+                            loc = SymbolLoc::LocationCounter(last_lc_idx, current_section_id);
                             if current_section_id.is_none() {
                                 output_sections.set_base_address(new_location.address.clone());
                                 continue;
@@ -388,6 +419,7 @@ impl<'data> LayoutRulesBuilder<'data> {
             file_bytes: input.script_bytes,
             memory_regions,
             program_headers,
+            location_counters,
         })
     }
 

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -135,8 +135,8 @@ impl SectionOutputInfo {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum LocationCounter<'data> {
-    Absolute(linker_script::Expression<'data>),
-    Relative(linker_script::Expression<'data>, OutputSectionId),
+    Absolute(linker_script::Expression<'data>, SymbolLoc),
+    Relative(linker_script::Expression<'data>, SymbolLoc, OutputSectionId),
 }
 
 fn loc_for_global_expr<'data>(
@@ -236,7 +236,8 @@ impl<'data> LayoutRulesBuilder<'data> {
                             loc = SymbolLoc::SectionEnd(primary_section_id);
 
                             let mut last_section_id = None;
-                            let mut last_symbol_loc = SymbolLoc::SectionStart(primary_section_id);
+                            let mut last_symbol_loc =
+                                SymbolLoc::SectionStartRelative(primary_section_id);
                             let mut inner_lc_idx = last_lc_idx;
                             let mut inner_lc_start_idx = last_lc_idx;
 
@@ -286,7 +287,7 @@ impl<'data> LayoutRulesBuilder<'data> {
                                         }
 
                                         last_section_id = Some(section_id);
-                                        last_symbol_loc = SymbolLoc::SectionEnd(section_id);
+                                        last_symbol_loc = SymbolLoc::SectionEndRelative(section_id);
                                     }
                                     ContentsCommand::SymbolAssignment(assignment) => {
                                         let placement = SymbolPlacement::Redirect(Redirect {
@@ -313,6 +314,7 @@ impl<'data> LayoutRulesBuilder<'data> {
                                     ContentsCommand::SetLocation(location) => {
                                         location_counters.push(LocationCounter::Relative(
                                             location.address.clone(),
+                                            last_symbol_loc,
                                             primary_section_id,
                                         ));
                                         last_symbol_loc = SymbolLoc::LocationCounter(
@@ -342,8 +344,8 @@ impl<'data> LayoutRulesBuilder<'data> {
                         }
                         SectionCommand::SetLocation(new_location) => {
                             location_counters
-                                .push(LocationCounter::Absolute(new_location.address.clone()));
-                            loc = SymbolLoc::LocationCounter(last_lc_idx, current_section_id);
+                                .push(LocationCounter::Absolute(new_location.address.clone(), loc));
+                            loc = SymbolLoc::LocationCounter(last_lc_idx, None);
                             if current_section_id.is_none() && self.num_location_counters == 0 {
                                 output_sections.set_base_address(new_location.address.clone());
                                 section_start_lc_idx = location_counters.len();

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -87,7 +87,6 @@ pub(crate) struct Sections<'a> {
 pub(crate) enum SectionCommand<'a> {
     Section(Section<'a>),
     SetLocation(Location<'a>),
-    Align(Alignment),
     Assert(AssertCommand<'a>),
     Provide(ProvideSymbolDefinition<'a>),
     SymbolAssignment(SymbolAssignment<'a>),
@@ -120,7 +119,6 @@ pub(crate) struct MemoryRegion<'a> {
 pub(crate) enum ContentsCommand<'a> {
     Matcher(Matcher<'a>),
     SymbolAssignment(SymbolAssignment<'a>),
-    Align(Alignment),
     Provide(ProvideSymbolDefinition<'a>),
     SetLocation(Location<'a>),
 }
@@ -1065,17 +1063,13 @@ fn parse_section_command<'input>(
     if opt("=").parse_next(input)?.is_some() {
         skip_comments_and_whitespace(input)?;
         if name == b"." {
-            let cmd = if input.starts_with(b"ALIGN") {
-                SectionCommand::Align(parse_alignment(input)?)
-            } else {
-                SectionCommand::SetLocation(parse_location.parse_next(input)?)
-            };
+            let location = parse_location.parse_next(input)?;
 
             skip_comments_and_whitespace(input)?;
             ';'.parse_next(input)?;
             skip_comments_and_whitespace(input)?;
 
-            return Ok(cmd);
+            return Ok(SectionCommand::SetLocation(location));
         }
         let expr = parse_expression.parse_next(input)?;
         skip_comments_and_whitespace(input)?;
@@ -1192,19 +1186,7 @@ fn parse_assignment<'input>(input: &mut &'input BStr) -> winnow::Result<Contents
     let expr = parse_expression.parse_next(input)?;
 
     let cmd = if name == b"." {
-        // `. = ALIGN(n)` inside section bodies
-        if let Expression::Align(alignment_expr) = &expr {
-            if let Expression::Number(n) = alignment_expr.as_ref() {
-                let alignment = Alignment::new(*n).map_err(|_| {
-                    ContextError::from_external_error(input, LinkerScriptError::InvalidAlignment)
-                })?;
-                ContentsCommand::Align(alignment)
-            } else {
-                return Err(ContextError::default());
-            }
-        } else {
-            ContentsCommand::SetLocation(Location { address: (expr) })
-        }
+        ContentsCommand::SetLocation(Location { address: (expr) })
     } else {
         ContentsCommand::SymbolAssignment(SymbolAssignment { name, expr })
     };
@@ -1571,7 +1553,9 @@ mod tests {
                             SectionCommand::SetLocation(Location {
                                 address: Expression::Number(0x1000000),
                             }),
-                            SectionCommand::Align(Alignment::new(16).unwrap()),
+                            SectionCommand::SetLocation(Location {
+                                address: Expression::Align(Box::new(Expression::Number(16))),
+                            }),
                             SectionCommand::Section(Section {
                                 output_section_name: b".foo",
                                 commands: vec![
@@ -1587,7 +1571,11 @@ mod tests {
                                             sorted: false,
                                         }],
                                     }),
-                                    ContentsCommand::Align(Alignment::new(32).unwrap()),
+                                    ContentsCommand::SetLocation(Location {
+                                        address: Expression::Align(Box::new(Expression::Number(
+                                            32,
+                                        ))),
+                                    }),
                                     ContentsCommand::SymbolAssignment(SymbolAssignment {
                                         name: b"end_foo",
                                         expr: Expression::LocationCounter,

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -1147,8 +1147,7 @@ impl platform::Platform for MachO {
                 },
                 kind: d.kind,
                 min_alignment: d.min_alignment,
-                location: None,
-                load_location: None,
+                location_info: None,
                 secondary_order: None,
                 phdr_name: None,
                 region_name: None,
@@ -1583,12 +1582,13 @@ impl platform::Platform for MachO {
         secondary: &crate::output_section_map::OutputSectionMap<
             Vec<crate::output_section_id::OutputSectionId>,
         >,
+        _location_counters: &[crate::layout_rules::LocationCounter<'data>],
     ) -> (
         crate::output_section_id::OutputOrder<'data>,
         crate::program_segments::ProgramSegments<Self::ProgramSegmentDef>,
     ) {
         let mut builder =
-            OutputOrderBuilder::<Self>::new(output_kind, output_sections, secondary, false);
+            OutputOrderBuilder::<Self>::new(output_kind, output_sections, secondary, false, &[]);
 
         // File header and all load commands.
         builder.add_section(output_section_id::FILE_HEADER);

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -195,6 +195,7 @@ pub(crate) struct OutputOrderBuilder<'scope, 'data, P: Platform> {
     output_kind: OutputKind,
     has_custom_phdrs: bool,
     location_counters: &'scope [crate::layout_rules::LocationCounter<'data>],
+    last_location_counter: Option<LocationCounterIndex>,
 }
 
 impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
@@ -215,30 +216,32 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
             output_kind,
             has_custom_phdrs,
             location_counters,
+            last_location_counter: location_counters.last().map(|_| 0),
         }
     }
 
-    fn emit_section_locations(&mut self, info: &SectionOutputInfo<'data, P>) {
-        if let Some(ref loc_info) = info.location_info {
-            let (start_idx, end_idx) = loc_info.location_counters;
-
-            for idx in start_idx..end_idx {
-                let lc = &self.location_counters[idx];
-                match lc {
-                    LocationCounter::Absolute(expr) => {
-                        self.events.push(OrderEvent::SetLocation(expr.clone(), idx));
-                    }
-                    LocationCounter::Relative(expr, section_id) => {
-                        let primary_id = self.output_sections.primary_output_section(*section_id);
-                        self.events.push(OrderEvent::SetLocationRelative(
-                            expr.clone(),
-                            primary_id,
-                            idx,
-                        ));
-                    }
+    fn emit_location_counters(
+        &mut self,
+        lc_start: LocationCounterIndex,
+        lc_end: LocationCounterIndex,
+    ) {
+        for idx in lc_start..lc_end {
+            let lc = &self.location_counters[idx];
+            match lc {
+                LocationCounter::Absolute(expr) => {
+                    self.events.push(OrderEvent::SetLocation(expr.clone(), idx));
+                }
+                LocationCounter::Relative(expr, section_id) => {
+                    let primary_id = self.output_sections.primary_output_section(*section_id);
+                    self.events.push(OrderEvent::SetLocationRelative(
+                        expr.clone(),
+                        primary_id,
+                        idx,
+                    ));
                 }
             }
         }
+        self.last_location_counter = self.last_location_counter.map(|l| l.max(lc_end));
     }
 
     pub(crate) fn add_section(&mut self, section_id: OutputSectionId) {
@@ -275,7 +278,10 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
             self.events.push(OrderEvent::SegmentStart(segment_id));
         }
 
-        self.emit_section_locations(section_info);
+        if let Some(ref loc_info) = section_info.location_info {
+            let (lc_start, lc_stop) = loc_info.location_counters;
+            self.emit_location_counters(lc_start, lc_stop);
+        }
 
         self.events.push(OrderEvent::Section(section_id));
 
@@ -298,7 +304,10 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
 
         for (_pri, sid) in keyed {
             let sec_info = self.output_sections.output_info(sid);
-            self.emit_section_locations(sec_info);
+            if let Some(ref loc_info) = sec_info.location_info {
+                let (lc_start, lc_stop) = loc_info.location_counters;
+                self.emit_location_counters(lc_start, lc_stop);
+            }
             self.events.push(OrderEvent::Section(sid));
         }
     }
@@ -436,7 +445,10 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
         self.events.push(OrderEvent::SegmentStart(segment_id));
         for section in sections {
             let section_info = output_sections.section_infos.get(*section);
-            self.emit_section_locations(section_info);
+            if let Some(ref loc_info) = section_info.location_info {
+                let (lc_start, lc_stop) = loc_info.location_counters;
+                self.emit_location_counters(lc_start, lc_stop);
+            }
             self.events.push(OrderEvent::Section(*section));
 
             let secondaries: &Vec<OutputSectionId> = self.secondary.get(*section);
@@ -455,6 +467,10 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
     }
 
     pub(crate) fn build(mut self) -> (OutputOrder<'data>, ProgramSegments<P::ProgramSegmentDef>) {
+        if let Some(lc) = self.last_location_counter {
+            self.emit_location_counters(lc, self.location_counters.len());
+        }
+
         for segment_id in self.active_segment_kinds.into_iter().flatten() {
             self.events.push(OrderEvent::SegmentEnd(segment_id));
         }
@@ -651,8 +667,12 @@ pub(crate) enum OrderEvent<'data> {
     SegmentStart(ProgramSegmentId),
     SegmentEnd(ProgramSegmentId),
     Section(OutputSectionId),
-    SetLocation(linker_script::Expression<'data>, usize),
-    SetLocationRelative(linker_script::Expression<'data>, OutputSectionId, usize),
+    SetLocation(linker_script::Expression<'data>, LocationCounterIndex),
+    SetLocationRelative(
+        linker_script::Expression<'data>,
+        OutputSectionId,
+        LocationCounterIndex,
+    ),
     SetSectionAddress(linker_script::Expression<'data>),
 }
 
@@ -1157,9 +1177,12 @@ impl Iterator for PartIdIterator {
     }
 }
 
+pub(crate) type LocationCounterIndex = usize;
+
 #[derive(Debug, Clone)]
 pub(crate) struct SectionLocationInfo<'data> {
-    pub(crate) location_counters: (usize, usize),
+    /// End is exclusive
+    pub(crate) location_counters: (LocationCounterIndex, LocationCounterIndex),
     pub(crate) location: Option<Expression<'data>>,
     pub(crate) at_location: Option<Expression<'data>>,
     pub(crate) is_top_level: bool,

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -172,6 +172,7 @@ pub(crate) struct OutputSections<'data, P: Platform> {
 #[derive(Debug)]
 pub(crate) struct OutputOrder<'data> {
     events: Vec<OrderEvent<'data>>,
+    num_location_counters: usize,
 }
 
 pub(crate) struct OutputOrderDisplay<'a, 'data, P: Platform> {
@@ -221,15 +222,19 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
         if let Some(ref loc_info) = info.location_info {
             let (start_idx, end_idx) = loc_info.location_counters;
 
-            for lc in &self.location_counters[start_idx..end_idx] {
+            for idx in start_idx..end_idx {
+                let lc = &self.location_counters[idx];
                 match lc {
                     LocationCounter::Absolute(expr) => {
-                        self.events.push(OrderEvent::SetLocation(expr.clone()));
+                        self.events.push(OrderEvent::SetLocation(expr.clone(), idx));
                     }
                     LocationCounter::Relative(expr, section_id) => {
                         let primary_id = self.output_sections.primary_output_section(*section_id);
-                        self.events
-                            .push(OrderEvent::SetLocationRelative(expr.clone(), primary_id));
+                        self.events.push(OrderEvent::SetLocationRelative(
+                            expr.clone(),
+                            primary_id,
+                            idx,
+                        ));
                     }
                 }
             }
@@ -465,6 +470,7 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
         (
             OutputOrder {
                 events: self.events,
+                num_location_counters: self.location_counters.len(),
             },
             self.program_segments,
         )
@@ -645,8 +651,8 @@ pub(crate) enum OrderEvent<'data> {
     SegmentStart(ProgramSegmentId),
     SegmentEnd(ProgramSegmentId),
     Section(OutputSectionId),
-    SetLocation(linker_script::Expression<'data>),
-    SetLocationRelative(linker_script::Expression<'data>, OutputSectionId),
+    SetLocation(linker_script::Expression<'data>, usize),
+    SetLocationRelative(linker_script::Expression<'data>, OutputSectionId, usize),
     SetSectionAddress(linker_script::Expression<'data>),
 }
 
@@ -1055,6 +1061,10 @@ impl<'data, 'a> IntoIterator for &'a OutputOrder<'data> {
 }
 
 impl<'data> OutputOrder<'data> {
+    pub(crate) fn num_location_counters(&self) -> usize {
+        self.num_location_counters
+    }
+
     pub(crate) fn display<'a, P: Platform>(
         &'a self,
         sections: &'a OutputSections<'data, P>,
@@ -1089,10 +1099,10 @@ impl<'data, P: Platform> Display for OutputOrderDisplay<'_, 'data, P> {
                 OrderEvent::Section(output_section_id) => {
                     writeln!(f, "  {}", self.sections.display_name(*output_section_id))?;
                 }
-                OrderEvent::SetLocation(expr) => {
+                OrderEvent::SetLocation(expr, _) => {
                     writeln!(f, "SET_LOCATION({expr:?})")?;
                 }
-                OrderEvent::SetLocationRelative(expr, section_id) => {
+                OrderEvent::SetLocationRelative(expr, section_id, _) => {
                     writeln!(
                         f,
                         "SET_LOCATION_RELATIVE({expr:?}, {})",

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -17,6 +17,7 @@ use crate::Result;
 use crate::alignment::Alignment;
 use crate::alignment::NUM_ALIGNMENTS;
 use crate::grouping::SequencedLinkerScript;
+use crate::layout_rules::LocationCounter;
 use crate::layout_rules::SectionKind;
 use crate::linker_script;
 use crate::linker_script::Expression;
@@ -192,6 +193,7 @@ pub(crate) struct OutputOrderBuilder<'scope, 'data, P: Platform> {
     secondary: &'scope OutputSectionMap<Vec<OutputSectionId>>,
     output_kind: OutputKind,
     has_custom_phdrs: bool,
+    location_counters: &'scope [crate::layout_rules::LocationCounter<'data>],
 }
 
 impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
@@ -200,6 +202,7 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
         output_sections: &'scope OutputSections<'data, P>,
         secondary: &'scope OutputSectionMap<Vec<OutputSectionId>>,
         has_custom_phdrs: bool,
+        location_counters: &'scope [crate::layout_rules::LocationCounter<'data>],
     ) -> Self {
         Self {
             events: Vec::new(),
@@ -210,6 +213,26 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
             secondary,
             output_kind,
             has_custom_phdrs,
+            location_counters,
+        }
+    }
+
+    fn emit_section_locations(&mut self, info: &SectionOutputInfo<'data, P>) {
+        if let Some(ref loc_info) = info.location_info {
+            let (start_idx, end_idx) = loc_info.location_counters;
+
+            for lc in &self.location_counters[start_idx..end_idx] {
+                match lc {
+                    LocationCounter::Absolute(expr) => {
+                        self.events.push(OrderEvent::SetLocation(expr.clone()));
+                    }
+                    LocationCounter::Relative(expr, section_id) => {
+                        let primary_id = self.output_sections.primary_output_section(*section_id);
+                        self.events
+                            .push(OrderEvent::SetLocationRelative(expr.clone(), primary_id));
+                    }
+                }
+            }
         }
     }
 
@@ -232,19 +255,22 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
             "Attempted to directly emit secondary section {section_id}"
         );
 
-        // Only emit SetLocation if the section has ALLOC flag, meaning it can be placed
-        // in a segment. Sections without ALLOC (like custom sections before their flags
-        // are propagated) will have their location handled directly in layout_section_parts
-        // via section_info.location.
-        if let Some(location) = &section_info.location
+        // Only emit SetSectionAddress if the section has ALLOC flag, meaning it can be placed in a
+        // segment. Sections without ALLOC (like custom sections before their flags are propagated)
+        // will have their location handled directly in layout_section_parts.
+        if let Some(ref loc_info) = section_info.location_info
+            && let Some(ref location) = loc_info.location
             && section_info.section_attributes.is_alloc()
         {
-            self.events.push(OrderEvent::SetLocation(location.clone()));
+            self.events
+                .push(OrderEvent::SetSectionAddress(location.clone()));
         }
 
         for segment_id in start {
             self.events.push(OrderEvent::SegmentStart(segment_id));
         }
+
+        self.emit_section_locations(section_info);
 
         self.events.push(OrderEvent::Section(section_id));
 
@@ -266,6 +292,8 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
         keyed.sort_by_key(|(pri, _sid)| *pri);
 
         for (_pri, sid) in keyed {
+            let sec_info = self.output_sections.output_info(sid);
+            self.emit_section_locations(sec_info);
             self.events.push(OrderEvent::Section(sid));
         }
     }
@@ -326,7 +354,12 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
         }
 
         let section_info = self.output_sections.output_info(section_id);
-        if section_info.location.is_some() {
+        if section_info
+            .location_info
+            .as_ref()
+            .and_then(|info| info.location.as_ref())
+            .is_some()
+        {
             // If we're setting the location, then first end all active segments.
             for (id, region) in self
                 .active_segment_kinds
@@ -398,11 +431,7 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
         self.events.push(OrderEvent::SegmentStart(segment_id));
         for section in sections {
             let section_info = output_sections.section_infos.get(*section);
-            if let Some(location) = &section_info.location
-                && section_info.section_attributes.is_alloc()
-            {
-                self.events.push(OrderEvent::SetLocation(location.clone()));
-            }
+            self.emit_section_locations(section_info);
             self.events.push(OrderEvent::Section(*section));
 
             let secondaries: &Vec<OutputSectionId> = self.secondary.get(*section);
@@ -516,8 +545,7 @@ pub(crate) struct SectionOutputInfo<'data, P: Platform> {
     pub(crate) kind: SectionKind<'data>,
     pub(crate) section_attributes: P::SectionAttributes,
     pub(crate) min_alignment: Alignment,
-    pub(crate) location: Option<linker_script::Expression<'data>>,
-    pub(crate) load_location: Option<linker_script::Expression<'data>>,
+    pub(crate) location_info: Option<SectionLocationInfo<'data>>,
     pub(crate) secondary_order: Option<SecondaryOrder>,
     pub(crate) phdr_name: Option<&'data [u8]>,
     pub(crate) region_name: Option<&'data [u8]>,
@@ -618,6 +646,8 @@ pub(crate) enum OrderEvent<'data> {
     SegmentEnd(ProgramSegmentId),
     Section(OutputSectionId),
     SetLocation(linker_script::Expression<'data>),
+    SetLocationRelative(linker_script::Expression<'data>, OutputSectionId),
+    SetSectionAddress(linker_script::Expression<'data>),
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -658,8 +688,14 @@ impl<'data, P: Platform> OutputSections<'data, P> {
             let location = args
                 .start_address_for_section(custom.name)
                 .map(linker_script::Expression::Number);
+            let location_info = location.map(|loc| SectionLocationInfo {
+                location_counters: (0, 0),
+                location: Some(loc),
+                at_location: None,
+                is_top_level: true,
+            });
             let section_id =
-                self.add_named_section(custom.name, custom.alignment, location, None, None, None);
+                self.add_named_section(custom.name, custom.alignment, None, None, location_info);
 
             section_part_ids[custom.index.0] = section_id.part_id_with_alignment(custom.alignment);
         }
@@ -675,8 +711,17 @@ impl<'data, P: Platform> OutputSections<'data, P> {
             (BSS, SectionName(b".bss")),
         ] {
             if let Some(address) = args.start_address_for_section(name) {
-                self.section_infos.get_mut(section_id).location =
-                    Some(linker_script::Expression::Number(address));
+                let info = self.section_infos.get_mut(section_id);
+                if let Some(ref mut loc_info) = info.location_info {
+                    loc_info.location = Some(linker_script::Expression::Number(address));
+                } else {
+                    info.location_info = Some(SectionLocationInfo {
+                        location_counters: (0, 0),
+                        location: Some(linker_script::Expression::Number(address)),
+                        at_location: None,
+                        is_top_level: true,
+                    });
+                }
             }
         }
     }
@@ -685,10 +730,9 @@ impl<'data, P: Platform> OutputSections<'data, P> {
         &mut self,
         name: SectionName<'data>,
         min_alignment: Alignment,
-        location: Option<linker_script::Expression<'data>>,
-        load_location: Option<linker_script::Expression<'data>>,
         phdr_name: Option<&'data [u8]>,
         region_name: Option<&'data [u8]>,
+        location_info: Option<SectionLocationInfo<'data>>,
     ) -> OutputSectionId {
         *self.custom_by_name.entry(name).or_insert_with(|| {
             self.section_infos.add_new(SectionOutputInfo {
@@ -697,8 +741,7 @@ impl<'data, P: Platform> OutputSections<'data, P> {
                 // that get placed into this output section.
                 section_attributes: Default::default(),
                 min_alignment,
-                location,
-                load_location,
+                location_info,
                 secondary_order: None,
                 phdr_name,
                 region_name,
@@ -711,17 +754,16 @@ impl<'data, P: Platform> OutputSections<'data, P> {
         primary_id: OutputSectionId,
         min_alignment: Alignment,
         secondary_order: Option<SecondaryOrder>,
-        location: Option<linker_script::Expression<'data>>,
+        location_info: Option<SectionLocationInfo<'data>>,
     ) -> OutputSectionId {
         let primary_info = self.section_infos.get(primary_id);
         let section_attributes = primary_info.section_attributes;
-        let load_location = primary_info.load_location.clone();
+        let location_info = location_info.or_else(|| primary_info.location_info.clone());
         self.section_infos.add_new(SectionOutputInfo {
             kind: SectionKind::Secondary(primary_id),
             section_attributes,
             min_alignment,
-            location,
-            load_location,
+            location_info,
             secondary_order,
             phdr_name: None,
             region_name: primary_info.region_name,
@@ -778,6 +820,7 @@ impl<'data, P: Platform> OutputSections<'data, P> {
         &self,
         output_kind: OutputKind,
         linker_scripts: &[&SequencedLinkerScript<'data, P>],
+        location_counters: &[crate::layout_rules::LocationCounter<'data>],
     ) -> Result<(OutputOrder<'data>, ProgramSegments<P::ProgramSegmentDef>)> {
         timing_phase!("Compute output order");
 
@@ -849,6 +892,7 @@ impl<'data, P: Platform> OutputSections<'data, P> {
                 &secondary,
                 linker_scripts,
                 &mut phdr_map.unwrap(),
+                location_counters,
             )
         } else {
             Ok(P::build_output_order_and_program_segments(
@@ -856,6 +900,7 @@ impl<'data, P: Platform> OutputSections<'data, P> {
                 output_kind,
                 self,
                 &secondary,
+                location_counters,
             ))
         }
     }
@@ -977,7 +1022,6 @@ impl<'data, P: Platform> OutputSections<'data, P> {
                 None,
                 None,
                 None,
-                None,
             )
         };
         add_name("ro");
@@ -1045,7 +1089,19 @@ impl<'data, P: Platform> Display for OutputOrderDisplay<'_, 'data, P> {
                 OrderEvent::Section(output_section_id) => {
                     writeln!(f, "  {}", self.sections.display_name(*output_section_id))?;
                 }
-                OrderEvent::SetLocation(expr) => writeln!(f, "SET_LOCATION({expr:?})")?,
+                OrderEvent::SetLocation(expr) => {
+                    writeln!(f, "SET_LOCATION({expr:?})")?;
+                }
+                OrderEvent::SetLocationRelative(expr, section_id) => {
+                    writeln!(
+                        f,
+                        "SET_LOCATION_RELATIVE({expr:?}, {})",
+                        self.sections.display_name(*section_id)
+                    )?;
+                }
+                OrderEvent::SetSectionAddress(expr) => {
+                    writeln!(f, "SET_SECTION_ADDRESS({expr:?})")?;
+                }
             }
         }
 
@@ -1089,4 +1145,12 @@ impl Iterator for PartIdIterator {
             Some(id)
         }
     }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SectionLocationInfo<'data> {
+    pub(crate) location_counters: (usize, usize),
+    pub(crate) location: Option<Expression<'data>>,
+    pub(crate) at_location: Option<Expression<'data>>,
+    pub(crate) is_top_level: bool,
 }

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -262,7 +262,7 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
 
         // Only emit SetSectionAddress if the section has ALLOC flag, meaning it can be placed in a
         // segment. Sections without ALLOC (like custom sections before their flags are propagated)
-        // will have their location handled directly in layout_section_parts.
+        // will have their location handled directly in compute_layout_sections.
         if let Some(ref loc_info) = section_info.location_info
             && let Some(ref location) = loc_info.location
             && section_info.section_attributes.is_alloc()

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -455,8 +455,27 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
             self.events.push(OrderEvent::Section(*section));
 
             let secondaries: &Vec<OutputSectionId> = self.secondary.get(*section);
-            for sid in secondaries {
-                self.events.push(OrderEvent::Section(*sid));
+            let mut keyed: Vec<(u16, OutputSectionId)> = secondaries
+                .iter()
+                .map(|&sid| {
+                    let key_pri = match output_sections.secondary_order(sid) {
+                        Some(crate::output_section_id::SecondaryOrder::InitFini { priority }) => {
+                            priority
+                        }
+                        None => u16::MAX,
+                    };
+                    (key_pri, sid)
+                })
+                .collect();
+            keyed.sort_by_key(|(pri, _sid)| *pri);
+
+            for (_pri, sid) in keyed {
+                let sec_info = output_sections.output_info(sid);
+                if let Some(ref loc_info) = sec_info.location_info {
+                    let (lc_start, lc_stop) = loc_info.location_counters;
+                    self.emit_location_counters(lc_start, lc_stop);
+                }
+                self.events.push(OrderEvent::Section(sid));
             }
         }
         self.events.push(OrderEvent::SegmentEnd(segment_id));

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -24,6 +24,7 @@ use crate::linker_script::Expression;
 use crate::output_kind::OutputKind;
 use crate::output_section_map::OutputSectionMap;
 use crate::output_section_part_map::OutputSectionPartMap;
+use crate::parsing::SymbolLoc;
 use crate::part_id;
 use crate::part_id::NUM_SINGLE_PART_SECTIONS;
 use crate::part_id::PartId;
@@ -228,14 +229,16 @@ impl<'scope, 'data, P: Platform> OutputOrderBuilder<'scope, 'data, P> {
         for idx in lc_start..lc_end {
             let lc = &self.location_counters[idx];
             match lc {
-                LocationCounter::Absolute(expr) => {
-                    self.events.push(OrderEvent::SetLocation(expr.clone(), idx));
+                LocationCounter::Absolute(expr, loc) => {
+                    self.events
+                        .push(OrderEvent::SetLocation(expr.clone(), loc.clone(), idx));
                 }
-                LocationCounter::Relative(expr, section_id) => {
+                LocationCounter::Relative(expr, loc, section_id) => {
                     let primary_id = self.output_sections.primary_output_section(*section_id);
                     self.events.push(OrderEvent::SetLocationRelative(
                         expr.clone(),
                         primary_id,
+                        loc.clone(),
                         idx,
                     ));
                 }
@@ -667,10 +670,15 @@ pub(crate) enum OrderEvent<'data> {
     SegmentStart(ProgramSegmentId),
     SegmentEnd(ProgramSegmentId),
     Section(OutputSectionId),
-    SetLocation(linker_script::Expression<'data>, LocationCounterIndex),
+    SetLocation(
+        linker_script::Expression<'data>,
+        SymbolLoc,
+        LocationCounterIndex,
+    ),
     SetLocationRelative(
         linker_script::Expression<'data>,
         OutputSectionId,
+        SymbolLoc,
         LocationCounterIndex,
     ),
     SetSectionAddress(linker_script::Expression<'data>),
@@ -1119,10 +1127,10 @@ impl<'data, P: Platform> Display for OutputOrderDisplay<'_, 'data, P> {
                 OrderEvent::Section(output_section_id) => {
                     writeln!(f, "  {}", self.sections.display_name(*output_section_id))?;
                 }
-                OrderEvent::SetLocation(expr, _) => {
+                OrderEvent::SetLocation(expr, ..) => {
                     writeln!(f, "SET_LOCATION({expr:?})")?;
                 }
-                OrderEvent::SetLocationRelative(expr, section_id, _) => {
+                OrderEvent::SetLocationRelative(expr, section_id, ..) => {
                     writeln!(
                         f,
                         "SET_LOCATION_RELATIVE({expr:?}, {})",

--- a/libwild/src/output_section_part_map.rs
+++ b/libwild/src/output_section_part_map.rs
@@ -213,6 +213,7 @@ fn test_merge_parts() {
                 crate::args::RelocationModel::NonRelocatable,
             ),
             &[],
+            &[],
         )
         .unwrap();
     let mut expected_sum_of_sums = 0;
@@ -334,6 +335,7 @@ fn test_output_order_map_consistent() {
                 crate::args::RelocationModel::NonRelocatable,
             ),
             &[],
+            &[],
         )
         .unwrap();
     let part_map = output_sections.new_part_map::<u32>();
@@ -390,6 +392,7 @@ fn test_output_order_map() {
             crate::output_kind::OutputKind::StaticExecutable(
                 crate::args::RelocationModel::NonRelocatable,
             ),
+            &[],
             &[],
         )
         .unwrap();

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -10,6 +10,7 @@ use crate::input_data::InputRef;
 use crate::layout_rules::LayoutRulesBuilder;
 use crate::layout_rules::LocationCounter;
 use crate::linker_script::Expression;
+use crate::output_section_id::LocationCounterIndex;
 use crate::output_section_id::OutputSectionId;
 use crate::platform::Args;
 use crate::platform::ObjectFile;
@@ -104,7 +105,7 @@ pub(crate) enum SymbolLoc {
     SectionStart(OutputSectionId),
     SectionEnd(OutputSectionId),
     FirstSection,
-    LocationCounter(usize, Option<OutputSectionId>),
+    LocationCounter(LocationCounterIndex, Option<OutputSectionId>),
     None,
 }
 

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -8,6 +8,7 @@ use crate::input_data::InputBytes;
 use crate::input_data::InputLinkerScript;
 use crate::input_data::InputRef;
 use crate::layout_rules::LayoutRulesBuilder;
+use crate::layout_rules::LocationCounter;
 use crate::linker_script::Expression;
 use crate::output_section_id::OutputSectionId;
 use crate::platform::Args;
@@ -55,6 +56,7 @@ pub(crate) struct ProcessedLinkerScript<'data, P: Platform> {
     pub(crate) file_bytes: &'data [u8],
     pub(crate) memory_regions: Vec<crate::linker_script::MemoryRegion<'data>>,
     pub(crate) program_headers: Vec<crate::linker_script::Phdr<'data>>,
+    pub(crate) location_counters: Vec<LocationCounter<'data>>,
 }
 
 #[derive(Debug)]
@@ -98,12 +100,11 @@ pub(crate) enum SymbolPlacement<'data> {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub(crate) enum SymbolLoc<'data> {
+pub(crate) enum SymbolLoc {
     SectionStart(OutputSectionId),
     SectionEnd(OutputSectionId),
     FirstSection,
-    Expression(Expression<'data>, Option<OutputSectionId>),
-    RelativeExpression(Expression<'data>, OutputSectionId),
+    LocationCounter(usize, Option<OutputSectionId>),
     None,
 }
 
@@ -111,7 +112,7 @@ pub(crate) enum SymbolLoc<'data> {
 pub(crate) struct Redirect<'data> {
     pub(crate) kind: RedirectKind,
     pub(crate) expression: Expression<'data>,
-    pub(crate) loc: SymbolLoc<'data>,
+    pub(crate) loc: SymbolLoc,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -102,7 +102,8 @@ pub(crate) enum SymbolPlacement<'data> {
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub(crate) enum SymbolLoc {
-    SectionStart(OutputSectionId),
+    SectionStartRelative(OutputSectionId),
+    SectionEndRelative(OutputSectionId),
     SectionEnd(OutputSectionId),
     FirstSection,
     LocationCounter(LocationCounterIndex, Option<OutputSectionId>),

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -772,6 +772,7 @@ pub(crate) trait Platform:
         output_kind: OutputKind,
         output_sections: &OutputSections<'data, Self>,
         secondary: &OutputSectionMap<Vec<OutputSectionId>>,
+        location_counters: &[crate::layout_rules::LocationCounter<'data>],
     ) -> (OutputOrder<'data>, ProgramSegments<Self::ProgramSegmentDef>);
 
     fn build_custom_output_order_and_program_segments<'data>(
@@ -781,12 +782,14 @@ pub(crate) trait Platform:
         secondary: &OutputSectionMap<Vec<OutputSectionId>>,
         _linker_scripts: &[&SequencedLinkerScript<'data, Self>],
         _phdr_map: &mut hashbrown::HashMap<&[u8], Vec<OutputSectionId>>,
+        location_counters: &[crate::layout_rules::LocationCounter<'data>],
     ) -> Result<(OutputOrder<'data>, ProgramSegments<Self::ProgramSegmentDef>)> {
         Ok(Self::build_output_order_and_program_segments(
             custom,
             output_kind,
             output_sections,
             secondary,
+            location_counters,
         ))
     }
 

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -2087,7 +2087,10 @@ impl<P: Platform> InternalSymDefInfo<'_, P> {
     pub(crate) fn section_id(&self) -> Option<OutputSectionId> {
         match self.placement {
             SymbolPlacement::Redirect(Redirect {
-                loc: SymbolLoc::SectionEnd(i) | SymbolLoc::SectionStart(i),
+                loc:
+                    SymbolLoc::SectionEnd(i)
+                    | SymbolLoc::SectionStartRelative(i)
+                    | SymbolLoc::SectionEndRelative(i),
                 ..
             }) => Some(i),
             SymbolPlacement::Undefined

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -3246,8 +3246,7 @@ impl platform::Platform for Wasm {
                 section_attributes: SectionAttributes::default(),
                 kind: d.kind,
                 min_alignment: crate::alignment::MIN,
-                location: None,
-                load_location: None,
+                location_info: None,
                 secondary_order: None,
                 phdr_name: None,
                 region_name: None,
@@ -3487,6 +3486,7 @@ impl platform::Platform for Wasm {
         secondary: &crate::output_section_map::OutputSectionMap<
             Vec<crate::output_section_id::OutputSectionId>,
         >,
+        _location_counters: &[crate::layout_rules::LocationCounter<'data>],
     ) -> (
         crate::output_section_id::OutputOrder<'data>,
         crate::program_segments::ProgramSegments<Self::ProgramSegmentDef>,
@@ -3498,6 +3498,7 @@ impl platform::Platform for Wasm {
             output_sections,
             secondary,
             false,
+            &[],
         );
 
         builder.add_section(osid::FILE_HEADER);

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter-2.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter-2.ld
@@ -1,0 +1,7 @@
+SECTIONS
+{
+    . = 0x120000;
+    val1 = .;
+}
+
+ASSERT(val1 == 0x120000, "val1 must be 0x120000")

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter-3.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter-3.ld
@@ -1,0 +1,7 @@
+SECTIONS
+{
+    . = ADDR(.data);
+    val2 = .;
+}
+
+ASSERT(val2 == 0x800000, "val2 must be 0x800000")

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter-phdrs.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter-phdrs.ld
@@ -1,5 +1,11 @@
 ENTRY(begin_here)
 
+PHDRS {
+    text PT_LOAD;
+    data PT_LOAD FLAGS(6);
+    rodata PT_LOAD FLAGS(4);
+}
+
 SECTIONS
 {
     . = 0x300000 * 2;
@@ -8,14 +14,14 @@ SECTIONS
         start_of_text = .;
         . = 0x8;
         . = . * 2;
-        text1 = . * 2;
+        text1 = .;
         *(.text)
         . = 0x200;
         text_foo_sym = .;
         *(.text.foo)
         . = 0x1000;
         text2 = .;
-    }
+    } :text
     . = 0x3fffff;
     . = . * 2;
     start_of_unaligned_data = .;
@@ -23,18 +29,22 @@ SECTIONS
     start_of_data = .;
     .data : {
         *(.data)
-    }
+    } :data
 
     .bss : {
         KEEP(*(.bss))
-    }
+    } :data
+
+    .eh_frame : {
+        KEEP(*(.eh_frame))
+    } :rodata
 }
 
 ASSERT(start_of_sections == 0x600000, "start_of_sections should be 0x600000");
 ASSERT(start_of_unaligned_data == 0x7ffffe, "start_of_unaligned_data should be 0x7ffffe");
 ASSERT(start_of_data == 0x800000, "start_of_data should be 0x800000");
 ASSERT(SIZEOF(.text) == 0x1000, "text section should be 0x1000 bytes");
-ASSERT(text1 == start_of_text + 0x10 * 2, "text1 should be 0x20 bytes after start_of_sections");
+ASSERT(text1 == start_of_text + 0x10, "text1 should be 0x10 bytes after start_of_sections");
 ASSERT(text_foo_sym == start_of_text + 0x200, "text_foo_sym should be 0x200");
 ASSERT(text2 == start_of_text + 0x1000, "text2 should be 0x1000 bytes after start_of_sections");
 ASSERT(ADDR(.data) == 0x800000, "ADDR(.data) should be 0x800000");

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
@@ -16,4 +16,6 @@
 
 #include "../common/runtime.h"
 
-void begin_here(void) { exit_syscall(42); }
+int ret = 42;
+
+void begin_here(void) { exit_syscall(ret); }

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
@@ -2,7 +2,7 @@
 //#LinkerScript:linker-script-location-counter.ld
 //#Object:runtime.c
 // RISC-V: BFD complains about missing __global_pointer$ (defined in the default linker script)
-//#SkipArch:riscv64
+//#SkipArch:riscv64,ppc64le
 
 //#Config:no_gc_sections:default
 //#LinkArgs:--no-gc-sections

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
@@ -1,5 +1,7 @@
 //#Config:default
 //#LinkerScript:linker-script-location-counter.ld
+//#LinkerScript:linker-script-location-counter-2.ld
+//#LinkerScript:linker-script-location-counter-3.ld
 //#Object:runtime.c
 // RISC-V: BFD complains about missing __global_pointer$ (defined in the default linker script)
 //#SkipArch:riscv64,ppc64le

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
@@ -6,6 +6,18 @@
 // RISC-V: BFD complains about missing __global_pointer$ (defined in the default linker script)
 //#SkipArch:riscv64,ppc64le
 
+//#Config:phdrs
+//#LinkerScript:linker-script-location-counter-phdrs.ld
+//#Object:runtime.c
+// RISC-V: BFD complains about missing __global_pointer$ (defined in the default linker script)
+//#SkipArch:riscv64,ppc64le
+
+//#Config:single_location_counter
+//#LinkerScript:linker-script-single-location-counter.ld
+//#Object:runtime.c
+// RISC-V: BFD complains about missing __global_pointer$ (defined in the default linker script)
+//#SkipArch:riscv64,ppc64le
+
 //#Config:no_gc_sections:default
 //#LinkArgs:--no-gc-sections
 
@@ -20,4 +32,10 @@
 
 int ret = 42;
 
-void begin_here(void) { exit_syscall(ret); }
+__attribute__((section(".text.foo")))
+void foo(void) {}
+
+void begin_here(void) {
+    foo();
+    exit_syscall(ret);
+}

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
@@ -32,10 +32,9 @@
 
 int ret = 42;
 
-__attribute__((section(".text.foo")))
-void foo(void) {}
+__attribute__((section(".text.foo"))) void foo(void) {}
 
 void begin_here(void) {
-    foo();
-    exit_syscall(ret);
+  foo();
+  exit_syscall(ret);
 }

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.ld
@@ -13,8 +13,10 @@ SECTIONS
         . = 0x1000;
         text2 = .;
     }
-    . = 0x400000;
+    . = 0x3fffff;
     . = . * 2;
+    start_of_unaligned_data = .;
+    . = ALIGN(8);
     start_of_data = .;
     .data : {
         *(.data)
@@ -26,6 +28,7 @@ SECTIONS
 }
 
 ASSERT(start_of_sections == 0x600000, "start_of_sections should be 0x600000");
+ASSERT(start_of_unaligned_data == 0x7ffffe, "start_of_unaligned_data should be 0x7ffffe");
 ASSERT(start_of_data == 0x800000, "start_of_data should be 0x800000");
 ASSERT(SIZEOF(.text) == 0x1000, "text section should be 0x1000 bytes");
 ASSERT(text1 == start_of_text + 0x10, "text1 should be 0x10 bytes after start_of_sections");

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.ld
@@ -8,7 +8,7 @@ SECTIONS
         start_of_text = .;
         . = 0x8;
         . = . * 2;
-        text1 = .;
+        text1 = . * 2;
         *(.text)
         . = 0x1000;
         text2 = .;
@@ -31,7 +31,7 @@ ASSERT(start_of_sections == 0x600000, "start_of_sections should be 0x600000");
 ASSERT(start_of_unaligned_data == 0x7ffffe, "start_of_unaligned_data should be 0x7ffffe");
 ASSERT(start_of_data == 0x800000, "start_of_data should be 0x800000");
 ASSERT(SIZEOF(.text) == 0x1000, "text section should be 0x1000 bytes");
-ASSERT(text1 == start_of_text + 0x10, "text1 should be 0x10 bytes after start_of_sections");
+ASSERT(text1 == start_of_text + 0x10 * 2, "text1 should be 0x20 bytes after start_of_sections");
 ASSERT(text2 == start_of_text + 0x1000, "text2 should be 0x1000 bytes after start_of_sections");
 ASSERT(ADDR(.data) == 0x800000, "ADDR(.data) should be 0x800000");
 ASSERT(ADDR(.bss) == ADDR(.data) + SIZEOF(.data), "ADDR(.bss) should be ADDR(.data) + SIZEOF(.data)");

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.ld
@@ -3,19 +3,25 @@ ENTRY(begin_here)
 SECTIONS
 {
     . = 0x300000 * 2;
-	start_of_sections = .;
+    start_of_sections = .;
     .text : {
-		start_of_text = .;
-        . = 0x10;
-		text1 = .;
+        start_of_text = .;
+        . = 0x8;
+        . = . * 2;
+        text1 = .;
         *(.text)
         . = 0x1000;
-		text2 = .;
+        text2 = .;
     }
-    . = 0x800000;
-	start_of_data = .;
+    . = 0x400000;
+    . = . * 2;
+    start_of_data = .;
     .data : {
         *(.data)
+    }
+
+    .bss : {
+        KEEP(*(.bss))
     }
 }
 
@@ -24,3 +30,5 @@ ASSERT(start_of_data == 0x800000, "start_of_data should be 0x800000");
 ASSERT(SIZEOF(.text) == 0x1000, "text section should be 0x1000 bytes");
 ASSERT(text1 == start_of_text + 0x10, "text1 should be 0x10 bytes after start_of_sections");
 ASSERT(text2 == start_of_text + 0x1000, "text2 should be 0x1000 bytes after start_of_sections");
+ASSERT(ADDR(.data) == 0x800000, "ADDR(.data) should be 0x800000");
+ASSERT(ADDR(.bss) == ADDR(.data) + SIZEOF(.data), "ADDR(.bss) should be ADDR(.data) + SIZEOF(.data)");

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-single-location-counter.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-single-location-counter.ld
@@ -1,0 +1,17 @@
+ENTRY(begin_here)
+
+SECTIONS
+{
+    .text 0x600000 : {
+        *(.text)
+    }
+    . = 0x800000;
+    .data : {
+        *(.data)
+    }
+    .bss : {
+        KEEP(*(.bss))
+    }
+}
+
+ASSERT(ADDR(.data) == 0x800000, "ADDR(.data) should be moved by the location counter");


### PR DESCRIPTION
This PR adds support for evaluating every location counter, instead of only the most recently referenced one. This enables assignments where a location counter depends on its previous value, example:
```ld
. = 0x1000;
. = . + 0x100;
```

It also brings `. = ALIGN(x)` in line with GNU ld behavior by aligning the location counter rather than setting the section header directly.