### PR TITLE
port(wasm): Synthesize `__wasm_first_page_end` and `__heap_end` for WASI heap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,8 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         id: rust-toolchain
+        with:
+          targets: wasm32-wasip1
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get update && sudo apt-get install -y wabt lld wasi-libc
       - uses: taiki-e/install-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
 
   wasm-test:
     name: Test Wasm
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -3056,39 +3056,57 @@ fn emit_reserved_linker_definitions(
     }
 }
 
-/// Write stack-pointer init and memory page sizes after static data layout.
-fn fill_linker_defined_values(
-    layout: &mut WasmLayout<'_>,
-    indices: &LinkerDefinedIndices,
-    needs_stack_gap: bool,
-    stack_size: u32,
-) -> Result {
-    if let Some(defined_slot) = indices.stack_pointer_defined_slot {
-        let sp = stack_high_after_data(layout.data_end, stack_size)?;
-        let global = layout
-            .globals
-            .get_mut(defined_slot as usize)
-            .ok_or_else(|| crate::error!("Wasm stack pointer global missing"))?;
-        ensure!(
-            global.ty.mutable && global.ty.content_type == wasmparser::ValType::I32,
-            "Wasm stack pointer global has unexpected type"
-        );
-        global.init_expr_body = Cow::Owned(encode_i32_const_body(sp as i32));
-    }
+fn wasm_page_size() -> u64 {
+    crate::args::wasm::WASM_PAGE_SIZE
+}
 
+fn ensure_memory_covers(
+    layout: &mut WasmLayout<'_>,
+    stack_size: u32,
+    reserve_post_data_stack: bool,
+) -> Result<u64> {
+    let page = wasm_page_size();
     let mut bytes_needed = u64::from(layout.data_end.max(layout.memory_base));
-    if indices.stack_pointer_defined_slot.is_some() || needs_stack_gap {
+    if reserve_post_data_stack && stack_size > 0 {
         bytes_needed = bytes_needed.max(u64::from(stack_high_after_data(
             layout.data_end,
             stack_size,
         )?));
     }
-    if bytes_needed > 0 && !layout.memories.is_empty() {
-        let pages_needed = bytes_needed.div_ceil(65536).max(1);
+    if !layout.memories.is_empty() && bytes_needed > 0 {
+        let pages_needed = bytes_needed.div_ceil(page).max(1);
         for memory in &mut layout.memories {
             memory.initial = memory.initial.max(pages_needed);
         }
     }
+    Ok(layout.memories.iter().map(|m| m.initial).max().unwrap_or(0))
+}
+
+/// `__heap_end` = end of initial linear memory (`memory.initial * page_size`).
+fn heap_end_from_initial_pages(initial_pages: u64) -> Result<u32> {
+    u32::try_from(initial_pages.saturating_mul(wasm_page_size()))
+        .map_err(|_| crate::error!("Wasm initial memory size overflow"))
+}
+
+/// Write stack-pointer init after static data layout.
+fn fill_stack_pointer_init(
+    layout: &mut WasmLayout<'_>,
+    indices: &LinkerDefinedIndices,
+    stack_size: u32,
+) -> Result {
+    let Some(defined_slot) = indices.stack_pointer_defined_slot else {
+        return Ok(());
+    };
+    let sp = stack_high_after_data(layout.data_end, stack_size)?;
+    let global = layout
+        .globals
+        .get_mut(defined_slot as usize)
+        .ok_or_else(|| crate::error!("Wasm stack pointer global missing"))?;
+    ensure!(
+        global.ty.mutable && global.ty.content_type == wasmparser::ValType::I32,
+        "Wasm stack pointer global has unexpected type"
+    );
+    global.init_expr_body = Cow::Owned(encode_i32_const_body(sp as i32));
     Ok(())
 }
 
@@ -3460,7 +3478,14 @@ where
         }
         layout.data_end = memory_cursor;
         let stack_size = symbol_db.args.z_stack_size;
-        let needs_stack_gap = compute_data_addresses(
+        let initial_pages = ensure_memory_covers(&mut layout, stack_size, stack_size > 0)?;
+        // wasm-ld only defines `__heap_end` when linear memory exists (end of `memory.initial`).
+        let heap_end = if layout.memories.is_empty() {
+            None
+        } else {
+            Some(heap_end_from_initial_pages(initial_pages)?)
+        };
+        compute_data_addresses(
             &mut layout.object_index_maps,
             &layout.per_object_symbols,
             &layout.object_data_layouts,
@@ -3468,8 +3493,9 @@ where
             symbol_db,
             layout.data_end,
             stack_size,
+            heap_end,
         )?;
-        fill_linker_defined_values(&mut layout, &indices, needs_stack_gap, stack_size)?;
+        fill_stack_pointer_init(&mut layout, &indices, stack_size)?;
         ensure_entry_export(
             &mut layout.exports,
             entry.as_ref(),
@@ -3673,6 +3699,7 @@ fn linker_defined_data_symbol_address(
     name: &[u8],
     data_end: u32,
     stack_size: u32,
+    heap_end: Option<u32>,
 ) -> Result<Option<LinkerDefinedDataAddress>> {
     match name {
         b"__data_end" => Ok(Some(LinkerDefinedDataAddress {
@@ -3682,6 +3709,14 @@ fn linker_defined_data_symbol_address(
         b"__heap_base" => Ok(Some(LinkerDefinedDataAddress {
             address: stack_high_after_data(data_end, stack_size)?,
             needs_stack_gap: stack_size > 0,
+        })),
+        b"__wasm_first_page_end" => Ok(Some(LinkerDefinedDataAddress {
+            address: u32::try_from(wasm_page_size())?,
+            needs_stack_gap: false,
+        })),
+        b"__heap_end" => Ok(heap_end.map(|address| LinkerDefinedDataAddress {
+            address,
+            needs_stack_gap: false,
         })),
         _ => Ok(None),
     }
@@ -3695,15 +3730,13 @@ fn compute_data_addresses(
     symbol_db: &SymbolDb<'_, Wasm>,
     data_end: u32,
     stack_size: u32,
-) -> Result<bool> {
+    heap_end: Option<u32>,
+) -> Result {
     let file_id_to_index: HashMap<crate::input_data::FileId, usize> = layout_inputs
         .iter()
         .enumerate()
         .map(|(i, input)| (input.file_id, i))
         .collect();
-
-    // True if any synthesised address assumes a stack gap after static data (`__heap_base`).
-    let mut needs_stack_gap = false;
 
     for (obj_idx, (index_map, symbols)) in object_index_maps
         .iter_mut()
@@ -3737,10 +3770,12 @@ fn compute_data_addresses(
 
             if def_sym.is_undefined() {
                 let name = symbol_db.symbol_name(name_symbol_id)?;
-                if let Some(resolved) =
-                    linker_defined_data_symbol_address(name.bytes(), data_end, stack_size)?
-                {
-                    needs_stack_gap |= resolved.needs_stack_gap;
+                if let Some(resolved) = linker_defined_data_symbol_address(
+                    name.bytes(),
+                    data_end,
+                    stack_size,
+                    heap_end,
+                )? {
                     data_addresses[sym_idx] = resolved.address;
                 }
                 continue;
@@ -3752,7 +3787,7 @@ fn compute_data_addresses(
         index_map.data_addresses = data_addresses;
     }
 
-    Ok(needs_stack_gap)
+    Ok(())
 }
 
 fn allocate_wasm_object_index_bases(
@@ -4638,20 +4673,32 @@ mod tests {
     use crate::args::wasm::DEFAULT_STACK_SIZE;
 
     #[test]
-    fn linker_defined_heap_base_requires_stack_gap() {
+    fn linker_defined_data_symbol_addresses() {
         let data_end = 1024u32;
-        let de = linker_defined_data_symbol_address(b"__data_end", data_end, DEFAULT_STACK_SIZE)
-            .unwrap()
-            .expect("__data_end");
+        let page = wasm_page_size();
+        let heap_end = heap_end_from_initial_pages(2).unwrap();
+        let de = linker_defined_data_symbol_address(
+            b"__data_end",
+            data_end,
+            DEFAULT_STACK_SIZE,
+            Some(heap_end),
+        )
+        .unwrap()
+        .expect("__data_end");
         assert_eq!(de.address, data_end);
         assert!(
             !de.needs_stack_gap,
             "`__data_end` is the end of static data. It must not force a stack reservation"
         );
 
-        let hb = linker_defined_data_symbol_address(b"__heap_base", data_end, DEFAULT_STACK_SIZE)
-            .unwrap()
-            .expect("__heap_base");
+        let hb = linker_defined_data_symbol_address(
+            b"__heap_base",
+            data_end,
+            DEFAULT_STACK_SIZE,
+            Some(heap_end),
+        )
+        .unwrap()
+        .expect("__heap_base");
         assert_eq!(
             hb.address,
             stack_high_after_data(data_end, DEFAULT_STACK_SIZE).unwrap()
@@ -4659,6 +4706,46 @@ mod tests {
         assert!(
             hb.needs_stack_gap,
             "`__heap_base` sits past the stack gap, so memory must cover that range"
+        );
+
+        let page_end = linker_defined_data_symbol_address(
+            b"__wasm_first_page_end",
+            data_end,
+            DEFAULT_STACK_SIZE,
+            Some(heap_end),
+        )
+        .unwrap()
+        .expect("__wasm_first_page_end");
+        assert_eq!(u64::from(page_end.address), page);
+        assert!(!page_end.needs_stack_gap);
+
+        let he = linker_defined_data_symbol_address(
+            b"__heap_end",
+            data_end,
+            DEFAULT_STACK_SIZE,
+            Some(heap_end),
+        )
+        .unwrap()
+        .expect("__heap_end");
+        assert_eq!(he.address, heap_end);
+        assert!(he.address >= hb.address);
+        assert_eq!(u64::from(he.address) % page, 0);
+
+        // If there is no output memory, `__heap_end` is not synthesised.
+        assert!(
+            linker_defined_data_symbol_address(b"__heap_end", data_end, DEFAULT_STACK_SIZE, None,)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            linker_defined_data_symbol_address(
+                b"__wasm_first_page_end",
+                data_end,
+                DEFAULT_STACK_SIZE,
+                None,
+            )
+            .unwrap()
+            .is_some()
         );
     }
 
@@ -4673,9 +4760,7 @@ mod tests {
     }
 
     #[test]
-    fn needs_stack_gap_grows_memory_that_would_not_cover_heap_base() {
-        // Default freestanding links often already request 2 pages, which hides a missing
-        // needs_stack_gap. Therefore start from a 1-page memory so the grow path is observable.
+    fn ensure_memory_covers_stack_and_matches_heap_end() {
         let data_end = 1024u32;
         let mut layout = WasmLayout {
             data_end,
@@ -4688,21 +4773,21 @@ mod tests {
             }],
             ..Default::default()
         };
-        let indices = LinkerDefinedIndices::default();
 
-        fill_linker_defined_values(&mut layout, &indices, false, DEFAULT_STACK_SIZE).unwrap();
-        assert_eq!(
-            layout.memories[0].initial, 1,
-            "without `needs_stack_gap`, a 1-page memory must stay 1 page"
-        );
+        let pages = ensure_memory_covers(&mut layout, DEFAULT_STACK_SIZE, false).unwrap();
+        assert_eq!(pages, 1);
+        assert_eq!(layout.memories[0].initial, 1);
 
-        fill_linker_defined_values(&mut layout, &indices, true, DEFAULT_STACK_SIZE).unwrap();
-        let bytes_needed = u64::from(data_end) + u64::from(DEFAULT_STACK_SIZE);
-        let pages_needed = bytes_needed.div_ceil(65536);
+        let pages = ensure_memory_covers(&mut layout, DEFAULT_STACK_SIZE, true).unwrap();
+        let expected_pages = (u64::from(data_end) + u64::from(DEFAULT_STACK_SIZE))
+            .div_ceil(wasm_page_size())
+            .max(1);
+        assert_eq!(pages, expected_pages);
+        assert_eq!(layout.memories[0].initial, expected_pages);
+        assert!(expected_pages > 1);
         assert_eq!(
-            layout.memories[0].initial, pages_needed,
-            "`needs_stack_gap` must grow memory to cover `data_end` + stack size"
+            heap_end_from_initial_pages(pages).unwrap(),
+            u32::try_from(pages * wasm_page_size()).unwrap()
         );
-        assert!(pages_needed > 1);
     }
 }

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -3690,8 +3690,6 @@ fn data_symbol_memory_address(
 #[derive(Debug, Clone, Copy)]
 struct LinkerDefinedDataAddress {
     address: u32,
-    /// True when the address assumes a stack reservation after static data.
-    needs_stack_gap: bool,
 }
 
 /// Absolute addresses for linker-defined data symbols.
@@ -3702,22 +3700,14 @@ fn linker_defined_data_symbol_address(
     heap_end: Option<u32>,
 ) -> Result<Option<LinkerDefinedDataAddress>> {
     match name {
-        b"__data_end" => Ok(Some(LinkerDefinedDataAddress {
-            address: data_end,
-            needs_stack_gap: false,
-        })),
+        b"__data_end" => Ok(Some(LinkerDefinedDataAddress { address: data_end })),
         b"__heap_base" => Ok(Some(LinkerDefinedDataAddress {
             address: stack_high_after_data(data_end, stack_size)?,
-            needs_stack_gap: stack_size > 0,
         })),
         b"__wasm_first_page_end" => Ok(Some(LinkerDefinedDataAddress {
             address: u32::try_from(wasm_page_size())?,
-            needs_stack_gap: false,
         })),
-        b"__heap_end" => Ok(heap_end.map(|address| LinkerDefinedDataAddress {
-            address,
-            needs_stack_gap: false,
-        })),
+        b"__heap_end" => Ok(heap_end.map(|address| LinkerDefinedDataAddress { address })),
         _ => Ok(None),
     }
 }
@@ -4686,10 +4676,6 @@ mod tests {
         .unwrap()
         .expect("__data_end");
         assert_eq!(de.address, data_end);
-        assert!(
-            !de.needs_stack_gap,
-            "`__data_end` is the end of static data. It must not force a stack reservation"
-        );
 
         let hb = linker_defined_data_symbol_address(
             b"__heap_base",
@@ -4703,10 +4689,6 @@ mod tests {
             hb.address,
             stack_high_after_data(data_end, DEFAULT_STACK_SIZE).unwrap()
         );
-        assert!(
-            hb.needs_stack_gap,
-            "`__heap_base` sits past the stack gap, so memory must cover that range"
-        );
 
         let page_end = linker_defined_data_symbol_address(
             b"__wasm_first_page_end",
@@ -4717,7 +4699,6 @@ mod tests {
         .unwrap()
         .expect("__wasm_first_page_end");
         assert_eq!(u64::from(page_end.address), page);
-        assert!(!page_end.needs_stack_gap);
 
         let he = linker_defined_data_symbol_address(
             b"__heap_end",

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -907,6 +907,7 @@ impl Architecture {
     fn default_target_triple_rustc(&self, platform: PlatformKind) -> String {
         match (platform, self) {
             (PlatformKind::Elf, Architecture::RiscV64) => "riscv64gc-unknown-linux-gnu".to_string(),
+            (PlatformKind::Wasm, _) => "wasm32-wasip1".to_string(),
             _ => self.default_target_triple(platform),
         }
     }
@@ -3103,14 +3104,22 @@ fn build_obj(
 
             command
                 .env("WILD_SAVE_SKIP_LINKING", "1")
-                .args(config.rustc_channel.as_arg())
-                .args(["-C", "linker=clang"])
-                .args(["-C", &format!("link-arg=--ld-path={wild}")]);
+                .args(config.rustc_channel.as_arg());
+
+            if config.platform == PlatformKind::Wasm {
+                command
+                    .args(["-C", &format!("linker={wild}")])
+                    .args(["-C", "linker-flavor=wasm-ld"]);
+            } else {
+                command
+                    .args(["-C", "linker=clang"])
+                    .args(["-C", &format!("link-arg=--ld-path={wild}")]);
+            }
 
             if let Some(arch) = cross_arch {
                 // Debian sets sysroot to `/` and uses real paths for libraries in linker scripts.
                 // So using real sysroot path breaks linking.
-                if !is_host_debian_based() {
+                if !is_host_debian_based() && config.platform != PlatformKind::Wasm {
                     command.args([
                         "-C",
                         &format!("link-arg=--sysroot={}", arch.get_cross_sysroot_path()),
@@ -3126,20 +3135,22 @@ fn build_obj(
                     ));
                     arch.default_target_triple(config.platform).to_owned()
                 });
-                let target_underscore = target.replace('-', "_");
-                let target_triple = target.replace("-unknown", "");
+                if config.platform != PlatformKind::Wasm {
+                    let target_underscore = target.replace('-', "_");
+                    let target_triple = target.replace("-unknown", "");
 
-                command.env(
-                    format!("CC_{target_underscore}"),
-                    format!("{target_triple}-gcc"),
-                );
+                    command.env(
+                        format!("CC_{target_underscore}"),
+                        format!("{target_triple}-gcc"),
+                    );
 
-                command.env(
-                    format!("AR_{target_underscore}"),
-                    format!("{target_triple}-ar"),
-                );
+                    command.env(
+                        format!("AR_{target_underscore}"),
+                        format!("{target_triple}-ar"),
+                    );
 
-                command.arg(format!("-Clink-arg=--target={target}"));
+                    command.arg(format!("-Clink-arg=--target={target}"));
+                }
             }
 
             if is_musl_used() {
@@ -3804,7 +3815,12 @@ impl LinkCommand {
         }
 
         if linker.is_wild() {
-            if matches!(config.linker_driver, LinkerDriver::Direct(_)) {
+            // For Script mode, the linker binary is the first script argument and extra flags must
+            // not precede `-flavor` inside the script args. Use env vars instead of CLI
+            // flags in that case.
+            let pass_wild_flags_via_cli = matches!(config.linker_driver, LinkerDriver::Direct(_))
+                && invocation_mode != LinkerInvocationMode::Script;
+            if pass_wild_flags_via_cli {
                 command.arg("--validate-output");
                 // TODO: Add a flag or do something so that unsupported flags get ignored. i.e. the
                 // equivalent of the line below, but for directly calling libwild. Perhaps rather
@@ -3816,7 +3832,7 @@ impl LinkCommand {
             }
 
             if config.should_diff || config.assertions.requires_metrics() {
-                if matches!(config.linker_driver, LinkerDriver::Direct(_)) {
+                if pass_wild_flags_via_cli {
                     command.arg("--write-layout");
                     command.arg("--write-trace");
                 } else {

--- a/wild/tests/sources/wasm/malloc/malloc.c
+++ b/wild/tests/sources/wasm/malloc/malloc.c
@@ -1,0 +1,29 @@
+//#RequiresWasiLibc:true
+//#CompArgs: --target=wasm32-wasi -isystem $WASI_SYSROOT/include/wasm32-wasi
+//#LinkArgs: $WASI_SYSROOT/lib/wasm32-wasi/crt1-command.o
+//#PostLinkArgs: -L$WASI_SYSROOT/lib/wasm32-wasi -lc
+
+#include <stdlib.h>
+#include <string.h>
+
+int main(void) {
+  char* p = malloc(64);
+  if (p == NULL) {
+    return 101;
+  }
+  memset(p, 0xab, 64);
+  if ((unsigned char)p[0] != 0xab || (unsigned char)p[63] != 0xab) {
+    return 102;
+  }
+  free(p);
+
+  /* Large enough to stress sbrk / memory.grow beyond a tiny initial window. */
+  char* q = malloc(256 * 1024);
+  if (q == NULL) {
+    return 103;
+  }
+  q[0] = 1;
+  q[256 * 1024 - 1] = 2;
+  free(q);
+  return 0;
+}

--- a/wild/tests/sources/wasm/rust-println/rust-println.rs
+++ b/wild/tests/sources/wasm/rust-println/rust-println.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("foo");
+}


### PR DESCRIPTION
Basic Rust programs linked with Wild were previously trapped at runtime:

```
（▰╹◡╹）❯  echo 'fn main() { println!("foo"); }' > wasm_rust.rs

（▰╹◡╹）❯  rustc --target wasm32-wasip1 wasm_rust.rs -o wasm_rust.wild.wasm -C linker=../../repos/wild/target/debug/wild -C linker-flavor=wasm-ld

（▰╹◡╹）❯  wasmtime wasm_rust.wild.wasm
Error: failed to run main module `wasm_rust.wild.wasm`

Caused by:
    0: failed to invoke command default
    1: error while executing at wasm backtrace:
    0:  0x36160 - <unknown>!<wasm function 1171>
    1:  0x356e6 - <unknown>!<wasm function 1170>
    2:   0x80b1 - <unknown>!<wasm function 212>
    3:   0x1bbc - <unknown>!<wasm function 103>
    4:   0x1c4e - <unknown>!<wasm function 110>
    5:  0x15396 - <unknown>!<wasm function 408>
    6:   0x1b61 - <unknown>!<wasm function 100>
    7:   0x1a7d - <unknown>!<wasm function 95>
    8:   0x1a51 - <unknown>!<wasm function 94>
    9:   0x1a9c - <unknown>!<wasm function 96>
   10:  0x13e17 - <unknown>!<wasm function 379>
   11:   0x1a21 - <unknown>!<wasm function 93>
   12:   0x1bae - <unknown>!<wasm function 102>
   13:   0x19d2 - <unknown>!<wasm function 92>
    2: wasm trap: wasm `unreachable` instruction executed
```

The function executing the `unreachable` instruction is shown below:

```
（▰╹◡╹）❯  wasm-objdump -d wasm_rust.wild.wasm | sed -n '/func\[1170\]/,/func\[1172\]/p' | head
0356e3 func[1170]:
 0356e4: 20 00                      | local.get 0
 0356e6: 10 93 89 80 80 00          | call 1171
 0356ec: 0b                         | end
0356ef func[1171]:
 0356f0: 0b 7f                      | local[1..11] type=i32
 0356f2: 23 81 80 80 80 00          | global.get 1
 0356f8: 41 10                      | i32.const 16
 0356fa: 6b                         | i32.sub
 0356fb: 22 01                      | local.tee 1
```

Comparing the binary linked with wasm-ld reveals that these functions correspond to `malloc`/`dlmalloc`:

```
（▰╹◡╹）❯  rustc --target wasm32-wasip1 wasm_rust.rs -o wasm_rust.wasm-ld.wasm

（▰╹◡╹）❯  wasm-objdump -d wasm_rust.wasm-ld.wasm | sed -n '/func\[143\]/,/func\[145\]/p' | head
004d50 func[143] <malloc>:
 004d51: 20 00                      | local.get 0
 004d53: 10 90 81 80 80 00          | call 144 <dlmalloc>
 004d59: 0b                         | end
004d5c func[144] <dlmalloc>:
 004d5d: 0b 7f                      | local[1..11] type=i32
 004d5f: 23 80 80 80 80 00          | global.get 0 <__stack_pointer>
 004d65: 41 10                      | i32.const 16
 004d67: 6b                         | i32.sub
 004d68: 22 01                      | local.tee 1
```

This suggests that the failure occurs during heap allocation. To investigate further, we compare the implementation of `sbrk` (which can be identified by its use of the `memory.size` instruction):

```
（▰╹◡╹）❯  wasm-objdump -d wasm_rust.wild.wasm | rg -C5 'memory.size'
033888 func[1122]:
 033889: 01 7f                      | local[1] type=i32
 03388b: 02 40                      | block
 03388d: 20 00                      |   local.get 0
 03388f: 0d 00                      |   br_if 0
 033891: 3f 00                      |   memory.size 0
 033893: 41 80 80 80 80 00          |   i32.const 0
 033899: 6c                         |   i32.mul
 03389a: 0f                         |   return
 03389b: 0b                         | end
 03389c: 02 40                      | block

（▰╹◡╹）❯  wasm-objdump -d wasm_rust.wasm-ld.wasm | rg -C5 'memory.size'
004cec func[142] <sbrk>:
 004ced: 01 7f                      | local[1] type=i32
 004cef: 02 40                      | block
 004cf1: 20 00                      |   local.get 0
 004cf3: 0d 00                      |   br_if 0
 004cf5: 3f 00                      |   memory.size 0
 004cf7: 41 80 80 84 80 00          |   i32.const 65536
 004cfd: 6c                         |   i32.mul
 004cfe: 0f                         |   return
 004cff: 0b                         | end
 004d00: 02 40                      | block
```

Comparing the two implementations shows that the page size used by `sbrk` is 0 in the Wild-linked binary, whereas it is set to 65536 in the wasm-ld binary.

Normally, this page size appears as a relocated `i32.const` placeholder. Instead, it is emitted as a relocation against the undefined `__wasm_first_page_end` symbol. Therefore, Wild has to synthesize this symbol during linking.

Similarly, `dlmalloc` references the `__heap_end` symbol to determine the end of initial linear memory, so Wild also needs to define this symbol.

With these changes, Wild is able to link and run a basic Rust program:

```
（▰╹◡╹）❯  wasmtime wasm_rust.new_wild.wasm
foo
```

Part of #1431