### PR TITLE
port(MachO): Support direct linking against dylibs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,7 @@ jobs:
     env:
       WILD_TEST_IGNORE_FORMAT: "1" # Checked by other jobs
     steps:
+      - run: brew install lld
       - uses: actions/checkout@v7
         with:
           persist-credentials: false

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -517,8 +517,7 @@ impl platform::Platform for Elf {
 
         common.allocate(part_id::DYNSTR, state.lib_name.len() as u64 + 1);
 
-        state.format_specific_state.symbol_versions_needed =
-            vec![false; state.object.verdefnum as usize];
+        state.format_specific.symbol_versions_needed = vec![false; state.object.verdefnum as usize];
     }
 
     fn pre_finalise_sizes_prelude<'scope, 'data>(
@@ -581,10 +580,10 @@ impl platform::Platform for Elf {
         memory_offsets: &mut OutputSectionPartMap<u64>,
         resources: &layout::FinaliseLayoutResources<'_, 'data, Self>,
         resolutions_out: &mut layout::ResolutionWriter<Self>,
-    ) -> Result<Self::DynamicLayoutExt<'data>> {
+    ) -> Result<Option<Self::DynamicLayoutExt<'data>>> {
         let mut is_last_verneed = false;
 
-        if let Some(v) = &state.format_specific_state.verneed_info
+        if let Some(v) = &state.format_specific.verneed_info
             && v.version_count > 0
         {
             memory_offsets.increment(
@@ -602,12 +601,12 @@ impl platform::Platform for Elf {
         }
 
         let version_mapping = compute_version_mapping(
-            &state.format_specific_state.symbol_versions_needed,
-            state.format_specific_state.non_addressable_indexes,
+            &state.format_specific.symbol_versions_needed,
+            state.format_specific.non_addressable_indexes,
         );
 
         let copy_relocation_symbols = state
-            .format_specific_state
+            .format_specific
             .copy_relocations
             .values()
             .map(|info| info.symbol_id)
@@ -661,12 +660,12 @@ impl platform::Platform for Elf {
             resolutions_out.write(Some(resolution))?;
         }
 
-        Ok(DynamicLayoutExt {
+        Ok(Some(DynamicLayoutExt {
             version_mapping,
-            verneed_info: core::mem::take(&mut state.format_specific_state.verneed_info),
+            verneed_info: core::mem::take(&mut state.format_specific.verneed_info),
             is_last_verneed,
             copy_relocation_symbols,
-        })
+        }))
     }
 
     fn compute_object_addresses<'data>(
@@ -1089,6 +1088,13 @@ impl platform::Platform for Elf {
         }
 
         Ok(())
+    }
+
+    fn new_dynamic_layout_state_ext<'data>(
+        _file: &crate::resolution::ResolvedDynamic<'data, Self>,
+        _args: &Self::Args,
+    ) -> Self::DynamicLayoutStateExt<'data> {
+        Default::default()
     }
 
     fn new_epilogue_layout<'data>(
