### PR TITLE
fix: use nop padding bytes in executable sections on x86 

### DIFF
--- a/libwild/src/elf_riscv64.rs
+++ b/libwild/src/elf_riscv64.rs
@@ -157,18 +157,18 @@ impl crate::platform::Arch for ElfRiscV64 {
         ]
     }
 
-    fn fill_nop_padding(buf: &mut [u8], offset: usize, len: usize) {
+    fn fill_nop_padding(buf: &mut [u8]) {
         // Fill with 4-byte NOP.
         let mut i = 0;
-        while i + 4 <= len {
-            buf[offset + i..offset + i + 4].copy_from_slice(&0x0000_0013u32.to_le_bytes());
+        while i + 4 <= buf.len() {
+            buf[i..i + 4].copy_from_slice(&0x0000_0013u32.to_le_bytes());
             i += 4;
         }
         // Fill a remaining 2-byte slot with c.nop. This is safe because a 2-byte
         // remainder only arises when the assembler used c.nop in the original sled,
         // which implies the C extension is enabled.
-        if i + 2 <= len {
-            buf[offset + i..offset + i + 2].copy_from_slice(&0x0001u16.to_le_bytes());
+        if i + 2 <= buf.len() {
+            buf[i..i + 2].copy_from_slice(&0x0001u16.to_le_bytes());
         }
     }
 

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -3000,7 +3000,8 @@ fn apply_relocation<
             let removed_bytes =
                 relax_deltas.map_or(0u64, |d| u64::from(d.delta_bytes_at(rel.offset())));
             let padding_bytes = addend.saturating_sub(removed_bytes) as usize;
-            A::fill_nop_padding(out, offset_in_section as usize, padding_bytes);
+            let offset_in_section = offset_in_section as usize;
+            A::fill_nop_padding(&mut out[offset_in_section..offset_in_section + padding_bytes]);
 
             return Ok(RelocationModifier::Normal);
         }

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2197,11 +2197,7 @@ fn write_section_raw<'out, 'data, A: Arch<Platform = Elf>>(
                 let section_size = object.object.section_size(object_section)?;
                 let (out, padding) = out.split_at_mut(section_size as usize);
                 object.object.copy_section_data(object_section, out)?;
-                if A::requires_nop_padding_for_section(section_flags) {
-                    A::fill_nop_padding(padding, 0, padding.len());
-                } else {
-                    padding.fill(0);
-                }
+                A::fill_section_padding(padding, section_flags);
                 Ok(out)
             }
             Some(deltas) => {
@@ -2231,11 +2227,7 @@ fn write_section_raw<'out, 'data, A: Arch<Platform = Elf>>(
                         .copy_from_slice(&input_data[input_pos..]);
                     output_pos += remaining;
                 }
-                if A::requires_nop_padding_for_section(section_flags) {
-                    A::fill_nop_padding(out, output_pos, out.len() - output_pos);
-                } else {
-                    out[output_pos..].fill(0);
-                }
+                A::fill_section_padding(&mut out[output_pos..], section_flags);
 
                 Ok(&mut out[..effective_size])
             }

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2004,7 +2004,7 @@ fn write_object_section<'data, A: Arch<Platform = Elf>>(
         }
     }
 
-    let out = write_section_raw(object, layout, section, section_index, buffers)?;
+    let out = write_section_raw::<A>(object, layout, section, section_index, buffers)?;
 
     // We need to reverse the contents and adjust relocations because .ctors/.dtors are executed in
     // reverse order while .init_array/.fini_array are executed in forward order.
@@ -2141,7 +2141,7 @@ fn write_debug_section<'data, A: Arch<Platform = Elf>>(
         return Ok(());
     }
 
