### PR TITLE
feat: do not override the global Rayon thread pool

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -344,12 +344,12 @@ impl CommonArgs {
         should_trace.then(|| tracing::trace_span!(crate::debug_trace::TRACE_SPAN_NAME).entered())
     }
 
-    /// Sets up the thread pool, using the explicit number of threads if specified,
+    /// Builds up the thread pool, using the explicit number of threads if specified,
     /// or falling back to the jobserver protocol if available.
     ///
     /// <https://www.gnu.org/software/make/manual/html_node/POSIX-Jobserver.html>
-    pub fn activate_thread_pool(&mut self) -> Result<ThreadPool> {
-        timing_phase!("Activate thread pool");
+    pub(crate) fn build_thread_pool(&mut self) -> Result<ThreadPool> {
+        timing_phase!("Build thread pool");
 
         let mut tokens = Vec::new();
         self.available_threads = self.num_threads.unwrap_or_else(|| {
@@ -365,19 +365,19 @@ impl CommonArgs {
             }
         });
 
-        // The pool might be already initialized, suppress the error intentionally.
-        if self.available_threads.get() == 1 {
-            let _ = ThreadPoolBuilder::new()
+        let pool = if self.available_threads.get() == 1 {
+            ThreadPoolBuilder::new()
                 .use_current_thread()
                 .num_threads(1)
-                .build_global();
+                .build()?
         } else {
-            let _ = ThreadPoolBuilder::new()
+            ThreadPoolBuilder::new()
                 .num_threads(self.available_threads.get())
-                .build_global();
-        }
+                .build()?
+        };
 
         Ok(ThreadPool {
+            pool,
             _jobserver_tokens: tokens,
         })
     }
@@ -498,10 +498,10 @@ pub(crate) enum FileReplacementMode {
     UpdateInPlaceWithFallback,
 }
 
-/// A type that indicates that the global thread pool has been created. Currently, you should only
-/// create one of these at a time. If a jobserver is being used, then dropping this instance will
+/// The thread pool used by the linker. If a jobserver is being used, dropping this instance will
 /// release jobserver tokens.
 pub struct ThreadPool {
+    pub(crate) pool: rayon::ThreadPool,
     _jobserver_tokens: Vec<Acquired>,
 }
 

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -365,16 +365,12 @@ impl CommonArgs {
             }
         });
 
