### PR TITLE
fix: Emit one zlib stream per compressed debug section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,6 +951,7 @@ dependencies = [
  "wasmparser 0.252.0",
  "winnow",
  "zerocopy",
+ "zlib-rs",
  "zstd",
 ]
 
@@ -2503,9 +2504,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c745c48e1007337ed136dc99df34128b9faa6ed542d80a1c673cf55a6d7236c8"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ derive_more = { version = "2.0.1", features = ["debug", "display"] }
 dhat = { version = "0.3.3" }
 diff = "0.1.13"
 flate2 = { version = "1.1.0", features = ["zlib-rs"] }
+zlib-rs = "0.6.4"
 foldhash = "0.2.0"
 gimli = "0.34.0"
 glob = "0.3.2"

--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -56,6 +56,7 @@ wasmparser.workspace = true
 winnow.workspace = true
 zerocopy.workspace = true
 zstd.workspace = true
+zlib-rs.workspace = true
 
 [target.'cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
 perf-event.workspace = true

--- a/libwild/src/compression.rs
+++ b/libwild/src/compression.rs
@@ -48,8 +48,32 @@ const MIN_CHUNK_SIZE: usize = 64 * 1024;
 /// threads because we want the output to not depend on the number of threads.
 const MAX_CHUNKS: usize = 128;
 
-const ZLIB_COMPRESSION_LEVEL: u32 = 1;
+const ZLIB_COMPRESSION_LEVEL: i32 = 1;
 const ZSTD_COMPRESSION_LEVEL: i32 = 3;
+
+/// zlib `windowBits`.
+const ZLIB_WINDOW_BITS: u8 = 15;
+
+/// Initial Adler-32 value (RFC 1950).
+const ADLER32_INITIAL: u32 = 1;
+
+/// zlib CMF+FLG header for deflate with a 32 KiB window and default FCHECK.
+const ZLIB_CMF_FLG: [u8; 2] = [0x78, 0x9c];
+
+/// Empty final deflate block (`BFINAL=1`, empty stored/fixed block) written after
+/// SyncFlush'd shards so the stream can be closed before the Adler-32 trailer.
+const ZLIB_EMPTY_FINAL_BLOCK: [u8; 2] = [0x03, 0x00];
+
+/// Size of multi-shard zlib trailer. Empty final block + Adler-32 (big-endian u32).
+const ZLIB_MULTI_SHARD_TRAILER_LEN: usize =
+    ZLIB_EMPTY_FINAL_BLOCK.len() + std::mem::size_of::<u32>();
+
+/// Extra bytes reserved beyond `compress_bound` so SyncFlush markers fit without an immediate
+/// realloc on the first flush attempt.
+const ZLIB_SYNC_FLUSH_SLACK: usize = 16;
+
+/// How much to grow the output buffer when a Finish/SyncFlush needs more space.
+const ZLIB_OUTPUT_GROW_BYTES: usize = 64;
 
 pub(crate) fn maybe_compress_debug_sections_elf<A: Arch<Platform = Elf>>(
     layout: &mut crate::layout::Layout<Elf>,
@@ -124,13 +148,14 @@ impl SectionCompressor for ZlibCompressor {
             checksum = adler32_combine(checksum, *shard_adler, shard.len() as u64);
         }
 
+        // Header chunk + one chunk per shard + trailer chunk.
         let mut chunks = Vec::with_capacity(shard_results.len() + 2);
-        chunks.push(vec![0x78, 0x9c]);
+        chunks.push(ZLIB_CMF_FLG.to_vec());
         for (compressed, _) in shard_results {
             chunks.push(compressed);
         }
-        let mut trailer = Vec::with_capacity(6);
-        trailer.extend_from_slice(&[3, 0]);
+        let mut trailer = Vec::with_capacity(ZLIB_MULTI_SHARD_TRAILER_LEN);
+        trailer.extend_from_slice(&ZLIB_EMPTY_FINAL_BLOCK);
         trailer.extend_from_slice(&checksum.to_be_bytes());
         chunks.push(trailer);
         Ok(chunks)
@@ -172,7 +197,7 @@ fn shard_size(uncompressed_len: usize) -> usize {
 
 /// Full zlib stream for a single input that doesn't need sharding.
 fn zlib_compress_whole(input: &[u8]) -> Result<Vec<u8>> {
-    let mut encoder = Deflate::new(ZLIB_COMPRESSION_LEVEL as i32, true, 15);
+    let mut encoder = Deflate::new(ZLIB_COMPRESSION_LEVEL, true, ZLIB_WINDOW_BITS);
     let mut output = vec![0u8; zlib_rs::compress_bound(input.len())];
 
     match encoder
@@ -188,8 +213,8 @@ fn zlib_compress_whole(input: &[u8]) -> Result<Vec<u8>> {
 
     loop {
         let bytes_written = encoder.total_out() as usize;
-        if bytes_written + 16 > output.len() {
-            output.resize(output.len() + 64, 0);
+        if bytes_written + ZLIB_SYNC_FLUSH_SLACK > output.len() {
+            output.resize(output.len() + ZLIB_OUTPUT_GROW_BYTES, 0);
         }
         match encoder
             .compress(&[], &mut output[bytes_written..], DeflateFlush::Finish)
@@ -208,10 +233,10 @@ fn zlib_compress_whole(input: &[u8]) -> Result<Vec<u8>> {
 /// uncompressed shard.
 fn zlib_compress_shard(input: &[u8]) -> Result<(Vec<u8>, u32)> {
     // Compute while `input` is hot for the following deflate pass.
-    let checksum = adler32(1, input);
+    let checksum = adler32(ADLER32_INITIAL, input);
 
-    let mut encoder = Deflate::new(ZLIB_COMPRESSION_LEVEL as i32, false, 15);
-    let mut output = vec![0u8; zlib_rs::compress_bound(input.len()) + 16];
+    let mut encoder = Deflate::new(ZLIB_COMPRESSION_LEVEL, false, ZLIB_WINDOW_BITS);
+    let mut output = vec![0u8; zlib_rs::compress_bound(input.len()) + ZLIB_SYNC_FLUSH_SLACK];
 
     match encoder
         .compress(input, &mut output, DeflateFlush::Block)
@@ -231,8 +256,8 @@ fn zlib_compress_shard(input: &[u8]) -> Result<(Vec<u8>, u32)> {
             output.truncate(new_bytes_written);
             return Ok((output, checksum));
         }
-        if new_bytes_written + 16 > output.len() {
-            output.resize(output.len() + 32, 0);
+        if new_bytes_written + ZLIB_SYNC_FLUSH_SLACK > output.len() {
+            output.resize(output.len() + ZLIB_OUTPUT_GROW_BYTES, 0);
         }
     }
 }
@@ -490,4 +515,69 @@ fn update_file_offset<P: Platform>(layout: &mut Layout<P>) -> Result {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flate2::read::ZlibDecoder;
+    use std::io::Read as _;
+
+    fn pattern_bytes(len: usize) -> Vec<u8> {
+        (0..len).map(|i| (i % 251) as u8).collect()
+    }
+
+    fn decompress_zlib(stream: &[u8]) -> Vec<u8> {
+        let mut decoder = ZlibDecoder::new(stream);
+        let mut out = Vec::new();
+        decoder
+            .read_to_end(&mut out)
+            .expect("zlib decompression failed");
+        out
+    }
+
+    #[test]
+    fn zlib_multi_shard_round_trip() {
+        let input = pattern_bytes(MIN_CHUNK_SIZE * 3 + 123);
+        assert!(
+            input.len() > shard_size(input.len()),
+            "test data must span multiple shards"
+        );
+
+        let chunks = ZlibCompressor::compress_section(&input).unwrap();
+        // Header + at least two raw-deflate shards + trailer.
+        assert!(
+            chunks.len() >= 4,
+            "expected multi-shard layout, got {} chunks",
+            chunks.len()
+        );
+
+        let stream: Vec<u8> = chunks.into_iter().flatten().collect();
+        let recovered = decompress_zlib(&stream);
+        assert_eq!(recovered, input);
+    }
+
+    #[test]
+    fn zlib_single_shard_round_trip() {
+        let input = pattern_bytes(1024);
+        assert!(input.len() <= shard_size(input.len()));
+
+        let chunks = ZlibCompressor::compress_section(&input).unwrap();
+        assert_eq!(chunks.len(), 1, "single-shard path emits one zlib stream");
+
+        let recovered = decompress_zlib(&chunks[0]);
+        assert_eq!(recovered, input);
+    }
+
+    #[test]
+    fn zstd_multi_shard_round_trip() {
+        let input = pattern_bytes(MIN_CHUNK_SIZE * 3 + 123);
+        let chunks = ZstdCompressor::compress_section(&input).unwrap();
+        assert!(chunks.len() > 1);
+
+        // Multi-frame zstd. Frames written sequentially form one valid stream.
+        let stream: Vec<u8> = chunks.into_iter().flatten().collect();
+        let recovered = zstd::decode_all(stream.as_slice()).unwrap();
+        assert_eq!(recovered, input);
+    }
 }

--- a/libwild/src/compression.rs
+++ b/libwild/src/compression.rs
@@ -20,7 +20,6 @@ use crate::platform::SectionFlags as _;
 use crate::resolution::SectionSlot;
 use crate::timing_phase;
 use crate::verbose_timing_phase;
-use itertools::Itertools;
 use object::LittleEndian;
 use object::bytes_of;
 use object::elf::CompressionHeader64;
@@ -29,7 +28,12 @@ use object::read::elf::Crel;
 use rayon::iter::IntoParallelIterator as _;
 use rayon::iter::IntoParallelRefIterator as _;
 use rayon::iter::ParallelIterator as _;
-use std::io::Write as _;
+use zlib_rs::Deflate;
+use zlib_rs::DeflateError;
+use zlib_rs::DeflateFlush;
+use zlib_rs::Status;
+use zlib_rs::adler32::adler32;
+use zlib_rs::adler32::adler32_combine;
 
 #[derive(Debug)]
 pub(crate) struct CompressedSection {
@@ -87,20 +91,49 @@ pub(crate) fn maybe_compress_debug_sections_elf<A: Arch<Platform = Elf>>(
     Ok(())
 }
 
-trait Compressor {
-    fn compress(chunk: &[u8]) -> Result<Vec<u8>>;
+trait SectionCompressor {
+    fn compress_section(uncompressed: &[u8]) -> Result<Vec<Vec<u8>>>;
 
     fn kind() -> CompressionType;
 }
 
 struct ZlibCompressor;
 
-impl Compressor for ZlibCompressor {
-    fn compress(chunk: &[u8]) -> Result<Vec<u8>> {
-        let compression = flate2::Compression::new(ZLIB_COMPRESSION_LEVEL);
-        let mut encoder = flate2::write::ZlibEncoder::new(Vec::new(), compression);
-        encoder.write_all(chunk)?;
-        Ok(encoder.finish()?)
+impl SectionCompressor for ZlibCompressor {
+    fn compress_section(uncompressed: &[u8]) -> Result<Vec<Vec<u8>>> {
+        verbose_timing_phase!("Compress zlib section");
+
+        let shard_size = shard_size(uncompressed.len());
+
+        if uncompressed.len() <= shard_size {
+            return Ok(vec![zlib_compress_whole(uncompressed)?]);
+        }
+
+        let shards: Vec<&[u8]> = uncompressed.chunks(shard_size).collect();
+
+        let shard_results: Vec<(Vec<u8>, u32)> = shards
+            .par_iter()
+            .map(|shard| -> Result<(Vec<u8>, u32)> {
+                verbose_timing_phase!("Compress zlib shard");
+                zlib_compress_shard(shard)
+            })
+            .collect::<Result<_>>()?;
+
+        let mut checksum = shard_results[0].1;
+        for ((_, shard_adler), shard) in shard_results.iter().skip(1).zip(shards.iter().skip(1)) {
+            checksum = adler32_combine(checksum, *shard_adler, shard.len() as u64);
+        }
+
+        let mut chunks = Vec::with_capacity(shard_results.len() + 2);
+        chunks.push(vec![0x78, 0x9c]);
+        for (compressed, _) in shard_results {
+            chunks.push(compressed);
+        }
+        let mut trailer = Vec::with_capacity(6);
+        trailer.extend_from_slice(&[3, 0]);
+        trailer.extend_from_slice(&checksum.to_be_bytes());
+        chunks.push(trailer);
+        Ok(chunks)
     }
 
     fn kind() -> CompressionType {
@@ -110,11 +143,18 @@ impl Compressor for ZlibCompressor {
 
 struct ZstdCompressor;
 
-impl Compressor for ZstdCompressor {
-    fn compress(chunk: &[u8]) -> Result<Vec<u8>> {
-        let mut output = Vec::new();
-        zstd::stream::copy_encode(chunk, &mut output, ZSTD_COMPRESSION_LEVEL)?;
-        Ok(output)
+impl SectionCompressor for ZstdCompressor {
+    fn compress_section(uncompressed: &[u8]) -> Result<Vec<Vec<u8>>> {
+        let shard_size = shard_size(uncompressed.len());
+        let shards: Vec<&[u8]> = uncompressed.chunks(shard_size).collect();
+
+        shards
+            .par_iter()
+            .map(|shard| -> Result<Vec<u8>> {
+                verbose_timing_phase!("Compress zstd shard");
+                zstd::encode_all(*shard, ZSTD_COMPRESSION_LEVEL).map_err(Into::into)
+            })
+            .collect()
     }
 
     fn kind() -> CompressionType {
@@ -122,7 +162,82 @@ impl Compressor for ZstdCompressor {
     }
 }
 
-fn compress_sections<A: Arch<Platform = Elf>, C: Compressor>(
+fn zlib_deflate_error(error: DeflateError) -> crate::error::Error {
+    crate::error::Error::with_message(format!("zlib compression failed: {error:?}"))
+}
+
+fn shard_size(uncompressed_len: usize) -> usize {
+    std::cmp::max(MIN_CHUNK_SIZE, uncompressed_len / MAX_CHUNKS)
+}
+
+/// Full zlib stream for a single input that doesn't need sharding.
+fn zlib_compress_whole(input: &[u8]) -> Result<Vec<u8>> {
+    let mut encoder = Deflate::new(ZLIB_COMPRESSION_LEVEL as i32, true, 15);
+    let mut output = vec![0u8; zlib_rs::compress_bound(input.len())];
+
+    match encoder
+        .compress(input, &mut output, DeflateFlush::Finish)
+        .map_err(zlib_deflate_error)?
+    {
+        Status::StreamEnd => {
+            output.truncate(encoder.total_out() as usize);
+            return Ok(output);
+        }
+        Status::Ok | Status::BufError => {}
+    }
+
+    loop {
+        let bytes_written = encoder.total_out() as usize;
+        if bytes_written + 16 > output.len() {
+            output.resize(output.len() + 64, 0);
+        }
+        match encoder
+            .compress(&[], &mut output[bytes_written..], DeflateFlush::Finish)
+            .map_err(zlib_deflate_error)?
+        {
+            Status::StreamEnd => {
+                output.truncate(encoder.total_out() as usize);
+                return Ok(output);
+            }
+            Status::Ok | Status::BufError => {}
+        }
+    }
+}
+
+/// Compresses one shard as raw deflate terminated with `SyncFlush`. Also returns Adler-32 of the
+/// uncompressed shard.
+fn zlib_compress_shard(input: &[u8]) -> Result<(Vec<u8>, u32)> {
+    // Compute while `input` is hot for the following deflate pass.
+    let checksum = adler32(1, input);
+
+    let mut encoder = Deflate::new(ZLIB_COMPRESSION_LEVEL as i32, false, 15);
+    let mut output = vec![0u8; zlib_rs::compress_bound(input.len()) + 16];
+
+    match encoder
+        .compress(input, &mut output, DeflateFlush::Block)
+        .map_err(zlib_deflate_error)?
+    {
+        Status::Ok | Status::BufError => {}
+        Status::StreamEnd => bail!("zlib block compression failed"),
+    }
+
+    loop {
+        let bytes_written = encoder.total_out() as usize;
+        encoder
+            .compress(&[], &mut output[bytes_written..], DeflateFlush::SyncFlush)
+            .map_err(zlib_deflate_error)?;
+        let new_bytes_written = encoder.total_out() as usize;
+        if new_bytes_written == bytes_written {
+            output.truncate(new_bytes_written);
+            return Ok((output, checksum));
+        }
+        if new_bytes_written + 16 > output.len() {
+            output.resize(output.len() + 32, 0);
+        }
+    }
+}
+
+fn compress_sections<A: Arch<Platform = Elf>, C: SectionCompressor>(
     layout: &mut Layout<Elf>,
     debug_sections: &[OutputSectionId],
 ) -> Result {
@@ -133,7 +248,7 @@ fn compress_sections<A: Arch<Platform = Elf>, C: Compressor>(
                 crate::output_section_id::OutputSectionId,
                 Option<CompressedSection>,
             )> {
-                timing_phase!("Process debug section");
+                verbose_timing_phase!("Process debug section");
 
                 let section_layout = layout.section_layouts.get(section_id);
                 let mut buffer = vec![0u8; section_layout.file_size];
@@ -154,22 +269,13 @@ fn compress_sections<A: Arch<Platform = Elf>, C: Compressor>(
     Ok(())
 }
 
-fn compress_section<C: Compressor>(
+fn compress_section<C: SectionCompressor>(
     uncompressed: &[u8],
     alignment: Alignment,
 ) -> Result<Option<CompressedSection>> {
     verbose_timing_phase!("Compress section");
 
-    let chunk_size = std::cmp::max(MIN_CHUNK_SIZE, uncompressed.len() / MAX_CHUNKS);
-    let chunks = uncompressed.chunks(chunk_size).collect_vec();
-
-    let mut compressed_chunks = chunks
-        .par_iter()
-        .map(|chunk| -> Result<Vec<u8>> {
-            verbose_timing_phase!("Compress chunk");
-            C::compress(chunk)
-        })
-        .collect::<Result<Vec<_>>>()?;
+    let mut compressed_chunks = C::compress_section(uncompressed)?;
 
     let mut header: CompressionHeader64<LittleEndian> = Default::default();
     header.ch_type.set(LittleEndian, C::kind());
@@ -177,9 +283,8 @@ fn compress_section<C: Compressor>(
     header.ch_addralign.set(LittleEndian, alignment.value());
 
     let header_bytes = bytes_of(&header).to_vec();
-
-    let total_compressed_size: usize =
-        header_bytes.len() + compressed_chunks.iter().map(|v| v.len()).sum::<usize>();
+    let body_size: usize = compressed_chunks.iter().map(Vec::len).sum();
+    let total_compressed_size = header_bytes.len() + body_size;
 
     // Return None if compression made things larger.
     if total_compressed_size >= uncompressed.len() {

--- a/wild/tests/sources/elf/compressed-debug-gdb-scripts/compressed-debug-gdb-scripts.rs
+++ b/wild/tests/sources/elf/compressed-debug-gdb-scripts/compressed-debug-gdb-scripts.rs
@@ -5,8 +5,6 @@
 
 //#Config:zlib:default
 //#CompArgs:-g -Clink-arg=-Wl,--compress-debug-sections=zlib
-// TODO: wild should emit one zlib stream per compressed section
-//#DiffIgnore:debug_info
 
 //#Config:zstd:default
 //#RequiresLinkerFlags:--compress-debug-sections=zstd

--- a/wild/tests/sources/elf/compressed-debug-merge/compressed-debug-merge.c
+++ b/wild/tests/sources/elf/compressed-debug-merge/compressed-debug-merge.c
@@ -4,9 +4,6 @@
 //#CompArgs:-g -gdwarf-5
 //#Object:runtime.c
 //#DiffIgnore:section.debug_*
-// wild and GNU ld compress `.debug_info` to different sizes; same underlying cause as #2119.
-//#DiffIgnore:debug_info
-// wild types `.eh_frame` as SHT_PROGBITS, GNU ld as SHT_X86_64_UNWIND.
 //#DiffIgnore:section.eh_frame.type
 
 //#Config:zlib:default
@@ -21,12 +18,6 @@
 
 #include "../common/runtime.h"
 
-// Regression test for #2113. With `--compress-debug-sections`, a merge-string debug section
-// (`.debug_str`) that actually compresses had its merged-strings map freed after compression,
-// before `.debug_str_offsets` relocations into it were resolved, causing "Failed to find
-// merge-string at offset 0". We need *enough* distinct, compressible debug strings that
-// `.debug_str` compresses (and so is freed); a narrow program doesn't trigger it. Each instance
-// contributes distinct type/member/function names to `.debug_str`.
 #define GENERATE_DEBUG_STUFF(id)                          \
   struct data_blob_##id {                                 \
     int field_a_##id;                                     \


### PR DESCRIPTION
Previously, large compressed debug sections could be emitted incorrectly once a section was split into multiple compression chunks (chunk size is at least 64 KiB). Consumers then saw truncated or corrupt DWARF. (Also see https://github.com/wild-linker/wild/pull/2119#discussion_r3449691345)

For example, with a buggy wild-linked binary:

```
（▰╹◡╹）❯  llvm-dwarfdump --statistics wild/tests/build/elf/x86_64/compressed-debug-gdb-scripts/zlib/compressed-debug-gdb-scripts.rs.wild|head
warning: DWARF unit at offset 0x000c8b80 has unsupported version 0, supported are 2-5
warning: unable to decode LEB128 at offset 0x0004a0fe: malformed uleb128, extends past end
warning: last sequence in debug line table at offset 0x000003fd is not terminated
{
  "version": 9,
  "file": "wild/tests/build/elf/x86_64/compressed-debug-gdb-scripts/zlib/compressed-debug-gdb-scripts.rs.wild",
  "format": "elf64-x86-64",
  "#functions": 50,
  "#functions with location": 49,
  "#out-of-line functions": 103,
  "#inlined functions": 1798,
  "#inlined functions with abstract origins": 1798,
  "#unique source variables": 13,
```

whereas GNU ld on the same inputs (note that there is no warning and the number of functions is very different from wild's case):

```
（▰╹◡╹）❯  llvm-dwarfdump --statistics wild/tests/build/elf/x86_64/compressed-debug-gdb-scripts/zlib/compressed-debug-gdb-scripts.rs.ld|head
{
  "version": 9,
  "file": "wild/tests/build/elf/x86_64/compressed-debug-gdb-scripts/zlib/compressed-debug-gdb-scripts.rs.ld",
  "format": "elf64-x86-64",
  "#functions": 9370,
  "#functions with location": 9370,
  "#out-of-line functions": 1925,
  "#inlined functions": 44899,
  "#inlined functions with abstract origins": 44899,
```

The root cause was concatenating complete zlib streams from `ZlibEncoder::finish()` per chunk. We now compress raw deflate shards in parallel with `Z_SYNC_FLUSH` boundaries, then emit a single zlib stream (header + shards + empty stored block + combined Adler-32).