### PR TITLE
chore(wasm): Add timing instrumentation for Wasm layout and write

### DIFF
--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -15,6 +15,8 @@ use crate::output_section_id::SectionName;
 use crate::platform;
 use crate::symbol::UnversionedSymbolName;
 use crate::symbol_db::SymbolDb;
+use crate::timing_phase;
+use crate::verbose_timing_phase;
 use crate::wasm_writer::OutputExport;
 use crate::wasm_writer::OutputGlobal;
 use crate::wasm_writer::OutputImport;
@@ -1617,6 +1619,7 @@ fn encode_wasm_section(section: &impl wasm_encoder::Section) -> Vec<u8> {
 
 impl<'data> WasmLayout<'data> {
     fn encode_metadata_sections(&mut self) -> Result {
+        timing_phase!("Encode Wasm metadata sections");
         let type_section = crate::wasm_writer::build_type_section(&self.output_types)?;
         if !type_section.is_empty() {
             self.encoded_sections.ty = Some(encode_wasm_section(&type_section));
@@ -2452,6 +2455,7 @@ fn resolve_cross_object_imports<'data>(
     inputs: &[WasmObjectLayoutInput<'data>],
     symbol_db: &crate::symbol_db::SymbolDb<'data, Wasm>,
 ) -> Result<Vec<ObjectImportResolutions>> {
+    timing_phase!("Resolve Wasm cross-object imports");
     let file_id_to_index: HashMap<crate::input_data::FileId, usize> = inputs
         .iter()
         .enumerate()
@@ -2461,6 +2465,7 @@ fn resolve_cross_object_imports<'data>(
     inputs
         .par_iter()
         .map(|input| {
+            verbose_timing_phase!("Resolve Wasm object imports");
             let (function_resolutions, unresolved_function_count) = resolve_import_symbols(
                 input.function_imports.len(),
                 WasmSymbolKind::Func,
@@ -3216,15 +3221,21 @@ fn build_output_module_layout<'data, 'files>(
 where
     'data: 'files,
 {
-    let objects_and_states: Vec<_> = layout::objects_iter(groups)
-        .map(|state| (&state.object, &state.format_specific))
-        .collect();
-    let layout_inputs = objects_and_states
-        .par_iter()
-        .map(|(object, state)| {
-            WasmObjectLayoutInput::from_file(object, state.symbol_id_range, state.file_id)
-        })
-        .collect::<Result<Vec<_>>>()?;
+    timing_phase!("Build Wasm module layout");
+
+    let layout_inputs = {
+        timing_phase!("Collect Wasm object layout inputs");
+        let objects_and_states: Vec<_> = layout::objects_iter(groups)
+            .map(|state| (&state.object, &state.format_specific))
+            .collect();
+        objects_and_states
+            .par_iter()
+            .map(|(object, state)| {
+                verbose_timing_phase!("Collect Wasm object layout input");
+                WasmObjectLayoutInput::from_file(object, state.symbol_id_range, state.file_id)
+            })
+            .collect::<Result<Vec<_>>>()?
+    };
 
     let import_resolutions = resolve_cross_object_imports(&layout_inputs, symbol_db)?;
     let has_init_funcs = layout_inputs
@@ -3243,19 +3254,23 @@ where
     )?;
     let index_bases =
         allocate_wasm_object_index_bases(&layout_inputs, &import_resolutions, &indices)?;
-    let object_layouts = layout_inputs
-        .par_iter()
-        .zip(import_resolutions.par_iter())
-        .enumerate()
-        .map(|(obj_idx, (input, resolutions))| {
-            input.build_object_output_layout(
-                index_bases[obj_idx],
-                resolutions,
-                &index_bases,
-                &indices,
-            )
-        })
-        .collect::<Result<Vec<_>>>()?;
+    let object_layouts = {
+        timing_phase!("Build per-object Wasm layouts");
+        layout_inputs
+            .par_iter()
+            .zip(import_resolutions.par_iter())
+            .enumerate()
+            .map(|(obj_idx, (input, resolutions))| {
+                verbose_timing_phase!("Build Wasm object output layout");
+                input.build_object_output_layout(
+                    index_bases[obj_idx],
+                    resolutions,
+                    &index_bases,
+                    &indices,
+                )
+            })
+            .collect::<Result<Vec<_>>>()?
+    };
 
     let linker_memory = any_object_needs_linker_memory(&layout_inputs);
     let mut layout = WasmLayout {
@@ -3268,31 +3283,36 @@ where
     };
     let mut memory_cursor = layout.memory_base;
     let mut section_cursor = 0u32;
-    for (obj_idx, (input, object_layout)) in layout_inputs.iter().zip(object_layouts).enumerate() {
-        layout.output_types.extend(object_layout.types);
-        layout.imports.extend(object_layout.imports);
-        layout
-            .function_type_indices
-            .extend(object_layout.function_type_indices);
-        layout.globals.extend(object_layout.globals);
-        layout.exports.extend(object_layout.exports);
-        let mut bodies = object_layout.function_bodies;
-        for body in &mut bodies {
-            body.object_index = obj_idx;
+    {
+        timing_phase!("Merge Wasm object layouts");
+        for (obj_idx, (input, object_layout)) in
+            layout_inputs.iter().zip(object_layouts).enumerate()
+        {
+            layout.output_types.extend(object_layout.types);
+            layout.imports.extend(object_layout.imports);
+            layout
+                .function_type_indices
+                .extend(object_layout.function_type_indices);
+            layout.globals.extend(object_layout.globals);
+            layout.exports.extend(object_layout.exports);
+            let mut bodies = object_layout.function_bodies;
+            for body in &mut bodies {
+                body.object_index = obj_idx;
+            }
+            layout.function_bodies.extend(bodies);
+            layout.memories.extend(object_layout.memories);
+            layout
+                .unsupported_output
+                .extend(object_layout.unsupported_output);
+            layout.object_index_maps.push(object_layout.index_map);
+            layout.per_object_symbols.push(input.symbols.clone());
+            layout.object_data_layouts.push(layout_object_data(
+                input,
+                layout.object_index_maps.last().expect("index map pushed"),
+                &mut memory_cursor,
+                &mut section_cursor,
+            )?);
         }
-        layout.function_bodies.extend(bodies);
-        layout.memories.extend(object_layout.memories);
-        layout
-            .unsupported_output
-            .extend(object_layout.unsupported_output);
-        layout.object_index_maps.push(object_layout.index_map);
-        layout.per_object_symbols.push(input.symbols.clone());
-        layout.object_data_layouts.push(layout_object_data(
-            input,
-            layout.object_index_maps.last().expect("index map pushed"),
-            &mut memory_cursor,
-            &mut section_cursor,
-        )?);
     }
 
     let init_function_indices =
@@ -3309,31 +3329,42 @@ where
         _ => None,
     };
 
-    emit_reserved_linker_definitions(&mut layout, &indices, call_ctors_body, entry_wrapper_body);
-    deduplicate_output_types(&mut layout);
+    {
+        timing_phase!("Wasm linker-defined symbols and data addresses");
+        emit_reserved_linker_definitions(
+            &mut layout,
+            &indices,
+            call_ctors_body,
+            entry_wrapper_body,
+        );
+        deduplicate_output_types(&mut layout);
 
-    if linker_memory && layout.memories.is_empty() {
-        layout
-            .memories
-            .push(linker_output_memory_type(&layout_inputs));
-        ensure_memory_export(&mut layout.exports);
+        if linker_memory && layout.memories.is_empty() {
+            layout
+                .memories
+                .push(linker_output_memory_type(&layout_inputs));
+            ensure_memory_export(&mut layout.exports);
+        }
+        layout.data_end = memory_cursor;
+        let needs_stack_gap = compute_data_addresses(
+            &mut layout.object_index_maps,
+            &layout.per_object_symbols,
+            &layout.object_data_layouts,
+            &layout_inputs,
+            symbol_db,
+            layout.data_end,
+        )?;
+        fill_linker_defined_values(&mut layout, &indices, needs_stack_gap)?;
+        ensure_entry_export(
+            &mut layout.exports,
+            entry.as_ref(),
+            indices.entry_wrapper_func,
+        );
     }
-    layout.data_end = memory_cursor;
-    let needs_stack_gap = compute_data_addresses(
-        &mut layout.object_index_maps,
-        &layout.per_object_symbols,
-        &layout.object_data_layouts,
-        &layout_inputs,
-        symbol_db,
-        layout.data_end,
-    )?;
-    fill_linker_defined_values(&mut layout, &indices, needs_stack_gap)?;
-    ensure_entry_export(
-        &mut layout.exports,
-        entry.as_ref(),
-        indices.entry_wrapper_func,
-    );
-    finalize_indirect_function_table(&mut layout, &layout_inputs)?;
+    {
+        timing_phase!("Finalize Wasm indirect function table");
+        finalize_indirect_function_table(&mut layout, &layout_inputs)?;
+    }
     layout.encode_metadata_sections()?;
     Ok(layout)
 }

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -3254,7 +3254,7 @@ where
     )?;
     let index_bases =
         allocate_wasm_object_index_bases(&layout_inputs, &import_resolutions, &indices)?;
-    let object_layouts = {
+    let mut object_layouts = {
         timing_phase!("Build per-object Wasm layouts");
         layout_inputs
             .par_iter()
@@ -3285,33 +3285,71 @@ where
     let mut section_cursor = 0u32;
     {
         timing_phase!("Merge Wasm object layouts");
-        for (obj_idx, (input, object_layout)) in
-            layout_inputs.iter().zip(object_layouts).enumerate()
+        let n_objects = object_layouts.len();
+        layout.object_index_maps.reserve(n_objects);
+        layout.per_object_symbols.reserve(n_objects);
+        layout.object_data_layouts.reserve(n_objects);
+
         {
-            layout.output_types.extend(object_layout.types);
-            layout.imports.extend(object_layout.imports);
-            layout
-                .function_type_indices
-                .extend(object_layout.function_type_indices);
-            layout.globals.extend(object_layout.globals);
-            layout.exports.extend(object_layout.exports);
-            let mut bodies = object_layout.function_bodies;
-            for body in &mut bodies {
-                body.object_index = obj_idx;
+            timing_phase!("Merge Wasm section lists");
+            for object_layout in &mut object_layouts {
+                layout
+                    .output_types
+                    .extend(std::mem::take(&mut object_layout.types));
+                layout
+                    .imports
+                    .extend(std::mem::take(&mut object_layout.imports));
+                layout
+                    .function_type_indices
+                    .extend(std::mem::take(&mut object_layout.function_type_indices));
+                layout
+                    .globals
+                    .extend(std::mem::take(&mut object_layout.globals));
+                layout
+                    .exports
+                    .extend(std::mem::take(&mut object_layout.exports));
+                layout
+                    .memories
+                    .extend(std::mem::take(&mut object_layout.memories));
+                layout
+                    .unsupported_output
+                    .extend(std::mem::take(&mut object_layout.unsupported_output));
             }
-            layout.function_bodies.extend(bodies);
-            layout.memories.extend(object_layout.memories);
-            layout
-                .unsupported_output
-                .extend(object_layout.unsupported_output);
-            layout.object_index_maps.push(object_layout.index_map);
-            layout.per_object_symbols.push(input.symbols.clone());
-            layout.object_data_layouts.push(layout_object_data(
-                input,
-                layout.object_index_maps.last().expect("index map pushed"),
-                &mut memory_cursor,
-                &mut section_cursor,
-            )?);
+        }
+        {
+            timing_phase!("Merge Wasm function bodies");
+            for (obj_idx, object_layout) in object_layouts.iter_mut().enumerate() {
+                let mut bodies = std::mem::take(&mut object_layout.function_bodies);
+                for body in &mut bodies {
+                    body.object_index = obj_idx;
+                }
+                layout.function_bodies.extend(bodies);
+            }
+        }
+        {
+            timing_phase!("Merge Wasm index maps");
+            for object_layout in &mut object_layouts {
+                layout
+                    .object_index_maps
+                    .push(std::mem::take(&mut object_layout.index_map));
+            }
+        }
+        {
+            timing_phase!("Clone Wasm symbol tables");
+            for input in &layout_inputs {
+                layout.per_object_symbols.push(input.symbols.clone());
+            }
+        }
+        {
+            timing_phase!("Layout Wasm data segments");
+            for (obj_idx, input) in layout_inputs.iter().enumerate() {
+                layout.object_data_layouts.push(layout_object_data(
+                    input,
+                    &layout.object_index_maps[obj_idx],
+                    &mut memory_cursor,
+                    &mut section_cursor,
+                )?);
+            }
         }
     }
 

--- a/libwild/src/wasm_writer.rs
+++ b/libwild/src/wasm_writer.rs
@@ -6,6 +6,8 @@ use crate::file_writer::SizedOutput;
 use crate::file_writer::split_output_into_sections;
 use crate::layout::Layout;
 use crate::platform::Arch;
+use crate::timing_phase;
+use crate::verbose_timing_phase;
 use crate::wasm::WASM_MAGIC;
 use crate::wasm::WASM_VERSION;
 use crate::wasm::Wasm;
@@ -48,6 +50,7 @@ pub(crate) fn write<'data, A: Arch<Platform = Wasm>>(
     sized_output: &mut SizedOutput,
     layout: &Layout<'data, Wasm>,
 ) -> Result<()> {
+    timing_phase!("Write Wasm output");
     let (mut section_buffers, mut padding) =
         split_output_into_sections(layout, &mut sized_output.out);
     padding.fill_zero();
@@ -63,15 +66,24 @@ pub(crate) fn write<'data, A: Arch<Platform = Wasm>>(
         bail!("Wasm {unsupported} emission is not implemented yet");
     }
 
-    copy_metadata_sections(&layout.format_specific, &mut section_buffers)?;
-    write_code_section(
-        &layout.format_specific,
-        section_buffers.get_mut(crate::output_section_id::WASM_CODE),
-    )?;
-    write_data_section(
-        &layout.format_specific,
-        section_buffers.get_mut(crate::output_section_id::WASM_DATA),
-    )?;
+    {
+        timing_phase!("Copy Wasm metadata sections");
+        copy_metadata_sections(&layout.format_specific, &mut section_buffers)?;
+    }
+    {
+        timing_phase!("Write Wasm code section");
+        write_code_section(
+            &layout.format_specific,
+            section_buffers.get_mut(crate::output_section_id::WASM_CODE),
+        )?;
+    }
+    {
+        timing_phase!("Write Wasm data section");
+        write_data_section(
+            &layout.format_specific,
+            section_buffers.get_mut(crate::output_section_id::WASM_DATA),
+        )?;
+    }
 
     Ok(())
 }
@@ -141,6 +153,7 @@ fn copy_encoded_section(encoded: Option<&Vec<u8>>, out: &mut [u8]) -> Result<()>
 // Each `WasmFunctionBody.bytes` is the raw body content (locals + operators) without a size prefix.
 // This function writes the LEB128 size prefix for each body, then resolves and applies relocations.
 fn write_code_section(wasm_layout: &WasmLayout<'_>, out: &mut [u8]) -> Result<()> {
+    verbose_timing_phase!("Apply Wasm code relocations");
     let bodies = &wasm_layout.function_bodies;
     let object_index_maps = &wasm_layout.object_index_maps;
     let per_object_symbols = &wasm_layout.per_object_symbols;
@@ -210,6 +223,7 @@ fn write_code_section(wasm_layout: &WasmLayout<'_>, out: &mut [u8]) -> Result<()
 }
 
 fn write_data_section(wasm_layout: &WasmLayout<'_>, out: &mut [u8]) -> Result<()> {
+    verbose_timing_phase!("Encode Wasm data section");
     let object_data_layouts = &wasm_layout.object_data_layouts;
     let has_segments = object_data_layouts
         .iter()


### PR DESCRIPTION
We've already been able to link several real-world programs for Wasm. For example, I've confirmed that SQLite can be built for WASI (though I've verified that some unsupported features cause incorrect runtime behavior. The build itself succeeds, however). Therefore, introducing instrumentation into each Wasm linking phase at this time seems worthwhile.

Part of #1431