### PR TITLE
port(wasm): Support `--export` in Wasm

### DIFF
--- a/libwild/src/args/wasm.rs
+++ b/libwild/src/args/wasm.rs
@@ -29,6 +29,7 @@ pub(crate) const WASM_PAGE_SIZE: u64 = WASM_PAGE_ALIGNMENT.value();
 pub struct WasmArgs {
     pub(crate) common: super::CommonArgs,
     pub(crate) lib_search_path: Vec<Box<Path>>,
+    pub(crate) export_symbols: Vec<String>,
 }
 
 impl WasmArgs {
@@ -46,6 +47,7 @@ impl Default for WasmArgs {
         Self {
             common: CommonArgs::default(),
             lib_search_path: Vec::new(),
+            export_symbols: Vec::new(),
         }
     }
 }
@@ -71,6 +73,10 @@ impl platform::Args for WasmArgs {
         // TODO: probably add option. wasm-ld defaults to `_start` for command
         // modules and no entry for reactor modules.
         b"_start"
+    }
+
+    fn force_export_symbol_names(&self) -> &[String] {
+        &self.export_symbols
     }
 
     fn lib_search_path(&self) -> &[Box<std::path::Path>] {
@@ -181,7 +187,42 @@ fn setup_argument_parser() -> ArgumentParser<WasmArgs> {
             Ok(())
         });
 
+    parser
+        .declare_with_param()
+        .long("export")
+        .help("Force a symbol to be exported")
+        .execute(|args, _modifier_stack, value| {
+            args.export_symbols.push(value.to_owned());
+            Ok(())
+        });
+
     super::declare_common_args(&mut parser);
 
     parser
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::platform::Args as _;
+
+    fn parse_args<'a>(args: impl IntoIterator<Item = &'a str>) -> WasmArgs {
+        let mut wasm_args = WasmArgs::new().unwrap();
+        wasm_args.parse(args.into_iter()).unwrap();
+        wasm_args
+    }
+
+    #[test]
+    fn parse_export_space_and_equals() {
+        let args = parse_args(["--export", "foo", "--export=bar", "-o", "out.wasm"]);
+        assert_eq!(args.export_symbols, ["foo", "bar"]);
+        assert_eq!(args.force_export_symbol_names(), ["foo", "bar"]);
+    }
+
+    #[test]
+    fn export_is_not_treated_as_input_path() {
+        let args = parse_args(["--export", "__main_void", "-o", "out.wasm"]);
+        assert_eq!(args.export_symbols, ["__main_void"]);
+        assert!(args.common.inputs.is_empty());
+    }
 }

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -13,6 +13,7 @@ use crate::layout_rules::SectionRule;
 use crate::layout_rules::SectionRuleOutcome;
 use crate::output_section_id::SectionName;
 use crate::platform;
+use crate::platform::Args as _;
 use crate::symbol::UnversionedSymbolName;
 use crate::symbol_db::SymbolDb;
 use crate::timing_phase;
@@ -3142,6 +3143,17 @@ fn push_function_export<'data>(
     });
 }
 
+fn push_global_export<'data>(exports: &mut Vec<OutputExport<'data>>, name: &'data str, index: u32) {
+    if export_name_exists(exports, name) {
+        return;
+    }
+    exports.push(OutputExport {
+        name,
+        kind: wasmparser::ExternalKind::Global,
+        index,
+    });
+}
+
 /// Resolved user entry function, if present among the linked objects.
 struct ResolvedEntry<'data> {
     export_name: &'data str,
@@ -3212,6 +3224,68 @@ fn ensure_entry_export<'data>(
         kind: wasmparser::ExternalKind::Func,
         index,
     });
+}
+
+/// Export symbols requested via `--export`.
+fn ensure_force_exports<'data>(
+    exports: &mut Vec<OutputExport<'data>>,
+    layout_inputs: &[WasmObjectLayoutInput<'data>],
+    object_index_maps: &[WasmObjectIndexMap],
+    symbol_db: &SymbolDb<'data, Wasm>,
+    entry: Option<&ResolvedEntry<'data>>,
+    entry_wrapper_func: Option<u32>,
+) -> Result<()> {
+    for name in symbol_db.args.force_export_symbol_names() {
+        let Some(symbol_id) =
+            symbol_db.get_unversioned(&UnversionedSymbolName::prehashed(name.as_bytes()))
+        else {
+            bail!("symbol exported via --export not found: {name}");
+        };
+        let def_id = symbol_db.definition(symbol_id);
+        let def_file_id = symbol_db.file_id_for_symbol(def_id);
+
+        let Some(def_obj_idx) = layout_inputs
+            .iter()
+            .position(|input| input.file_id == def_file_id)
+        else {
+            bail!("symbol exported via --export not found: {name}");
+        };
+        let def_input = &layout_inputs[def_obj_idx];
+        let def_sym = &def_input.symbols[def_input.symbol_id_range.id_to_offset(def_id)];
+        if def_sym.is_undefined() {
+            bail!("symbol exported via --export not found: {name}");
+        }
+
+        let index_map = object_index_maps
+            .get(def_obj_idx)
+            .context("missing Wasm object index map for --export symbol definition")?;
+        let export_name = core::str::from_utf8(symbol_db.symbol_name(def_id)?.bytes())
+            .context("invalid UTF-8 in Wasm --export symbol name")?;
+
+        match def_sym.kind {
+            WasmSymbolKind::Func => {
+                let mut index =
+                    remap_wasm_index(&index_map.function_indices, def_sym.index, "function")?;
+                // If this is the entry and we wrap it, export the wrapper.
+                if let (Some(entry), Some(wrapper)) = (entry, entry_wrapper_func)
+                    && export_name == entry.export_name
+                {
+                    index = wrapper;
+                }
+                push_function_export(exports, export_name, index);
+            }
+            WasmSymbolKind::Global => {
+                let index = remap_wasm_index(&index_map.global_indices, def_sym.index, "global")?;
+                push_global_export(exports, export_name, index);
+            }
+            _ => {
+                bail!(
+                    "Wasm --export of non-function/non-global symbols is not yet supported: {name}"
+                );
+            }
+        }
+    }
+    Ok(())
 }
 
 fn build_output_module_layout<'data, 'files>(
@@ -3398,6 +3472,14 @@ where
             entry.as_ref(),
             indices.entry_wrapper_func,
         );
+        ensure_force_exports(
+            &mut layout.exports,
+            &layout_inputs,
+            &layout.object_index_maps,
+            symbol_db,
+            entry.as_ref(),
+            indices.entry_wrapper_func,
+        )?;
     }
     {
         timing_phase!("Finalize Wasm indirect function table");

--- a/wild/tests/sources/wasm/export/export.c
+++ b/wild/tests/sources/wasm/export/export.c
@@ -1,0 +1,18 @@
+//#Config:export-functions
+//#LinkArgs: --export=foo
+//#Contains: foo
+//#DoesNotContain: not_exported
+
+//#Config:missing-export
+//#LinkArgs: --export does_not_exist
+//#ExpectError: symbol exported via --export not found: does_not_exist
+
+int foo(void) { return 42; }
+
+void not_exported(void) {}
+
+void _start(void) {
+  if (foo() != 42) {
+    __builtin_trap();
+  }
+}


### PR DESCRIPTION
This flag is passed by rustc when building a regular Rust program for wasm32-wasi.

Part of #1431