### PR TITLE
chore: Disable unused features of all dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,15 +134,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
 name = "atomic-take"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,12 +235,6 @@ name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -382,15 +361,8 @@ checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width",
  "windows-sys",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "constant_time_eq"
@@ -433,12 +405,6 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -544,7 +510,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common",
 ]
 
@@ -683,9 +648,6 @@ version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1033caf0b349c518623b5396bfb2cf0bddf44f0306d543a250e5743297aafd10"
 dependencies = [
- "fnv",
- "hashbrown 0.17.1",
- "indexmap",
  "stable_deref_trait",
 ]
 
@@ -694,15 +656,6 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
-]
 
 [[package]]
 name = "hashbrown"
@@ -719,25 +672,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.2.0",
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "heapless"
-version = "0.7.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
-dependencies = [
- "atomic-polyfill",
- "hash32",
- "rustc_version",
- "serde",
- "spin",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -796,7 +731,6 @@ checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
  "portable-atomic",
- "unicode-width",
  "unit-prefix",
  "web-time",
 ]
@@ -1453,7 +1387,6 @@ dependencies = [
  "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
- "heapless",
  "serde",
 ]
 
@@ -1837,15 +1770,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,7 +1853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -2005,12 +1929,10 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
  "toml_parser",
- "toml_writer",
  "winnow",
 ]
 
@@ -2033,31 +1955,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
-
-[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2250,7 +2154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.252.0",
 ]
 
 [[package]]