@@ -1829,7 +1835,7 @@ impl platform::Platform for Elf {
         let address = symbol.value();
 
         let info = state
-            .format_specific_state
+            .format_specific
             .copy_relocations
             .entry(address)
             .or_insert_with(|| CopyRelocationInfo {
@@ -2208,7 +2214,7 @@ fn load_glibc_abi_dt_relr_version(
         {
             let symbol_index = state.symbol_id_range.id_to_offset(symbol_id);
             state
-                .format_specific_state
+                .format_specific
                 .mark_version_as_needed(state.object.versym[symbol_index])?;
         }
     }
@@ -2620,10 +2626,11 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
     fn dynamic_symbol_used(
         &self,
         symbol_index: object::SymbolIndex,
-        state: &mut DynamicLayoutStateExt<'data>,
+        file: &mut layout::DynamicLayoutState<'data, Elf>,
     ) -> Result {
         if let Some(version_index) = self.versym.get(symbol_index.0) {
-            state.mark_version_as_needed(*version_index)?;
+            file.format_specific
+                .mark_version_as_needed(*version_index)?;
         }
 
         Ok(())
@@ -5444,7 +5451,7 @@ fn finalise_copy_relocations<'data>(
         for file in &mut group.files {
             if let layout::FileLayoutState::Dynamic(dynamic) = file {
                 // Skip iterating over our symbol table if we don't have any copy relocations.
-                if dynamic.format_specific_state.copy_relocations.is_empty() {
+                if dynamic.format_specific.copy_relocations.is_empty() {
                     continue;
                 }
 
@@ -5472,11 +5479,7 @@ fn select_copy_relocation_alternatives<'data>(
 ) -> Result {
     for (i, symbol) in state.object.enumerate_symbols() {
         let address = symbol.value();
-        let Some(info) = state
-            .format_specific_state
-            .copy_relocations
-            .get_mut(&address)
-        else {
+        let Some(info) = state.format_specific.copy_relocations.get_mut(&address) else {
             continue;
         };
 
@@ -5507,7 +5510,7 @@ fn allocate_for_copy_relocations<'data>(
     state: &layout::DynamicLayoutState<'data, Elf>,
     common: &mut CommonGroupState<'data, Elf>,
 ) -> Result {
-    for value in state.format_specific_state.copy_relocations.values() {
+    for value in state.format_specific.copy_relocations.values() {
         let symbol_id = value.symbol_id;
 
         let symbol_index = state.symbol_id_range().id_to_input(symbol_id);

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -4352,7 +4352,7 @@ fn write_dynamic_symbol_definitions(table_writer: &mut TableWriter, layout: &Elf
                             copy_symbol_version(
                                 object.object.symbol_versions(),
                                 object.symbol_id_range.id_to_offset(sym_def.symbol_id),
-                                &object.format_specific_layout.version_mapping,
+                                &object.format_specific.version_mapping,
                                 versym,
                             )?;
                         }
@@ -5577,7 +5577,7 @@ fn write_dynamic_file<'data, A: Arch<Platform = Elf>>(
                     copy_symbol_version(
                         object.object.symbol_versions(),
                         object.symbol_id_range.id_to_offset(symbol_id),
-                        &object.format_specific_layout.version_mapping,
+                        &object.format_specific.version_mapping,
                         versym,
                     )?;
                 }
@@ -5589,7 +5589,7 @@ fn write_dynamic_file<'data, A: Arch<Platform = Elf>>(
         }
     }
 
-    if let Some(verneed_info) = &object.format_specific_layout.verneed_info {
+    if let Some(verneed_info) = &object.format_specific.verneed_info {
         let mut verdefs = verneed_info.defs.clone();
         let e = LittleEndian;
 
@@ -5601,7 +5601,7 @@ fn write_dynamic_file<'data, A: Arch<Platform = Elf>>(
 
         let ver_need = table_writer.version_writer.take_verneed()?;
 
-        let next_verneed_offset = if object.format_specific_layout.is_last_verneed {
+        let next_verneed_offset = if object.format_specific.is_last_verneed {
             0
         } else {
             (size_of::<Verneed>() + size_of::<Vernaux>() * verneed_info.version_count as usize)
@@ -5638,7 +5638,7 @@ fn write_dynamic_file<'data, A: Arch<Platform = Elf>>(
             }
 
             let output_version = object
-                .format_specific_layout
+                .format_specific
                 .version_mapping
                 .get(usize::from(input_version - object::elf::VER_NDX_GLOBAL))
                 .copied()
@@ -5696,7 +5696,7 @@ fn write_copy_relocations<'data, A: Arch<Platform = Elf>>(
     table_writer: &mut TableWriter,
     layout: &ElfLayout,
 ) -> Result {
-    for &symbol_id in &object.format_specific_layout.copy_relocation_symbols {
+    for &symbol_id in &object.format_specific.copy_relocation_symbols {
         write_copy_relocation_for_symbol::<A>(symbol_id, table_writer, layout).with_context(
             || {
                 format!(

--- a/libwild/src/file_kind.rs
+++ b/libwild/src/file_kind.rs
@@ -18,6 +18,7 @@ pub(crate) enum FileKind {
     ElfObject,
     ElfDynamic,
     MachOObject,
+    MachODylib,
     FatMachOObject,
     MachOStubLibrary,
     WasmObject,
@@ -60,21 +61,10 @@ impl FileKind {
                 object::elf::ET_DYN => Ok(FileKind::ElfDynamic),
                 t => bail!("Unsupported ELF kind {t}"),
             }
-        } else if bytes.starts_with(macho::MH_MAGIC_64.as_bytes()) {
-            let header = macho::MachHeader64::<object::Endianness>::parse(bytes, 0)?;
-            ensure!(
-                header.endian()?.is_little_endian(),
-                "Only little endian is currently supported"
-            );
-            ensure!(
-                header.cputype(Endianness::Little) == macho::CPU_TYPE_ARM64,
-                "Only ARM64 is currently supported"
-            );
-            ensure!(
-                header.filetype(Endianness::Little) == macho::MH_OBJECT,
-                "Expected object file"
-            );
-            Ok(FileKind::MachOObject)
+        } else if bytes.starts_with(macho::MH_MAGIC_64.as_bytes())
+            || bytes.starts_with(&macho::MH_MAGIC_64.to_be_bytes())
+        {
+            determine_macho_kind(bytes)
         } else if bytes.starts_with(b"\0asm") {
             // Wasm binary magic number is `\0asm` followed by a 4-byte version.
             ensure!(bytes.len() >= 8, "Invalid Wasm file (too short)");
@@ -98,6 +88,26 @@ impl FileKind {
 
     pub(crate) fn is_compiler_ir(self) -> bool {
         matches!(self, FileKind::LlvmIr | FileKind::GccIr)
+    }
+}
+
+fn determine_macho_kind(bytes: &[u8]) -> Result<FileKind> {
+    let header = macho::MachHeader64::<object::Endianness>::parse(bytes, 0)?;
+
+    ensure!(
+        header.endian()?.is_little_endian(),
+        "Only little endian is currently supported"
+    );
+
+    ensure!(
+        header.cputype(Endianness::Little) == macho::CPU_TYPE_ARM64,
+        "Only ARM64 is currently supported"
+    );
+
+    match header.filetype(Endianness::Little) {
+        macho::MH_OBJECT => Ok(FileKind::MachOObject),
+        macho::MH_DYLIB => Ok(FileKind::MachODylib),
+        other => bail!("Unsupported MachO input file type {other:?}"),
     }
 }
 
@@ -134,6 +144,7 @@ impl std::fmt::Display for FileKind {
             FileKind::ElfObject => "ELF object",
             FileKind::ElfDynamic => "ELF dynamic",
             FileKind::MachOObject => "Mach-O object",
+            FileKind::MachODylib => "Mach-O dylib",
             FileKind::WasmObject => "Wasm object",
             FileKind::FatMachOObject => "Fat Mach-O object",
             FileKind::MachOStubLibrary => "Mach-O TBD library",

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -852,7 +852,7 @@ pub(crate) struct EpilogueLayoutState<P: Platform> {
 pub(crate) struct StubLibraryLayoutState<'data, P: Platform> {
     input: InputRef<'data>,
     file_id: FileId,
-    symbol_id_range: SymbolIdRange,
+    pub(crate) symbol_id_range: SymbolIdRange,
     pub(crate) format_specific: P::StubLibraryLayoutStateExt,
 }
 
@@ -933,7 +933,7 @@ pub(crate) struct DynamicLayout<'data, P: Platform> {
 
     pub(crate) object: &'data P::File<'data>,
 
-    pub(crate) format_specific_layout: P::DynamicLayoutExt<'data>,
+    pub(crate) format_specific: P::DynamicLayoutExt<'data>,
 }
 
 pub(crate) trait HandlerData {
@@ -1082,8 +1082,7 @@ impl<'data, P: Platform> SymbolRequestHandler<'data, P> for DynamicLayoutState<'
         _scope: &Scope<'scope>,
     ) -> Result {
         let local_index = object::SymbolIndex(symbol_id.to_offset(self.symbol_id_range()));
-        self.object
-            .dynamic_symbol_used(local_index, &mut self.format_specific_state)?;
+        self.object.dynamic_symbol_used(local_index, self)?;
 
         // Check for arch-specific VARIANT_PCS flags.
         if A::is_symbol_variant_pcs(self.object, local_index) {
@@ -1337,7 +1336,7 @@ pub(crate) struct DynamicLayoutState<'data, P: Platform> {
     pub(crate) symbol_id_range: SymbolIdRange,
     pub(crate) lib_name: &'data [u8],
 
-    pub(crate) format_specific_state: P::DynamicLayoutStateExt<'data>,
+    pub(crate) format_specific: P::DynamicLayoutStateExt<'data>,
 }
 
 #[derive(derive_more::Debug, Clone, Copy)]
@@ -2139,7 +2138,7 @@ fn apply_non_addressable_indexes<'data, P: Platform>(
                     s.object.apply_non_addressable_indexes_dynamic(
                         &mut indexes,
                         &mut counts,
-                        &mut s.format_specific_state,
+                        &mut s.format_specific,
                     )?;
                 }
                 FileLayoutState::Epilogue(s) => {
@@ -2761,11 +2760,7 @@ impl<'data, P: Platform> FileLayoutState<'data, P> {
                 resolutions_out,
                 resources,
             )?),
-            Self::Dynamic(s) => FileLayout::Dynamic(s.finalise_layout(
-                memory_offsets,
-                resolutions_out,
-                resources,
-            )?),
+            Self::Dynamic(s) => s.finalise_layout(memory_offsets, resolutions_out, resources)?,
             Self::StubLibrary(s) => {
                 s.finalise_layout(memory_offsets, resolutions_out, resources)?
             }
@@ -3902,6 +3897,7 @@ fn new_object_layout_state<P: Platform>(
 
 fn new_dynamic_object_layout_state<'data, P: Platform>(
     input_state: &resolution::ResolvedDynamic<'data, P>,
+    args: &P::Args,
 ) -> FileLayoutState<'data, P> {
     FileLayoutState::Dynamic(DynamicLayoutState {
         file_id: input_state.common.file_id,
@@ -3909,7 +3905,7 @@ fn new_dynamic_object_layout_state<'data, P: Platform>(
         lib_name: input_state.lib_name(),
         object: input_state.common.object,
         input: input_state.common.input,
-        format_specific_state: Default::default(),
+        format_specific: P::new_dynamic_layout_state_ext(input_state, args),
     })
 }
 
@@ -4626,34 +4622,42 @@ impl<'data, P: Platform> StubLibraryLayoutState<'data, P> {
         resolutions_out: &mut ResolutionWriter<P>,
         resources: &FinaliseLayoutResources<'_, 'data, P>,
     ) -> Result<FileLayout<'data, P>> {
-        for symbol_id in self.symbol_id_range {
-            let flags: ValueFlags = resources
-                .symbol_db
-                .flags_for_symbol(resources.per_symbol_flags, symbol_id);
-            if flags.has_resolution() && resources.symbol_db.is_canonical(symbol_id) {
-                resolutions_out.write(Some(P::create_resolution(
-                    flags,
-                    0,
-                    None,
-                    memory_offsets,
-                )))?;
-            } else {
-                resolutions_out.write(None)?;
-            }
-        }
-
-        Ok(match P::finalise_layout_stub(self, resources)? {
-            Some(format_specific) => FileLayout::StubLibrary(StubLibraryLayout { format_specific }),
-            None => FileLayout::NotLoaded,
-        })
+        Ok(
+            match P::finalise_layout_stub(self, memory_offsets, resources, resolutions_out)? {
+                Some(format_specific) => {
+                    FileLayout::StubLibrary(StubLibraryLayout { format_specific })
+                }
+                None => FileLayout::NotLoaded,
+            },
+        )
     }
+}
+
+pub(crate) fn default_create_resolutions<'data, P: Platform>(
+    memory_offsets: &mut OutputSectionPartMap<u64>,
+    resolutions_out: &mut ResolutionWriter<'_, '_, P>,
+    resources: &FinaliseLayoutResources<'_, 'data, P>,
+    symbol_id_range: SymbolIdRange,
+) -> Result {
+    for symbol_id in symbol_id_range {
+        let flags: ValueFlags = resources
+            .symbol_db
+            .flags_for_symbol(resources.per_symbol_flags, symbol_id);
+        if flags.has_resolution() && resources.symbol_db.is_canonical(symbol_id) {
+            resolutions_out.write(Some(P::create_resolution(flags, 0, None, memory_offsets)))?;
+        } else {
+            resolutions_out.write(None)?;
+        }
+    }
+
+    Ok(())
 }
 
 impl<'data, P: Platform> resolution::ResolvedFile<'data, P> {
     fn create_layout_state(self, args: &P::Args) -> FileLayoutState<'data, P> {
         match self {
             resolution::ResolvedFile::Object(s) => new_object_layout_state(s),
-            resolution::ResolvedFile::Dynamic(s) => new_dynamic_object_layout_state(&s),
+            resolution::ResolvedFile::Dynamic(s) => new_dynamic_object_layout_state(&s, args),
             resolution::ResolvedFile::StubLibrary(s) => {
                 FileLayoutState::StubLibrary(StubLibraryLayoutState::new(&s, args))
             }
@@ -5467,7 +5471,7 @@ impl<'data, P: Platform> DynamicLayoutState<'data, P> {
 
         self.object.finalise_sizes_dynamic(
             self.lib_name,
-            &mut self.format_specific_state,
+            &mut self.format_specific,
             &mut common.mem_sizes,
         )?;
 
@@ -5479,20 +5483,23 @@ impl<'data, P: Platform> DynamicLayoutState<'data, P> {
         memory_offsets: &mut OutputSectionPartMap<u64>,
         resolutions_out: &mut ResolutionWriter<P>,
         resources: &FinaliseLayoutResources<'_, 'data, P>,
-    ) -> Result<DynamicLayout<'data, P>> {
-        let format_specific_layout =
-            P::finalise_layout_dynamic(&mut self, memory_offsets, resources, resolutions_out)?;
-
+    ) -> Result<FileLayout<'data, P>> {
         let file_id = self.file_id();
 
-        Ok(DynamicLayout {
-            file_id,
-            input: self.input,
-            lib_name: self.lib_name,
-            object: self.object,
-            symbol_id_range: self.symbol_id_range,
-            format_specific_layout,
-        })
+        Ok(
+            match P::finalise_layout_dynamic(&mut self, memory_offsets, resources, resolutions_out)?
+            {
+                Some(format_specific) => FileLayout::Dynamic(DynamicLayout {
+                    file_id,
+                    input: self.input,
+                    lib_name: self.lib_name,
+                    object: self.object,
+                    symbol_id_range: self.symbol_id_range,
+                    format_specific,
+                }),
+                None => FileLayout::NotLoaded,
+            },
+        )
     }
 }
 

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -3,10 +3,10 @@ use crate::alignment;
 use crate::alignment::Alignment;
 use crate::alignment::MACHO_PAGE_ALIGNMENT;
 use crate::args::macho::MachOArgs;
-use crate::bail;
 use crate::ensure;
 use crate::error;
 use crate::error::Result;
+use crate::file_kind::FileKind;
 use crate::file_writer::copy_section_data;
 use crate::grouping::SequencedInput;
 use crate::input_data::FileId;
@@ -172,17 +172,28 @@ pub(crate) struct File<'data> {
     #[debug(skip)]
     pub(crate) data: &'data [u8],
     #[debug(skip)]
-    pub(crate) sections: SectionTable<'data>,
-    #[debug(skip)]
     pub(crate) symbols: SymbolTable<'data>,
     #[allow(unused)]
     pub(crate) flags: object::macho::FileFlags,
+    kind: ObjectKind<'data>,
+}
+
+#[derive(Debug)]
+enum ObjectKind<'data> {
+    Regular(RegularObject<'data>),
+    Dylib,
+}
+
+#[derive(derive_more::Debug)]
+struct RegularObject<'data> {
+    #[debug(skip)]
+    pub(crate) sections: SectionTable<'data>,
 }
 
 impl<'data> platform::ObjectFile<'data> for File<'data> {
     type Platform = MachO;
 
-    fn parse_bytes(input: &'data [u8], _is_dynamic: bool) -> crate::error::Result<Self> {
+    fn parse_bytes(input: &'data [u8], is_dynamic: bool) -> crate::error::Result<Self> {
         let header = macho::MachHeader64::<object::Endianness>::parse(input, 0)?;
         let mut commands = header.load_commands(LE, input, 0)?;
 
@@ -193,18 +204,28 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
             if let Some(symtab_command) = command.symtab()? {
                 ensure!(symbols.is_none(), "At most one symtab command expected");
                 symbols = Some(symtab_command.symbols::<macho::MachHeader64<_>, _>(LE, input)?);
-            } else if let Some((segment_command, segment_data)) = command.segment_64()? {
+            } else if !is_dynamic
+                && let Some((segment_command, segment_data)) = command.segment_64()?
+            {
                 ensure!(sections.is_none(), "At most one segment command expected");
                 let section_list = segment_command.sections(LE, segment_data)?;
                 sections = Some(section_list);
             }
         }
 
+        let kind = if is_dynamic {
+            ObjectKind::Dylib
+        } else {
+            ObjectKind::Regular(RegularObject {
+                sections: sections.ok_or("Missing segment command")?,
+            })
+        };
+
         Ok(File {
             data: input,
             symbols: symbols.ok_or("Missing symbol table")?,
-            sections: sections.ok_or("Missing segment command")?,
             flags: header.flags(LE),
+            kind,
         })
     }
 
@@ -213,12 +234,11 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
         _args: &<Self::Platform as platform::Platform>::Args,
     ) -> crate::error::Result<Self> {
         // TODO
-        Self::parse_bytes(input.data, false)
+        Self::parse_bytes(input.data, input.kind == FileKind::MachODylib)
     }
 
     fn is_dynamic(&self) -> bool {
-        // TODO
-        false
+        matches!(self.kind, ObjectKind::Dylib)
     }
 
     fn num_symbols(&self) -> usize {
@@ -266,11 +286,11 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
     }
 
     fn num_sections(&self) -> usize {
-        self.sections.len()
+        self.sections().len()
     }
 
     fn section_iter<'a>(&'a self) -> <Self::Platform as platform::Platform>::SectionIterator<'a> {
-        self.sections.iter()
+        self.sections().iter()
     }
 
     fn enumerate_sections(
@@ -281,7 +301,7 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
             &<Self::Platform as platform::Platform>::SectionHeader,
         ),
     > {
-        self.sections
+        self.sections()
             .iter()
             .enumerate()
             .map(|(i, section)| (object::SectionIndex(i), section))
@@ -291,7 +311,7 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
         &self,
         index: object::SectionIndex,
     ) -> crate::error::Result<&<Self::Platform as platform::Platform>::SectionHeader> {
-        self.sections
+        self.sections()
             .get(index.0)
             .ok_or(error!("section index out of range"))
     }
@@ -325,10 +345,13 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
 
     fn dynamic_symbol_used(
         &self,
-        _symbol_index: object::SymbolIndex,
-        _state: &mut <Self::Platform as platform::Platform>::DynamicLayoutStateExt<'data>,
+        symbol_index: object::SymbolIndex,
+        file: &mut layout::DynamicLayoutState<'data, MachO>,
     ) -> crate::error::Result {
-        todo!()
+        file.format_specific
+            .imported_symbols
+            .push(file.symbol_id_range.input_to_id(symbol_index));
+        Ok(())
     }
 
     fn finalise_sizes_dynamic(
@@ -337,7 +360,7 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
         _state: &mut <Self::Platform as platform::Platform>::DynamicLayoutStateExt<'data>,
         _mem_sizes: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
     ) -> crate::error::Result {
-        todo!()
+        Ok(())
     }
 
     fn apply_non_addressable_indexes_dynamic(
@@ -346,12 +369,12 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
         _counts: &mut <Self::Platform as platform::Platform>::NonAddressableCounts,
         _state: &mut <Self::Platform as platform::Platform>::DynamicLayoutStateExt<'data>,
     ) -> crate::error::Result {
-        todo!()
+        Ok(())
     }
 
     fn section_name(&self, index: object::SectionIndex) -> crate::error::Result<&'data [u8]> {
         let section = self
-            .sections
+            .sections()
             .get(index.0)
             .ok_or(error!("section index out of range"))?;
         Ok(section.name())
@@ -403,7 +426,7 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
     ) -> crate::error::Result<<Self::Platform as platform::Platform>::RelocationList<'data>> {
         Ok(RelocationList {
             relocations: self
-                .sections
+                .sections()
                 .get(index.0)
                 .ok_or(error!("section index out of range"))?
                 .relocations(LE, self.data)?,
@@ -430,22 +453,27 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
     fn dynamic_tag_values(
         &self,
     ) -> Option<<Self::Platform as platform::Platform>::DynamicTagValues<'data>> {
-        None
+        match self.kind {
+            ObjectKind::Regular(_) => None,
+            ObjectKind::Dylib => Some(DynamicTagValues::default()),
+        }
     }
 
     fn get_version_names(
         &self,
     ) -> crate::error::Result<<Self::Platform as platform::Platform>::VersionNames<'data>> {
-        todo!()
+        Ok(())
     }
 
     fn get_symbol_name_and_version(
         &self,
-        _symbol: &<Self::Platform as platform::Platform>::SymtabEntry,
+        symbol: &<Self::Platform as platform::Platform>::SymtabEntry,
         _local_index: usize,
         _version_names: &<Self::Platform as platform::Platform>::VersionNames<'data>,
     ) -> crate::error::Result<<Self::Platform as platform::Platform>::RawSymbolName<'data>> {
-        bail!("Mach-O does not support versioned symbols")
+        Ok(RawSymbolName {
+            name: self.symbol_name(symbol)?,
+        })
     }
 
     fn should_enforce_undefined(
@@ -836,7 +864,7 @@ impl<'data> platform::RelocationList<'data> for RelocationList<'data> {
 
 impl<'data> platform::DynamicTagValues<'data> for DynamicTagValues<'data> {
     fn lib_name(&self, _input: &crate::input_data::InputRef<'data>) -> &'data [u8] {
-        todo!()
+        &[]
     }
 }
 
@@ -902,8 +930,8 @@ impl platform::Platform for MachO {
     type EpilogueLayoutExt = EpilogueLayoutExt;
     type GroupLayoutExt = ();
     type CommonGroupStateExt = ();
-    type StubLibraryLayoutStateExt = StubLibraryLayoutStateExt;
-    type StubLibraryLayoutExt = StubLibraryLayoutExt;
+    type StubLibraryLayoutStateExt = DynamicLayoutStateExt;
+    type StubLibraryLayoutExt = DynamicLayoutExt;
     type ArchIdentifier = ();
     type Args = MachOArgs;
     type ResolutionExt = ResolutionExt;
@@ -915,8 +943,8 @@ impl platform::Platform for MachO {
     type SectionIterator<'a> = core::slice::Iter<'a, SectionHeader>;
     type DynamicTagValues<'data> = DynamicTagValues<'data>;
     type RelocationList<'data> = RelocationList<'data>;
-    type DynamicLayoutStateExt<'data> = ();
-    type DynamicLayoutExt<'data> = ();
+    type DynamicLayoutStateExt<'data> = DynamicLayoutStateExt;
+    type DynamicLayoutExt<'data> = DynamicLayoutExt;
     type LayoutResourcesExt<'data> = ();
     type PreludeLayoutStateExt = PreludeLayoutExt;
     type PreludeLayoutExt = PreludeLayoutExt;
@@ -983,7 +1011,6 @@ impl platform::Platform for MachO {
         _state: &mut crate::layout::DynamicLayoutState<'data, Self>,
         _common: &mut crate::layout::CommonGroupState<'data, Self>,
     ) {
-        todo!()
     }
 
     fn pre_finalise_sizes_prelude<'scope, 'data>(
@@ -997,7 +1024,7 @@ impl platform::Platform for MachO {
         _object: &mut crate::layout::DynamicLayoutState<'data, Self>,
         _common: &mut crate::layout::CommonGroupState<'data, Self>,
     ) -> crate::error::Result {
-        todo!()
+        Ok(())
     }
 
     fn finalise_object_sizes<'data>(
@@ -1013,33 +1040,35 @@ impl platform::Platform for MachO {
     }
 
     fn finalise_layout_dynamic<'data>(
-        _state: &mut crate::layout::DynamicLayoutState<'data, Self>,
-        _memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
-        _resources: &crate::layout::FinaliseLayoutResources<'_, 'data, Self>,
-        _resolutions_out: &mut crate::layout::ResolutionWriter<Self>,
-    ) -> crate::error::Result<Self::DynamicLayoutExt<'data>> {
-        todo!()
+        state: &mut crate::layout::DynamicLayoutState<'data, Self>,
+        memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
+        resources: &crate::layout::FinaliseLayoutResources<'_, 'data, Self>,
+        resolutions_out: &mut crate::layout::ResolutionWriter<Self>,
+    ) -> crate::error::Result<Option<Self::DynamicLayoutExt<'data>>> {
+        layout::default_create_resolutions(
+            memory_offsets,
+            resolutions_out,
+            resources,
+            state.symbol_id_range,
+        )?;
+
+        create_dynamic_layout_ext(state.file_id(), resources)
     }
 
     fn finalise_layout_stub<'data>(
         state: layout::StubLibraryLayoutState<'data, Self>,
-        resources: &layout::FinaliseLayoutResources<'_, 'data, Self>,
+        memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
+        resources: &crate::layout::FinaliseLayoutResources<'_, 'data, Self>,
+        resolutions_out: &mut crate::layout::ResolutionWriter<Self>,
     ) -> Result<Option<Self::StubLibraryLayoutExt>> {
-        let Some(index) = resources
-            .format_specific
-            .imported_libraries
-            .iter()
-            .position(|file_id| *file_id == state.file_id())
-        else {
-            return Ok(None);
-        };
+        layout::default_create_resolutions(
+            memory_offsets,
+            resolutions_out,
+            resources,
+            state.symbol_id_range,
+        )?;
 
-        Ok(Some(StubLibraryLayoutExt {
-            ordinal: NonZeroU8::new(
-                u8::try_from(index + 1).context("Too many loaded stub libraries")?,
-            )
-            .unwrap(),
-        }))
+        create_dynamic_layout_ext(state.file_id(), resources)
     }
 
     fn take_dynsym_index(
@@ -1149,6 +1178,13 @@ impl platform::Platform for MachO {
                         imported_symbols
                             .extend_from_slice(state.format_specific.imported_symbols.as_slice());
                     }
+                    layout::FileLayoutState::Dynamic(state) => {
+                        if state.format_specific.loaded {
+                            imported_libraries.push(state.file_id());
+                        }
+                        imported_symbols
+                            .extend_from_slice(state.format_specific.imported_symbols.as_slice());
+                    }
                     _ => {}
                 }
             }
@@ -1229,8 +1265,11 @@ impl platform::Platform for MachO {
             .iter()
             .flat_map(|group| {
                 group.files.iter().flat_map(|file| match file {
-                    layout::FileLayoutState::StubLibrary(stub_state) => {
-                        stub_state.format_specific.imported_symbols.as_slice()
+                    layout::FileLayoutState::StubLibrary(file) => {
+                        file.format_specific.imported_symbols.as_slice()
+                    }
+                    layout::FileLayoutState::Dynamic(file) => {
+                        file.format_specific.imported_symbols.as_slice()
                     }
                     _ => &[],
                 })
@@ -1369,12 +1408,7 @@ impl platform::Platform for MachO {
             .format_specific
             .imported_library_file_ids
             .iter()
-            .map(|&file_id| {
-                let SequencedInput::StubLibrary(stub) = resources.symbol_db.file(file_id) else {
-                    panic!("Internal error: Expected StubLibrary");
-                };
-                load_dylib_command_size(stub.defined_symbols.install_name.as_bytes())
-            })
+            .map(|&file_id| load_dylib_command_size(install_name(file_id, resources.symbol_db)))
             .collect();
         let load_dylib_command_sizes = prelude.format_specific.load_dylib_command_sizes.clone();
         for command_size in load_dylib_command_sizes {
@@ -1394,10 +1428,14 @@ impl platform::Platform for MachO {
         _stub: &resolution::ResolvedStubLibrary<'data>,
         args: &Self::Args,
     ) -> Self::StubLibraryLayoutStateExt {
-        StubLibraryLayoutStateExt {
-            imported_symbols: Default::default(),
-            loaded: !args.dead_strip_dylibs,
-        }
+        DynamicLayoutStateExt::new(args)
+    }
+
+    fn new_dynamic_layout_state_ext<'data>(
+        _file: &resolution::ResolvedDynamic<'data, Self>,
+        args: &Self::Args,
+    ) -> Self::DynamicLayoutStateExt<'data> {
+        DynamicLayoutStateExt::new(args)
     }
 
     fn load_stub_library_symbol<'data>(
@@ -1617,6 +1655,38 @@ impl platform::Platform for MachO {
     }
 }
 
+pub(crate) fn install_name<'data>(
+    file_id: FileId,
+    symbol_db: &crate::symbol_db::SymbolDb<'data, MachO>,
+) -> &'data [u8] {
+    match symbol_db.file(file_id) {
+        SequencedInput::StubLibrary(stub) => stub.defined_symbols.install_name.as_bytes(),
+        SequencedInput::Object(obj) => obj.parsed.input.lib_name(),
+        _ => {
+            panic!("Internal error: Expected StubLibrary or Dynamic");
+        }
+    }
+}
+
+fn create_dynamic_layout_ext<'data>(
+    target_file_id: FileId,
+    resources: &layout::FinaliseLayoutResources<'_, 'data, MachO>,
+) -> Result<Option<DynamicLayoutExt>> {
+    let Some(index) = resources
+        .format_specific
+        .imported_libraries
+        .iter()
+        .position(|file_id| *file_id == target_file_id)
+    else {
+        return Ok(None);
+    };
+
+    Ok(Some(DynamicLayoutExt {
+        ordinal: NonZeroU8::new(u8::try_from(index + 1).context("Too many loaded stub libraries")?)
+            .unwrap(),
+    }))
+}
+
 const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
     let mut defs: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] =
         [DEFAULT_DEFS; NUM_BUILT_IN_SECTIONS];
@@ -1695,13 +1765,13 @@ pub(crate) struct EpilogueLayoutExt {
 }
 
 #[derive(Debug)]
-pub(crate) struct StubLibraryLayoutStateExt {
+pub(crate) struct DynamicLayoutStateExt {
     imported_symbols: Vec<SymbolId>,
     loaded: bool,
 }
 
 #[derive(Debug)]
-pub(crate) struct StubLibraryLayoutExt {
+pub(crate) struct DynamicLayoutExt {
     pub(crate) ordinal: NonZeroU8,
 }
 
@@ -1861,10 +1931,7 @@ fn process_relocation<'data, 'scope, A: platform::Arch<Platform = MachO>>(
 
         let relocation = A::relocation_from_raw(rel_info)?;
         let mut flags_to_add = layout::resolution_flags(relocation.kind);
-        if matches!(
-            symbol_db.file(symbol_db.file_id_for_symbol(symbol_id)),
-            SequencedInput::StubLibrary(_)
-        ) {
+        if is_dynamic_library(&symbol_db.file(symbol_db.file_id_for_symbol(symbol_id))) {
             flags_to_add |= ValueFlags::GOT;
             // TODO: classify symbols more reliably, likely by checking whether their section is
             // __text.
@@ -1892,4 +1959,36 @@ fn process_relocation<'data, 'scope, A: platform::Arch<Platform = MachO>>(
     }
 
     Ok(())
+}
+
+fn is_dynamic_library(file: &SequencedInput<MachO>) -> bool {
+    match file {
+        SequencedInput::StubLibrary(_) => true,
+        SequencedInput::Object(obj) => obj.is_dynamic(),
+        _ => false,
+    }
+}
+
+impl<'data> File<'data> {
+    fn sections(&self) -> &'data [SectionHeader] {
+        self.kind.sections()
+    }
+}
+
+impl<'data> ObjectKind<'data> {
+    fn sections(&self) -> &'data [SectionHeader] {
+        match self {
+            ObjectKind::Regular(regular_object) => regular_object.sections,
+            ObjectKind::Dylib => &[],
+        }
+    }
+}
+
+impl DynamicLayoutStateExt {
+    fn new(args: &MachOArgs) -> Self {
+        Self {
+            imported_symbols: Default::default(),
+            loaded: !args.dead_strip_dylibs,
+        }
+    }
 }

--- a/libwild/src/macho_aarch64.rs
+++ b/libwild/src/macho_aarch64.rs
@@ -13,6 +13,7 @@ use linker_utils::elf::RelocationKindInfo;
 use linker_utils::elf::RelocationSize;
 use linker_utils::elf::SIZE_4KB;
 use linker_utils::elf::Sign;
+use std::borrow::Cow;
 
 pub(crate) struct MachOAArch64;
 
@@ -171,8 +172,12 @@ impl crate::platform::Arch for MachOAArch64 {
         })
     }
 
-    fn rel_type_to_string(r_type: u32) -> std::borrow::Cow<'static, str> {
-        todo!()
+    fn rel_type_to_string(r_type: u32) -> Cow<'static, str> {
+        if let Some(name) = object::macho::NAMES_ARM64_RELOC.name(r_type as u8) {
+            Cow::Borrowed(name)
+        } else {
+            Cow::Owned(format!("Unknown arm64 relocation type 0x{r_type:x}"))
+        }
     }
 
     fn tp_offset_start(layout: &crate::layout::Layout<Self::Platform>) -> u64 {

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -9,7 +9,6 @@ use crate::file_writer::SizedOutput;
 use crate::file_writer::split_buffers_by_alignment;
 use crate::file_writer::split_output_by_group;
 use crate::file_writer::split_output_into_sections;
-use crate::grouping::SequencedInput;
 use crate::layout::EpilogueLayout;
 use crate::layout::FileLayout;
 use crate::layout::Layout;
@@ -240,12 +239,9 @@ fn write_prelude<'data, A: Arch<Platform = MachO>>(
         let command_buffer = load_command_buffer.split_off_mut(..command_size).unwrap();
         let (dylib_command, dylib_path_buffer) =
             from_bytes_mut(command_buffer).map_err(load_cmd_err)?;
-        let SequencedInput::StubLibrary(stub) = layout.symbol_db.file(file_id) else {
-            bail!("Internal error: All imported libraries must be StubLibraries");
-        };
-        let path = stub.defined_symbols.install_name;
+        let path = crate::macho::install_name(file_id, &layout.symbol_db);
 
-        write_dylib_command::<A>(dylib_command, dylib_path_buffer, path.as_bytes());
+        write_dylib_command::<A>(dylib_command, dylib_path_buffer, path);
     }
 
     let (chained_fixups_command, load_command_buffer) =
@@ -675,7 +671,15 @@ fn apply_relocation<'data, A: Arch<Platform = MachO>>(
             symbol_name = %layout.symbol_db.symbol_name_for_display(local_symbol_id),
             "relocation applied");
 
-    rel_info.write_to_buffer(value, &mut out[offset_in_section as usize..])?;
+    rel_info
+        .write_to_buffer(value, &mut out[offset_in_section as usize..])
+        .with_context(|| {
+            format!(
+                "Failed to apply relocation {} to {}",
+                A::rel_type_to_string(rel.r_type.into()),
+                layout.symbol_debug(local_symbol_id)
+            )
+        })?;
 
     Ok(())
 }
@@ -1011,11 +1015,15 @@ fn write_chained_fixup_table<A: Arch<Platform = MachO>>(
             .symbol_db
             .file_id_for_symbol(imported_symbol.symbol_id);
 
-        let FileLayout::StubLibrary(stub) = layout.file_layout(file_id) else {
-            bail!("Internal error: Internal symbol refers to non-stub library");
+        let dynamic = match layout.file_layout(file_id) {
+            FileLayout::StubLibrary(file) => &file.format_specific,
+            FileLayout::Dynamic(file) => &file.format_specific,
+            _ => {
+                bail!("Internal error: Internal symbol refers to non-stub library");
+            }
         };
 
-        let lib_ordinal = stub.format_specific.ordinal.get();
+        let lib_ordinal = dynamic.ordinal.get();
 
         imports[i].set(
             Endianness::Little,

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -277,7 +277,7 @@ pub(crate) trait Platform:
         Self: 'a;
     type DynamicTagValues<'data>: DynamicTagValues<'data>;
     type RelocationList<'data>: RelocationList<'data>;
-    type DynamicLayoutStateExt<'data>: Default + Send + Sync + 'data;
+    type DynamicLayoutStateExt<'data>: Send + Sync + 'data;
     type DynamicLayoutExt<'data>: std::fmt::Debug + Send + Sync + 'data;
     type LayoutResourcesExt<'data>: std::fmt::Debug + Send + Sync + 'data;
     type PreludeLayoutStateExt: std::fmt::Debug + Default + Send + Sync + 'static;
@@ -431,11 +431,13 @@ pub(crate) trait Platform:
         memory_offsets: &mut OutputSectionPartMap<u64>,
         resources: &layout::FinaliseLayoutResources<'_, 'data, Self>,
         resolutions_out: &mut layout::ResolutionWriter<Self>,
-    ) -> Result<Self::DynamicLayoutExt<'data>>;
+    ) -> Result<Option<Self::DynamicLayoutExt<'data>>>;
 
     fn finalise_layout_stub<'data>(
         _state: layout::StubLibraryLayoutState<'data, Self>,
+        _memory_offsets: &mut OutputSectionPartMap<u64>,
         _resources: &layout::FinaliseLayoutResources<'_, 'data, Self>,
+        _resolutions_out: &mut layout::ResolutionWriter<Self>,
     ) -> Result<Option<Self::StubLibraryLayoutExt>> {
         Ok(None)
     }
@@ -656,6 +658,13 @@ pub(crate) trait Platform:
         _stub: &resolution::ResolvedStubLibrary<'data>,
         _args: &Self::Args,
     ) -> Self::StubLibraryLayoutStateExt {
+        unimplemented!()
+    }
+
+    fn new_dynamic_layout_state_ext<'data>(
+        _file: &resolution::ResolvedDynamic<'data, Self>,
+        _args: &Self::Args,
+    ) -> Self::DynamicLayoutStateExt<'data> {
         unimplemented!()
     }
 