-    let out = write_section_raw(object, layout, section, section_index, buffers)?;
+    let out = write_section_raw::<A>(object, layout, section, section_index, buffers)?;
     let relocations = object.relocations(section_index)?;
     let result = match relocations {
         elf::RelocationList::Rela(rela) => apply_debug_relocations::<A, Rela, _>(
@@ -2165,7 +2165,7 @@ fn write_debug_section<'data, A: Arch<Platform = Elf>>(
     Ok(())
 }
 
-fn write_section_raw<'out, 'data>(
+fn write_section_raw<'out, 'data, A: Arch<Platform = Elf>>(
     object: &ObjectLayout<'data, Elf>,
     layout: &ElfLayout,
     sec: Section,
@@ -2190,13 +2190,18 @@ fn write_section_raw<'out, 'data>(
         let out = section_buffer.split_off_mut(..allocation_size).unwrap();
         let object_section = object.object.section(section_index)?;
         let relax_deltas = object.section_relax_deltas.get(section_index.0);
+        let section_flags = object_section.sh_flags(LittleEndian);
 
         match relax_deltas {
             None => {
                 let section_size = object.object.section_size(object_section)?;
                 let (out, padding) = out.split_at_mut(section_size as usize);
                 object.object.copy_section_data(object_section, out)?;
-                padding.fill(0);
+                if A::requires_nop_padding_for_section(section_flags) {
+                    A::fill_nop_padding(padding, 0, padding.len());
+                } else {
+                    padding.fill(0);
+                }
                 Ok(out)
             }
             Some(deltas) => {
@@ -2226,7 +2231,11 @@ fn write_section_raw<'out, 'data>(
                         .copy_from_slice(&input_data[input_pos..]);
                     output_pos += remaining;
                 }
-                out[output_pos..].fill(0);
+                if A::requires_nop_padding_for_section(section_flags) {
+                    A::fill_nop_padding(out, output_pos, out.len() - output_pos);
+                } else {
+                    out[output_pos..].fill(0);
+                }
 
                 Ok(&mut out[..effective_size])
             }

--- a/libwild/src/elf_x86_64.rs
+++ b/libwild/src/elf_x86_64.rs
@@ -484,6 +484,17 @@ impl crate::platform::Arch for ElfX86_64 {
             offset_in_section,
         )
     }
+
+    fn fill_nop_padding(buf: &mut [u8], offset: usize, len: usize) {
+        buf[offset..offset + len].fill(0xcc);
+    }
+
+    fn requires_nop_padding_for_section(section_flags: object::elf::SectionFlags) -> bool {
+        if section_flags.contains(object::elf::SHF_EXECINSTR) {
+            return true;
+        }
+        false
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/libwild/src/elf_x86_64.rs
+++ b/libwild/src/elf_x86_64.rs
@@ -489,11 +489,12 @@ impl crate::platform::Arch for ElfX86_64 {
         buf[offset..offset + len].fill(0xcc);
     }
 
-    fn requires_nop_padding_for_section(section_flags: object::elf::SectionFlags) -> bool {
+    fn fill_section_padding(buf: &mut [u8], section_flags: object::elf::SectionFlags) {
         if section_flags.contains(object::elf::SHF_EXECINSTR) {
-            return true;
+            Self::fill_nop_padding(buf, 0, buf.len());
+        } else {
+            buf.fill(0);
         }
-        false
     }
 }
 

--- a/libwild/src/elf_x86_64.rs
+++ b/libwild/src/elf_x86_64.rs
@@ -485,13 +485,13 @@ impl crate::platform::Arch for ElfX86_64 {
         )
     }
 
-    fn fill_nop_padding(buf: &mut [u8], offset: usize, len: usize) {
-        buf[offset..offset + len].fill(0xcc);
+    fn fill_nop_padding(buf: &mut [u8]) {
+        buf.fill(0xcc);
     }
 
     fn fill_section_padding(buf: &mut [u8], section_flags: object::elf::SectionFlags) {
         if section_flags.contains(object::elf::SHF_EXECINSTR) {
-            Self::fill_nop_padding(buf, 0, buf.len());
+            Self::fill_nop_padding(buf);
         } else {
             buf.fill(0);
         }

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -214,8 +214,8 @@ pub(crate) trait Arch: Send + Sync + 'static {
         }
     }
 
-    fn requires_nop_padding_for_section(_section_flags: object::elf::SectionFlags) -> bool {
-        false
+    fn fill_section_padding(buf: &mut [u8], _section_flags: object::elf::SectionFlags) {
+        buf.fill(0);
     }
 }
 

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -180,7 +180,7 @@ pub(crate) trait Arch: Send + Sync + 'static {
     ) -> Option<Self::Relaxation>;
 
     /// Fill `len` bytes of NOP padding at `offset` in `buf`.
-    fn fill_nop_padding(_buf: &mut [u8], _offset: usize, _len: usize) {}
+    fn fill_nop_padding(_buf: &mut [u8]) {}
 
     fn process_riscv_attributes<'data>(
         _object: &<Self::Platform as Platform>::File<'data>,

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -179,7 +179,7 @@ pub(crate) trait Arch: Send + Sync + 'static {
         relax_deltas: Option<&SectionRelaxDeltas>,
     ) -> Option<Self::Relaxation>;
 
-    /// Fill `len` bytes of NOP padding at `offset` in `buf`.
+    /// Fill `buf` with NOP padding.
     fn fill_nop_padding(_buf: &mut [u8]) {}
 
     fn process_riscv_attributes<'data>(

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -213,6 +213,10 @@ pub(crate) trait Arch: Send + Sync + 'static {
             Self::DEFAULT_LOAD_ADDRESS
         }
     }
