### PR TITLE
port(wasm): Align data segments and stack like wasm-ld

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         id: rust-toolchain
       - uses: Swatinem/rust-cache@v2
-      - run: sudo apt-get update && sudo apt-get install -y wabt lld
+      - run: sudo apt-get update && sudo apt-get install -y wabt lld wasi-libc
       - uses: taiki-e/install-action@v2
         with:
           tool: wasm-tools

--- a/libwild/src/alignment.rs
+++ b/libwild/src/alignment.rs
@@ -59,7 +59,7 @@ pub(crate) const EH_FRAME_HDR: Alignment = Alignment { exponent: 2 };
 pub(crate) const NOTE_GNU_PROPERTY: Alignment = Alignment { exponent: 3 };
 pub(crate) const NOTE_GNU_BUILD_ID: Alignment = Alignment { exponent: 2 };
 
-// GNU_STACK.alignment
+// GNU_STACK.alignment and Wasm stack alignment
 pub(crate) const STACK_ALIGNMENT: Alignment = Alignment { exponent: 4 };
 
 // Mach-O specific

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -116,9 +116,6 @@ const LINKER_MEMORY_BASE: u32 = 1024;
 /// Default stack size reserved above `__data_end` for the main stack.
 const LINKER_STACK_SIZE: u32 = 64 * 1024;
 
-/// Stack and post-data gap alignment.
-const LINKER_STACK_ALIGNMENT: Alignment = crate::alignment::STACK_ALIGNMENT;
-
 /// Empty function body: zero locals + `end`.
 const EMPTY_FUNCTION_BODY: &[u8] = &[0x00, 0x0b];
 
@@ -1792,9 +1789,9 @@ fn classify_data_relocations(
     per_segment
 }
 
-/// Align `data_end` to [`LINKER_STACK_ALIGNMENT`], then add the stack size.
+/// Align `data_end` to [`STACK_ALIGNMENT`], then add the stack size.
 fn stack_high_after_data(data_end: u32) -> Result<u32> {
-    let stack_base = u32::try_from(LINKER_STACK_ALIGNMENT.align_up(u64::from(data_end)))
+    let stack_base = u32::try_from(crate::alignment::STACK_ALIGNMENT.align_up(u64::from(data_end)))
         .map_err(|_| crate::error!("Wasm stack base overflow"))?;
     stack_base
         .checked_add(LINKER_STACK_SIZE)

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -3527,12 +3527,10 @@ fn linker_defined_data_symbol_address(
             address: data_end,
             needs_stack_gap: false,
         })),
-        b"__heap_base" => {
-            Ok(Some(LinkerDefinedDataAddress {
-                address: stack_high_after_data(data_end)?,
-                needs_stack_gap: true,
-            }))
-        }
+        b"__heap_base" => Ok(Some(LinkerDefinedDataAddress {
+            address: stack_high_after_data(data_end)?,
+            needs_stack_gap: true,
+        })),
         _ => Ok(None),
     }
 }

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -21,6 +21,7 @@ use crate::wasm_writer::OutputImport;
 use crate::wasm_writer::OutputImportEntity;
 use hashbrown::HashMap;
 use hashbrown::HashSet;
+use leb128::write::signed_len as sleb128_size;
 use leb128::write::unsigned_len as uleb128_size;
 use linker_utils::utils::u32_from_slice;
 use rayon::prelude::*;
@@ -1718,9 +1719,9 @@ fn wasm_data_segment_encoded_size(kind: &DataKind<'_>, data_len: usize) -> Resul
     }
 }
 
