### PR TITLE
ci: Install llvm-gold on openSUSE

### DIFF
--- a/docker/ci/opensuse.Dockerfile
+++ b/docker/ci/opensuse.Dockerfile
@@ -5,7 +5,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     PATH=/usr/local/cargo/bin:$PATH
 
 RUN zypper refresh \
-    && zypper in -y gcc gcc-c++ glibc-devel-static clang lld curl rustup \
+    && zypper in -y gcc gcc-c++ glibc-devel-static clang lld llvm-gold curl rustup \
     && zypper clean --all \
     && curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-linux-$(uname -m).gz \
         | gzip -d - | install -m 755 /dev/stdin /usr/local/bin/taplo \

--- a/docker/opensuse.Dockerfile
+++ b/docker/opensuse.Dockerfile
@@ -15,6 +15,7 @@ RUN zypper install -y -t pattern devel_C_C++ && \
         cross-riscv64-binutils \
         qemu-linux-user \
         lld \
+        llvm-gold \
         vim \
         less
 RUN rustup toolchain install nightly \


### PR DESCRIPTION
Otherwise, ld.bfd and Wild cannot use LLVM LTO plugin.

Before:

<details>
<summary>Collapsed because of lots of text</summary>

```
test elf/loongarch64/rust-integration/linker-plugin-lto ... ignored (Architecture disabled)
test elf/ppc64le/rust-integration/linker-plugin-lto     ... ignored (Architecture disabled)
test elf/x86_64/rust-integration/linker-plugin-lto      ... ignored (Can't use rust+clang with linker plugin. LLVM version mismatch? Check that clang --version matches LLVM version reported by `rustc -vV`.
  Caused by:
    Failed platform test requirements. "rustc" "+nightly" "/wild/wild/tests/sources/framework/lto-verifier.rs" "-Clinker=clang" "-Clinker-plugin-lto" "-Clink-arg=-flto" "-o" "/tmp/rust-x86_64.out": error: linking with `clang` failed: exit status: 1
  |
  = note:  "clang" "-m64" "/tmp/rustcy4g2N8/symbols.o" "<2 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib/{libstd-*,libpanic_unwind-*,libobject-*,libmemchr-*,libaddr2line-*,libgimli-*,libcfg_if-*,librustc_demangle-*,libstd_detect-*,libhashbrown-*,librustc_std_workspace_alloc-*,libminiz_oxide-*,libadler2-*,libunwind-*,liblibc-*,librustc_std_workspace_core-*,liballoc-*,libcore-*,libcompiler_builtins-*}.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-L" "/tmp/rustcy4g2N8/raw-dylibs" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-Wl,-plugin-opt=O0,-plugin-opt=mcpu=x86-64" "-L" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "/tmp/rust-x86_64.out" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-nodefaultlibs" "-flto"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: /usr/bin/ld.bfd: /usr/bin/../lib64/LLVMgold.so: error loading plugin: /usr/bin/../lib64/LLVMgold.so: cannot open shared object file: No such file or directory
          clang: error: linker command failed with exit code 1 (use -v to see invocation)


error: aborting due to 1 previous error


)
test elf/aarch64/rust-integration/linker-plugin-lto     ... ignored (Can't use rust+clang with linker plugin. LLVM version mismatch? Check that clang --version matches LLVM version reported by `rustc -vV`.
  Caused by:
    Failed platform test requirements. "rustc" "+nightly" "/wild/wild/tests/sources/framework/lto-verifier.rs" "-Clinker=clang" "-Clinker-plugin-lto" "-Clink-arg=-flto" "-o" "/tmp/rust-aarch64.out": error: linking with `clang` failed: exit status: 1
  |
  = note:  "clang" "-m64" "/tmp/rustcdnxlpo/symbols.o" "<2 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib/{libstd-*,libpanic_unwind-*,libobject-*,libmemchr-*,libaddr2line-*,libgimli-*,libcfg_if-*,librustc_demangle-*,libstd_detect-*,libhashbrown-*,librustc_std_workspace_alloc-*,libminiz_oxide-*,libadler2-*,libunwind-*,liblibc-*,librustc_std_workspace_core-*,liballoc-*,libcore-*,libcompiler_builtins-*}.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-L" "/tmp/rustcdnxlpo/raw-dylibs" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-Wl,-plugin-opt=O0,-plugin-opt=mcpu=x86-64" "-L" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "/tmp/rust-aarch64.out" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-nodefaultlibs" "-flto"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: /usr/bin/ld.bfd: /usr/bin/../lib64/LLVMgold.so: error loading plugin: /usr/bin/../lib64/LLVMgold.so: cannot open shared object file: No such file or directory
          clang: error: linker command failed with exit code 1 (use -v to see invocation)


error: aborting due to 1 previous error


)
test elf/riscv64/rust-integration/linker-plugin-lto     ... ignored (Can't use rust+clang with linker plugin. LLVM version mismatch? Check that clang --version matches LLVM version reported by `rustc -vV`.
  Caused by:
    Failed platform test requirements. "rustc" "+nightly" "/wild/wild/tests/sources/framework/lto-verifier.rs" "-Clinker=clang" "-Clinker-plugin-lto" "-Clink-arg=-flto" "-o" "/tmp/rust-riscv64.out": error: linking with `clang` failed: exit status: 1
  |
  = note:  "clang" "-m64" "/tmp/rustca5ex40/symbols.o" "<2 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib/{libstd-*,libpanic_unwind-*,libobject-*,libmemchr-*,libaddr2line-*,libgimli-*,libcfg_if-*,librustc_demangle-*,libstd_detect-*,libhashbrown-*,librustc_std_workspace_alloc-*,libminiz_oxide-*,libadler2-*,libunwind-*,liblibc-*,librustc_std_workspace_core-*,liballoc-*,libcore-*,libcompiler_builtins-*}.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-L" "/tmp/rustca5ex40/raw-dylibs" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-Wl,-plugin-opt=O0,-plugin-opt=mcpu=x86-64" "-L" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "/tmp/rust-riscv64.out" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-nodefaultlibs" "-flto"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: /usr/bin/ld.bfd: /usr/bin/../lib64/LLVMgold.so: error loading plugin: /usr/bin/../lib64/LLVMgold.so: cannot open shared object file: No such file or directory
          clang: error: linker command failed with exit code 1 (use -v to see invocation)


error: aborting due to 1 previous error


)
```

</details>

After:
```
test elf/loongarch64/rust-integration/linker-plugin-lto ... ignored (Architecture disabled)
test elf/ppc64le/rust-integration/linker-plugin-lto     ... ignored (Architecture disabled)
test elf/x86_64/rust-integration/linker-plugin-lto      ... ok
test elf/riscv64/rust-integration/linker-plugin-lto     ... FAILED
test elf/aarch64/rust-integration/linker-plugin-lto     ... ok

failures:

---- elf/riscv64/rust-integration/linker-plugin-lto ----
Test failed: `rust-integration.rs` with linker `wild` config `linker-plugin-lto`
  Caused by:
    Unexpected output on stderr:
Hard-float 'd' ABI can't be used for a target that doesn't support the D instruction set extension (ignoring target-abi)
```