### PR TITLE
port(MachO): Align __LINKEDIT sections

### DIFF
--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -1318,7 +1318,10 @@ impl platform::Platform for MachO {
         fixup_table_size += CHAINED_FIXUP_PAGE_START_SIZE
             * (state.imported_symbols.len() as u64).div_ceil(MACHO_PAGE_ALIGNMENT.value());
 
-        mem_sizes.increment(part_id::CHAINED_FIXUP_TABLE, fixup_table_size);
+        mem_sizes.increment(
+            part_id::CHAINED_FIXUP_TABLE,
+            alignment::USIZE.align_up(fixup_table_size),
+        );
     }
 
     fn finalise_sizes_all<'data>(
@@ -1709,10 +1712,12 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
     };
     defs[output_section_id::CHAINED_FIXUP_TABLE.as_usize()] = BuiltInSectionDetails {
         kind: SectionKind::Primary(SectionName(b"DYLD_CHAINED_FIXUPS_TABLE")),
+        min_alignment: alignment::USIZE,
         ..DEFAULT_DEFS
     };
     defs[output_section_id::SYMTAB_GLOBAL.as_usize()] = BuiltInSectionDetails {
         kind: SectionKind::Primary(SectionName(b"SYMTAB")),
+        min_alignment: alignment::USIZE,
         ..DEFAULT_DEFS
     };
     defs[output_section_id::CODE_SIGNATURE.as_usize()] = BuiltInSectionDetails {

--- a/linker-diff/src/header_diff.rs
+++ b/linker-diff/src/header_diff.rs
@@ -22,13 +22,19 @@ use object::ObjectSymbol as _;
 use object::Section;
 #[allow(clippy::wildcard_imports)]
 use object::elf::*;
+use object::macho::LC_CODE_SIGNATURE;
+use object::macho::LC_DYLD_CHAINED_FIXUPS;
 use object::read::elf::Dyn;
+use object::read::macho::LoadCommandVariant;
 use object::read::macho::MachHeader;
 use std::borrow::Cow;
 use std::collections::BTreeSet;
 use tabled::Table;
 use tabled::settings::Style;
 use tabled::settings::style::HorizontalLine;
+
+const MACHO64_LINKEDIT_ALIGNMENT: u32 = 8;
+const MACHO_CODE_SIGNATURE_ALIGNMENT: u32 = 16;
 
 #[derive(Clone, Copy)]
 pub(crate) enum Converter {
@@ -195,6 +201,15 @@ pub(crate) fn check_dynamic_headers(report: &mut Report, objects: &[crate::Binar
         read_dynamic_fields,
         DYNAMIC_SECTION_NAME_STR,
         DiffMode::IgnoreIfAllErrors,
+    ));
+}
+
+pub(crate) fn check_macho_linkedit_alignment(report: &mut Report, objects: &[crate::Binary]) {
+    report.add_diffs(diff_fields(
+        objects,
+        read_macho_linkedit_fields,
+        "linkedit",
+        DiffMode::IgnoreMissingValues,
     ));
 }
 
@@ -708,4 +723,50 @@ fn read_dynamic_fields(obj: &Binary) -> Result<FieldValues> {
     }
 
     Ok(values)
+}
+
+fn read_macho_linkedit_fields(obj: &Binary) -> Result<FieldValues> {
+    let mut values = FieldValues::default();
+    let object::File::MachO64(file) = obj.file else {
+        return Ok(values);
+    };
+    let e = file.endianness();
+    let mut load_commands = file.macho_load_commands()?;
+
+    while let Some(load_command) = load_commands.next()? {
+        match load_command.variant()? {
+            LoadCommandVariant::Symtab(symtab) => {
+                values.insert_string(
+                    "SYMTAB.symoff.alignment",
+                    format_alignment(symtab.symoff.get(e), MACHO64_LINKEDIT_ALIGNMENT),
+                );
+            }
+            LoadCommandVariant::LinkeditData(linkedit) => match linkedit.cmd.get(e) {
+                LC_DYLD_CHAINED_FIXUPS => {
+                    values.insert_string(
+                        "DYLD_CHAINED_FIXUPS.dataoff.alignment",
+                        format_alignment(linkedit.dataoff.get(e), MACHO64_LINKEDIT_ALIGNMENT),
+                    );
+                }
+                LC_CODE_SIGNATURE => {
+                    values.insert_string(
+                        "CODE_SIGNATURE.dataoff.alignment",
+                        format_alignment(linkedit.dataoff.get(e), MACHO_CODE_SIGNATURE_ALIGNMENT),
+                    );
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+
+    Ok(values)
+}
+
+fn format_alignment(offset: u32, alignment: u32) -> String {
+    if offset.is_multiple_of(alignment) {
+        "OK".to_owned()
+    } else {
+        format!("offset 0x{offset:x} is not {alignment}-byte aligned")
+    }
 }

--- a/linker-diff/src/lib.rs
+++ b/linker-diff/src/lib.rs
@@ -674,6 +674,7 @@ impl Report {
         );
         header_diff::check_dynamic_headers(self, objects);
         header_diff::check_file_headers(self, objects);
+        header_diff::check_macho_linkedit_alignment(self, objects);
         header_diff::report_section_diffs(self, objects);
         eh_frame_diff::report_diffs(self, objects);
         version_diff::report_diffs(self, objects);


### PR DESCRIPTION
Fixes #2063.

According to dyld ([alignments](https://github.com/apple-oss-distributions/dyld/blob/fd8d0c4d52320ebf64db34f3cb280310d905c5ae/common/MachOLayout.cpp#L129-L207), [alignment check](https://github.com/apple-oss-distributions/dyld/blob/fd8d0c4d52320ebf64db34f3cb280310d905c5ae/common/MachOLayout.cpp#L270-L274)) and lld ([alignments](https://github.com/llvm/llvm-project/blob/6f47c92a82cc142fe5b728a4d90987e15876b372/lld/MachO/SyntheticSections.h#L54-L80), [code signature alignment](https://github.com/llvm/llvm-project/blob/6f47c92a82cc142fe5b728a4d90987e15876b372/lld/MachO/SyntheticSections.cpp#L1567-L1590)), the current `__LINKEDIT` blobs/“sections” we have are expected to have a minimum alignment of: 

```
STRTAB: 1
CHAINED_FIXUPS: 8
SYMTAB: 8
CODE_SIGNATURE: 16
```

`STRTAB` and `CODE_SIGNATURE` are already correctly aligned, so the alignments were only changed for `CHAINED_FIXUPS` and `SYMTAB`. `CHAINED_FIXUPS`’ size was also aligned upwards to USIZE since `OffsetVerifier` needs this “section” to have an aligned size (`wild: error: Unexpected memory offsets: Part #36 (section DYLD_CHAINED_FIXUPS_TABLE alignment: 8) has non aligned size: 0x4e`). This follows what [lld does for padding `CHAINED_FIXUPS`](https://github.com/llvm/llvm-project/blob/6f47c92a82cc142fe5b728a4d90987e15876b372/lld/MachO/SyntheticSections.h#L71-L80). 

I manually checked with dyld_info and otool using misaligned files, and while this fixes the errors for misaligned `__LINKEDIT` content, there’s another dyld_info error (`chained fixups, segment_offset does not match vmaddr from LC_SEGMENT in segment #2`) that seems like an off-by-one in how we calculate the index for `__DATA_CONST` when writing the chained fixup table. I’ve opened a separate issue for that here: #2185.