### PR TITLE
feat: parse and ignore `CONSTRUCTORS` in linker scripts

### DIFF
--- a/LINKER_SCRIPT_SUPPORT.md
+++ b/LINKER_SCRIPT_SUPPORT.md
@@ -119,7 +119,7 @@ see at a glance what remains before Wild can link the kernel.
 | `>region` and `AT>region` memory region placement | 📅 | |
 | `SORT_BY_NAME(...)`, `SORT_BY_ALIGNMENT(...)`, `SORT_BY_INIT_PRIORITY(...)` | 📅 | |
 | `EXCLUDE_FILE(...)` inside input section matchers | 📅 | |
-| `CONSTRUCTORS` command | 📅 | |
+| `CONSTRUCTORS` command | ✅ | Parsed and ignored, it is a nop for ELF.  |
 | `PHDRS` command for explicit program header definition | 🧪 | The FILEHDR and PHDRS keywords aren't yet supported. |
 | Ternary operator (`condition ? a : b`) | ✅ | |
 | `DEFINED(sym)` function | 📅 | |

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -317,6 +317,10 @@ impl<'data> LayoutRulesBuilder<'data> {
                                             primary_section_id,
                                         );
                                     }
+                                    // The CONSTRUCTORS command is used in legacy file formats only.
+                                    // On ELF it is a nop.
+                                    // (https://sourceware.org/binutils/docs/ld/Output-Section-Keywords.html#index-CONSTRUCTORS)
+                                    ContentsCommand::Constructors => (),
                                 }
                             }
                             if let Some(location) = last_location.take() {

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -123,6 +123,7 @@ pub(crate) enum ContentsCommand<'a> {
     Align(Alignment),
     Provide(ProvideSymbolDefinition<'a>),
     SetLocation(Location<'a>),
+    Constructors,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -1171,7 +1172,7 @@ fn parse_at_address<'input>(input: &mut &'input BStr) -> winnow::Result<Expressi
 fn parse_contents_command<'input>(
     input: &mut &'input BStr,
 ) -> winnow::Result<ContentsCommand<'input>> {
-    alt((parse_contents_provide, parse_matcher, parse_assignment)).parse_next(input)
+    alt((parse_contents_provide, parse_matcher, parse_assignment, parse_constructors)).parse_next(input)
 }
 
 fn parse_contents_provide<'input>(
@@ -1213,6 +1214,12 @@ fn parse_assignment<'input>(input: &mut &'input BStr) -> winnow::Result<Contents
     skip_comments_and_whitespace(input)?;
 
     Ok(cmd)
+}
+
+fn parse_constructors<'input>(input: &mut &'input BStr) -> winnow::Result<ContentsCommand<'input>> {
+    "CONSTRUCTORS".parse_next(input)?;
+    skip_comments_and_whitespace(input)?;
+    Ok(ContentsCommand::Constructors)
 }
 
 fn parse_matcher<'input>(input: &mut &'input BStr) -> winnow::Result<ContentsCommand<'input>> {

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -1172,7 +1172,13 @@ fn parse_at_address<'input>(input: &mut &'input BStr) -> winnow::Result<Expressi
 fn parse_contents_command<'input>(
     input: &mut &'input BStr,
 ) -> winnow::Result<ContentsCommand<'input>> {
-    alt((parse_contents_provide, parse_matcher, parse_assignment, parse_constructors)).parse_next(input)
+    alt((
+        parse_contents_provide,
+        parse_matcher,
+        parse_assignment,
+        parse_constructors,
+    ))
+    .parse_next(input)
 }
 
 fn parse_contents_provide<'input>(

--- a/wild/tests/sources/elf/linker-script/linker-script.ld
+++ b/wild/tests/sources/elf/linker-script/linker-script.ld
@@ -3,6 +3,7 @@ SECTIONS {
     bar : ALIGN(8) {
         start_bar = .;
         KEEP(*(.data.foo .data.baz*));
+        CONSTRUCTORS
         start_aaa = .;
         KEEP(*(.data.aaa));
         end_bar = .;


### PR DESCRIPTION
`CONSTRUCTORS` is a legacy keyword that is used to define where the linker must place C++ constructors and destructors, in ECOFF and XCOFF file formats. On ELF, we can ignore and treat it as a nop.
ref: https://sourceware.org/binutils/docs/ld/Output-Section-Keywords.html#index-CONSTRUCTORS