### PR TITLE
feat: support the DEFINED command in linker scripts

### DIFF
--- a/LINKER_SCRIPT_SUPPORT.md
+++ b/LINKER_SCRIPT_SUPPORT.md
@@ -82,7 +82,7 @@ end lists the features required to link the Linux kernel.
 | `MIN(a, b)` | ✅ | |
 | `MAX(a, b)` | ✅ | |
 | Ternary operator (`condition ? a : b`) | ✅ | |
-| `DEFINED(sym)` | 📅 | |
+| `DEFINED(sym)` | ✅ | |
 | `SIZEOF_HEADERS` | ✅ | |
 | `SEGMENT_START(segment, default)` | ✅ | Supports `"text"`, `"data"`, `"bss"`, `"rodata"`; returns `-Ttext`/`-Tdata`/`-Tbss` override if provided, otherwise `default`; unknown segment names always return `default` |
 
@@ -122,6 +122,6 @@ see at a glance what remains before Wild can link the kernel.
 | `CONSTRUCTORS` command | 📅 | |
 | `PHDRS` command for explicit program header definition | 🧪 | The FILEHDR and PHDRS keywords aren't yet supported. |
 | Ternary operator (`condition ? a : b`) | ✅ | |
-| `DEFINED(sym)` function | 📅 | |
+| `DEFINED(sym)` function | ✅ | |
 | `SIZEOF_HEADERS` built-in symbol | ✅ | |
 | `/DISCARD/` command | ✅ | |

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -213,6 +213,9 @@ pub(crate) fn evaluate_expression<'data, P: Platform>(
                 eval!(if_false)
             }
         }
+        Expression::Defined(name) => Ok(symbol_db
+            .get_unversioned(&UnversionedSymbolName::prehashed(name))
+            .map_or(0, |_| 1)),
     }
 }
 

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -170,7 +170,8 @@ pub(crate) struct Phdr<'a> {
 /// - Bitwise: &, |, ^, ~, <<, >>
 /// - Logical: &&, ||
 /// - Unary: -, !, ~
-/// - Functions: SIZEOF, ALIGNOF, LENGTH, ORIGIN, ADDR, LOADADDR, ALIGN, MIN, MAX, SEGMENT_START
+/// - Functions: SIZEOF, ALIGNOF, LENGTH, ORIGIN, ADDR, LOADADDR, ALIGN, MIN, MAX, SEGMENT_START,
+///   DEFINED
 /// - Numbers (hex/decimal), symbols, location counter (.)
 /// - Parentheses for grouping
 /// - Ternary operator (? :)
@@ -229,6 +230,7 @@ pub(crate) enum Expression<'a> {
         Box<Expression<'a>>,
         Box<Expression<'a>>,
     ),
+    Defined(&'a [u8]),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -261,7 +263,8 @@ impl<'a> Expression<'a> {
             | Expression::Addr(_)
             | Expression::Loadaddr(_)
             | Expression::Symbol(_)
-            | Expression::SizeofHeaders => {}
+            | Expression::SizeofHeaders
+            | Expression::Defined(_) => {}
             Expression::Add(l, r)
             | Expression::Subtract(l, r)
             | Expression::Multiply(l, r)
@@ -925,6 +928,10 @@ fn parse_identifier_or_function<'a>(input: &mut &'a BStr) -> winnow::Result<Expr
                     segment_name,
                     Box::new(default_expr),
                 ))
+            }
+            b"DEFINED" => {
+                let symbol = parse_function_arg.parse_next(input)?;
+                Ok(Expression::Defined(symbol))
             }
             _ => Err(ContextError::default()),
         }

--- a/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.c
+++ b/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.c
@@ -1,10 +1,15 @@
 //#LinkArgs:-T ./linker-script-assert-pass.ld
 //#RunEnabled:false
 //#DiffEnabled:false
