### PR TITLE
port(MachO): Write LC_UUID hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2153,6 +2153,7 @@ version = "0.9.0"
 dependencies = [
  "ar",
  "bitflags",
+ "blake3",
  "dhat",
  "diff",
  "foldhash 0.2.0",

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -24,6 +24,7 @@ use crate::macho::CS_BLOB_HEADERS_SIZE;
 use crate::macho::CS_BLOCK_SIZE;
 use crate::macho::CS_BLOCK_SIZE_EXP;
 use crate::macho::CS_HASH_SIZE;
+use crate::macho::CS_HEADERS_SIZE;
 use crate::macho::ChainedFixupsHeader;
 use crate::macho::CodeSignatureCommand;
 use crate::macho::DYLINKER_PATH;
@@ -100,6 +101,7 @@ use object::macho::LC_MAIN;
 use object::macho::LC_SEGMENT_64;
 use object::macho::LC_SYMTAB;
 use object::macho::LC_UUID;
+use object::macho::LoadCommand;
 use object::macho::MH_CIGAM_64;
 use object::macho::MH_EXECUTE;
 use object::macho::N_ABS;
@@ -163,7 +165,9 @@ pub(crate) fn write<'data, A: Arch<Platform = MachO>>(
     write_got_entries(layout, section_buffers.get_mut(output_section_id::GOT))?;
     write_plt_entries::<A>(layout, section_buffers.get_mut(output_section_id::PLT_GOT))?;
 
-    write_code_signature(layout, sized_output)?;
+    write_code_signature_metadata(layout, sized_output)?;
+    write_uuid(layout, sized_output)?;
+    write_code_signature_hashes(layout, sized_output)?;
 
     Ok(())
 }
