### PR TITLE
fix: Relax -z noplt form of TLS GD to Local Exec on x86_64

### DIFF
--- a/libwild/src/elf_x86_64.rs
+++ b/libwild/src/elf_x86_64.rs
@@ -358,7 +358,9 @@ impl crate::platform::Arch for ElfX86_64 {
             }
             object::elf::R_X86_64_TLSGD if !interposable && output_kind.is_executable() => {
                 let kind = match TlsGdForm::identify(section_bytes, offset)? {
-                    TlsGdForm::Regular => RelaxationKind::TlsGdToLocalExec,
+                    TlsGdForm::Regular | TlsGdForm::RegularNoPlt => {
+                        RelaxationKind::TlsGdToLocalExec
+                    }
                     TlsGdForm::Large => RelaxationKind::TlsGdToLocalExecLarge,
                 };
                 return Some(Relaxation {
@@ -370,7 +372,7 @@ impl crate::platform::Arch for ElfX86_64 {
             object::elf::R_X86_64_TLSGD if output_kind.is_executable() => {
                 let kind = match TlsGdForm::identify(section_bytes, offset)? {
                     TlsGdForm::Regular => RelaxationKind::TlsGdToInitialExec,
-                    TlsGdForm::Large => {
+                    TlsGdForm::RegularNoPlt | TlsGdForm::Large => {
                         // TODO
                         return None;
                     }
@@ -514,6 +516,7 @@ impl crate::platform::Relaxation for Relaxation {
 enum TlsGdForm {
     Regular,
     Large,
+    RegularNoPlt,
 }
 
 impl TlsGdForm {
@@ -524,6 +527,14 @@ impl TlsGdForm {
             && bytes.get(offset + 4..offset + 8) == Some(&[0x66, 0x66, 0x48, 0xe8])
         {
             return Some(Self::Regular);
+        }
+
+        // data16 lea 0x0(%rip),%rdi
+        // data16 rex.W call *__tls_get_addr@GOTPCREL(%rip)
+        if bytes.get(offset - 4..offset) == Some(&[0x66, 0x48, 0x8d, 0x3d])
+            && bytes.get(offset + 4..offset + 8) == Some(&[0x66, 0x48, 0xff, 0x15])
+        {
+            return Some(Self::RegularNoPlt);
         }
 
         // lea 0x0(%rip),%rdi

--- a/wild/tests/sources/elf/tls-gd-noplt/tls-gd-noplt.s
+++ b/wild/tests/sources/elf/tls-gd-noplt/tls-gd-noplt.s
@@ -1,0 +1,21 @@
+// Test that Wild relaxes the -z noplt form of TLS GD (indirect call to
+// __tls_get_addr via GOTPCREL) to Local Exec, matching the relaxation
+// already applied to the regular (PLT) form. Both lld and GNU ld
+// correctly relax this pattern.
+//#Arch:x86_64
+//#LinkArgs:-nostdlib --no-gc-sections
+//#ReferenceLinkers:lld,bfd
+//#RunEnabled:false
+.globl _start
+_start:
+    .byte 0x66
+    leaq tlsvar@tlsgd(%rip), %rdi
+    .byte 0x66
+    .byte 0x48
+    call *__tls_get_addr@GOTPCREL(%rip)
+    ret
+
+.section .tbss,"awT",@nobits
+.globl tlsvar
+tlsvar:
+    .long 0


### PR DESCRIPTION
Wild's TlsGdForm::identify only recognized the regular TLS GD sequence with a direct PLT call (0xe8). The -z noplt variant uses an indirect call through the GOT instead (0x66 0x48 0xff 0x15), which wasn't recognized, causing Wild to error with "Undefined symbol __tls_get_addr" instead of relaxing to Local Exec.

Fixes #2155