+
+    fn requires_nop_padding_for_section(_section_flags: object::elf::SectionFlags) -> bool {
+        false
+    }
 }
 
 pub(crate) trait Relaxation: Send + Sync + 'static {

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -77,8 +77,8 @@
 //!
 //! NoSection:{section_name} Checks that the specified section does not exist in the output binary.
 //!
-//! ExpectSectionBytes:{section_name}=0x{hex_bytes} Checks that the specified section contains
-//! exactly the given bytes.
+//! ExpectSectionBytes:{section_name}=0x{hex_bytes} [start_range..end_range] Checks that the
+//! specified section contains exactly the given bytes.
 //!
 //! ExpectGdbIndexCuCount:{count} Checks that the `.gdb_index` section contains exactly the
 //! specified number of CU entries.

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -1957,7 +1957,7 @@ fn process_directive(
             let match_range = if let Some(match_range) = match_range {
                 let (start_range, end_range) = match_range.split_once("..").with_context(|| {
                     format!(
-                        "ExpectSectionBytes requires section_name=0xhex_bytes .. 0xhex_bytes, got `{match_range}`"
+                        "ExpectSectionBytes requires section_name=0xhex_bytes start_range..end_range, got `{match_range}`"
                     )
                 })?;
                 Some(start_range.parse::<usize>()?..end_range.parse::<usize>()?)

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -328,6 +328,7 @@ use std::io::BufReader;
 use std::io::ErrorKind;
 use std::io::IsTerminal;
 use std::io::Read;
+use std::ops::Range;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
@@ -1524,6 +1525,7 @@ struct Assertions {
 struct ExpectedSectionBytes {
     section_name: String,
     expected_bytes: Vec<u8>,
+    match_range: Option<Range<usize>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1947,6 +1949,21 @@ fn process_directive(
             let (section_name, hex_str) = arg.split_once('=').with_context(|| {
                 format!("ExpectSectionBytes requires section_name=0xhex_bytes, got `{arg}`")
             })?;
+            let (hex_str, match_range) = hex_str
+                .split_once(' ')
+                .map_or((hex_str, None), |(hex_str, match_range)| {
+                    (hex_str, Some(match_range.trim()))
+                });
+            let match_range = if let Some(match_range) = match_range {
+                let (start_range, end_range) = match_range.split_once("..").with_context(|| {
+                    format!(
+                        "ExpectSectionBytes requires section_name=0xhex_bytes .. 0xhex_bytes, got `{match_range}`"
+                    )
+                })?;
+                Some(start_range.parse::<usize>()?..end_range.parse::<usize>()?)
+            } else {
+                None
+            };
             let hex_str = hex_str.trim().strip_prefix("0x").with_context(|| {
                 format!("ExpectSectionBytes value must start with 0x, got `{hex_str}`")
             })?;
@@ -1959,6 +1976,7 @@ fn process_directive(
                 .push(ExpectedSectionBytes {
                     section_name: section_name.to_owned(),
                     expected_bytes,
+                    match_range,
                 });
         }
         "ExpectDynamic" => config
@@ -4397,7 +4415,11 @@ impl Assertions {
             let section = obj
                 .section_by_name(&expected.section_name)
                 .with_context(|| format!("Section `{}` not found", expected.section_name))?;
-            let data = section.data()?;
+            let data = if let Some(range) = &expected.match_range {
+                &section.data()?[range.clone()]
+            } else {
+                section.data()?
+            };
             ensure!(
                 data == expected.expected_bytes.as_slice(),
                 "Section `{}` bytes mismatch: expected {:02x?}, got {:02x?}",

--- a/wild/tests/sources/elf/exec-section-padding/exec-section-padding.s
+++ b/wild/tests/sources/elf/exec-section-padding/exec-section-padding.s
@@ -1,0 +1,20 @@
+//#ReferenceLinkers:lld
+//#Arch:x86_64
+//#ExpectSectionBytes:.text=0x48c7c03c000000c3cccccccccccccccc 0..16
+
+.section .text.1
+.balign 16
+.globl foo
+foo:
+    mov $60, %rax
+    ret
+
+.section .text.2
+.balign 16
+.globl _start
+_start:
+    call foo
+    xor %rdi, %rdi
+    mov $42, %edi
+    syscall
+    ret


### PR DESCRIPTION
Closes #2191

On x86, emit the `int3` instruction, instead of using zero byte padding, in sections with executable instructions.