-void _start() {}
+//#Object:runtime.c
+// RISC-V: BFD complains about missing __global_pointer$ (defined in the default linker script)
+//#SkipArch:riscv64
+
+#include "../common/runtime.h"
 
 int symbol4 = 0x4000;
 int symbol6 __attribute__((weak));
 int symbol7 __attribute__((weak)) = 0x7000;
 extern int symbol8 __attribute__((weak));
-extern int symbol9;
+
+void _start() { exit_syscall(symbol4 + symbol6 + symbol7 + symbol8); }

--- a/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.c
+++ b/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.c
@@ -4,3 +4,7 @@
 void _start() {}
 
 int symbol4 = 0x4000;
+int symbol6 __attribute__((weak));
+int symbol7 __attribute__((weak)) = 0x7000;
+extern int symbol8 __attribute__((weak));
+extern int symbol9;

--- a/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.c
+++ b/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.c
@@ -2,3 +2,5 @@
 //#RunEnabled:false
 //#DiffEnabled:false
 void _start() {}
+
+int symbol4 = 0x4000;

--- a/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
+++ b/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
@@ -1,7 +1,10 @@
 ENTRY(_start)
 
 SECTIONS {
-    .text : { *(.text*) }
+    .text : {
+        *(.text*)
+        symbol3 = 0x3000;
+    }
     .data : { *(.data*) }
     .bss  : { *(.bss*)  }
 }
@@ -27,3 +30,7 @@ ASSERT(symbol1 + symbol2 != symbol1 - symbol2, "symbol1 + symbol2 must not be sy
 ASSERT(0xffffffff81000000 == (0xffffffff80000000 + (((symbol1 * 0x1000) + (symbol2 * 0x100 - 1)) & ~(0x200000 - 1))), "Incorrect Value");
 ASSERT((5 > 4 ? !1 ? 3 : 5 : 4) == 5, "5 > 4 ? !1 ? 3 : 5 : 4 must be 5");
 ASSERT((symbol1 > symbol2 ? symbol1 : symbol2) == MAX(symbol1, symbol2), "Expected MAX(symbol1, symbol2)");
+ASSERT(DEFINED(symbol1), "symbol1 must be defined");
+ASSERT(DEFINED(symbol3), "symbol3 must be defined");
+ASSERT(DEFINED(symbol4), "symbol4 must be defined");
+ASSERT(!DEFINED(symbol5), "symbol5 is not defined");

--- a/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
+++ b/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
@@ -37,4 +37,3 @@ ASSERT(!DEFINED(symbol5), "symbol5 should not be defined");
 ASSERT(DEFINED(symbol6), "symbol6 must be defined");
 ASSERT(DEFINED(symbol7), "symbol7 must be defined");
 ASSERT(!DEFINED(symbol8), "symbol8 should not be defined");
-ASSERT(!DEFINED(symbol9), "symbol9 should not be defined");

--- a/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
+++ b/wild/tests/sources/elf/linker-script-assert-pass/linker-script-assert-pass.ld
@@ -33,4 +33,8 @@ ASSERT((symbol1 > symbol2 ? symbol1 : symbol2) == MAX(symbol1, symbol2), "Expect
 ASSERT(DEFINED(symbol1), "symbol1 must be defined");
 ASSERT(DEFINED(symbol3), "symbol3 must be defined");
 ASSERT(DEFINED(symbol4), "symbol4 must be defined");
-ASSERT(!DEFINED(symbol5), "symbol5 is not defined");
+ASSERT(!DEFINED(symbol5), "symbol5 should not be defined");
+ASSERT(DEFINED(symbol6), "symbol6 must be defined");
+ASSERT(DEFINED(symbol7), "symbol7 must be defined");
+ASSERT(!DEFINED(symbol8), "symbol8 should not be defined");
+ASSERT(!DEFINED(symbol9), "symbol9 should not be defined");


### PR DESCRIPTION
This PR adds support for the `DEFINED` command in linker scripts, which is used to check if a symbol has been declared or not.