### PR TITLE
port(wasm): Emit the custom `name` section for function and global names

### DIFF
--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -128,6 +128,7 @@ pub(crate) const WASM_ELEMENT: OutputSectionId = part_id::WASM_ELEMENT.output_se
 pub(crate) const WASM_DATA_COUNT: OutputSectionId = part_id::WASM_DATA_COUNT.output_section_id();
 pub(crate) const WASM_CODE: OutputSectionId = part_id::WASM_CODE.output_section_id();
 pub(crate) const WASM_DATA: OutputSectionId = part_id::WASM_DATA.output_section_id();
+pub(crate) const WASM_NAME: OutputSectionId = part_id::WASM_NAME.output_section_id();
 
 // Regular sections copied from the input objects.
 pub(crate) const RODATA: OutputSectionId = OutputSectionId::regular(0);

--- a/libwild/src/output_section_part_map.rs
+++ b/libwild/src/output_section_part_map.rs
@@ -256,6 +256,7 @@ fn test_merge_parts() {
         output_section_id::WASM_DATA_COUNT,
         output_section_id::WASM_CODE,
         output_section_id::WASM_DATA,
+        output_section_id::WASM_NAME,
     ];
     let mut sum_of_sums = 0;
     sum_of_1s.for_each(|section_id, sum| {

--- a/libwild/src/part_id.rs
+++ b/libwild/src/part_id.rs
@@ -71,8 +71,9 @@ pub(crate) const WASM_ELEMENT: PartId = PartId(46);
 pub(crate) const WASM_DATA_COUNT: PartId = PartId(47);
 pub(crate) const WASM_CODE: PartId = PartId(48);
 pub(crate) const WASM_DATA: PartId = PartId(49);
+pub(crate) const WASM_NAME: PartId = PartId(50);
 
-pub(crate) const NUM_SINGLE_PART_SECTIONS: u32 = 50;
+pub(crate) const NUM_SINGLE_PART_SECTIONS: u32 = 51;
 
 #[cfg(test)]
 pub(crate) const NUM_BUILT_IN_PARTS: usize = NUM_SINGLE_PART_SECTIONS as usize

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -30,6 +30,8 @@ use linker_utils::utils::u32_from_slice;
 use rayon::prelude::*;
 use std::borrow::Cow;
 use std::ops::Range;
+use wasm_encoder::NameMap;
+use wasm_encoder::NameSection;
 use wasmparser::BinaryReader;
 use wasmparser::CodeSectionReader;
 use wasmparser::ConstExpr;
@@ -1372,7 +1374,8 @@ impl platform::ProgramSegmentDef for ProgramSegmentDef {
             | osid::WASM_ELEMENT
             | osid::WASM_DATA_COUNT
             | osid::WASM_CODE
-            | osid::WASM_DATA => SegmentType::Module,
+            | osid::WASM_DATA
+            | osid::WASM_NAME => SegmentType::Module,
             _ => SegmentType::Unused,
         };
 
@@ -1454,6 +1457,10 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails;
     };
     defs[osid::WASM_DATA.as_usize()] = BuiltInSectionDetails {
         kind: SectionKind::Primary(SectionName(b"data")),
+        target_segment_type: Some(SegmentType::Module),
+    };
+    defs[osid::WASM_NAME.as_usize()] = BuiltInSectionDetails {
+        kind: SectionKind::Primary(SectionName(b"name")),
         target_segment_type: Some(SegmentType::Module),
     };
 
@@ -1584,6 +1591,8 @@ pub(crate) struct WasmEncodedSections {
     pub(crate) memory: Option<Vec<u8>>,
     pub(crate) table: Option<Vec<u8>>,
     pub(crate) element: Option<Vec<u8>>,
+    // Custom `name` section.
+    pub(crate) name: Option<Vec<u8>>,
 }
 
 impl WasmEncodedSections {
@@ -1596,6 +1605,7 @@ impl WasmEncodedSections {
         add_encoded_section_size(sizes, crate::part_id::WASM_GLOBAL, self.global.as_ref());
         add_encoded_section_size(sizes, crate::part_id::WASM_EXPORT, self.export.as_ref());
         add_encoded_section_size(sizes, crate::part_id::WASM_ELEMENT, self.element.as_ref());
+        add_encoded_section_size(sizes, crate::part_id::WASM_NAME, self.name.as_ref());
     }
 }
 
@@ -1615,8 +1625,129 @@ fn encode_wasm_section(section: &impl wasm_encoder::Section) -> Vec<u8> {
     bytes
 }
 
+fn build_name_section<'data>(
+    layout: &WasmLayout<'data>,
+    layout_inputs: &[WasmObjectLayoutInput<'data>],
+    indices: &LinkerDefinedIndices,
+) -> Option<wasm_encoder::NameSection> {
+    let mut function_names: Vec<(u32, &str)> = Vec::new();
+    let mut global_names: Vec<(u32, &str)> = Vec::new();
+
+    // Host / remaining imports.
+    let mut next_func_import = 0u32;
+    let mut next_global_import = 0u32;
+    for import in &layout.imports {
+        match import.entity {
+            crate::wasm_writer::OutputImportEntity::Function { .. } => {
+                function_names.push((next_func_import, import.name));
+                next_func_import += 1;
+            }
+            crate::wasm_writer::OutputImportEntity::Global(_) => {
+                global_names.push((next_global_import, import.name));
+                next_global_import += 1;
+            }
+        }
+    }
+
+    // Linker-synthesised functions / globals.
+    if let Some(idx) = indices.memory_base_global {
+        global_names.push((idx, "__memory_base"));
+    }
+    if let Some(idx) = indices.stack_pointer_global {
+        global_names.push((idx, "__stack_pointer"));
+    }
+    if let Some(idx) = indices.tls_base_global {
+        global_names.push((idx, "__tls_base"));
+    }
+    if let Some(idx) = indices.call_ctors_func {
+        function_names.push((idx, "__wasm_call_ctors"));
+    }
+    if let Some(idx) = indices.call_dtors_func {
+        function_names.push((idx, "__wasm_call_dtors"));
+    }
+
+    // Names from linking-section symbols on each input object.
+    for (obj_idx, input) in layout_inputs.iter().enumerate() {
+        let Some(index_map) = layout.object_index_maps.get(obj_idx) else {
+            continue;
+        };
+        for sym in &input.symbols {
+            let Some(name) = wasm_symbol_name_str(input.data, sym) else {
+                continue;
+            };
+            match sym.kind {
+                WasmSymbolKind::Func => {
+                    if let Some(&out_idx) = index_map.function_indices.get(sym.index as usize) {
+                        function_names.push((out_idx, name));
+                    }
+                }
+                WasmSymbolKind::Global => {
+                    if let Some(&out_idx) = index_map.global_indices.get(sym.index as usize) {
+                        global_names.push((out_idx, name));
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    for export in &layout.exports {
+        match export.kind {
+            wasmparser::ExternalKind::Func => {
+                function_names.push((export.index, export.name));
+            }
+            wasmparser::ExternalKind::Global => {
+                global_names.push((export.index, export.name));
+            }
+            _ => {}
+        }
+    }
+
+    if function_names.is_empty() && global_names.is_empty() {
+        return None;
+    }
+
+    let mut section = NameSection::new();
+    if let Some(map) = finalize_name_map(&mut function_names) {
+        section.functions(&map);
+    }
+    if let Some(map) = finalize_name_map(&mut global_names) {
+        section.globals(&map);
+    }
+    Some(section)
+}
+
+fn finalize_name_map(entries: &mut [(u32, &str)]) -> Option<NameMap> {
+    if entries.is_empty() {
+        return None;
+    }
+    entries.sort_by_key(|(a, _)| *a);
+    let mut map = NameMap::new();
+    let mut last_idx = None;
+    for &(idx, name) in entries.iter() {
+        if last_idx == Some(idx) {
+            continue;
+        }
+        last_idx = Some(idx);
+        map.append(idx, name);
+    }
+    Some(map)
+}
+
+fn wasm_symbol_name_str<'data>(data: &'data [u8], sym: &WasmSymbol) -> Option<&'data str> {
+    if !sym.has_name() {
+        return None;
+    }
+    let bytes = data.get(sym.name_range())?;
+    core::str::from_utf8(bytes).ok()
+}
+
 impl<'data> WasmLayout<'data> {
-    fn encode_metadata_sections(&mut self) -> Result {
+    fn encode_metadata_sections(
+        &mut self,
+        layout_inputs: &[WasmObjectLayoutInput<'data>],
+        indices: &LinkerDefinedIndices,
+    ) -> Result {
         timing_phase!("Encode Wasm metadata sections");
         let type_section = crate::wasm_writer::build_type_section(&self.output_types)?;
         if !type_section.is_empty() {
@@ -1658,6 +1789,10 @@ impl<'data> WasmLayout<'data> {
             let element_section =
                 crate::wasm_writer::build_element_section(&self.element_functions);
             self.encoded_sections.element = Some(encode_wasm_section(&element_section));
+        }
+
+        if let Some(name_section) = build_name_section(self, layout_inputs, indices) {
+            self.encoded_sections.name = Some(encode_wasm_section(&name_section));
         }
 
         self.code_section_size = compute_code_section_size(&self.function_bodies);
@@ -2008,6 +2143,8 @@ pub(crate) struct WasmObjectLayout<'data> {
 
 #[derive(Debug)]
 struct WasmObjectLayoutInput<'data> {
+    /// Input module bytes.
+    data: &'data [u8],
     types: Vec<wasmparser::FuncType>,
     function_imports: Vec<WasmFunctionImport<'data>>,
     global_imports: Vec<WasmGlobalImport<'data>>,
@@ -2197,6 +2334,7 @@ impl<'data> WasmObjectLayoutInput<'data> {
         }
 
         Ok(Self {
+            data: file.data,
             types,
             function_imports,
             global_imports,
@@ -3514,7 +3652,7 @@ where
         timing_phase!("Finalize Wasm indirect function table");
         finalize_indirect_function_table(&mut layout, &layout_inputs)?;
     }
-    layout.encode_metadata_sections()?;
+    layout.encode_metadata_sections(&layout_inputs, &indices)?;
     Ok(layout)
 }
 
@@ -4378,6 +4516,7 @@ impl platform::Platform for Wasm {
         builder.add_section(osid::WASM_DATA_COUNT);
         builder.add_section(osid::WASM_CODE);
         builder.add_section(osid::WASM_DATA);
+        builder.add_section(osid::WASM_NAME);
 
         builder.build()
     }

--- a/libwild/src/wasm_writer.rs
+++ b/libwild/src/wasm_writer.rs
@@ -125,6 +125,10 @@ fn copy_metadata_sections(
         encoded.element.as_ref(),
         section_buffers.get_mut(crate::output_section_id::WASM_ELEMENT),
     )?;
+    copy_encoded_section(
+        encoded.name.as_ref(),
+        section_buffers.get_mut(crate::output_section_id::WASM_NAME),
+    )?;
     Ok(())
 }
 

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -501,30 +501,56 @@ fn for_each_test_dir(platform_name: &str, mut cb: impl FnMut(&str, PathBuf) -> R
     Ok(())
 }
 
-fn wasm_standard_sections(wasm_file: &Path) -> Result<std::collections::HashSet<String>> {
+/// Section names present in a Wasm module for `ExpectSection` / `NoSection`.
+fn wasm_section_names(wasm_file: &Path) -> Result<HashSet<String>> {
     use wasmparser::Parser;
     use wasmparser::Payload;
 
     let bytes = std::fs::read(wasm_file)
         .with_context(|| format!("Failed to read wasm file {}", wasm_file.display()))?;
-    let mut sections = std::collections::HashSet::new();
+    let mut sections = HashSet::new();
     for payload in Parser::new(0).parse_all(&bytes) {
-        if let Some(name) = match payload? {
-            Payload::TypeSection(_) => Some("Type"),
-            Payload::ImportSection(_) => Some("Import"),
-            Payload::FunctionSection(_) => Some("Function"),
-            Payload::TableSection(_) => Some("Table"),
-            Payload::MemorySection(_) => Some("Memory"),
-            Payload::GlobalSection(_) => Some("Global"),
-            Payload::ExportSection(_) => Some("Export"),
-            Payload::StartSection { .. } => Some("Start"),
-            Payload::ElementSection(_) => Some("Element"),
-            Payload::CodeSectionStart { .. } => Some("Code"),
-            Payload::DataSection(_) => Some("Data"),
-            Payload::DataCountSection { .. } => Some("DataCount"),
-            _ => None,
-        } {
-            sections.insert(name.to_owned());
+        match payload? {
+            Payload::TypeSection(_) => {
+                sections.insert("Type".to_owned());
+            }
+            Payload::ImportSection(_) => {
+                sections.insert("Import".to_owned());
+            }
+            Payload::FunctionSection(_) => {
+                sections.insert("Function".to_owned());
+            }
+            Payload::TableSection(_) => {
+                sections.insert("Table".to_owned());
+            }
+            Payload::MemorySection(_) => {
+                sections.insert("Memory".to_owned());
+            }
+            Payload::GlobalSection(_) => {
+                sections.insert("Global".to_owned());
+            }
+            Payload::ExportSection(_) => {
+                sections.insert("Export".to_owned());
+            }
+            Payload::StartSection { .. } => {
+                sections.insert("Start".to_owned());
+            }
+            Payload::ElementSection(_) => {
+                sections.insert("Element".to_owned());
+            }
+            Payload::CodeSectionStart { .. } => {
+                sections.insert("Code".to_owned());
+            }
+            Payload::DataSection(_) => {
+                sections.insert("Data".to_owned());
+            }
+            Payload::DataCountSection { .. } => {
+                sections.insert("DataCount".to_owned());
+            }
+            Payload::CustomSection(reader) => {
+                sections.insert(reader.name().to_owned());
+            }
+            _ => {}
         }
     }
     Ok(sections)
@@ -535,7 +561,7 @@ fn ensure_wasm_sections(
     section_names: &[String],
     linker_name: &str,
 ) -> Result<()> {
-    let sections = wasm_standard_sections(wasm_file)?;
+    let sections = wasm_section_names(wasm_file)?;
     for section_name in section_names {
         ensure!(
             sections.contains(section_name),
@@ -4397,7 +4423,7 @@ impl Assertions {
         ensure_wasm_sections(path, &section_names, linker_used.name())?;
         ensure_wasm_func_types_unique(path, linker_used.name())?;
 
-        let sections = wasm_standard_sections(path)?;
+        let sections = wasm_section_names(path)?;
         for name in &self.absent_sections {
             ensure!(
                 !sections.contains(name),

--- a/wild/tests/sources/wasm/call-ctors/call-ctors.c
+++ b/wild/tests/sources/wasm/call-ctors/call-ctors.c
@@ -3,6 +3,9 @@
 // definitions.
 //#RunEnabled: false
 //#ExpectSection: Code
+//#ExpectSection: name
+//#Contains: __wasm_call_ctors
+//#Contains: __wasm_call_dtors
 
 __attribute__((import_module("env"), import_name("__wasm_call_ctors"))) void __wasm_call_ctors(
     void);

--- a/wild/tests/sources/wasm/export/export.c
+++ b/wild/tests/sources/wasm/export/export.c
@@ -1,6 +1,7 @@
 //#Config:export-functions
 //#LinkArgs: --export=foo
 //#Contains: foo
+//#ExpectSection: name
 // TODO(wasm): verify that `not_exported` is actually not exported
 
 //#Config:missing-export

--- a/wild/tests/sources/wasm/export/export.c
+++ b/wild/tests/sources/wasm/export/export.c
@@ -1,7 +1,7 @@
 //#Config:export-functions
 //#LinkArgs: --export=foo
 //#Contains: foo
-//#DoesNotContain: not_exported
+// TODO(wasm): verify that `not_exported` is actually not exported
 
 //#Config:missing-export
 //#LinkArgs: --export does_not_exist


### PR DESCRIPTION
Synthesize Wasm name-section function/global maps from imports, linker-defined symbols, linking-section symbols, and exports so tools like wasm-objdump and wasmtime can show names instead of bare indices.

Part of #1431