-/// Byte length of the offset `expr` we emit (`i32.const` + LEB + `end`).
+/// Byte length of the offset `expr` we emit (`i32.const` + SLEB + `end`).
 fn output_i32_const_init_expr_size(offset: u32) -> u32 {
-    1 + uleb128_size(u64::from(offset)) as u32 + 1
+    1 + sleb128_size(i64::from(offset)) as u32 + 1
 }
 
 fn output_data_segment_encoded_size(

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -115,6 +115,9 @@ const LINKER_MEMORY_BASE: u32 = 1024;
 /// Default stack size reserved above `__data_end` for the main stack.
 const LINKER_STACK_SIZE: u32 = 64 * 1024;
 
+/// Stack and post-data gap alignment.
+const LINKER_STACK_ALIGNMENT: Alignment = crate::alignment::STACK_ALIGNMENT;
+
 /// Empty function body: zero locals + `end`.
 const EMPTY_FUNCTION_BODY: &[u8] = &[0x00, 0x0b];
 
@@ -1788,6 +1791,15 @@ fn classify_data_relocations(
     per_segment
 }
 
+/// Align `data_end` to [`LINKER_STACK_ALIGNMENT`], then add the stack size.
+fn stack_high_after_data(data_end: u32) -> Result<u32> {
+    let stack_base = u32::try_from(LINKER_STACK_ALIGNMENT.align_up(u64::from(data_end)))
+        .map_err(|_| crate::error!("Wasm stack base overflow"))?;
+    stack_base
+        .checked_add(LINKER_STACK_SIZE)
+        .ok_or_else(|| crate::error!("Wasm stack pointer overflow"))
+}
+
 fn layout_object_data<'data>(
     input: &WasmObjectLayoutInput<'data>,
     index_map: &WasmObjectIndexMap,
@@ -1803,6 +1815,14 @@ fn layout_object_data<'data>(
         };
         let output_memory_index =
             remap_wasm_index(&index_map.memory_indices, memory_index, "memory")?;
