### PR TITLE
port(wasm): Link static WASI libraries and preserve host imports

### DIFF
--- a/libwild/src/args/wasm.rs
+++ b/libwild/src/args/wasm.rs
@@ -4,6 +4,8 @@ use crate::alignment::Alignment;
 use crate::args::ArgumentParser;
 use crate::args::CommonArgs;
 use crate::args::FILES_PER_GROUP_ENV;
+use crate::args::Input;
+use crate::args::InputSpec;
 use crate::args::Modifiers;
 use crate::args::REFERENCE_LINKER_ENV;
 use crate::args::RelocationModel;
@@ -26,6 +28,7 @@ pub(crate) const WASM_PAGE_SIZE: u64 = WASM_PAGE_ALIGNMENT.value();
 #[derive(Debug)]
 pub struct WasmArgs {
     pub(crate) common: super::CommonArgs,
+    pub(crate) lib_search_path: Vec<Box<Path>>,
 }
 
 impl WasmArgs {
@@ -42,6 +45,7 @@ impl Default for WasmArgs {
     fn default() -> Self {
         Self {
             common: CommonArgs::default(),
+            lib_search_path: Vec::new(),
         }
     }
 }
@@ -70,7 +74,7 @@ impl platform::Args for WasmArgs {
     }
 
     fn lib_search_path(&self) -> &[Box<std::path::Path>] {
-        todo!()
+        &self.lib_search_path
     }
 
     fn common(&self) -> &crate::args::CommonArgs {
@@ -134,6 +138,37 @@ fn setup_argument_parser() -> ArgumentParser<WasmArgs> {
         .help("Set the output filename")
         .execute(|args, _modifier_stack, value| {
             args.common.output = Arc::from(Path::new(value));
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .prefix("L")
+        .help("Add directory to library search path")
+        .execute(|args, _modifier_stack, value| {
+            args.common.save_dir.handle_file(value);
+            args.lib_search_path.push(Box::from(Path::new(value)));
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .prefix("l")
+        .help("Link with library")
+        .execute(|args, modifier_stack, value| {
+            // Prefer static archives. Wasm has no shared-object loading.
+            let mut modifiers = *modifier_stack.last().unwrap();
+            modifiers.allow_shared = false;
+            let spec = if let Some(stripped) = value.strip_prefix(':') {
+                InputSpec::Search(Box::from(stripped))
+            } else {
+                InputSpec::Lib(Box::from(value))
+            };
+            args.common.inputs.push(Input {
+                spec,
+                search_first: None,
+                modifiers,
+            });
             Ok(())
         });
 

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -121,6 +121,9 @@ const EMPTY_FUNCTION_BODY: &[u8] = &[0x00, 0x0b];
 /// `i32.const` body for `LINKER_MEMORY_BASE`.
 const LINKER_MEMORY_BASE_INIT_EXPR: &[u8] = &[0x41, 0x80, 0x08];
 
+/// `i32.const 0`. Used for immutable `__tls_base` when no TLS segment is laid out.
+const ZERO_I32_INIT_EXPR: &[u8] = &[0x41, 0x00];
+
 #[derive(derive_more::Debug)]
 pub(crate) struct File<'data> {
     #[debug(skip)]
@@ -2567,6 +2570,7 @@ struct LinkerImportAbsorption {
     absorbed_globals: u32,
     needs_memory_base: bool,
     needs_stack_pointer: bool,
+    needs_tls_base: bool,
     needs_ctors: bool,
     needs_dtors: bool,
 }
@@ -2612,6 +2616,11 @@ impl LinkerImportAbsorption {
                     absorption.needs_stack_pointer = true;
                     absorption.absorbed_globals += 1;
                 }
+                // Single-threaded. Immutable base (no TLS segment yet).
+                "__tls_base" => {
+                    absorption.needs_tls_base = true;
+                    absorption.absorbed_globals += 1;
+                }
                 _ => {}
             }
         }
@@ -2632,6 +2641,7 @@ fn remaining_unresolved_imports(unresolved: u32, absorbed: u32) -> Result<u32> {
 struct LinkerDefinedIndices {
     memory_base_global: Option<u32>,
     stack_pointer_global: Option<u32>,
+    tls_base_global: Option<u32>,
     /// Index of `__stack_pointer` among the defined globals prepended by
     /// `emit_reserved_linker_definitions` (not the Wasm module global index).
     stack_pointer_defined_slot: Option<u32>,
@@ -2683,6 +2693,7 @@ impl LinkerDefinedIndices {
     ) -> Result<Self> {
         let mut needs_memory_base = false;
         let mut needs_stack_pointer = false;
+        let mut needs_tls_base = false;
         let mut needs_ctors = has_init_funcs;
         let mut needs_dtors = false;
         let mut function_import_count = 0u32;
@@ -2694,6 +2705,7 @@ impl LinkerDefinedIndices {
             needs_dtors |= absorption.needs_dtors;
             needs_memory_base |= absorption.needs_memory_base;
             needs_stack_pointer |= absorption.needs_stack_pointer;
+            needs_tls_base |= absorption.needs_tls_base;
 
             function_import_count = function_import_count
                 .checked_add(remaining_unresolved_imports(
@@ -2735,6 +2747,12 @@ impl LinkerDefinedIndices {
             next_defined_global_slot += 1;
             idx
         });
+        let tls_base_global = needs_tls_base.then(|| {
+            let idx = next_global;
+            next_global += 1;
+            next_defined_global_slot += 1;
+            idx
+        });
         let num_defined_globals = next_global - global_import_count;
 
         let mut next_func = function_import_count;
@@ -2758,6 +2776,7 @@ impl LinkerDefinedIndices {
         Ok(Self {
             memory_base_global,
             stack_pointer_global,
+            tls_base_global,
             stack_pointer_defined_slot,
             call_ctors_func,
             call_dtors_func,
@@ -2771,6 +2790,7 @@ impl LinkerDefinedIndices {
         match name {
             "__memory_base" => self.memory_base_global,
             "__stack_pointer" => self.stack_pointer_global,
+            "__tls_base" => self.tls_base_global,
             _ => None,
         }
     }
@@ -2964,6 +2984,16 @@ fn emit_reserved_linker_definitions(
                 shared: false,
             },
             init_expr_body: Cow::Borrowed(LINKER_MEMORY_BASE_INIT_EXPR),
+        });
+    }
+    if indices.tls_base_global.is_some() {
+        linker_globals.push(OutputGlobal {
+            ty: GlobalType {
+                content_type: wasmparser::ValType::I32,
+                mutable: false,
+                shared: false,
+            },
+            init_expr_body: Cow::Borrowed(ZERO_I32_INIT_EXPR),
         });
     }
     if !linker_globals.is_empty() {
@@ -3405,7 +3435,18 @@ fn is_memory_addr_relocation(ty: u8) -> bool {
 }
 
 fn is_supported_data_relocation(ty: u8) -> bool {
-    is_memory_addr_relocation(ty) || ty == reloc_type::FUNCTION_INDEX_I32
+    is_memory_addr_relocation(ty)
+        || matches!(
+            ty,
+            reloc_type::FUNCTION_INDEX_I32
+                | reloc_type::FUNCTION_INDEX_LEB
+                | reloc_type::TABLE_INDEX_I32
+                | reloc_type::TABLE_INDEX_SLEB
+                | reloc_type::TABLE_NUMBER_LEB
+                | reloc_type::GLOBAL_INDEX_I32
+                | reloc_type::GLOBAL_INDEX_LEB
+                | reloc_type::TYPE_INDEX_LEB
+        )
 }
 
 fn data_relocations_are_supported(relocs: &[WasmRelocation]) -> bool {

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -202,6 +202,8 @@
 //!
 //! The following input types support an optional template parameter. This should look something
 //! like `Shared:template(--push-state --as-needed $O --pop-state):filename.c`.
+//! `$O` is replaced with the built input path. `$OUT_DIR` is replaced with the test build
+//! directory (same as in `LinkArgs`). At least one of `$O` or `$OUT_DIR` must appear.
 //!
 //! Object:{source-filename}[:extra-compilation-args] Builds the specified filename as a regular
 //! object and adds it to the link.
@@ -630,6 +632,7 @@ type Result<T = (), E = libwild::error::Error> = core::result::Result<T, E>;
 type ElfFile64<'data> = object::read::elf::ElfFile64<'data, LittleEndian>;
 
 const TEMPLATE_PLACEHOLDER: &str = "$O";
+const TEMPLATE_OUT_DIR_PLACEHOLDER: &str = "$OUT_DIR";
 
 fn base_dir() -> &'static Path {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -2111,8 +2114,13 @@ fn process_directive(
                     .split_once("):")
                     .with_context(|| format!("Missing '):' in {arg}"))?;
                 let parts = t.split(' ').map(|p| p.to_owned()).collect_vec();
-                if !parts.iter().any(|a| a.contains(TEMPLATE_PLACEHOLDER)) {
-                    bail!("Template `{t}` must contain {TEMPLATE_PLACEHOLDER}");
+                if !parts.iter().any(|a| {
+                    a.contains(TEMPLATE_PLACEHOLDER) || a.contains(TEMPLATE_OUT_DIR_PLACEHOLDER)
+                }) {
+                    bail!(
+                        "Template `{t}` must contain {TEMPLATE_PLACEHOLDER} or \
+                         {TEMPLATE_OUT_DIR_PLACEHOLDER}"
+                    );
                 }
                 template = Some(parts);
                 arg = rest;
@@ -4090,13 +4098,17 @@ fn add_inputs_to_command(config: &Config, inputs: &[LinkerInput], command: &mut 
         command.args(input.prefix_arg);
         if let Some(template) = input.template.as_ref() {
             let path_str = input.path.to_str().expect("Non-UTF-8 paths not supported");
+            let out_dir = config
+                .build_dir()
+                .to_str()
+                .expect("Non-UTF-8 paths not supported")
+                .to_owned();
 
             for a in template {
-                if a.contains(TEMPLATE_PLACEHOLDER) {
-                    command.arg(a.replace(TEMPLATE_PLACEHOLDER, path_str));
-                } else {
-                    command.arg(a);
-                }
+                let arg = a
+                    .replace(TEMPLATE_OUT_DIR_PLACEHOLDER, &out_dir)
+                    .replace(TEMPLATE_PLACEHOLDER, path_str);
+                command.arg(arg);
             }
         } else {
             command.arg(&input.path);

--- a/wild/tests/sources/wasm/lib-search/lib-search.c
+++ b/wild/tests/sources/wasm/lib-search/lib-search.c
@@ -1,0 +1,9 @@
+//#Archive:template(-L$OUT_DIR -lfoo):libfoo.c
+
+extern int from_lib(void);
+
+void _start(void) {
+  if (from_lib() != 42) {
+    __builtin_trap();
+  }
+}

--- a/wild/tests/sources/wasm/lib-search/libfoo.c
+++ b/wild/tests/sources/wasm/lib-search/libfoo.c
@@ -1,0 +1,1 @@
+int from_lib(void) { return 42; }

--- a/wild/tests/sources/wasm/wasi-import/wasi-import.c
+++ b/wild/tests/sources/wasm/wasi-import/wasi-import.c
@@ -1,0 +1,8 @@
+// Unresolved host imports keep the object's import module/name (WASI contract).
+//#Contains: wasi_snapshot_preview1
+//#DoesNotContain: __wasi_proc_exit
+
+__attribute__((import_module("wasi_snapshot_preview1"), import_name("proc_exit"))) void proc_exit(
+    int code);
+
+void _start(void) { proc_exit(0); }


### PR DESCRIPTION
Add `-L`/`-l` for Wasm so `libc.a` can be pulled from the search path. Allow table/index relocations in data so wasi-libc objects layout. Absorb unresolved `__tls_base` as a linker-defined global. Unresolved host imports keep their original module and name (`wasi_snapshot_preview1.*`).

Part of #1431 