### PR TITLE
feat(API): Make zstd support optional at build time

### DIFF
--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -55,8 +55,8 @@ wasm-encoder.workspace = true
 wasmparser.workspace = true
 winnow.workspace = true
 zerocopy.workspace = true
-zstd.workspace = true
 zlib-rs.workspace = true
+zstd = { workspace = true, optional = true }
 
 [target.'cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
 perf-event.workspace = true
@@ -72,6 +72,8 @@ ar.workspace = true
 tempfile.workspace = true
 
 [features]
+default = ["zstd"]
+
 # Support for running the linker as a subprocess.
 fork = []
 
@@ -89,6 +91,9 @@ wasm = []
 
 # Experimental support for linking Mach-O. Currently incomplete.
 macho = []
+
+# Support for zstd compression and decompression of sections.
+zstd = ["dep:zstd"]
 
 [lints]
 workspace = true

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -425,6 +425,7 @@ impl CommonArgs {
 
         let files_per_group = std::env::var(FILES_PER_GROUP_ENV)
             .ok()
+            .filter(|s| !s.is_empty())
             .map(|s| s.parse())
             .transpose()?;
 
@@ -441,7 +442,7 @@ impl CommonArgs {
             ..Default::default()
         };
 
-        if std::env::var(REFERENCE_LINKER_ENV).is_ok() {
+        if std::env::var(REFERENCE_LINKER_ENV).is_ok_and(|val| !val.is_empty()) {
             common.write_layout = true;
             common.write_trace = true;
         }

--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -425,7 +425,6 @@ impl CommonArgs {
 
         let files_per_group = std::env::var(FILES_PER_GROUP_ENV)
             .ok()
-            .filter(|s| !s.is_empty())
             .map(|s| s.parse())
             .transpose()?;
 
@@ -442,7 +441,7 @@ impl CommonArgs {
             ..Default::default()
         };
 
-        if std::env::var(REFERENCE_LINKER_ENV).is_ok_and(|val| !val.is_empty()) {
+        if std::env::var(REFERENCE_LINKER_ENV).is_ok() {
             common.write_layout = true;
             common.write_trace = true;
         }

--- a/libwild/src/compression.rs
+++ b/libwild/src/compression.rs
@@ -49,6 +49,7 @@ const MIN_CHUNK_SIZE: usize = 64 * 1024;
 const MAX_CHUNKS: usize = 128;
 
 const ZLIB_COMPRESSION_LEVEL: i32 = 1;
+#[cfg(feature = "zstd")]
 const ZSTD_COMPRESSION_LEVEL: i32 = 3;
 
 /// zlib `windowBits`.
@@ -170,16 +171,25 @@ struct ZstdCompressor;
 
 impl SectionCompressor for ZstdCompressor {
     fn compress_section(uncompressed: &[u8]) -> Result<Vec<Vec<u8>>> {
-        let shard_size = shard_size(uncompressed.len());
-        let shards: Vec<&[u8]> = uncompressed.chunks(shard_size).collect();
+        #[cfg(not(feature = "zstd"))]
+        {
+            let _ = uncompressed;
+            bail!("wild was compiled without zstd support");
+        }
 
-        shards
-            .par_iter()
-            .map(|shard| -> Result<Vec<u8>> {
-                verbose_timing_phase!("Compress zstd shard");
-                zstd::encode_all(*shard, ZSTD_COMPRESSION_LEVEL).map_err(Into::into)
-            })
-            .collect()
+        #[cfg(feature = "zstd")]
+        {
+            let shard_size = shard_size(uncompressed.len());
+            let shards: Vec<&[u8]> = uncompressed.chunks(shard_size).collect();
+
+            shards
+                .par_iter()
+                .map(|shard| -> Result<Vec<u8>> {
+                    verbose_timing_phase!("Compress zstd shard");
+                    zstd::encode_all(*shard, ZSTD_COMPRESSION_LEVEL).map_err(Into::into)
+                })
+                .collect()
+        }
     }
 
     fn kind() -> CompressionType {

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -125,7 +125,6 @@ use rayon::Scope;
 use rayon::prelude::*;
 use smallvec::SmallVec;
 use std::borrow::Cow;
-use std::io::Read as _;
 use std::mem::offset_of;
 use std::num::NonZeroU32;
 use std::num::NonZeroU64;
@@ -3247,7 +3246,15 @@ fn decompress_into(
         // With the official library, the linking time of Clang binary (contains 1GB of debug info
         // sections) shrinks by 30%!
         object::elf::ELFCOMPRESS_ZSTD => {
-            zstd::stream::Decoder::new(input)?.read_exact(out)?;
+            #[cfg(feature = "zstd")]
+            {
+                use std::io::Read as _;
+                zstd::stream::Decoder::new(input)?.read_exact(out)?;
+            }
+            #[cfg(not(feature = "zstd"))]
+            {
+                bail!("wild was compiled without zstd support");
+            }
         }
         c => bail!("Unsupported compression format: {}", c),
     }

--- a/libwild/src/fs.rs
+++ b/libwild/src/fs.rs
@@ -31,13 +31,6 @@ pub(crate) fn path_from_bytes(bytes: &[u8]) -> PathBuf {
         std::path::Path::new(OsStr::from_bytes(bytes)).to_path_buf()
     }
 
-    #[cfg(windows)]
-    {
-        use std::path::PathBuf;
-        let path = std::str::from_utf8(bytes).expect("Invalid UTF-8 in archive path name");
-        PathBuf::from(path)
-    }
-
     #[cfg(target_os = "wasi")]
     {
         use std::ffi::OsStr;
@@ -45,7 +38,7 @@ pub(crate) fn path_from_bytes(bytes: &[u8]) -> PathBuf {
         std::path::Path::new(OsStr::from_bytes(bytes)).to_path_buf()
     }
 
-    #[cfg(not(any(unix, windows, target_os = "wasi")))]
+    #[cfg(not(any(unix, target_os = "wasi")))]
     {
         let path = std::str::from_utf8(bytes).expect("Invalid UTF-8 in archive path name");
         PathBuf::from(path)

--- a/libwild/src/fs.rs
+++ b/libwild/src/fs.rs
@@ -44,4 +44,10 @@ pub(crate) fn path_from_bytes(bytes: &[u8]) -> PathBuf {
         use std::os::wasi::ffi::OsStrExt as _;
         std::path::Path::new(OsStr::from_bytes(bytes)).to_path_buf()
     }
+
+    #[cfg(not(any(unix, windows, target_os = "wasi")))]
+    {
+        let path = std::str::from_utf8(bytes).expect("Invalid UTF-8 in archive path name");
+        PathBuf::from(path)
+    }
 }

--- a/libwild/src/save_dir.rs
+++ b/libwild/src/save_dir.rs
@@ -75,7 +75,9 @@ impl SaveDir {
 }
 
 fn save_dir_from_env() -> Result<Option<PathBuf>> {
-    if let Ok(d) = std::env::var(SAVE_DIR_ENV) {
+    if let Ok(d) = std::env::var(SAVE_DIR_ENV)
+        && !d.is_empty()
+    {
         let dir = PathBuf::from(d);
 
         if dir.exists() {
@@ -99,7 +101,9 @@ fn save_dir_from_env() -> Result<Option<PathBuf>> {
         return Ok(Some(dir));
     }
 
-    if let Ok(d) = std::env::var(SAVE_BASE_ENV) {
+    if let Ok(d) = std::env::var(SAVE_BASE_ENV)
+        && !d.is_empty()
+    {
         let base = PathBuf::from(d);
         std::fs::create_dir_all(&base).with_context(|| {
             format!(

--- a/libwild/src/save_dir.rs
+++ b/libwild/src/save_dir.rs
@@ -488,6 +488,11 @@ fn create_symlink(target: &Path, dest_path: &Path) -> Result {
         let _ = (target, dest_path);
         bail!("creating symlinks on wasi not supported on stable rust");
     }
+    #[cfg(not(any(unix, windows, target_os = "wasi")))]
+    {
+        let _ = (target, dest_path);
+        bail!("creating symlinks is not supported on this platform");
+    }
 }
 
 fn make_linker_script_relative(bytes: &[u8], source_path: &Path) -> Result<Vec<u8>> {

--- a/libwild/src/save_dir.rs
+++ b/libwild/src/save_dir.rs
@@ -75,9 +75,7 @@ impl SaveDir {
 }
 
 fn save_dir_from_env() -> Result<Option<PathBuf>> {
-    if let Ok(d) = std::env::var(SAVE_DIR_ENV)
-        && !d.is_empty()
-    {
+    if let Ok(d) = std::env::var(SAVE_DIR_ENV) {
         let dir = PathBuf::from(d);
 
         if dir.exists() {
@@ -101,9 +99,7 @@ fn save_dir_from_env() -> Result<Option<PathBuf>> {
         return Ok(Some(dir));
     }
 
-    if let Ok(d) = std::env::var(SAVE_BASE_ENV)
-        && !d.is_empty()
-    {
+    if let Ok(d) = std::env::var(SAVE_BASE_ENV) {
         let base = PathBuf::from(d);
         std::fs::create_dir_all(&base).with_context(|| {
             format!(

--- a/wild/Cargo.toml
+++ b/wild/Cargo.toml
@@ -18,7 +18,7 @@ path = "tests/integration_tests.rs"
 harness = false
 
 [dependencies]
-libwild = { path = "../libwild", version = "0.9.0" }
+libwild = { path = "../libwild", version = "0.9.0", default-features = false }
 
 # This is off by default, since it doesn't appear to help. However, if you're linking against musl
 # libc, which has a comparatively slow allocator, then enabling this does help. To enable this,
@@ -55,9 +55,11 @@ which.workspace = true
 wait-timeout.workspace = true
 
 [features]
-default = ["fork", "plugins"]
+default = ["fork", "plugins", "zstd"]
 
 fork = ["libwild/fork"]
+
+zstd = ["libwild/zstd"]
 
 plugins = ["libwild/plugins"]
 


### PR DESCRIPTION
The change is motivated by the being able to cross compile the library for `+succinct` target: `riscv64im-succinct-zkvm-elf` ([^1]):
```
❯ cargo +succinct b --target=riscv64im-succinct-zkvm-elf --bin wild --no-default-features
info: `cargo` is unavailable for the active toolchain
info: falling back to "/home/marxin/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/bin/cargo"
    Finished [`dev` profile [unoptimized + debuginfo]](https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles) target(s) in 0.11s
```

[^1]: https://docs.succinct.xyz/docs/sp1/introduction