### PR TITLE
chore: Overhaul update-in-place testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,6 +294,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +667,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1411,7 +1423,7 @@ dependencies = [
  "libc",
  "nix 0.30.1",
  "prost",
- "rand",
+ "rand 0.9.2",
  "windows-sys",
 ]
 
@@ -1541,7 +1553,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1551,7 +1574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1562,6 +1585,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -2337,6 +2366,7 @@ dependencies = [
  "mimalloc",
  "object 0.39.1",
  "os_info",
+ "rand 0.10.2",
  "regex",
  "serde",
  "serde-keyvalue",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ paste = "1.0.15"
 perf-event = "=0.4.8"
 perfetto-recorder = "0.3.0"
 postcard = { version = "1.1.1", features = ["use-std"] }
+rand = "0.10.2"
 rayon = "1.5.1"
 regex = { version = "1.12.0", features = ["std"] }
 serde = { version = "1.0.225", features = ["derive"] }

--- a/wild/Cargo.toml
+++ b/wild/Cargo.toml
@@ -42,6 +42,7 @@ libtest-mimic = { workspace = true }
 object.workspace = true
 wasmparser.workspace = true
 os_info.workspace = true
+rand.workspace = true
 regex.workspace = true
 serde.workspace = true
 serde-keyvalue = { workspace = true }

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -1353,7 +1353,8 @@ impl Config {
     }
 
     fn can_use_wild_in_process(&self) -> bool {
-        self.expect_stderr.is_empty()
+        !self.test_update_in_place
+            && self.expect_stderr.is_empty()
             && self.expect_stdout.is_empty()
             && self.active_malfunction.is_none()
     }
@@ -2150,10 +2151,14 @@ impl ProgramInputs {
             )
             .collect::<Result<Vec<_>>>()?;
 
+        if config.test_update_in_place && linker.is_wild() {
+            let _ = std::fs::remove_file(linker.output_path(self.name(), config));
+        }
+
         let link_output = linker.link(self.name(), &inputs, config, cross_arch)?;
 
         if config.test_update_in_place && matches!(linker, Linker::Wild) {
-            self.run_update_in_place_test(&inputs, config, cross_arch)?;
+            self.run_update_in_place_test(&inputs, config, cross_arch, &link_output)?;
         }
 
         let shared_objects = inputs
@@ -2181,92 +2186,62 @@ impl ProgramInputs {
         inputs: &[LinkerInput],
         config: &Config,
         cross_arch: Option<Architecture>,
-    ) -> Result<()> {
-        // Link normally, using unlink-and-replace
-        let link_output_1 = Linker::Wild.link(self.name(), inputs, config, cross_arch)?;
-        let original_content = std::fs::read(&link_output_1.binary).with_context(|| {
-            format!(
-                "Failed to read first build output: {}",
-                link_output_1.binary.display()
-            )
-        })?;
+        reference_output: &LinkOutput,
+    ) -> Result {
+        let original_content = std::fs::read(&reference_output.binary)
+            .with_context(|| format!("Failed to read: {}", reference_output.binary.display()))?;
 
-        // Overwrite the file with random data with a different length
-        let random_data = (0..original_content.len() + 1024)
-            .map(|i| (i % 256) as u8)
+        // Create initial file with random data and a different length.
+        let random_data = rand::random_iter()
+            .take(original_content.len() + 1024)
             .collect_vec();
-        std::fs::write(&link_output_1.binary, &random_data).with_context(|| {
-            format!(
-                "Failed to overwrite file with random data: {}",
-                link_output_1.binary.display()
-            )
-        })?;
 
-        // Link again with --update-in-place
+        // Force-enable --update-in-place and specify an odd number of threads, which serves to
+        // validate that we don't produce different output based on number of threads.
         let mut config_update_in_place = config.clone();
-        let arg = match config.linker_driver {
-            LinkerDriver::Compiler(_) => "-Wl,--update-in-place",
-            LinkerDriver::Direct(_) => "--update-in-place",
+        let args: &[&str] = match config.linker_driver {
+            LinkerDriver::Compiler(_) => &["-Wl,--update-in-place,--threads=3"],
+            LinkerDriver::Direct(_) => &["--update-in-place", "--threads=3"],
         };
         config_update_in_place
             .wild_extra_linker_args
             .args
-            .push(arg.to_string());
+            .extend(args.iter().map(|a| a.to_string()));
 
-        let link_output_2 =
+        let path = &reference_output.binary;
+
+        std::fs::write(path, &random_data)
+            .with_context(|| format!("Failed to write: {}", path.display()))?;
+
+        let updated_link_output =
             Linker::Wild.link(self.name(), inputs, &config_update_in_place, cross_arch)?;
 
         // Verify the content matches the first build
-        let final_content = std::fs::read(&link_output_2.binary).with_context(|| {
+        let final_content = std::fs::read(&updated_link_output.binary).with_context(|| {
             format!(
                 "Failed to read second build output: {}",
-                link_output_2.binary.display()
+                updated_link_output.binary.display()
             )
         })?;
 
         if original_content != final_content {
             let diffs = sections_with_diffs(&original_content, &final_content)?;
 
-            let mut original = link_output_1.binary.clone();
-            let mut updated = link_output_2.binary.clone();
-
-            fn make_variant(path: &mut std::path::PathBuf, suffix: &str) {
-                let stem = path.file_stem().unwrap_or_default();
-                let ext = path.extension();
-                let mut filename = std::ffi::OsString::from(stem);
-                filename.push(suffix);
-                if let Some(ext) = ext {
-                    filename.push(".");
-                    filename.push(ext);
-                }
-                path.set_file_name(filename);
-            }
-
-            make_variant(&mut original, "-original");
-            make_variant(&mut updated, "-updated");
-
-            std::fs::write(&original, &original_content).with_context(|| {
-                format!("Failed to write original file: {}", original.display())
-            })?;
-            std::fs::rename(&link_output_2.binary, &updated).with_context(|| {
-                format!(
-                    "Failed to rename {} to {}",
-                    link_output_2.binary.display(),
-                    updated.display()
-                )
-            })?;
+            let original_path = add_to_path(path, ".original");
+            std::fs::write(&original_path, &original_content)
+                .with_context(|| format!("Failed to write {}", original_path.display()))?;
 
             bail!(
-                "Update-in-place test failed for {file}: content of {original} differs \
-                from {updated} after update-in-place linking. Original size: {original_len}, \
+                "Update-in-place test failed for {file}: content of {path} differs \
+                from {original} after update-in-place linking. Original size: {original_len}, \
                 Final size: {final_len}. Diffs:\n{diffs:#?}\n\
                 Rerun with:\n{cmd}",
                 file = self.name(),
-                original = original.display(),
-                updated = updated.display(),
+                path = path.display(),
+                original = original_path.display(),
                 original_len = original_content.len(),
                 final_len = final_content.len(),
-                cmd = link_output_2.command,
+                cmd = updated_link_output.command,
             );
         }
 
@@ -2315,22 +2290,30 @@ fn sections_with_diffs(bytes_a: &[u8], bytes_b: &[u8]) -> Result<Vec<SectionDiff
 
         let offset = offset as u64;
 
-        for section in file.sections() {
-            let Some(start_and_len) = section.file_range() else {
-                continue;
-            };
+        let section_with_diff = file.sections().find(|section| {
+            section.file_range().is_some_and(|start_and_len| {
+                (start_and_len.0..start_and_len.0 + start_and_len.1).contains(&offset)
+            })
+        });
 
-            if (start_and_len.0..start_and_len.0 + start_and_len.1).contains(&offset) {
-                let name_bytes = section.name_bytes()?;
-                let info = sections.entry(name_bytes).or_insert_with(|| SectionDiff {
-                    name: String::from_utf8_lossy(name_bytes).into_owned(),
-                    section_start: start_and_len.0,
-                    section_size: start_and_len.1,
-                    offsets_with_diff: Vec::new(),
-                });
-                info.offsets_with_diff.push(offset);
-            }
-        }
+        let (section_start, section_size) = section_with_diff
+            .as_ref()
+            .and_then(|s| s.file_range())
+            .unwrap_or((0, 0));
+
+        let name_bytes = section_with_diff
+            .map(|s| s.name_bytes())
+            .transpose()?
+            .unwrap_or(b"Section not found");
+
+        let info = sections.entry(name_bytes).or_insert_with(|| SectionDiff {
+            name: String::from_utf8_lossy(name_bytes).into_owned(),
+            section_start,
+            section_size,
+            offsets_with_diff: Vec::new(),
+        });
+
+        info.offsets_with_diff.push(offset);
     }
 
     let mut sections = sections.into_values().collect_vec();

--- a/wild/tests/sources/macho/trivial-dynamic/trivial-dynamic.c
+++ b/wild/tests/sources/macho/trivial-dynamic/trivial-dynamic.c
@@ -5,6 +5,7 @@
 //#DiffIgnore:section.__const
 
 //#Config:dylib:default
+//#TestUpdateInPlace:true
 //#Shared:foo.c
 
 //#Config:fat-dylib:default


### PR DESCRIPTION
Rather than running the linker once for the main test then twice for the update-in-place verification, we only run the linker once for the main test, then one extra time for the update-in-place verification. We also now set `--threads=3` for the verification run so that we can check that the output doesn't change due to a change in the number of threads.