### PR TITLE
feat: implement --sort-section flag

### DIFF
--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -137,6 +137,13 @@ pub struct ElfArgs {
     experimental_sframe: bool,
 
     pub(crate) debug_compression_kind: Option<CompressionKind>,
+    pub(crate) sort_section: Option<SortSectionMode>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SortSectionMode {
+    Name,
+    Alignment,
 }
 
 #[derive(Debug)]
@@ -335,6 +342,7 @@ impl Default for ElfArgs {
 
             experimental_sframe: false,
             debug_compression_kind: None,
+            sort_section: None,
             gdb_index: false,
         }
     }
@@ -1550,7 +1558,14 @@ fn setup_argument_parser() -> ArgumentParser<ElfArgs> {
         .long("sort-section")
         .help("Specify section sorting criteria")
         .execute(|args, _modifier_stack, value| {
-            args.warn_unsupported(&format!("--sort-section={value}"))?;
+            args.sort_section = Some(match value {
+                "name" => SortSectionMode::Name,
+                "alignment" => SortSectionMode::Alignment,
+                other => {
+                    args.warn_unsupported(&format!("--sort-section={other}"))?;
+                    return Ok(());
+                }
+            });
             Ok(())
         });
 
@@ -1956,6 +1971,10 @@ impl platform::Args for ElfArgs {
 
     fn should_relax(&self) -> bool {
         self.relax
+    }
+
+    fn sort_sections_by_name(&self) -> bool {
+        self.sort_section == Some(SortSectionMode::Name)
     }
 
     fn should_emit_got_plt_syms(&self) -> bool {

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -4583,11 +4583,12 @@ fn get_symbol_attributes(
                 .and_then(|section_index| {
                     let slot = &obj.sections[section_index.0];
                     match slot {
-                        SectionSlot::Loaded(_) | SectionSlot::MergeStrings(_) => {
+                        SectionSlot::Loaded(_)
+                        | SectionSlot::MergeStrings(_)
+                        | SectionSlot::Sorted(_) => {
                             let output_section_id = obj
                                 .section_part_id(section_index, &layout.symbol_db.section_part_ids)
                                 .output_section_id();
-
                             layout
                                 .output_sections
                                 .output_index_of_section(output_section_id)
@@ -4819,8 +4820,11 @@ fn write_regular_object_dynamic_symbol_definition<'data>(
             SectionSlot::Loaded(_) | SectionSlot::MergeStrings(_) => object
                 .section_part_id(section_index, &layout.symbol_db.section_part_ids)
                 .output_section_id(),
+            SectionSlot::Sorted(_) => object
+                .section_part_id(section_index, &layout.symbol_db.section_part_ids)
+                .output_section_id(),
             _ => bail!(
-                "Internal error: Defined symbols should always be for a loaded or merge-strings section"
+                "Internal error: Defined symbols should always be for a loaded, merge-strings or sorted section"
             ),
         };
         let output_section_id = layout

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -1377,6 +1377,10 @@ pub(crate) trait Args: std::fmt::Debug + Send + Sync + 'static {
         false
     }
 
+    fn sort_sections_by_name(&self) -> bool {
+        false
+    }
+
     fn rosegment(&self) -> bool {
         true
     }

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -1347,7 +1347,7 @@ fn resolve_section<'data, P: Platform>(
             must_load |= output_info.must_keep;
 
             unloaded_section = UnloadedSection::new();
-            unloaded_section.needs_sorting = output_info.sorted;
+            unloaded_section.needs_sorting = output_info.sorted || args.sort_sections_by_name();
         }
         SectionRuleOutcome::SortedSection(output_info) => {
             part_id = if output_info.section_id.is_regular() {

--- a/wild/tests/sources/elf/sort-section-alignments/sort-section-alignments.s
+++ b/wild/tests/sources/elf/sort-section-alignments/sort-section-alignments.s
@@ -1,0 +1,22 @@
+// Verify that --sort-section=alignment sorts sections by alignment (largest first).
+// Input order: .data.aaa (align 8) first, .data.zzz (align 64) second
+// With --sort-section=alignment: .data.zzz (align 64) should come first
+//#AbstractConfig:default
+//#LinkArgs:-shared --no-gc-sections --sort-section=alignment
+//#RunEnabled:false
+//#ReferenceLinkers:bfd
+//#DiffIgnore:.dynamic.DT_FLAGS_1.NOW
+//#DiffIgnore:segment.LOAD.RX.alignment
+//#Config:x86_64:default
+//#Arch:x86_64
+//#ExpectSectionBytes:.data=0x3300000000000000 0..8
+
+    .section .data.aaa,"aw",@progbits
+    .balign 8
+    .byte 0x11
+    .zero 7
+
+    .section .data.zzz,"aw",@progbits
+    .balign 64
+    .byte 0x33
+    .zero 63

--- a/wild/tests/sources/elf/sort-section-name/sort-section-name.s
+++ b/wild/tests/sources/elf/sort-section-name/sort-section-name.s
@@ -1,0 +1,24 @@
+// Verify that --sort-section=name sorts input sections alphabetically.
+// Also verifies that exported symbols in sorted sections work correctly.
+// Without sorting: .data.zzz (0x33) comes first (input order)
+// With --sort-section=name: .data.aaa (0x11) comes first (alphabetical)
+//#AbstractConfig:default
+//#LinkArgs:-shared --no-gc-sections --sort-section=name
+//#RunEnabled:false
+//#ReferenceLinkers:bfd
+//#DiffIgnore:.dynamic.DT_FLAGS_1.NOW
+//#DiffIgnore:segment.LOAD.RX.alignment
+//#Config:x86_64:default
+//#Arch:x86_64
+//#ExpectSectionBytes:.data=0x11000000000000003300000000000000 0..16
+    .section .data.zzz,"aw",@progbits
+    .balign 8
+    .byte 0x33
+    .zero 7
+
+    .globl exported
+    .section .data.aaa,"aw",@progbits
+    .balign 8
+exported:
+    .byte 0x11
+    .zero 7


### PR DESCRIPTION
Previously, Wild would warn that --sort-section was unsupported. Now: `--sort-section=name` sorts input sections alphabetically within each output section, matching GNU ld behavior. `--sort-section=alignment `is accepted silently, since Wild already places sections in alignment order by default.


Fixes #1659 