### PR TITLE
fix: Relax -z noplt form of TLS GD to Initial Exec on x86_64

### DIFF
--- a/libwild/src/elf_x86_64.rs
+++ b/libwild/src/elf_x86_64.rs
@@ -371,8 +371,10 @@ impl crate::platform::Arch for ElfX86_64 {
             }
             object::elf::R_X86_64_TLSGD if output_kind.is_executable() => {
                 let kind = match TlsGdForm::identify(section_bytes, offset)? {
-                    TlsGdForm::Regular => RelaxationKind::TlsGdToInitialExec,
-                    TlsGdForm::RegularNoPlt | TlsGdForm::Large => {
+                    TlsGdForm::Regular | TlsGdForm::RegularNoPlt => {
+                        RelaxationKind::TlsGdToInitialExec
+                    }
+                    TlsGdForm::Large => {
                         // TODO
                         return None;
                     }

--- a/wild/tests/sources/elf/tls-gd-noplt-ie/tls-gd-noplt-ie-shared.s
+++ b/wild/tests/sources/elf/tls-gd-noplt-ie/tls-gd-noplt-ie-shared.s
@@ -1,0 +1,4 @@
+.section .tbss,"awT",@nobits
+.globl tlsvar
+tlsvar:
+    .long 0

--- a/wild/tests/sources/elf/tls-gd-noplt-ie/tls-gd-noplt-ie.s
+++ b/wild/tests/sources/elf/tls-gd-noplt-ie/tls-gd-noplt-ie.s
@@ -1,0 +1,21 @@
+// Test that Wild relaxes the -z noplt form of TLS GD to Initial Exec
+// when the TLS symbol is in a shared object. The indirect call form
+// (call *__tls_get_addr@GOTPCREL(%rip), encoded as 0xff 0x15) must
+// relax to IE (mov %fs:0,%rax; add offset(%rip),%rax) like the
+// regular PLT call form. Both lld and GNU ld handle this correctly.
+//#Arch:x86_64
+//#Mode:dynamic
+//#LinkArgs:--no-gc-sections
+//#Shared:tls-gd-noplt-ie-shared.s
+//#SoSingleLinker:wild
+//#ReferenceLinkers:lld,bfd
+//#RunEnabled:false
+//#DiffIgnore:.dynamic.DT_FLAGS_1.NOW
+.globl _start
+_start:
+    .byte 0x66
+    leaq tlsvar@tlsgd(%rip), %rdi
+    .byte 0x66
+    .byte 0x48
+    call *__tls_get_addr@GOTPCREL(%rip)
+    ret


### PR DESCRIPTION
When a TLS symbol is in a shared object, Wild needs to relax TLS GD to IE (Initial Exec) rather than LE. The -z noplt variant uses an indirect call through the GOT (0x66 0x48 0xff 0x15) instead of a direct PLT call. This form was grouped with the Large variant and returned None, causing Wild to error with "Undefined symbol __tls_get_addr" instead of relaxing to IE.


Both lld and GNU ld already handle this pattern correctly.


Fixes  #2164