### PR TITLE
port(MachO): Fix chained fixups __DATA_CONST segment index

### DIFF
--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -918,7 +918,8 @@ fn write_chained_fixup_table(layout: &MachOLayout, chained_fixup_table: &mut [u8
         return Ok(());
     };
 
-    starts_in_image[data_const_segment_index + 1].set(LE, starts_in_image_len as u32);
+    // Accounts for both seg_count and __PAGEZERO.
+    starts_in_image[data_const_segment_index + 2].set(LE, starts_in_image_len as u32);
 
     let (starts_in_segment, rest) = DyldChainedStartsInSegment::mut_from_prefix(rest)
         .map_err(|_| error!("Invalid chained fixups starts in segment allocation"))?;

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -309,7 +309,11 @@ use object::Object as _;
 use object::ObjectKind;
 use object::ObjectSection;
 use object::ObjectSymbol as _;
+use object::macho::LC_DYLD_CHAINED_FIXUPS;
+use object::macho::SEG_TEXT;
 use object::read::elf::ProgramHeader;
+use object::read::macho::LoadCommandVariant;
+use object::read::macho::Segment;
 use regex::Regex;
 use serde::Deserialize;
 use serde::Serialize;
@@ -4232,6 +4236,7 @@ impl Assertions {
         self.verify_strings(bytes)?;
         verify_no_overlapping_sections(obj)?;
         verify_no_overlapping_segments(obj)?;
+        verify_chained_fixups_segment_offsets(obj, bytes)?;
         Ok(())
     }
 
@@ -4935,6 +4940,82 @@ fn verify_no_overlapping_segments(obj: &object::File) -> Result {
             );
         }
     }
+    Ok(())
+}
+
+fn verify_chained_fixups_segment_offsets(obj: &object::File, bytes: &[u8]) -> Result {
+    let object::File::MachO64(file) = obj else {
+        return Ok(());
+    };
+
+    let e = file.endianness();
+    let mut load_commands = file.macho_load_commands()?;
+    let mut segments = Vec::new();
+    let mut chained_fixups = None;
+
+    while let Some(load_command) = load_commands.next()? {
+        match load_command.variant()? {
+            LoadCommandVariant::Segment64(segment, _) => {
+                segments.push(segment);
+            }
+            LoadCommandVariant::LinkeditData(linkedit)
+                if linkedit.cmd.get(e) == LC_DYLD_CHAINED_FIXUPS =>
+            {
+                chained_fixups = Some(linkedit);
+            }
+            _ => {}
+        }
+    }
+
+    let Some(chained_fixups) = chained_fixups else {
+        return Ok(());
+    };
+
+    let load_addr = segments
+        .iter()
+        .find(|segment| segment.name() == SEG_TEXT.as_bytes())
+        .map(|segment| segment.vmaddr.get(e))
+        .context("Missing __TEXT segment")?;
+
+    let dataoff = usize::try_from(chained_fixups.dataoff.get(e))?;
+    let datasize = usize::try_from(chained_fixups.datasize.get(e))?;
+    let dataend = dataoff
+        .checked_add(datasize)
+        .context("Chained fixups data range overflow")?;
+    let blob = bytes
+        .get(dataoff..dataend)
+        .context("Invalid chained fixups data range")?;
+
+    let starts_offset = usize::try_from(u32::from_le_bytes(blob[4..8].try_into()?))?;
+    let starts_in_image = blob
+        .get(starts_offset..)
+        .context("Invalid chained fixups starts_offset")?;
+    let seg_count = usize::try_from(u32::from_le_bytes(starts_in_image[..4].try_into()?))?;
+    let seg_info_offsets = &starts_in_image[4..];
+
+    for (i, offset_bytes) in seg_info_offsets.chunks_exact(4).take(seg_count).enumerate() {
+        let seg_info_offset = usize::try_from(u32::from_le_bytes(offset_bytes.try_into()?))?;
+        if seg_info_offset == 0 {
+            continue;
+        }
+
+        let starts_in_segment = starts_in_image
+            .get(seg_info_offset..)
+            .context("Invalid chained fixups seg_info_offset")?;
+        let segment_offset = u64::from_le_bytes(starts_in_segment[8..16].try_into()?);
+        let expected_segment_offset = segments[i]
+            .vmaddr
+            .get(e)
+            .checked_sub(load_addr)
+            .context("Chained fixups segment address is before __TEXT")?;
+
+        ensure!(
+            segment_offset == expected_segment_offset,
+            "Chained fixups segment {i} has segment_offset {segment_offset:#x}, \
+            expected offset {expected_segment_offset:#x}"
+        );
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Fixes #2185 as described in the issue, now accounting for both `seg_count` and `__PAGEZERO` when calculating the `__DATA_CONST` segment index for the chained fixups table.

Also added a regression check for verifying each chained fixups `segment_offset` with the corresponding `LC_SEGMENT_64` offset relative to `__TEXT`, with the following output before vs. after the fix:

**Before:**
```
cargo test -p wild-linker --features macho --test integration_tests -- --exact macho/aarch64/trivial-libsystem/default
   Compiling wild-linker v0.9.0 (/Users/joannajo/wild/wild)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.32s
     Running tests/integration_tests.rs (target/debug/deps/integration_tests-e09ef3bd42fdfb60)

running 1 test
test macho/aarch64/trivial-libsystem/default ... FAILED

failures:

---- macho/aarch64/trivial-libsystem/default ----
Output binary assertions failed. Binary `/Users/joannajo/wild/wild/tests/build/macho/aarch64/trivial-libsystem/default/trivial-libsystem.c.wild`. Relink with:
WILD_WRITE_LAYOUT=1 WILD_WRITE_TRACE=1 OUT=/Users/joannajo/wild/wild/tests/build/macho/aarch64/trivial-libsystem/default/trivial-libsystem.c.wild /Users/joannajo/wild/wild/tests/build/macho/aarch64/trivial-libsystem/default/trivial-libsystem.c.save/run-with cargo run --bin wild --
  Caused by:
    Chained fixups segment 2 has segment_offset 0x8000, expected offset 0x4000



failures:
    macho/aarch64/trivial-libsystem/default

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.73s
```

**After:**
```
cargo test -p wild-linker --features macho --test integration_tests -- --exact macho/aarch64/trivial-libsystem/default
   Compiling libwild v0.9.0 (/Users/joannajo/wild/libwild)
   Compiling wild-linker v0.9.0 (/Users/joannajo/wild/wild)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 4.22s
     Running tests/integration_tests.rs (target/debug/deps/integration_tests-e09ef3bd42fdfb60)

running 1 test
test macho/aarch64/trivial-libsystem/default ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 1.07s
```