@@ -2286,8 +2189,6 @@ dependencies = [
  "bitflags",
  "hashbrown 0.17.1",
  "indexmap",
- "semver",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,44 +25,66 @@ edition = "2024"
 # the lowest version that we can support.
 
 [workspace.dependencies]
-anstyle = "1.0.13"
-anyhow = "1.0.97"
-ar = "0.9.0"
-atomic-take = "1.0.0"
-bitflags = { version = "2.4.1", features = ["serde"] }
-blake3 = { version = "1.0.0", features = ["rayon"] }
-bumpalo-herd = "0.1.2"
-bytesize = "2.0.0"
-clap = { version = "4.1.0", features = ["derive"] }
-colored = "3.0.0"
-colosseum = "0.2.2"
-crossbeam-queue = "0.3.10"
-crossbeam-utils = "0.8.18"
-derive_more = { version = "2.0.1", features = ["debug", "display"] }
-dhat = { version = "0.3.3" }
-diff = "0.1.13"
-flate2 = { version = "1.1.0", features = ["zlib-rs"] }
-zlib-rs = "0.6.4"
-foldhash = "0.2.0"
-gimli = "0.34.0"
-glob = "0.3.2"
-hashbrown = "0.17.1"
-hex = "0.4.0"
+anstyle = { version = "1.0.13", default-features = false }
+anyhow = { version = "1.0.97", default-features = false }
+ar = { version = "0.9.0", default-features = false }
+atomic-take = { version = "1.0.0", default-features = false }
+bitflags = { version = "2.4.1", default-features = false, features = ["serde"] }
+blake3 = { version = "1.0.0", default-features = false, features = ["rayon"] }
+bumpalo-herd = { version = "0.1.2", default-features = false }
+bytesize = { version = "2.0.0", default-features = false }
+cc = { version = "1.1.12", default-features = false }
+clap = { version = "4.1.0", default-features = false, features = [
+  "derive",
+  "help",
+  "std",
+  "usage",
+] }
+colored = { version = "3.0.0", default-features = false }
+colosseum = { version = "0.2.2", default-features = false }
+crossbeam-queue = { version = "0.3.10", default-features = false, features = [
+  "alloc",
+] }
+crossbeam-utils = { version = "0.8.18", default-features = false }
+derive_more = { version = "2.0.1", default-features = false, features = [
+  "debug",
+  "display",
+] }
+dhat = { version = "0.3.3", default-features = false }
+diff = { version = "0.1.13", default-features = false }
+flate2 = { version = "1.1.0", default-features = false, features = ["zlib-rs"] }
+zlib-rs = { version = "0.6.4", default-features = false, features = [
+  "rust-allocator",
+] }
+foldhash = { version = "0.2.0", default-features = false, features = ["std"] }
+gimli = { version = "0.34.0", default-features = false, features = [
+  "read-all",
+] }
+glob = { version = "0.3.2", default-features = false }
+hashbrown = { version = "0.17.1", default-features = false, features = [
+  "default-hasher",
+  "inline-more",
+] }
+hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 iced-x86 = { version = "1.17.0", default-features = false, features = [
   "std",
   "decoder",
   "gas",
 ] }
-indexmap = "2.14.0"
-indicatif = "0.18.3"
-itertools = "0.15.0"
-jobserver = "0.1.30"
-leb128 = "0.2.7"
-libc = "0.2.180"
-libloading = "0.9.0"
-libtest-mimic = "0.8.2"
-memchr = "2.7.0"
-memmap2 = "0.9.0"
+indexmap = { version = "2.14.0", default-features = false, features = ["std"] }
+indicatif = { version = "0.18.6", default-features = false, features = [
+  "wasmbind",
+] }
+itertools = { version = "0.15.0", default-features = false, features = [
+  "use_std",
+] }
+jobserver = { version = "0.1.30", default-features = false }
+leb128 = { version = "0.2.7", default-features = false }
+libc = { version = "0.2.180", default-features = false }
+libloading = { version = "0.9.0", default-features = false, features = ["std"] }
+libtest-mimic = { version = "0.8.2", default-features = false }
+memchr = { version = "2.7.0", default-features = false }
+memmap2 = { version = "0.9.0", default-features = false }
 mimalloc = { version = "0.1", default-features = false }
 nix = { version = "0.31.1", default-features = false, features = [
   "resource",
@@ -80,47 +102,64 @@ object = { git = "https://github.com/gimli-rs/object", rev = "a0bfa322", default
   "names",
 ] }
 os_info = { version = "3.1.0", default-features = false }
-paste = "1.0.15"
+paste = { version = "1.0.15", default-features = false }
 # 0.4.9 contains breaking changes.
-perf-event = "=0.4.8"
-perfetto-recorder = "0.3.0"
-postcard = { version = "1.1.1", features = ["use-std"] }
-rand = "0.10.2"
-rayon = "1.5.1"
-regex = { version = "1.12.0", features = ["std"] }
-serde = { version = "1.0.225", features = ["derive"] }
-serde-keyvalue = "0.1.0"
-serde_yaml = "0.9"
-sha2 = "0.11.0"
-sharded-offset-map = "0.3.0"
-sharded-vec-writer = "0.4.0"
-smallvec = "1.6.1"
-strum = { version = "0.28.0", features = ["derive"] }
-symbolic-common = "13.0.0"
+perf-event = { version = "=0.4.8", default-features = false }
+perfetto-recorder = { version = "0.3.0", default-features = false }
+postcard = { version = "1.1.1", default-features = false, features = [
+  "use-std",
+] }
+rand = { version = "0.10.2", default-features = false, features = [
+  "thread_rng",
+] }
+rayon = { version = "1.5.1", default-features = false }
+regex = { version = "1.12.0", default-features = false, features = ["std"] }
+serde = { version = "1.0.225", default-features = false, features = ["derive"] }
+serde-keyvalue = { version = "0.1.0", default-features = false }
+serde_yaml = { version = "0.9", default-features = false }
+sha2 = { version = "0.11.0", default-features = false }
+sharded-offset-map = { version = "0.3.0", default-features = false }
+sharded-vec-writer = { version = "0.4.0", default-features = false }
+smallvec = { version = "1.6.1", default-features = false }
+strum = { version = "0.28.0", default-features = false, features = ["derive"] }
+symbolic-common = { version = "13.0.0", default-features = false }
 symbolic-demangle = { version = "13.0.0", default-features = false, features = [
   "cpp",
   "rust",
 ] }
 tabled = { version = "0.21.0", default-features = false, features = ["std"] }
-tempfile = "3.0.2"
-thread_local = "1.1.9"
-toml = "1.0.3"
-tracing = "0.1.35"
+tempfile = { version = "3.15.0", default-features = false, features = [
+  "getrandom",
+] }
+thread_local = { version = "1.1.9", default-features = false }
+toml = { version = "1.0.3", default-features = false, features = [
+  "parse",
+  "serde",
+] }
+tracing = { version = "0.1.35", default-features = false }
 tracing-subscriber = { version = "0.3.16", default-features = false, features = [
   "ansi",
   "env-filter",
   "fmt",
   "registry",
 ] }
-uuid = { version = "1.3.0", features = ["v4"] }
-wait-timeout = "0.2.0"
-wait4 = "0.1.3"
-wasmparser = "0.252.0"
-wasm-encoder = "0.252.0"
-which = "8.0.0"
-winnow = { version = "1.0.0", features = ["simd"] }
-zerocopy = { version = "0.8.27", features = ["derive"] }
-zstd = "0.13.0"
+uuid = { version = "1.3.0", default-features = false, features = ["v4"] }
+wait-timeout = { version = "0.2.0", default-features = false }
+wait4 = { version = "0.1.3", default-features = false }
+wasmparser = { version = "0.252.0", default-features = false, features = [
+  "hash-collections",
+] }
+wasm-encoder = { version = "0.252.0", default-features = false }
+which = { version = "8.0.0", default-features = false, features = ["real-sys"] }
+winnow = { version = "1.0.0", default-features = false, features = [
+  "ascii",
+  "simd",
+  "std",
+] }
+zerocopy = { version = "0.8.27", default-features = false, features = [
+  "derive",
+] }
+zstd = { version = "0.13.0", default-features = false }
 
 [profile.release]
 codegen-units = 1

--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -65,7 +65,7 @@ perf-event.workspace = true
 nix.workspace = true
 
 [build-dependencies]
-cc = "1.1.12"
+cc.workspace = true
 
 [dev-dependencies]
 ar.workspace = true

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
@@ -24,7 +24,7 @@
 //#Config:underflow
 //#Object:runtime.c
 //#LinkerScript:linker-script-location-counter-underflow.ld
-//#ExpectError:(?i)cannot move location counter backwards
+//#ExpectError:(?i-u)cannot move location counter backwards
 
 #include <stddef.h>
 

--- a/wild/tests/sources/elf/linker-script-region/linker-script-region.c
+++ b/wild/tests/sources/elf/linker-script-region/linker-script-region.c
@@ -24,13 +24,13 @@
 // GNU ld only prints a warning.
 //#ReferenceLinkers:lld
 //#LinkerScript:linker-script-region-missing.ld
-//#ExpectError:(?i)memory region 'FLASH' not declared
+//#ExpectError:(?i-u)memory region 'FLASH' not declared
 
 //#Config:region-overflow:default
 // lld gives a similar error, but with a different message.
 //#ReferenceLinkers:bfd
 //#LinkerScript:linker-script-region-overflow.ld
-//#ExpectError:(?i)region .FLASH' overflowed by 1 byte
+//#ExpectError:(?i-u)region [`']FLASH' overflowed by 1 byte
 
 static int var1 __attribute__((used, section(".data.ram1"))) = 0x01;
 static int var2 __attribute__((used, section(".data.rom"))) = 0x02;

--- a/wild/tests/sources/elf/nmagic/nmagic.c
+++ b/wild/tests/sources/elf/nmagic/nmagic.c
@@ -20,7 +20,7 @@
 // Re-enable ppc64le here: this config links fine, but inherits the SkipArch from `default`.
 //#Arch: x86_64,aarch64,riscv64,loongarch64,ppc64le
 //#Shared:force-dynamic-linking.c
-//#ExpectError:(?i)Attempted static link of dynamic object
+//#ExpectError:(?i-u)Attempted static link of dynamic object
 
 #include "../common/runtime.h"
 

--- a/wild/tests/sources/elf/no-dynamic-in-static/no-dynamic-in-static.c
+++ b/wild/tests/sources/elf/no-dynamic-in-static/no-dynamic-in-static.c
@@ -1,5 +1,5 @@
 //#Mode:static
 //#Shared:force-dynamic-linking.c
-//#ExpectError:(?i)Attempted static link of dynamic object
+//#ExpectError:(?i-u)Attempted static link of dynamic object
 
 int main() { return 42; }


### PR DESCRIPTION
This removes 11 crates from our Cargo.lock. Some tests needed updating to switch regexes to not require unicode tables.