@@ -936,9 +945,11 @@ pub(crate) trait ObjectFile<'data>: Sized + Send + Sync + std::fmt::Debug + 'dat
 
     fn dynamic_symbol_used(
         &self,
-        symbol_index: object::SymbolIndex,
-        state: &mut <Self::Platform as Platform>::DynamicLayoutStateExt<'data>,
-    ) -> Result;
+        _symbol_index: object::SymbolIndex,
+        _file: &mut layout::DynamicLayoutState<'data, Self::Platform>,
+    ) -> Result {
+        unimplemented!();
+    }
 
     fn finalise_sizes_dynamic(
         &self,

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -853,15 +853,6 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
         &[]
     }
 
-    fn dynamic_symbol_used(
-        &self,
-        _symbol_index: object::SymbolIndex,
-        _state: &mut <Self::Platform as platform::Platform>::DynamicLayoutStateExt<'data>,
-    ) -> crate::error::Result {
-        // Wasm has no dynamic objects yet.
-        Ok(())
-    }
-
     fn finalise_sizes_dynamic(
         &self,
         _lib_name: &[u8],
@@ -3026,8 +3017,8 @@ impl platform::Platform for Wasm {
         _memory_offsets: &mut crate::output_section_part_map::OutputSectionPartMap<u64>,
         _resources: &crate::layout::FinaliseLayoutResources<'_, 'data, Self>,
         _resolutions_out: &mut crate::layout::ResolutionWriter<Self>,
-    ) -> crate::error::Result<Self::DynamicLayoutExt<'data>> {
-        Ok(())
+    ) -> crate::error::Result<Option<Self::DynamicLayoutExt<'data>>> {
+        Ok(None)
     }
 
     fn take_dynsym_index(

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -585,6 +585,12 @@ enum Linker {
     ThirdParty(ThirdPartyLinker),
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum IntermediateKind {
+    Shared,
+    Partial,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ThirdPartyLinker {
     name: &'static str,
@@ -610,7 +616,7 @@ impl Linker {
         so_path: &Path,
         config: &Config,
         cross_arch: Option<Architecture>,
-        is_shared: bool,
+        kind: IntermediateKind,
     ) -> Result<LinkerInput> {
         let mut linker_args = config.linker_args.clone();
 
@@ -618,11 +624,9 @@ impl Linker {
             .args
             .extend(config.linker_so_args.args.iter().cloned());
 
-        linker_args.args.push(if is_shared {
-            "-shared".to_owned()
-        } else {
-            "-r".to_owned()
-        });
+        linker_args
+            .args
+            .push(config.platform.arg_for_intermediate(kind)?.to_owned());
 
         let mut command = LinkCommand::new(
             self,
@@ -2669,14 +2673,14 @@ fn build_linker_input(
         }
         InputType::SharedObject | InputType::Relocatable => {
             let linker = config.so_single_linker.as_ref().unwrap_or(linker);
-            let (obj_ext, is_shared) = if dep.input_type == InputType::SharedObject {
-                (format!("{linker}.so"), true)
+            let kind = if dep.input_type == InputType::SharedObject {
+                IntermediateKind::Shared
             } else {
-                (format!("{linker}.o"), false)
+                IntermediateKind::Partial
             };
-            let obj_path = first_obj_path.with_extension(obj_ext);
-            let out =
-                linker.link_intermediate(&objects, &obj_path, &config, cross_arch, is_shared)?;
+            let ext = config.platform.intermediate_extension(kind)?;
+            let obj_path = first_obj_path.with_extension(format!("{linker}.{ext}"));
+            let out = linker.link_intermediate(&objects, &obj_path, &config, cross_arch, kind)?;
             let assertions = Assertions::default();
             assertions
                 .check_path(&out.path, linker)
@@ -2868,6 +2872,10 @@ fn build_obj(
             command.arg("-MF");
             command.arg(&deps_path);
             command.arg("-MD");
+
+            if config.platform == PlatformKind::MachO {
+                command.arg("-mmacosx-version-min=11.0");
+            }
         }
         CompilerKind::Rust => {
             let wild = wild_path().to_str().context("Need UTF-8 path")?.to_owned();
@@ -3487,7 +3495,7 @@ impl LinkCommand {
                         }
                     }
 
-                    if arch == Architecture::AArch64 {
+                    if config.platform == PlatformKind::Elf && arch == Architecture::AArch64 {
                         // Provide a workaround for ld.lld: error: unknown argument
                         // '--fix-cortex-a53-835769' Bug link: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105941
                         command.arg("-mno-fix-cortex-a53-835769");
@@ -6010,6 +6018,24 @@ impl PlatformKind {
             },
             PlatformKind::Elf | PlatformKind::MachO => ArgumentSet::default_for_compiling(),
         }
+    }
+
+    fn arg_for_intermediate(self, kind: IntermediateKind) -> Result<&'static str> {
+        Ok(match (self, kind) {
+            (PlatformKind::Elf, IntermediateKind::Shared) => "-shared",
+            (PlatformKind::Elf, IntermediateKind::Partial) => "-r",
+            (PlatformKind::MachO, IntermediateKind::Shared) => "-dynamiclib",
+            _ => bail!("Unsupported {self:?}, {kind:?}"),
+        })
+    }
+
+    fn intermediate_extension(&self, kind: IntermediateKind) -> Result<&'static str> {
+        Ok(match (self, kind) {
+            (PlatformKind::Elf, IntermediateKind::Shared) => "so",
+            (PlatformKind::Elf, IntermediateKind::Partial) => "o",
+            (PlatformKind::MachO, IntermediateKind::Shared) => "dylib",
+            _ => bail!("Unsupported {self:?}, {kind:?}"),
+        })
     }
 }
 

--- a/wild/tests/sources/macho/trivial-dynamic/foo.c
+++ b/wild/tests/sources/macho/trivial-dynamic/foo.c
@@ -1,0 +1,1 @@
+int foo(void) { return 42; }

--- a/wild/tests/sources/macho/trivial-dynamic/trivial-dynamic.c
+++ b/wild/tests/sources/macho/trivial-dynamic/trivial-dynamic.c
@@ -1,0 +1,9 @@
+//#LinkerDriver:clang
+//#SoSingleLinker:lld
+//#Shared:foo.c
+//#DiffIgnore:section.__unwind_info
+//#DiffIgnore:section.__const
+
+int foo(void);
+
+int main() { return foo(); }


### PR DESCRIPTION
There's quite a lot of similarity between our handling of stub libraries and dylibs. I suspect we might want to do some future refactoring to try and unify them some more. For now, where there's duplicated logic, I've just extracted it out into a function and called it from both places. The primary difference between e.g. `DynamicLayoutState` and `StubLibraryLayoutState` is that the former contains a `platform::File` reference, where the latter cannot, since one does not exist. One option would be to remove this reference from `DynamicLayoutState` and leave it up to the `DynamicLayoutStateExt` whether and how to store the reference. I prototyped this change. The difficulty is that the same difference applies to our other stages, e.g. `ResolvedDynamic` and making the same refactoring there started to look complicated, so I decided to hold off on it for now.

Fixes #2067