@@ -775,7 +779,6 @@ fn write_build_version_command(layout: &MachOLayout, command: &mut BuildVersionC
 fn write_uuid_command(command: &mut UuidCommand) {
     command.cmd.set(LE, LC_UUID);
     command.cmdsize.set(LE, size_of::<UuidCommand>() as u32);
-    // TODO: write a proper UUID
     command.uuid.zero();
 }
 
@@ -998,19 +1001,49 @@ fn write_chained_fixup_table(layout: &MachOLayout, chained_fixup_table: &mut [u8
     Ok(())
 }
 
-fn write_code_signature(layout: &MachOLayout, sized_output: &mut SizedOutput) -> Result {
-    verbose_timing_phase!("Write code signature");
+fn write_uuid(layout: &MachOLayout, sized_output: &mut SizedOutput) -> Result {
+    verbose_timing_phase!("Write UUID");
+
+    let hash = blake3::Hasher::new()
+        .update_rayon(&sized_output.out)
+        .finalize();
+
+    let mut section_buffers = split_output_into_sections(layout, &mut sized_output.out).0;
+    let load_commands = section_buffers.get_mut(output_section_id::LOAD_COMMANDS);
+
+    while !load_commands.is_empty() {
+        let header = object::from_bytes::<LoadCommand<Endianness>>(load_commands)
+            .map_err(|_| error!("Invalid load command header"))?
+            .0;
+        let cmd_type = header.cmd.get(LE);
+        let cmd_size = header.cmdsize.get(LE) as usize;
+        let mut cmd = load_commands
+            .split_off_mut(..cmd_size)
+            .context("Invalid load command allocation")?;
+
+        if cmd_type == LC_UUID {
+            let uuid_cmd = take_mut::<UuidCommand>(&mut cmd)?;
+            let uuid_size = uuid_cmd.uuid.len();
+
+            uuid_cmd.uuid.copy_from_slice(&hash.as_bytes()[..uuid_size]);
+            // Match lld's UUID Version 3 from RFC 9562.
+            uuid_cmd.uuid[6] = (uuid_cmd.uuid[6] & 0x0f) | 0x30;
+            uuid_cmd.uuid[8] = (uuid_cmd.uuid[8] & 0x3f) | 0x80;
+            return Ok(());
+        }
+    }
+
+    bail!("Missing LC_UUID");
+}
+
+fn write_code_signature_metadata(layout: &MachOLayout, sized_output: &mut SizedOutput) -> Result {
+    verbose_timing_phase!("Write code signature metadata");
 
     let code_signature_section = layout
         .section_layouts
         .get(output_section_id::CODE_SIGNATURE);
     let code_signature_identifier = code_signature_identifier(layout.args());
     let padded_identifier_size = code_signature_padded_identifier_size(layout.args()) as usize;
-    let calculated_hashes: Vec<_> = sized_output.out[..code_signature_section.file_offset]
-        .par_chunks(CS_BLOCK_SIZE)
-        .map(Sha256::digest)
-        .collect();
-    let calculated_hashes = calculated_hashes.into_iter().flatten().collect_vec();
 
     let mut section_buffers = split_output_into_sections(layout, &mut sized_output.out).0;
     let code_signature = section_buffers.get_mut(output_section_id::CODE_SIGNATURE);
@@ -1080,6 +1113,31 @@ fn write_code_signature(layout: &MachOLayout, sized_output: &mut SizedOutput) ->
 
     identifier[..code_signature_identifier.len()].copy_from_slice(code_signature_identifier);
     identifier[code_signature_identifier.len()..].fill(0);
+    hashes.fill(0);
+
+    Ok(())
+}
+
+fn write_code_signature_hashes(layout: &MachOLayout, sized_output: &mut SizedOutput) -> Result {
+    verbose_timing_phase!("Write code signature hashes");
+
+    let code_signature_section = layout
+        .section_layouts
+        .get(output_section_id::CODE_SIGNATURE);
+    let calculated_hashes: Vec<_> = sized_output.out[..code_signature_section.file_offset]
+        .par_chunks(CS_BLOCK_SIZE)
+        .map(Sha256::digest)
+        .collect();
+    let calculated_hashes = calculated_hashes.into_iter().flatten().collect_vec();
+
+    let mut section_buffers = split_output_into_sections(layout, &mut sized_output.out).0;
+    let code_signature = section_buffers.get_mut(output_section_id::CODE_SIGNATURE);
+    let hashes_offset =
+        (CS_HEADERS_SIZE + code_signature_padded_identifier_size(layout.args())) as usize;
+    let hashes = code_signature
+        .get_mut(hashes_offset..)
+        .ok_or_else(|| error!("Invalid CODE_SIGNATURE allocation"))?;
+
     hashes.copy_from_slice(&calculated_hashes);
 
     #[cfg(target_os = "macos")]

--- a/wild/Cargo.toml
+++ b/wild/Cargo.toml
@@ -30,6 +30,7 @@ dhat = { workspace = true, optional = true }
 [dev-dependencies]
 ar.workspace = true
 bitflags.workspace = true
+blake3.workspace = true
 diff.workspace = true
 itertools.workspace = true
 foldhash.workspace = true

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -321,6 +321,7 @@ use object::Object as _;
 use object::ObjectKind;
 use object::ObjectSection;
 use object::ObjectSymbol as _;
+use object::macho::LC_CODE_SIGNATURE;
 use object::macho::LC_DYLD_CHAINED_FIXUPS;
 use object::macho::SEG_TEXT;
 use object::read::elf::ProgramHeader;
@@ -4264,7 +4265,7 @@ impl Assertions {
 
         // For Mach-O.
         if matches!(obj, object::File::MachO64(_)) {
-            return self.check_macho_path(&obj, &bytes);
+            return self.check_macho_path(&obj, &bytes, linker_used);
         }
 
         self.verify_file_kind(&obj)?;
@@ -4307,7 +4308,7 @@ impl Assertions {
         Ok(())
     }
 
-    fn check_macho_path(&self, obj: &object::File, bytes: &[u8]) -> Result {
+    fn check_macho_path(&self, obj: &object::File, bytes: &[u8], linker_used: &Linker) -> Result {
         // Allowlist of assertion fields implemented for Mach-O.
         let supported = Assertions {
             expected_symtab_entries: self.expected_symtab_entries.clone(),
@@ -4343,6 +4344,10 @@ impl Assertions {
         verify_no_overlapping_sections(obj)?;
         verify_no_overlapping_segments(obj)?;
         verify_chained_fixups_segment_offsets(obj, bytes)?;
+
+        if linker_used.is_wild() {
+            verify_uuid(obj, bytes)?;
+        }
         Ok(())
     }
 
@@ -5161,6 +5166,80 @@ fn verify_chained_fixups_segment_offsets(obj: &object::File, bytes: &[u8]) -> Re
         );
     }
 
+    Ok(())
+}
+
+fn verify_uuid(obj: &object::File, bytes: &[u8]) -> Result {
+    const CS_BLOCK_SIZE: usize = 4096;
+    const CS_HASH_SIZE: usize = 32;
+
+    let object::File::MachO64(file) = obj else {
+        return Ok(());
+    };
+
+    let e = file.endianness();
+    let mut load_commands = file.macho_load_commands()?;
+    let mut code_signature = None;
+    let mut uuid = None;
+
+    while let Some(load_command) = load_commands.next()? {
+        match load_command.variant()? {
+            LoadCommandVariant::LinkeditData(linkedit)
+                if linkedit.cmd.get(e) == LC_CODE_SIGNATURE =>
+            {
+                code_signature = Some(linkedit);
+            }
+            LoadCommandVariant::Uuid(uuid_cmd) => {
+                uuid = Some(uuid_cmd);
+            }
+            _ => {}
+        }
+    }
+
+    let code_signature = code_signature.context("Missing LC_CODE_SIGNATURE")?;
+    let uuid = uuid.context("Missing LC_UUID")?;
+
+    let uuid_size = uuid.uuid.len();
+    let uuid_start = bytes
+        .element_offset(&uuid.uuid[0])
+        .context("Invalid UUID offset")?;
+    let uuid_end = uuid_start
+        .checked_add(uuid_size)
+        .context("Invalid UUID size")?;
+
+    let code_signature_offset = usize::try_from(code_signature.dataoff.get(e))?;
+    let hashes_size = code_signature_offset
+        .div_ceil(CS_BLOCK_SIZE)
+        .checked_mul(CS_HASH_SIZE)
+        .context("Invalid code signature hashes size")?;
+    let hashes_start = bytes
+        .len()
+        .checked_sub(hashes_size)
+        .context("Invalid code signature hashes range")?;
+    let zero_hashes = vec![0; hashes_size];
+
+    ensure!(
+        uuid_end <= hashes_start,
+        "UUID range {uuid_start:#x}..{uuid_end:#x} overlaps code signature hashes \
+        starting at {hashes_start:#x}"
+    );
+
+    let expected_hash = blake3::Hasher::new()
+        .update(&bytes[..uuid_start])
+        .update(&[0; 16])
+        .update_rayon(&bytes[uuid_end..hashes_start])
+        .update(&zero_hashes)
+        .finalize();
+
+    let mut expected_uuid = [0; 16];
+    expected_uuid.copy_from_slice(&expected_hash.as_bytes()[..uuid_size]);
+    expected_uuid[6] = (expected_uuid[6] & 0x0f) | 0x30;
+    expected_uuid[8] = (expected_uuid[8] & 0x3f) | 0x80;
+
+    ensure!(
+        uuid.uuid == expected_uuid,
+        "LC_UUID does not match expected hash"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
Generates a BLAKE3 hash, then takes the first 16 bytes to fill out LC_UUID’s `uuid` field, along with setting the UUID version and variant bits. Two things I wanted to note were:

* The UUID hash is calculated by the contents (including the code signature), and the code signature page hashes depend on the UUID since one of the hashed pages will include `LC_UUID`. We can circumvent this by zeroing out the UUID and code signature when calculating the UUID hash, but then otherwise identical outputs linked under different filenames would produce the same UUID.
    * Looking at lld’s implementation, code signature metadata is written first ([phases](https://github.com/llvm/llvm-project/blob/7812fef524a0aef0b34599c2eb81b66843fbcdd8/lld/MachO/Writer.cpp#L1305-L1316), [code signature metadata](https://github.com/llvm/llvm-project/blob/7812fef524a0aef0b34599c2eb81b66843fbcdd8/lld/MachO/SyntheticSections.cpp#L1624-L1664), [code signature hashes](https://github.com/llvm/llvm-project/blob/7812fef524a0aef0b34599c2eb81b66843fbcdd8/lld/MachO/Writer.cpp#L1298-L1303)) so that this metadata (and specifically the identifier) differentiates identical files. I matched this implementation, but it required refactoring and splitting `write_code_signature` into separate metadata and hashing phases so that the ordering is now: `write_code_signature_metadata` -> `write_uuid` -> `write_code_signature_hashes`.

* [RFC 9562](https://datatracker.ietf.org/doc/html/rfc9562) describes the specification for UUIDs. Likewise, I matched [what lld does](https://github.com/llvm/llvm-project/blob/95ff1fa00ed4c35b3589fa92b591e02444fcc5d5/lld/MachO/Writer.cpp#L554-L565) and used UUID Version 3 to specify the version and variant fields in our hash. Although the RFC states that these “values are created by computing an MD5 hash,” it seems like lld acknowledges this as the “least bad lie” and uses this version format for their XXH3 UUID hashes.

Testing, before vs. after:

**Before:**
```
running 1 test
test macho/aarch64/trivial/default ... FAILED

failures:

---- macho/aarch64/trivial/default ----
Output binary assertions failed. Binary `/Users/joannajo/wild/wild/tests/build/macho/aarch64/trivial/default/trivial.c.wild`. Relink with:
        cargo run --bin wild -- -flavor darwin -o /Users/joannajo/wild/wild/tests/build/macho/aarch64/trivial/default/trivial.c.wild /Users/joannajo/wild/wild/tests/build/macho/aarch64/trivial/default/trivial.c.o /Users/joannajo/wild/wild/tests/build/macho/aarch64/trivial/default/runtime.c.o --validate-output --write-layout --write-trace
  Caused by:
    LC_UUID does not match expected hash



failures:
    macho/aarch64/trivial/default

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.72s
```

**After:**
```
running 1 test
test macho/aarch64/trivial/default ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.55s
```

Resolves #2120