-        let pool = if self.available_threads.get() == 1 {
-            ThreadPoolBuilder::new()
-                .use_current_thread()
-                .num_threads(1)
-                .build()?
-        } else {
-            ThreadPoolBuilder::new()
-                .num_threads(self.available_threads.get())
-                .build()?
-        };
+        // Always let Rayon spawn the pool's workers, even when only one thread is requested.
+        // Reusing the current thread would fail if it already belonged to another pool; instead,
+        // it blocks in `install` until linking finishes.
+        let pool = ThreadPoolBuilder::new()
+            .num_threads(self.available_threads.get())
+            .build()?;
 
         Ok(ThreadPool {
             pool,

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -132,6 +132,7 @@ use object::from_bytes_mut;
 use object::read::elf::Crel;
 use object::read::elf::SectionHeader as _;
 use object::read::elf::Sym as _;
+use rayon::iter::IndexedParallelIterator;
 use rayon::iter::IntoParallelIterator as _;
 use rayon::iter::IntoParallelRefMutIterator as _;
 use rayon::iter::ParallelBridge as _;
@@ -274,6 +275,7 @@ fn write_file_contents<'data, A: Arch<Platform = Elf>>(
     let groups_and_buffers = split_output_by_group(layout, &mut writable_buckets);
     groups_and_buffers
         .into_par_iter()
+        .with_max_len(1)
         .try_for_each(|(group, mut buffers)| -> Result {
             verbose_timing_phase!("Write group");
 

--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -208,6 +208,12 @@ impl Linker {
     /// Runs the linker. The returned value isn't useful for anything, but is somewhat expensive to
     /// drop, so we leave it up to the caller to decide when to drop it. At the point at which we
     /// return, the output file should be usable.
+    ///
+    /// This method runs in whatever Rayon thread pool is currently installed. If no thread pool is
+    /// installed, then Rayon's default global thread pool will be created and used. In either case,
+    /// the value of `--threads` in `args` has no effect. If you want a thread pool configured from
+    /// the supplied arguments, use the top-level [`run`] function instead, which creates such a
+    /// pool, runs the linker in it, then tears it down together with other associated resources.
     pub fn run<'layout_inputs>(
         &'layout_inputs self,
         args: &'layout_inputs Args,

--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -125,14 +125,18 @@ use tracing_subscriber::fmt;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
-/// Runs the linker and cleans up associated resources. Only use this function if you've OK with
+/// Runs the linker in a Rayon thread pool configured from the supplied arguments or the available
+/// jobserver tokens, then cleans up associated resources. Only use this function if you've OK with
 /// waiting for cleanup.
 pub fn run(mut args: Args) -> error::Result {
-    let thread_pool = args.common_mut().activate_thread_pool()?;
-    let linker = Linker::new();
-    linker.run(&args, &thread_pool)?;
-    drop(linker);
-    timing::finalise_perfetto_trace()?;
+    let thread_pool = args.common_mut().build_thread_pool()?;
+    thread_pool.pool.install(move || -> error::Result {
+        let linker = Linker::new();
+        linker.run(&args)?;
+        timing::finalise_perfetto_trace()?;
+        Ok(())
+    })?;
+
     Ok(())
 }
 
@@ -206,10 +210,6 @@ impl Linker {
     pub fn run<'layout_inputs>(
         &'layout_inputs self,
         args: &'layout_inputs Args,
-        // We don't actually use this, but take it as an argument to ensure that the caller has
-        // created it. We may decide to actually use it in future, if we stop using rayon's global
-        // thread pool.
-        _thread_pool: &crate::args::ThreadPool,
     ) -> error::Result<LinkerOutput<'layout_inputs>> {
         let identity = args.common().linker_identity();
         match args.common().version_mode {
@@ -451,8 +451,4 @@ pub fn init_timing() -> Result {
 
 pub fn should_fork(args: &Args) -> bool {
     args.common().should_fork()
-}
-
-pub fn activate_thread_pool(args: &mut Args) -> Result<crate::args::ThreadPool> {
-    args.common_mut().activate_thread_pool()
 }

--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -133,6 +133,7 @@ pub fn run(mut args: Args) -> error::Result {
     thread_pool.pool.install(move || -> error::Result {
         let linker = Linker::new();
         linker.run(&args)?;
+        drop(linker);
         timing::finalise_perfetto_trace()?;
         Ok(())
     })?;

--- a/libwild/src/subprocess.rs
+++ b/libwild/src/subprocess.rs
@@ -44,11 +44,11 @@ fn subprocess_result(mut args: Args) -> Result<i32> {
             let thread_pool = args.common_mut().build_thread_pool()?;
             thread_pool.pool.install(|| -> Result {
                 let linker = crate::Linker::new();
-                linker.run(&args)?;
+                let _outputs = linker.run(&args)?;
                 crate::timing::finalise_perfetto_trace()?;
+                inform_parent_done(&fds);
                 Ok(())
             })?;
-            inform_parent_done(&fds);
             Ok(0)
         }
         -1 => {

--- a/libwild/src/subprocess.rs
+++ b/libwild/src/subprocess.rs
@@ -41,10 +41,13 @@ fn subprocess_result(mut args: Args) -> Result<i32> {
             // Fork success in child - Run linker in this process.
 
             crate::setup_tracing(&args)?;
-            let thread_pool = args.common_mut().activate_thread_pool()?;
-            let linker = crate::Linker::new();
-            let _outputs = linker.run(&args, &thread_pool)?;
-            crate::timing::finalise_perfetto_trace()?;
+            let thread_pool = args.common_mut().build_thread_pool()?;
+            thread_pool.pool.install(|| -> Result {
+                let linker = crate::Linker::new();
+                linker.run(&args)?;
+                crate::timing::finalise_perfetto_trace()?;
+                Ok(())
+            })?;
             inform_parent_done(&fds);
             Ok(0)
         }

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -3939,7 +3939,6 @@ impl LinkCommand {
                 .collect::<Option<Vec<&str>>>()
                 .context("Linker args must be valid utf-8")?;
 
-            let linker = libwild::Linker::new();
             let get_args = || std::iter::once("wild").chain(args.iter().copied());
             let mut parsed_args = libwild::Args::new(get_args)?;
             parsed_args.set_version("integration-test");
@@ -3952,10 +3951,7 @@ impl LinkCommand {
 
             // This call is expected to error for all but the first call.
             let _ = libwild::setup_tracing(&parsed_args);
-            let thread_pool = libwild::activate_thread_pool(&mut parsed_args)?;
-
-            linker
-                .run(&parsed_args, &thread_pool)
+            libwild::run(parsed_args)
                 .with_context(|| format!("libwild reported error. Rerun command(s):\n{self}"))?;
 
             let warnings = warnings.lock().unwrap();


### PR DESCRIPTION
Reorganize the public `libwild` API so downstream clients can control the number of threads used for linking.

Clients can either:
- use `libwild::run`, which derives the thread count from the arguments and jobserver; or
- construct a `Linker` with `Linker::new` and call `run`, allowing the thread count to be controlled externally.

Note I tested the perfetto traces are properly emitted and show reasonable output in the Web UI.

Resolves: #2204