### PR TITLE
fix: don't double count section sizes in scripts

### DIFF
--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -1770,7 +1770,11 @@ pub(crate) fn merge_secondary_parts<P: Platform>(
         if let SectionKind::Secondary(primary_id) = info.kind {
             let secondary_layout = take(section_layouts.get_mut(id));
             let primary = section_layouts.get_mut(primary_id);
-            if info.location_info.is_some() {
+            let has_location_counters = info
+                .location_info
+                .as_ref()
+                .is_some_and(|li| li.location_counters.0 < li.location_counters.1);
+            if has_location_counters {
                 let mem_end = secondary_layout.mem_offset + secondary_layout.mem_size;
                 if mem_end > primary.mem_offset + primary.mem_size {
                     primary.mem_size = mem_end - primary.mem_offset;
@@ -1779,8 +1783,12 @@ pub(crate) fn merge_secondary_parts<P: Platform>(
                 if file_end > primary.file_offset + primary.file_size {
                     primary.file_size = file_end - primary.file_offset;
                 }
+                if secondary_layout.mem_size > 0 {
+                    primary.alignment = primary.alignment.max(secondary_layout.alignment);
+                }
+            } else {
+                primary.merge(&secondary_layout);
             }
-            primary.merge(&secondary_layout);
         }
     }
 }

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.c
@@ -21,6 +21,12 @@
 //#Config:no_gc_sections:default
 //#LinkArgs:--no-gc-sections
 
+//#Config:section_sizeof
+//#LinkerScript:linker-script-section-sizeof.ld
+//#Object:runtime.c
+// RISC-V: BFD complains about missing __global_pointer$ (defined in the default linker script)
+//#SkipArch:riscv64,ppc64le
+
 //#Config:underflow
 //#Object:runtime.c
 //#LinkerScript:linker-script-location-counter-underflow.ld
@@ -31,6 +37,9 @@
 #include "../common/runtime.h"
 
 int ret = 42;
+
+__attribute__((section(".foo.first"))) int data_first = 1;
+__attribute__((section(".foo.second"), aligned(8))) int data_second = 2;
 
 __attribute__((section(".text.foo"))) void foo(void) {}
 

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-location-counter.ld
@@ -28,6 +28,11 @@ SECTIONS
     .bss : {
         KEEP(*(.bss))
     }
+
+    /DISCARD/ : {
+        *(.foo.first)
+        *(.foo.second)
+    }
 }
 
 ASSERT(start_of_sections == 0x600000, "start_of_sections should be 0x600000");

--- a/wild/tests/sources/elf/linker-script-location-counter/linker-script-section-sizeof.ld
+++ b/wild/tests/sources/elf/linker-script-location-counter/linker-script-section-sizeof.ld
@@ -1,0 +1,16 @@
+ENTRY(begin_here)
+
+SECTIONS
+{
+    . = 0x600000;
+    .text : {
+        *(.text)
+    }
+    . = 0x800000;
+    .foo : {
+        KEEP(*(.foo.first))
+        KEEP(*(.foo.second))
+    }
+}
+
+ASSERT(SIZEOF(.foo) == 12, "foo section size must be 12");


### PR DESCRIPTION
The size of a section with secondary sections was being calculated twice if the section had a location specified using linker scripts, this PR fixes the issue to calculate the section sizes only once.