### PR TITLE
chore: refactor RELR bitmap encoder into one

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -5100,7 +5100,7 @@ const RELR_ADDRESS_RANGE: u64 = RELR_BITMAP_SLOTS * RELR_TYPE_BYTE_SIZE;
 
 struct RelrBitmap {
     range: Range<u64>,
-    bitmap: u64,
+    encoded: u64,
 }
 
 impl RelrBitmap {
@@ -5109,7 +5109,7 @@ impl RelrBitmap {
         let start = address + RELR_TYPE_BYTE_SIZE;
         Self {
             range: start..start + RELR_ADDRESS_RANGE,
-            bitmap: 1,
+            encoded: 1,
         }
     }
 
@@ -5117,7 +5117,7 @@ impl RelrBitmap {
     fn next(&self) -> Self {
         Self {
             range: self.range.start + RELR_ADDRESS_RANGE..self.range.end + RELR_ADDRESS_RANGE,
-            bitmap: 1,
+            encoded: 1,
         }
     }
 
@@ -5128,7 +5128,7 @@ impl RelrBitmap {
         if !self.range.contains(&address) || !offset.is_multiple_of(RELR_TYPE_BYTE_SIZE) {
             false
         } else {
-            self.bitmap |= 1 << (offset / RELR_TYPE_BYTE_SIZE + 1);
+            self.encoded |= 1 << (offset / RELR_TYPE_BYTE_SIZE + 1);
             true
         }
     }
@@ -5176,7 +5176,7 @@ impl RelrEncoder {
             }
             RelrState::AddressOnly { mut next_bitmap } => {
                 if next_bitmap.insert(address) {
-                    encode_fn(next_bitmap.bitmap, RelrEntryEncoding::New)?;
+                    encode_fn(next_bitmap.encoded, RelrEntryEncoding::New)?;
                     RelrState::WithBitmap {
                         bitmap: next_bitmap,
                     }
@@ -5189,15 +5189,15 @@ impl RelrEncoder {
             }
             RelrState::WithBitmap { mut bitmap } => {
                 if bitmap.insert(address) {
-                    encode_fn(bitmap.bitmap, RelrEntryEncoding::Update)?;
+                    encode_fn(bitmap.encoded, RelrEntryEncoding::Update)?;
                     RelrState::WithBitmap { bitmap }
                 } else {
+                    // Current window has bits — try next window.
+                    // lld only advances to a new bitmap if the current one is
+                    // non-empty (breaks on empty bitmap). Same rule here.
                     let mut next_bitmap = bitmap.next();
                     if next_bitmap.insert(address) {
-                        // Current window has bits — try next window.
-                        // lld only advances to a new bitmap if the current one is
-                        // non-empty (breaks on empty bitmap). Same rule here.
-                        encode_fn(next_bitmap.bitmap, RelrEntryEncoding::New)?;
+                        encode_fn(next_bitmap.encoded, RelrEntryEncoding::New)?;
                         RelrState::WithBitmap {
                             bitmap: next_bitmap,
                         }

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -2896,7 +2896,7 @@ fn process_eh_frame_relocations<'data, 'scope, A: Arch<Platform = Elf>, R: Reloc
                     queue,
                     false,
                     scope,
-                    &mut RelrRunState::default(), // eh_frame relocations are never RELR-eligible
+                    &mut RelrEncoder::default(), // eh_frame relocations are never RELR-eligible
                 )?;
 
                 if rel.symbol().is_none() {
@@ -3002,7 +3002,7 @@ fn process_section_exception_frames<'data, 'scope, A: Arch<Platform = Elf>, R: R
                 queue,
                 true,
                 scope,
-                &mut RelrRunState::default(), // eh_frame relocations are never RELR-eligible
+                &mut RelrEncoder::default(), // eh_frame relocations are never RELR-eligible
             )?;
         }
         common.format_specific.exception_frame_relocations +=
@@ -3351,7 +3351,6 @@ pub(crate) const RELA_ENTRY_SIZE: u64 = size_of::<Rela>() as u64;
 pub(crate) const RELR_ENTRY_SIZE: u64 = size_of::<Relr>() as u64;
 
 pub(crate) const SYMTAB_ENTRY_SIZE: u64 = size_of::<SymtabEntry>() as u64;
-pub(crate) const RELR_BITMAP_SLOTS: u64 = 63;
 pub(crate) const SYMTAB_SHNDX_ENTRY_SIZE: u64 = size_of::<SymtabShndxEntry>() as u64;
 pub(crate) const GNU_VERSION_ENTRY_SIZE: u64 = size_of::<Versym>() as u64;
 
@@ -3468,20 +3467,6 @@ impl<'data> platform::DynamicTagValues<'data> for DynamicTagValues<'data> {
     fn lib_name(&self, input: &InputRef<'data>) -> &'data [u8] {
         self.soname.unwrap_or_else(|| input.lib_name())
     }
-}
-
-/// Tracks RELR bitmap packing state within a single input section during layout.
-/// Only packs within input sections — avoids cross-section address ordering
-/// issues in Wild's parallel layout phase.
-#[derive(Default)]
-enum RelrRunState {
-    /// No run in progress.
-    #[default]
-    NoRun,
-    /// In a run. `bitmap_base` is the start of the current bitmap window
-    /// (addr+8 initially, advances by 63*8 per emitted bitmap).
-    /// `has_bitmap` tracks whether a bitmap entry is allocated for this window.
-    InRun { bitmap_base: u64, has_bitmap: bool },
 }
 
 struct SymDebug<'data>(pub(crate) &'data crate::elf::SymtabEntry);
@@ -5077,7 +5062,7 @@ fn load_section_relocations<'scope, 'data, A: Arch<Platform = Elf>, R: Relocatio
     scope: &Scope<'scope>,
 ) -> Result {
     let mut modifier = RelocationModifier::Normal;
-    let mut relr_run = RelrRunState::default();
+    let mut relr_writer = RelrEncoder::default();
     for rel in relocations {
         if modifier == RelocationModifier::SkipNextRelocation {
             modifier = RelocationModifier::Normal;
@@ -5096,7 +5081,7 @@ fn load_section_relocations<'scope, 'data, A: Arch<Platform = Elf>, R: Relocatio
             queue,
             false,
             scope,
-            &mut relr_run,
+            &mut relr_writer,
         )
         .with_context(|| {
             format!(
@@ -5107,6 +5092,139 @@ fn load_section_relocations<'scope, 'data, A: Arch<Platform = Elf>, R: Relocatio
     }
 
     Ok(())
+}
+
+const RELR_TYPE_BYTE_SIZE: u64 = 8;
+pub(crate) const RELR_BITMAP_SLOTS: u64 = 8 * RELR_TYPE_BYTE_SIZE - 1;
+const RELR_ADDRESS_RANGE: u64 = RELR_BITMAP_SLOTS * RELR_TYPE_BYTE_SIZE;
+
+struct RelrBitmap {
+    range: Range<u64>,
+    bitmap: u64,
+}
+
+impl RelrBitmap {
+    // Return bitmap starting after the current address.
+    fn after(address: u64) -> Self {
+        let start = address.wrapping_add(RELR_TYPE_BYTE_SIZE);
+        Self {
+            range: start..start.wrapping_add(RELR_ADDRESS_RANGE),
+            bitmap: 1,
+        }
+    }
+
+    // Return bitmap that will follow after the current bitmap range.
+    fn next(&self) -> Self {
+        Self {
+            range: self.range.start + RELR_ADDRESS_RANGE..self.range.end + RELR_ADDRESS_RANGE,
+            bitmap: 1,
+        }
+    }
+
+    // Encoding address if properly aligned and fits in the current range. If fits, true is
+    // returned.
+    fn insert(&mut self, address: u64) -> bool {
+        let offset = address.wrapping_sub(self.range.start);
+        if !self.range.contains(&address) || !offset.is_multiple_of(RELR_TYPE_BYTE_SIZE) {
+            false
+        } else {
+            self.bitmap |= 1 << (offset / RELR_TYPE_BYTE_SIZE + 1);
+            true
+        }
+    }
+
+    // Return true if the bitmap does not encode any address.
+    fn is_empty(&self) -> bool {
+        self.bitmap == 1
+    }
+}
+
+/// Tracks RELR bitmap packing within one input section. Runs deliberately don't
+/// cross section boundaries because layout of separate sections is parallel.
+#[derive(Default)]
+enum RelrState {
+    #[default]
+    NoRun,
+    AddressOnly {
+        next_bitmap: RelrBitmap,
+    },
+    WithBitmap {
+        bitmap: RelrBitmap,
+    },
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum RelrEntryEncoding {
+    New,
+    Update,
+}
+
+#[derive(Default)]
+pub(crate) struct RelrEncoder {
+    state: RelrState,
+}
+
+// RELR bitmap packing state used for both allocation and the actual writting of relocations
+// to the output stream.
+impl RelrEncoder {
+    pub(crate) fn encode(
+        &mut self,
+        address: u64,
+        mut encode_fn: impl FnMut(u64, RelrEntryEncoding) -> Result,
+    ) -> Result {
+        self.state = match std::mem::take(&mut self.state) {
+            RelrState::NoRun => {
+                encode_fn(address, RelrEntryEncoding::New)?;
+                RelrState::AddressOnly {
+                    next_bitmap: RelrBitmap::after(address),
+                }
+            }
+            RelrState::AddressOnly { mut next_bitmap } => {
+                if next_bitmap.insert(address) {
+                    encode_fn(next_bitmap.bitmap, RelrEntryEncoding::New)?;
+                    RelrState::WithBitmap {
+                        bitmap: next_bitmap,
+                    }
+                } else {
+                    encode_fn(address, RelrEntryEncoding::New)?;
+                    RelrState::AddressOnly {
+                        next_bitmap: RelrBitmap::after(address),
+                    }
+                }
+            }
+            RelrState::WithBitmap { mut bitmap } => {
+                if bitmap.insert(address) {
+                    encode_fn(bitmap.bitmap, RelrEntryEncoding::Update)?;
+                    RelrState::WithBitmap { bitmap }
+                } else if !bitmap.is_empty() {
+                    let mut next_bitmap = bitmap.next();
+                    if next_bitmap.insert(address) {
+                        // Current window has bits — try next window.
+                        // lld only advances to a new bitmap if the current one is
+                        // non-empty (breaks on empty bitmap). Same rule here.
+                        encode_fn(next_bitmap.bitmap, RelrEntryEncoding::New)?;
+                        RelrState::WithBitmap {
+                            bitmap: next_bitmap,
+                        }
+                    } else {
+                        // Gap too large — start new address entry.
+                        encode_fn(address, RelrEntryEncoding::New)?;
+                        RelrState::AddressOnly {
+                            next_bitmap: RelrBitmap::after(address),
+                        }
+                    }
+                } else {
+                    // Unaligned, or current window empty and out of range.
+                    // lld breaks on empty bitmap — start new address entry.
+                    encode_fn(address, RelrEntryEncoding::New)?;
+                    RelrState::AddressOnly {
+                        next_bitmap: RelrBitmap::after(address),
+                    }
+                }
+            }
+        };
+        Ok(())
+    }
 }
 
 #[inline(always)]
@@ -5120,7 +5238,7 @@ fn process_relocation<'data, 'scope, A: Arch<Platform = Elf>, R: Relocation>(
     queue: &mut layout::LocalWorkQueue,
     is_debug_section: bool,
     scope: &Scope<'scope>,
-    relr_run: &mut RelrRunState,
+    relr_writer: &mut RelrEncoder,
 ) -> Result<RelocationModifier> {
     let args = resources.symbol_db.args;
     let mut next_modifier = RelocationModifier::Normal;
@@ -5220,67 +5338,12 @@ fn process_relocation<'data, 'scope, A: Arch<Platform = Elf>, R: Relocation>(
                 // Odd offsets can't be encoded as RELR address entries (LSB used as
                 // bitmap marker), so fall back to RELA for them.
                 if resources.symbol_db.args.is_relr_enabled() && rel.offset().is_multiple_of(2) {
-                    let offset = rel.offset();
-                    const WORD_SIZE: u64 = 8;
-                    *relr_run = match *relr_run {
-                        RelrRunState::NoRun => {
-                            // No run — start one with an address entry.
+                    relr_writer.encode(rel.offset(), |_, encoding| {
+                        if matches!(encoding, RelrEntryEncoding::New) {
                             common.allocate(part_id::RELR_DYN, elf::RELR_ENTRY_SIZE);
-                            RelrRunState::InRun {
-                                bitmap_base: offset + WORD_SIZE,
-                                has_bitmap: false,
-                            }
                         }
-                        RelrRunState::InRun {
-                            mut bitmap_base,
-                            has_bitmap,
-                        } => {
-                            let d = offset.wrapping_sub(bitmap_base);
-                            if d % WORD_SIZE == 0 && d < RELR_BITMAP_SLOTS * WORD_SIZE {
-                                // Fits in current bitmap window.
-                                if !has_bitmap {
-                                    // First member in this window: allocate bitmap entry.
-                                    common.allocate(part_id::RELR_DYN, elf::RELR_ENTRY_SIZE);
-                                }
-                                RelrRunState::InRun {
-                                    bitmap_base,
-                                    has_bitmap: true,
-                                }
-                            } else if has_bitmap && d % WORD_SIZE == 0 {
-                                // Current window has bits — try next window.
-                                // lld only advances to a new bitmap if the current one is
-                                // non-empty (breaks on empty bitmap). Same rule here.
-                                let next_base = bitmap_base + RELR_BITMAP_SLOTS * WORD_SIZE;
-                                let d2 = offset.wrapping_sub(next_base);
-                                if d2.is_multiple_of(WORD_SIZE)
-                                    && d2 < RELR_BITMAP_SLOTS * WORD_SIZE
-                                {
-                                    // Fits in next window — new bitmap entry, advance window.
-                                    common.allocate(part_id::RELR_DYN, elf::RELR_ENTRY_SIZE);
-                                    bitmap_base = next_base;
-                                    RelrRunState::InRun {
-                                        bitmap_base,
-                                        has_bitmap: true,
-                                    }
-                                } else {
-                                    // Gap too large — start new address entry.
-                                    common.allocate(part_id::RELR_DYN, elf::RELR_ENTRY_SIZE);
-                                    RelrRunState::InRun {
-                                        bitmap_base: offset + WORD_SIZE,
-                                        has_bitmap: false,
-                                    }
-                                }
-                            } else {
-                                // Unaligned, or current window empty and out of range.
-                                // lld breaks on empty bitmap — start new address entry.
-                                common.allocate(part_id::RELR_DYN, elf::RELR_ENTRY_SIZE);
-                                RelrRunState::InRun {
-                                    bitmap_base: offset + WORD_SIZE,
-                                    has_bitmap: false,
-                                }
-                            }
-                        }
-                    };
+                        Ok(())
+                    })?;
                 } else {
                     common.allocate(part_id::RELA_DYN_RELATIVE, elf::RELA_ENTRY_SIZE);
                 }

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -5106,9 +5106,9 @@ struct RelrBitmap {
 impl RelrBitmap {
     // Return bitmap starting after the current address.
     fn after(address: u64) -> Self {
-        let start = address.wrapping_add(RELR_TYPE_BYTE_SIZE);
+        let start = address + RELR_TYPE_BYTE_SIZE;
         Self {
-            range: start..start.wrapping_add(RELR_ADDRESS_RANGE),
+            range: start..start + RELR_ADDRESS_RANGE,
             bitmap: 1,
         }
     }
@@ -5131,11 +5131,6 @@ impl RelrBitmap {
             self.bitmap |= 1 << (offset / RELR_TYPE_BYTE_SIZE + 1);
             true
         }
-    }
-
-    // Return true if the bitmap does not encode any address.
-    fn is_empty(&self) -> bool {
-        self.bitmap == 1
     }
 }
 
@@ -5164,7 +5159,7 @@ pub(crate) struct RelrEncoder {
     state: RelrState,
 }
 
-// RELR bitmap packing state used for both allocation and the actual writting of relocations
+// RELR bitmap packing state used for both allocation and the actual writing of relocations
 // to the output stream.
 impl RelrEncoder {
     pub(crate) fn encode(
@@ -5196,7 +5191,7 @@ impl RelrEncoder {
                 if bitmap.insert(address) {
                     encode_fn(bitmap.bitmap, RelrEntryEncoding::Update)?;
                     RelrState::WithBitmap { bitmap }
-                } else if !bitmap.is_empty() {
+                } else {
                     let mut next_bitmap = bitmap.next();
                     if next_bitmap.insert(address) {
                         // Current window has bits — try next window.
@@ -5212,13 +5207,6 @@ impl RelrEncoder {
                         RelrState::AddressOnly {
                             next_bitmap: RelrBitmap::after(address),
                         }
-                    }
-                } else {
-                    // Unaligned, or current window empty and out of range.
-                    // lld breaks on empty bitmap — start new address entry.
-                    encode_fn(address, RelrEntryEncoding::New)?;
-                    RelrState::AddressOnly {
-                        next_bitmap: RelrBitmap::after(address),
                     }
                 }
             }

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -1181,7 +1181,7 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
                         let entry = self
                             .current_relr_dyn
                             .as_deref_mut()
-                            .ok_or_else(|| insufficient_allocation(".relr.dyn"))?;
+                            .ok_or_else(|| error!("Internal error in RELR bitmap encoding"))?;
                         entry.0.set(LittleEndian, encoded);
                     }
                 }

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -21,6 +21,7 @@ use crate::elf::NonAddressableCounts;
 use crate::elf::ProgramHeader;
 use crate::elf::RawSymbolName;
 use crate::elf::Rela;
+use crate::elf::RelrEncoder;
 use crate::elf::RiscVAttribute;
 use crate::elf::SectionHeader;
 use crate::elf::SymtabEntry;
@@ -602,19 +603,6 @@ impl<'out> VersionWriter<'out> {
     }
 }
 
-/// Writer-phase RELR bitmap packing state.
-/// Carries slice indices so bitmap entries can be updated in-place.
-#[derive(Default)]
-enum RelrWriterState {
-    #[default]
-    NoRun,
-    /// Address entry written, no bitmap entry yet for current window.
-    /// `bitmap_base` = addr+8 initially, advances by 63*8 per emitted bitmap.
-    AddressOnly { bitmap_base: u64 },
-    /// Bitmap entry written at `bitmap_idx`; `bitmap_base` is current window start.
-    WithBitmap { bitmap_base: u64, bitmap_idx: usize },
-}
-
 struct TableWriter<'layout, 'out> {
     output_kind: OutputKind,
     got: &'out mut [u64],
@@ -625,10 +613,9 @@ struct TableWriter<'layout, 'out> {
     rela_dyn_relative: &'out mut [crate::elf::Rela],
     rela_dyn_general: &'out mut [crate::elf::Rela],
     relr_dyn: Option<&'out mut [elf::Relr]>,
-    /// Index of next free slot in relr_dyn.
-    relr_dyn_index: usize,
-    /// Writer-phase RELR run state for bitmap packing.
-    relr_state: RelrWriterState,
+    current_relr_dyn: Option<&'out mut elf::Relr>,
+    /// RELR run state for bitmap packing.
+    relr_writer: RelrEncoder,
     dynsym_writer: SymbolTableWriter<'layout, 'out>,
     debug_symbol_writer: SymbolTableWriter<'layout, 'out>,
     eh_frame_start_address: u64,
@@ -697,8 +684,8 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
             relr_dyn: pack_relative_relocs
                 .then(|| slice_from_all_bytes_mut(buffers.take(part_id::RELR_DYN)))
                 .filter(|b| !b.is_empty()),
-            relr_dyn_index: 0,
-            relr_state: RelrWriterState::NoRun,
+            current_relr_dyn: None,
+            relr_writer: RelrEncoder::default(),
             dynsym_writer,
             debug_symbol_writer,
             eh_frame_start_address,
@@ -958,7 +945,8 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
     /// Resets RELR run state between input sections.
     /// Layout tracks runs per-section; writer must do the same to stay in sync.
     fn reset_relr_run(&mut self) {
-        self.relr_state = RelrWriterState::NoRun;
+        self.relr_writer = RelrEncoder::default();
+        self.current_relr_dyn = None;
     }
 
     /// Writes bitmap-packed RELR entries for the entire GOT_RELR block.
@@ -971,23 +959,19 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
             return Ok(());
         };
         // Write address entry for base.
-        let idx = self.relr_dyn_index;
-        if idx >= relr_writer.len() {
-            return Err(insufficient_allocation(".relr.dyn"));
-        }
-        relr_writer[idx].0.set(LittleEndian, base);
-        self.relr_dyn_index += 1;
+        let entry = relr_writer
+            .split_off_first_mut()
+            .ok_or_else(|| insufficient_allocation(".relr.dyn"))?;
+        entry.0.set(LittleEndian, base);
         // Write bitmap entries for remaining n-1 slots.
         let mut remaining = n - 1;
         while remaining > 0 {
             let slots = remaining.min(elf::RELR_BITMAP_SLOTS);
             let bitmap: u64 = ((1u64 << slots) - 1) << 1 | 1;
-            let idx = self.relr_dyn_index;
-            if idx >= relr_writer.len() {
-                return Err(insufficient_allocation(".relr.dyn"));
-            }
-            relr_writer[idx].0.set(LittleEndian, bitmap);
-            self.relr_dyn_index += 1;
+            let entry = relr_writer
+                .split_off_first_mut()
+                .ok_or_else(|| insufficient_allocation(".relr.dyn"))?;
+            entry.0.set(LittleEndian, bitmap);
             remaining = remaining.saturating_sub(elf::RELR_BITMAP_SLOTS);
         }
         Ok(())
@@ -1023,15 +1007,14 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
                 *mem_sizes.get(part_id::RELA_DYN_GENERAL),
             ));
         }
-        if let Some(relr_dyn) = &self.relr_dyn {
-            let remaining = relr_dyn.len() - self.relr_dyn_index;
-            if remaining != 0 {
-                return Err(excessive_allocation(
-                    ".relr.dyn",
-                    remaining as u64 * elf::RELR_ENTRY_SIZE,
-                    *mem_sizes.get(part_id::RELR_DYN),
-                ));
-            }
+        if let Some(relr_dyn) = &self.relr_dyn
+            && !relr_dyn.is_empty()
+        {
+            return Err(excessive_allocation(
+                ".relr.dyn",
+                relr_dyn.len() as u64 * elf::RELR_ENTRY_SIZE,
+                *mem_sizes.get(part_id::RELR_DYN),
+            ));
         }
         self.dynsym_writer.check_exhausted()?;
         self.debug_symbol_writer.check_exhausted()?;
@@ -1148,12 +1131,10 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
         if let Some(relr_writer) = &mut self.relr_dyn
             && place.is_multiple_of(2)
         {
-            let idx = self.relr_dyn_index;
-            if idx >= relr_writer.len() {
-                return Err(insufficient_allocation(".relr.dyn"));
-            }
-            relr_writer[idx].0.set(LittleEndian, place);
-            self.relr_dyn_index += 1;
+            let entry = relr_writer
+                .split_off_first_mut()
+                .ok_or_else(|| insufficient_allocation(".relr.dyn"))?;
+            entry.0.set(LittleEndian, place);
             Ok(relative_address)
         } else {
             let rela = self
@@ -1187,95 +1168,25 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
         if let Some(relr_writer) = &mut self.relr_dyn
             && place.is_multiple_of(2)
         {
-            const WORD_SIZE: u64 = 8;
-            self.relr_state = match self.relr_state {
-                RelrWriterState::NoRun => {
-                    // No run — write address entry and start run.
-                    let idx = self.relr_dyn_index;
-                    if idx >= relr_writer.len() {
-                        return Err(insufficient_allocation(".relr.dyn"));
+            self.relr_writer.encode(place, |encoded, encoding| {
+                match encoding {
+                    elf::RelrEntryEncoding::New => {
+                        let entry = relr_writer
+                            .split_off_first_mut()
+                            .ok_or_else(|| insufficient_allocation(".relr.dyn"))?;
+                        entry.0.set(LittleEndian, encoded);
+                        self.current_relr_dyn = Some(entry);
                     }
-                    relr_writer[idx].0.set(LittleEndian, place);
-                    self.relr_dyn_index += 1;
-                    RelrWriterState::AddressOnly {
-                        bitmap_base: place + WORD_SIZE,
-                    }
-                }
-                RelrWriterState::AddressOnly { bitmap_base }
-                | RelrWriterState::WithBitmap { bitmap_base, .. } => {
-                    let d = place.wrapping_sub(bitmap_base);
-                    if d % WORD_SIZE == 0 && d < elf::RELR_BITMAP_SLOTS * WORD_SIZE {
-                        // Fits in current bitmap window.
-                        let bit = d / WORD_SIZE + 1;
-                        if let RelrWriterState::WithBitmap { bitmap_idx, .. } = self.relr_state {
-                            // Bitmap entry exists — OR in the new bit.
-                            let current = relr_writer[bitmap_idx].0.get(LittleEndian);
-                            relr_writer[bitmap_idx]
-                                .0
-                                .set(LittleEndian, current | (1 << bit));
-                            RelrWriterState::WithBitmap {
-                                bitmap_base,
-                                bitmap_idx,
-                            }
-                        } else {
-                            // First member in this window — write bitmap entry.
-                            let idx = self.relr_dyn_index;
-                            if idx >= relr_writer.len() {
-                                return Err(insufficient_allocation(".relr.dyn"));
-                            }
-                            relr_writer[idx].0.set(LittleEndian, 1 | (1 << bit));
-                            self.relr_dyn_index += 1;
-                            RelrWriterState::WithBitmap {
-                                bitmap_base,
-                                bitmap_idx: idx,
-                            }
-                        }
-                    } else if let RelrWriterState::WithBitmap { .. } = self.relr_state
-                        && d % WORD_SIZE == 0
-                    {
-                        // Current window has bits — try next window.
-                        let next_base = bitmap_base + elf::RELR_BITMAP_SLOTS * WORD_SIZE;
-                        let d2 = place.wrapping_sub(next_base);
-                        if d2.is_multiple_of(WORD_SIZE) && d2 < elf::RELR_BITMAP_SLOTS * WORD_SIZE {
-                            // Fits in next window — write new bitmap entry.
-                            let bit = d2 / WORD_SIZE + 1;
-                            let idx = self.relr_dyn_index;
-                            if idx >= relr_writer.len() {
-                                return Err(insufficient_allocation(".relr.dyn"));
-                            }
-                            relr_writer[idx].0.set(LittleEndian, 1 | (1 << bit));
-                            self.relr_dyn_index += 1;
-                            RelrWriterState::WithBitmap {
-                                bitmap_base: next_base,
-                                bitmap_idx: idx,
-                            }
-                        } else {
-                            // Gap too large — start new address entry.
-                            let idx = self.relr_dyn_index;
-                            if idx >= relr_writer.len() {
-                                return Err(insufficient_allocation(".relr.dyn"));
-                            }
-                            relr_writer[idx].0.set(LittleEndian, place);
-                            self.relr_dyn_index += 1;
-                            RelrWriterState::AddressOnly {
-                                bitmap_base: place + WORD_SIZE,
-                            }
-                        }
-                    } else {
-                        // Unaligned or current window empty and out of range.
-                        // Start new address entry.
-                        let idx = self.relr_dyn_index;
-                        if idx >= relr_writer.len() {
-                            return Err(insufficient_allocation(".relr.dyn"));
-                        }
-                        relr_writer[idx].0.set(LittleEndian, place);
-                        self.relr_dyn_index += 1;
-                        RelrWriterState::AddressOnly {
-                            bitmap_base: place + WORD_SIZE,
-                        }
+                    elf::RelrEntryEncoding::Update => {
+                        let entry = self
+                            .current_relr_dyn
+                            .as_deref_mut()
+                            .ok_or_else(|| insufficient_allocation(".relr.dyn"))?;
+                        entry.0.set(LittleEndian, encoded);
                     }
                 }
-            };
+                Ok(())
+            })?;
             Ok(relative_address)
         } else {
             let rela = self


### PR DESCRIPTION
The change unifies the encoding logic for RELR bitmap relocations into once place, where both the allocation and encoding can pretty neatly communicate via the provided `encode_fn` argument.

CC: @deepakshirkem 