### PR TITLE
feat: print version and emulation info when the -V flag is used

### DIFF
--- a/libwild/src/arch.rs
+++ b/libwild/src/arch.rs
@@ -45,3 +45,8 @@ impl Display for Architecture {
         write!(f, "{arch}")
     }
 }
+
+pub(crate) const SUPPORTED_TARGETS: &str =
+    "elf64-x86-64 elf64-littleaarch64 elf64-littleriscv elf64-loongarch elf64-powerpcle";
+pub(crate) const SUPPORTED_EMULATIONS: &str =
+    "elf_x86_64 aarch64elf elf64lriscv elf64loongarch elf64lppc";

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -208,7 +208,8 @@ impl Args {
             Args::Elf(_) => {
                 writeln!(
                     stdout,
-                    "supported emulations: elf_x86_64 aarch64elf elf64lriscv elf64loongarch elf64lppc"
+                    "supported emulations: {}",
+                    crate::arch::SUPPORTED_EMULATIONS
                 )?;
             }
             Args::MachO(_) | Args::Wasm(_) => (),

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -25,6 +25,7 @@ use jobserver::Acquired;
 use jobserver::Client;
 use rayon::ThreadPoolBuilder;
 use std::fmt::Display;
+use std::io::Write;
 use std::num::NonZeroUsize;
 use std::path::Path;
 use std::path::PathBuf;
@@ -200,6 +201,19 @@ impl Args {
             Args::MachO(macho_args) => &mut macho_args.common,
             Args::Wasm(wasm_args) => &mut wasm_args.common,
         }
+    }
+
+    pub(crate) fn print_emulation_info(&self, stdout: &mut dyn Write) -> Result<()> {
+        match self {
+            Args::Elf(_) => {
+                writeln!(
+                    stdout,
+                    "supported emulations: elf_x86_64 aarch64elf elf64lriscv elf64loongarch elf64lppc"
+                )?;
+            }
+            Args::MachO(_) | Args::Wasm(_) => (),
+        }
+        Ok(())
     }
 }
 

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -247,8 +247,11 @@ impl PlatformKind {
 pub(crate) enum VersionMode {
     /// Don't print version
     None,
-    /// Print version and continue linking (-v)
+    /// Print version and continue linking if object files are specified (-v).
     Verbose,
+    /// Print version along with supported emulations and continue linking if object files are
+    /// specified (-V).
+    VerboseWithEmulations,
     /// Print version and exit immediately (--version)
     ExitAfterPrint,
 }

--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -878,8 +878,8 @@ fn setup_argument_parser() -> ArgumentParser<ElfArgs> {
             writeln!(stdout, "{}", parser.generate_help())?;
 
             // The following listing is something autoconf detection relies on.
-            writeln!(stdout, "wild: supported targets: elf64-x86-64 elf64-littleaarch64 elf64-littleriscv elf64-loongarch")?;
-            writeln!(stdout, "wild: supported emulations: elf_x86_64 aarch64elf elf64lriscv elf64loongarch")?;
+            writeln!(stdout, "wild: supported targets: elf64-x86-64 elf64-littleaarch64 elf64-littleriscv elf64-loongarch elf64-powerpcle")?;
+            writeln!(stdout, "wild: supported emulations: elf_x86_64 aarch64elf elf64lriscv elf64loongarch elf64lppc")?;
 
             std::process::exit(0);
         });
@@ -896,9 +896,18 @@ fn setup_argument_parser() -> ArgumentParser<ElfArgs> {
     parser
         .declare()
         .short("v")
-        .help("Print version and continue linking")
+        .help("Print version and continue linking if object files are specified")
         .execute(|args, _modifier_stack| {
             args.common.version_mode = VersionMode::Verbose;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .short("V")
+        .help("Print version along with supported emulations and continue linking if object files are specified")
+        .execute(|args, _modifier_stack| {
+            args.common.version_mode = VersionMode::VerboseWithEmulations;
             Ok(())
         });
 

--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -7,6 +7,8 @@ use super::Input;
 use super::InputSpec;
 use crate::alignment::Alignment;
 use crate::arch::Architecture;
+use crate::arch::SUPPORTED_EMULATIONS;
+use crate::arch::SUPPORTED_TARGETS;
 use crate::args::CommonArgs;
 use crate::args::CopyRelocations;
 use crate::args::CopyRelocationsDisabledReason;
@@ -878,8 +880,8 @@ fn setup_argument_parser() -> ArgumentParser<ElfArgs> {
             writeln!(stdout, "{}", parser.generate_help())?;
 
             // The following listing is something autoconf detection relies on.
-            writeln!(stdout, "wild: supported targets: elf64-x86-64 elf64-littleaarch64 elf64-littleriscv elf64-loongarch elf64-powerpcle")?;
-            writeln!(stdout, "wild: supported emulations: elf_x86_64 aarch64elf elf64lriscv elf64loongarch elf64lppc")?;
+            writeln!(stdout, "wild: supported targets: {SUPPORTED_TARGETS}")?;
+            writeln!(stdout, "wild: supported emulations: {SUPPORTED_EMULATIONS}")?;
 
             std::process::exit(0);
         });

--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -228,10 +228,7 @@ impl Linker {
             args::VersionMode::VerboseWithEmulations => {
                 let mut stdout = std::io::stdout().lock();
                 writeln!(stdout, "{identity}")?;
-                writeln!(
-                    stdout,
-                    "supported emulations: elf_x86_64 aarch64elf elf64lriscv elf64loongarch elf64lppc"
-                )?;
+                args.print_emulation_info(&mut stdout)?;
                 // Continue linking if object files are specified
                 if args.common().inputs.is_empty() {
                     return Ok(LinkerOutput { layout: None });

--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -220,7 +220,22 @@ impl Linker {
             args::VersionMode::Verbose => {
                 let mut stdout = std::io::stdout().lock();
                 writeln!(stdout, "{identity}")?;
-                // Continue linking
+                // Continue linking if object files are specified
+                if args.common().inputs.is_empty() {
+                    return Ok(LinkerOutput { layout: None });
+                }
+            }
+            args::VersionMode::VerboseWithEmulations => {
+                let mut stdout = std::io::stdout().lock();
+                writeln!(stdout, "{identity}")?;
+                writeln!(
+                    stdout,
+                    "supported emulations: elf_x86_64 aarch64elf elf64lriscv elf64loongarch elf64lppc"
+                )?;
+                // Continue linking if object files are specified
+                if args.common().inputs.is_empty() {
+                    return Ok(LinkerOutput { layout: None });
+                }
             }
             args::VersionMode::None => {
                 // Don't print version


### PR DESCRIPTION
This PR adds support for the `-V` flag, which prints version info and supported emulations. It also fixed an issue with `-v`, we now continue linking if input object files are provided.

Also adds powerpcle to the supported target and emulation lists.