### PR TITLE
fix: Create canonical PLT entry for R_X86_64_PC32 to STT_FUNC DSO symbols in PIE

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2889,6 +2889,7 @@ fn apply_relocation<
     if layout.symbol_db.output_kind.is_position_independent()
         && (flags.is_interposable() || flags.is_dynamic())
         && !flags.needs_copy_relocation()
+        && !flags.needs_plt()
         && A::is_illegal_in_shared_object(r_type)
     {
         bail!(

--- a/wild/tests/sources/elf/pie-pc32-dso-code-ref-data/pie-pc32-dso-code-ref-data.s
+++ b/wild/tests/sources/elf/pie-pc32-dso-code-ref-data/pie-pc32-dso-code-ref-data.s
@@ -1,15 +1,13 @@
-// Scenario: code references DSO data symbol via R_X86_64_PC32 - invalid in PIE.
-// SkipLinker:lld because lld creates a canonical PLT entry for R_X86_64_PC32 to
-// STT_FUNC DSO symbols and succeeds, while Wild doesn't support canonical PLT and errors.
-// This case will be revisited when canonical PLT support is added to Wild.
+// Scenario: code references DSO STT_FUNC symbol via R_X86_64_PC32 in PIE.
+// Wild and lld create a canonical PLT entry and link successfully.
+// GNU ld errors on R_X86_64_PC32 against DSO symbol in PIE, so skip it.
 //#Arch:x86_64
 //#Mode:dynamic
 //#Shared:pie-pc32-dso-shared.s
 //#SoSingleLinker:wild
 //#LinkArgs:-pie --no-gc-sections
-//#ExpectErrorWild:R_X86_64_PC32
 //#SkipLinker:ld
-//#SkipLinker:lld
+//#RunEnabled:false
 .global _start
 _start:
     mov zed_fn - ., %eax


### PR DESCRIPTION
When a PIE binary uses R_X86_64_PC32 against a STT_FUNC DSO symbol, Wild was erroring with "recompile with -fPIC" instead of creating acanonical PLT entry like lld and GNU ld do.

The layout phase already correctly allocates a PLT entry for STT_FUNC DSO symbols via the `flags.is_function()` branch in `elf.rs`. The error in `elf_writer.rs` was firing before relocation application without checking if a PLT entry had already been allocated for the symbol.

Fixes #2144