### PR TITLE
chore: Update Arch Linux container base

### DIFF
--- a/docker/arch-basic.Dockerfile
+++ b/docker/arch-basic.Dockerfile
@@ -4,7 +4,7 @@
 #
 # docker run -it wild-dev-arch-basic
 
-FROM archlinux:base-20251005.0.430597 AS chef
+FROM archlinux:base-20260628.0.549485 AS chef
 
 RUN pacman --noconfirm -Syu \
     wget \

--- a/docker/arch.Dockerfile
+++ b/docker/arch.Dockerfile
@@ -9,7 +9,7 @@
 # `--cap-add=SYS_PTRACE --security-opt seccomp=unconfined`
 # See https://github.com/rr-debugger/rr/wiki/Docker
 
-FROM archlinux:base-20251005.0.430597 AS chef
+FROM archlinux:base-20260628.0.549485 AS chef
 
 RUN pacman --noconfirm -Syu \
     wget \


### PR DESCRIPTION
Current base is so old some of the keys have expired:
```
❯ podman build --progress=plain -t wild-dev-arch . -f docker/arch.Dockerfile ...
error: filesystem: signature from "David Runge <dvzrv@archlinux.org>" is unknown trust
:: File /var/cache/pacman/pkg/filesystem-2025.10.12-1-any.pkg.tar.zst is corrupted (invalid or corrupted package (PGP signature)).
```