+        // Linking `SegmentInfo.alignment` is a power-of-two exponent.
+        let align = input
+            .segment_alignments
+            .get(segment_index)
+            .copied()
+            .unwrap_or(crate::alignment::MIN);
+        *memory_cursor = u32::try_from(align.align_up(u64::from(*memory_cursor)))
+            .map_err(|_| crate::error!("Wasm data segment alignment overflow"))?;
         let output_memory_offset = *memory_cursor;
         let output_section_offset = *section_cursor;
         let encoded_output_size = output_data_segment_encoded_size(
@@ -2002,6 +2022,7 @@ struct WasmObjectLayoutInput<'data> {
     unsupported_output: Vec<&'static str>,
     code_relocations: Vec<WasmRelocation>,
     data_segments: Vec<WasmDataSegment<'data>>,
+    segment_alignments: Vec<Alignment>,
     data_relocations: Vec<WasmRelocation>,
     symbols: Vec<WasmSymbol>,
     init_funcs: Vec<WasmInitFunc>,
@@ -2190,6 +2211,7 @@ impl<'data> WasmObjectLayoutInput<'data> {
             unsupported_output,
             code_relocations,
             data_segments,
+            segment_alignments: file.segments.iter().map(|s| s.alignment).collect(),
             data_relocations,
             symbols: file.symbols.clone(),
             init_funcs: file.init_funcs.clone(),
@@ -3040,10 +3062,7 @@ fn fill_linker_defined_values(
     needs_stack_gap: bool,
 ) -> Result {
     if let Some(defined_slot) = indices.stack_pointer_defined_slot {
-        let sp = layout
-            .data_end
-            .checked_add(LINKER_STACK_SIZE)
-            .ok_or_else(|| crate::error!("Wasm stack pointer overflow"))?;
+        let sp = stack_high_after_data(layout.data_end)?;
         let global = layout
             .globals
             .get_mut(defined_slot as usize)
@@ -3057,8 +3076,7 @@ fn fill_linker_defined_values(
 
     let mut bytes_needed = u64::from(layout.data_end.max(layout.memory_base));
     if indices.stack_pointer_defined_slot.is_some() || needs_stack_gap {
-        bytes_needed =
-            bytes_needed.max(u64::from(layout.data_end.saturating_add(LINKER_STACK_SIZE)));
+        bytes_needed = bytes_needed.max(u64::from(stack_high_after_data(layout.data_end)?));
     }
     if bytes_needed > 0 && !layout.memories.is_empty() {
         let pages_needed = bytes_needed.div_ceil(65536).max(1);
@@ -3509,14 +3527,8 @@ fn linker_defined_data_symbol_address(
             needs_stack_gap: false,
         })),
         b"__heap_base" => {
-            let address = data_end
-                .checked_add(LINKER_STACK_SIZE)
-                .ok_or_else(|| crate::error!("Wasm __heap_base address overflow"))?;
             Ok(Some(LinkerDefinedDataAddress {
-                address,
-                // We place the stack in [data_end, data_end + LINKER_STACK_SIZE) and define
-                // __heap_base as the end of that range (same as initial __stack_pointer). The
-                // address itself therefore requires that memory cover the stack gap.
+                address: stack_high_after_data(data_end)?,
                 needs_stack_gap: true,
             }))
         }
@@ -4486,11 +4498,21 @@ mod tests {
         let hb = linker_defined_data_symbol_address(b"__heap_base", data_end)
             .unwrap()
             .expect("__heap_base");
-        assert_eq!(hb.address, data_end + LINKER_STACK_SIZE);
+        assert_eq!(hb.address, stack_high_after_data(data_end).unwrap());
         assert!(
             hb.needs_stack_gap,
             "`__heap_base` sits past the stack gap, so memory must cover that range"
         );
+    }
+
+    #[test]
+    fn stack_high_is_sixteen_byte_aligned() {
+        // Unaligned data_end must still yield a 16-byte-aligned stack top (wasm-ld).
+        for data_end in [1u32, 2, 7, 1025, 4738] {
+            let sp = stack_high_after_data(data_end).unwrap();
+            assert_eq!(sp % 16, 0, "data_end={data_end} sp={sp}");
+            assert!(sp >= data_end + LINKER_STACK_SIZE);
+        }
     }
 
     #[test]

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -656,11 +656,12 @@ fn wasi_sysroot() -> Option<PathBuf> {
     candidates.find(|root| root.join("lib/wasm32-wasi/libc.a").exists())
 }
 
-fn wasi_sysroot_display() -> String {
+fn wasi_sysroot_path_str() -> String {
     wasi_sysroot()
         .unwrap_or_else(|| PathBuf::from("/usr"))
-        .display()
-        .to_string()
+        .to_str()
+        .expect("WASI_SYSROOT must be valid UTF-8")
+        .to_owned()
 }
 
 fn expand_test_arg_placeholders(arg: &str, config: &Config) -> String {
@@ -668,7 +669,7 @@ fn expand_test_arg_placeholders(arg: &str, config: &Config) -> String {
         TEMPLATE_OUT_DIR_PLACEHOLDER,
         &config.build_dir().display().to_string(),
     )
-    .replace(TEMPLATE_WASI_SYSROOT_PLACEHOLDER, &wasi_sysroot_display())
+    .replace(TEMPLATE_WASI_SYSROOT_PLACEHOLDER, &wasi_sysroot_path_str())
 }
 
 fn base_dir() -> &'static Path {
@@ -4171,7 +4172,7 @@ fn add_inputs_to_command(config: &Config, inputs: &[LinkerInput], command: &mut 
                 .expect("Non-UTF-8 paths not supported")
                 .to_owned();
 
-            let wasi_sysroot = wasi_sysroot_display();
+            let wasi_sysroot = wasi_sysroot_path_str();
             for a in template {
                 let arg = a
                     .replace(TEMPLATE_OUT_DIR_PLACEHOLDER, &out_dir)

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -1741,8 +1741,8 @@ impl Config {
             linker_args: platform.default_args_for_linking(),
             post_linker_args: ArgumentSet::empty(),
             linker_so_args: platform.default_args_for_linking(),
-            compiler_args: platform.default_compiler_args(),
-            compiler_so_args: platform.default_compiler_args(),
+            compiler_args: ArgumentSet::default_for_compiling(),
+            compiler_so_args: ArgumentSet::default_for_compiling(),
             wild_extra_linker_args: ArgumentSet::empty(),
             diff_ignore: Default::default(),
             reference_linkers: None,
@@ -6428,18 +6428,6 @@ impl PlatformKind {
         match self {
             PlatformKind::Elf => "gcc",
             PlatformKind::MachO | PlatformKind::Wasm => "clang",
-        }
-    }
-
-    /// TODO(wasm): Remove the Wasm special case (and possibly this helper) once tests can rely on a
-    /// normal toolchain / WASI crt like ELF, and set freestanding flags via `CompArgs` only where
-    /// needed.
-    fn default_compiler_args(self) -> ArgumentSet {
-        match self {
-            PlatformKind::Wasm => ArgumentSet {
-                args: vec!["-nostdlib".to_owned()],
-            },
-            PlatformKind::Elf | PlatformKind::MachO => ArgumentSet::default_for_compiling(),
         }
     }
 

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -21,7 +21,11 @@
 //! LinkArgs:... Arguments to pass to the linker. If using a LinkerDriver, these arguments should be
 //! whatever the linker driver expects. e.g. `-Wl,--strip-all` rather than `--strip-all`.
 //! `./<filename>` will be replaced with the path to the input file. `$OUT_DIR` will be replaced
-//! with the path to the test's build directory.
+//! with the path to the test's build directory. `$WASI_SYSROOT` will be replaced with the wasi-libc
+//! sysroot (see RequiresWasiLibc). These arguments are passed before input objects.
+//!
+//! PostLinkArgs:... Like LinkArgs, but appended after input objects. Useful for archive libraries
+//! such as `-lc` that need to appear after objects that reference them.
 //!
 //! LinkSoArgs:... Arguments to pass when linking a shared object.
 //!
@@ -171,6 +175,11 @@
 //! checks that a simple C program can be compiled with `-flto` and skips the test if that fails.
 //! This can be used for both C and Rust tests. In the case of Rust tests, the clang compiler will
 //! be checked. Also checks that wild was not statically linked.
+//!
+//! RequiresWasiLibc:{bool} Defaults to false. Set to true to skip this test when wasi-libc is not
+//! available. When set, `$WASI_SYSROOT` in LinkArgs, PostLinkArgs, CompArgs and input templates is
+//! expanded to the wasi-libc sysroot. The sysroot is taken from the `WASI_SYSROOT` environment
+//! variable if set, otherwise `/usr` when `/usr/lib/wasm32-wasi/libc.a` exists.
 //!
 //! AutoAddObjects:{bool} Whether to automatically add input objects for the test to the command
 //! line. Defaults to true.
@@ -633,6 +642,34 @@ type ElfFile64<'data> = object::read::elf::ElfFile64<'data, LittleEndian>;
 
 const TEMPLATE_PLACEHOLDER: &str = "$O";
 const TEMPLATE_OUT_DIR_PLACEHOLDER: &str = "$OUT_DIR";
+const TEMPLATE_WASI_SYSROOT_PLACEHOLDER: &str = "$WASI_SYSROOT";
+
+/// Returns the wasi-libc sysroot if available.
+///
+/// Expected layout: `{sysroot}/lib/wasm32-wasi/libc.a` and `{sysroot}/include/wasm32-wasi/`.
+fn wasi_sysroot() -> Option<PathBuf> {
+    let mut candidates = std::env::var_os("WASI_SYSROOT")
+        .map(PathBuf::from)
+        .into_iter()
+        .chain(std::iter::once(PathBuf::from("/usr")));
+
+    candidates.find(|root| root.join("lib/wasm32-wasi/libc.a").exists())
+}
+
+fn wasi_sysroot_display() -> String {
+    wasi_sysroot()
+        .unwrap_or_else(|| PathBuf::from("/usr"))
+        .display()
+        .to_string()
+}
+
+fn expand_test_arg_placeholders(arg: &str, config: &Config) -> String {
+    arg.replace(
+        TEMPLATE_OUT_DIR_PLACEHOLDER,
+        &config.build_dir().display().to_string(),
+    )
+    .replace(TEMPLATE_WASI_SYSROOT_PLACEHOLDER, &wasi_sysroot_display())
+}
 
 fn base_dir() -> &'static Path {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -1013,6 +1050,7 @@ struct Config {
     assertions: Assertions,
     linker_driver: LinkerDriver,
     linker_args: ArgumentSet,
+    post_linker_args: ArgumentSet,
     linker_so_args: ArgumentSet,
     wild_extra_linker_args: ArgumentSet,
     compiler_args: ArgumentSet,
@@ -1041,6 +1079,7 @@ struct Config {
     requires_compiler_flags: Vec<String>,
     requires_linker_flags: Vec<String>,
     requires_nightly_rustc: bool,
+    requires_wasi_libc: bool,
     auto_add_objects: bool,
     remove_sections: Vec<String>,
     rustc_channel: RustcChannel,
@@ -1700,6 +1739,7 @@ impl Config {
             assertions: Default::default(),
             linker_driver: LinkerDriver::Direct(DirectConfig::default()),
             linker_args: platform.default_args_for_linking(),
+            post_linker_args: ArgumentSet::empty(),
             linker_so_args: platform.default_args_for_linking(),
             compiler_args: platform.default_compiler_args(),
             compiler_so_args: platform.default_compiler_args(),
@@ -1730,6 +1770,7 @@ impl Config {
             requires_linker_flags: Vec::new(),
             requires_nightly_rustc: false,
             requires_linker_plugin: false,
+            requires_wasi_libc: false,
             auto_add_objects: true,
             rustc_channel: RustcChannel::Default,
             requires_rust_musl: false,
@@ -1859,7 +1900,7 @@ fn process_directive(
             if is_rust {
                 bail!("LinkArgs is not used when building Rust code");
             }
-            let arg = &arg.replace("$OUT_DIR", &config.build_dir().display().to_string());
+            let arg = expand_test_arg_placeholders(arg, config);
             if let Some((_, rest)) = arg.split_once("./") {
                 let filename = rest.split_once(' ').map_or(rest, |(f, _)| f);
                 let src_path = config.test_src_dir.join(filename);
@@ -1868,8 +1909,15 @@ fn process_directive(
                     arg.replace(&format!("./{filename}"), &src_path.display().to_string());
                 config.linker_args = ArgumentSet::parse(&with_replaced_path)?
             } else {
-                config.linker_args = ArgumentSet::parse(arg)?
+                config.linker_args = ArgumentSet::parse(&arg)?
             }
+        }
+        "PostLinkArgs" => {
+            if is_rust {
+                bail!("PostLinkArgs is not used when building Rust code");
+            }
+            let arg = expand_test_arg_placeholders(arg, config);
+            config.post_linker_args = ArgumentSet::parse(&arg)?
         }
         "LinkSoArgs" => {
             if is_rust {
@@ -1891,8 +1939,14 @@ fn process_directive(
             config.linker_driver = LinkerDriver::parse(arg)?;
         }
         "WildExtraLinkArgs" => config.wild_extra_linker_args = ArgumentSet::parse(arg)?,
-        "CompArgs" => config.compiler_args = ArgumentSet::parse(arg)?,
-        "CompSoArgs" => config.compiler_so_args = ArgumentSet::parse(arg)?,
+        "CompArgs" => {
+            let arg = expand_test_arg_placeholders(arg, config);
+            config.compiler_args = ArgumentSet::parse(&arg)?
+        }
+        "CompSoArgs" => {
+            let arg = expand_test_arg_placeholders(arg, config);
+            config.compiler_so_args = ArgumentSet::parse(&arg)?
+        }
         "ExpectSym" => config
             .assertions
             .expected_symtab_entries
@@ -2196,6 +2250,9 @@ fn process_directive(
         }
         "RequiresLinkerPlugin" => {
             config.requires_linker_plugin = arg.to_lowercase().parse()?;
+        }
+        "RequiresWasiLibc" => {
+            config.requires_wasi_libc = parse_bool(arg, "RequiresWasiLibc")?;
         }
         "TestUpdateInPlace" => {
             config.test_update_in_place = arg.to_lowercase().parse()?;
@@ -3038,7 +3095,7 @@ fn build_obj(
             }
 
             if let Some(arch) = cross_arch {
-                let target = get_target(&compiler_args).cloned().unwrap_or_else(|_| {
+                let target = get_target(&compiler_args).unwrap_or_else(|_| {
                     command.arg(format!(
                         "--target={}",
                         arch.default_target_triple_rustc(config.platform)
@@ -3218,7 +3275,6 @@ fn add_cross_args(
     if !platform.is_host() || cross_arch.is_some() {
         let arch = cross_arch.unwrap_or_else(get_host_architecture);
         let target = get_target(compiler_args)
-            .cloned()
             .unwrap_or_else(|_| arch.default_target_triple(platform).to_owned());
         command.arg(format!("--target={target}"));
     }
@@ -3318,16 +3374,26 @@ fn compiler_for_file(
     Ok(Some((compiler, compiler_kind)))
 }
 
-/// Returns the value of the --target flag.
-fn get_target(compiler_args: &[String]) -> Result<&String> {
+/// Returns the value of the `--target` / `-target` flag, if present.
+fn get_target(compiler_args: &[String]) -> Result<String> {
     let mut is_next = false;
 
     for arg in compiler_args {
         if is_next {
-            return Ok(arg);
+            return Ok(arg.clone());
         }
 
-        is_next = arg == "--target";
+        if arg == "--target" || arg == "-target" {
+            is_next = true;
+            continue;
+        }
+
+        if let Some(target) = arg
+            .strip_prefix("--target=")
+            .or_else(|| arg.strip_prefix("-target="))
+        {
+            return Ok(target.to_owned());
+        }
     }
 
     bail!("No --target flag found");
@@ -3710,6 +3776,7 @@ impl LinkCommand {
             }
 
             add_inputs_to_command(config, inputs, &mut command);
+            command.args(&config.post_linker_args.args);
         }
 
         if linker.is_wild() {
@@ -4104,10 +4171,12 @@ fn add_inputs_to_command(config: &Config, inputs: &[LinkerInput], command: &mut 
                 .expect("Non-UTF-8 paths not supported")
                 .to_owned();
 
+            let wasi_sysroot = wasi_sysroot_display();
             for a in template {
                 let arg = a
                     .replace(TEMPLATE_OUT_DIR_PLACEHOLDER, &out_dir)
-                    .replace(TEMPLATE_PLACEHOLDER, path_str);
+                    .replace(TEMPLATE_PLACEHOLDER, path_str)
+                    .replace(TEMPLATE_WASI_SYSROOT_PLACEHOLDER, &wasi_sysroot);
                 command.arg(arg);
             }
         } else {
@@ -6031,6 +6100,18 @@ fn run_integration_test(
     if !test_config.allow_rust_musl_target && config.requires_rust_musl {
         return Ok(libtest_mimic::Completion::ignored_with(
             "Test doesn't support musl-libc",
+        ));
+    }
+
+    if config.requires_wasi_libc && wasi_sysroot().is_none() {
+        if full_test_platform_required() {
+            bail!(
+                "RequiresWasiLibc is set, but wasi-libc was not found. Install the wasi-libc \
+                 package or set WASI_SYSROOT to a sysroot containing lib/wasm32-wasi/libc.a"
+            );
+        }
+        return Ok(libtest_mimic::Completion::ignored_with(
+            "wasi-libc not found (install wasi-libc or set WASI_SYSROOT)",
         ));
     }
 

--- a/wild/tests/sources/wasm/pic-data-rel/pic-data-rel.c
+++ b/wild/tests/sources/wasm/pic-data-rel/pic-data-rel.c
@@ -1,4 +1,4 @@
-//#CompArgs:-nostdlib -fPIC
+//#CompArgs:-fPIC
 
 int g = 7;
 int* p = &g;

--- a/wild/tests/sources/wasm/wasi-libc-multi/libhelper.c
+++ b/wild/tests/sources/wasm/wasi-libc-multi/libhelper.c
@@ -1,0 +1,12 @@
+#include <string.h>
+
+static const char greeting[] = "hello-from-archive";
+
+const char* helper_greeting(void) { return greeting; }
+
+int helper_answer(void) {
+  if (strlen(greeting) != 18) {
+    return -1;
+  }
+  return 42;
+}

--- a/wild/tests/sources/wasm/wasi-libc-multi/wasi-libc-multi.c
+++ b/wild/tests/sources/wasm/wasi-libc-multi/wasi-libc-multi.c
@@ -1,0 +1,19 @@
+//#RequiresWasiLibc:true
+//#CompArgs: --target=wasm32-wasi -isystem $WASI_SYSROOT/include/wasm32-wasi
+//#LinkArgs: $WASI_SYSROOT/lib/wasm32-wasi/crt1-command.o
+//#Archive:template(-L$OUT_DIR -lhelper):libhelper.c
+//#PostLinkArgs: -L$WASI_SYSROOT/lib/wasm32-wasi -lc
+//#Contains: wasi_snapshot_preview1
+
+#include <stdio.h>
+
+const char* helper_greeting(void);
+int helper_answer(void);
+
+int main(void) {
+  puts(helper_greeting());
+  if (helper_answer() != 42) {
+    return 1;
+  }
+  return 0;
+}

--- a/wild/tests/sources/wasm/wasi-libc/wasi-libc.c
+++ b/wild/tests/sources/wasm/wasi-libc/wasi-libc.c
@@ -1,5 +1,5 @@
 //#RequiresWasiLibc:true
-//#CompArgs: --target=wasm32-wasi -nostdlib -isystem $WASI_SYSROOT/include/wasm32-wasi
+//#CompArgs: --target=wasm32-wasi -isystem $WASI_SYSROOT/include/wasm32-wasi
 //#LinkArgs: $WASI_SYSROOT/lib/wasm32-wasi/crt1-command.o
 //#PostLinkArgs: -L$WASI_SYSROOT/lib/wasm32-wasi -lc
 //#Contains: wasi_snapshot_preview1

--- a/wild/tests/sources/wasm/wasi-libc/wasi-libc.c
+++ b/wild/tests/sources/wasm/wasi-libc/wasi-libc.c
@@ -1,0 +1,13 @@
+//#RequiresWasiLibc:true
+//#CompArgs: --target=wasm32-wasi -nostdlib -isystem $WASI_SYSROOT/include/wasm32-wasi
+//#LinkArgs: $WASI_SYSROOT/lib/wasm32-wasi/crt1-command.o
+//#PostLinkArgs: -L$WASI_SYSROOT/lib/wasm32-wasi -lc
+//#Contains: wasi_snapshot_preview1
+
+#include <stdio.h>
+
+int main(void) {
+  puts("hello-wasi");
+  printf("answer=%d\n", 42);
+  return 0;
+}


### PR DESCRIPTION
Without segment alignment and 16-byte stack alignment, Wild's layout diverged from wasm-ld and WASI binaries could misbehave.

This patch makes wasi-libc-linked C programs actually runnable.

Part of #1431