### PR TITLE
test: Fix race condition in Rust LTO support detection

### DIFF
--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -6298,7 +6298,7 @@ fn verify_linker_plugin_requirements(
                 "-Clinker-plugin-lto",
                 "-Clink-arg=-flto",
                 "-o",
-                "/tmp/rust.out",
+                &format!("/tmp/rust-{}.out", config.arch),
             ]);
             verify_command_success(&mut command).context(
                 "Can't use rust+clang with linker plugin. LLVM version mismatch? \


### PR DESCRIPTION
Different architectures might be tested in parallel, and we cannot use /dev/null in this specific case. That means we need a unique name for the each arch, otherwise one test might replace the outputs before the previous one has done reading them.

Observed in https://github.com/wild-linker/wild/issues/2184