### PR TITLE
port(wasm): Define Wasm linker symbols through SymbolDb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,6 +873,7 @@ dependencies = [
  "sharded-offset-map",
  "sharded-vec-writer",
  "smallvec",
+ "strum",
  "symbolic-common",
  "symbolic-demangle",
  "tempfile",

--- a/libwild/Cargo.toml
+++ b/libwild/Cargo.toml
@@ -45,6 +45,7 @@ sha2.workspace = true
 sharded-offset-map.workspace = true
 sharded-vec-writer.workspace = true
 smallvec.workspace = true
+strum.workspace = true
 symbolic-common.workspace = true
 symbolic-demangle.workspace = true
 thread_local.workspace = true

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -300,6 +300,7 @@ impl platform::Platform for Elf {
     type File<'data> = File<'data>;
     type FileFlags = object::elf::FileFlags;
     type SymtabEntry = SymtabEntry;
+    type PlatformSpecificSymbol = core::convert::Infallible;
     type SectionHeader = SectionHeader;
     type SectionFlags = SectionFlags;
     type SectionAttributes = SectionAttributes;

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3634,7 +3634,9 @@ fn create_internal_symbol_resolution<'data, P: Platform>(
     }
 
     let raw_value = match def_info.placement {
-        SymbolPlacement::Undefined | SymbolPlacement::ForceUndefined => 0,
+        SymbolPlacement::Undefined
+        | SymbolPlacement::ForceUndefined
+        | SymbolPlacement::LinkerDefined => 0,
         SymbolPlacement::SectionStart(section_id) => {
             resources.section_layouts.get(section_id).mem_offset
         }

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3246,7 +3246,7 @@ impl<'data, P: Platform> PreludeLayoutState<'data, P> {
                 }
 
                 // We always emit symbols that the user requested be undefined.
-                let mut should_emit = def_info.placement == SymbolPlacement::ForceUndefined;
+                let mut should_emit = matches!(def_info.placement, SymbolPlacement::ForceUndefined);
 
                 // Keep the symbol if we're going to write the section, even though the symbol isn't
                 // referenced. It can be useful to have symbols like _GLOBAL_OFFSET_TABLE_ when
@@ -3636,7 +3636,7 @@ fn create_internal_symbol_resolution<'data, P: Platform>(
     let raw_value = match def_info.placement {
         SymbolPlacement::Undefined
         | SymbolPlacement::ForceUndefined
-        | SymbolPlacement::LinkerDefined => 0,
+        | SymbolPlacement::PlatformSpecific(_) => 0,
         SymbolPlacement::SectionStart(section_id) => {
             resources.section_layouts.get(section_id).mem_offset
         }

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -914,6 +914,7 @@ impl platform::Platform for MachO {
     type File<'data> = File<'data>;
     type FileFlags = u32;
     type SymtabEntry = SymtabEntry;
+    type PlatformSpecificSymbol = core::convert::Infallible;
     type SectionHeader = SectionHeader;
     type SectionFlags = SectionFlags;
     type SectionAttributes = SectionAttributes;

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -69,13 +69,13 @@ pub(crate) struct SyntheticSymbols {
 #[derive(Clone, derive_more::Debug)]
 pub(crate) struct InternalSymDefInfo<'data, P: Platform> {
     pub(crate) symbol: P::SymtabEntry,
-    pub(crate) placement: SymbolPlacement<'data>,
+    pub(crate) placement: SymbolPlacement<'data, P>,
     #[debug("{:?}", String::from_utf8_lossy(name))]
     pub(crate) name: &'data [u8],
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub(crate) enum SymbolPlacement<'data> {
+pub(crate) enum SymbolPlacement<'data, P: Platform> {
     /// Symbol 0 - the undefined symbol.
     Undefined,
 
@@ -99,8 +99,8 @@ pub(crate) enum SymbolPlacement<'data> {
     /// Symbol will point to the start of the first loadable segment.
     LoadBaseAddress,
 
-    /// A symbol defined by the linker.
-    LinkerDefined,
+    /// Platform-specific linker symbol.
+    PlatformSpecific(P::PlatformSpecificSymbol),
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -159,7 +159,7 @@ pub(crate) fn parse_number(s: &str) -> Result<u64, ()> {
 }
 
 impl<'data, P: Platform> InternalSymDefInfo<'data, P> {
-    pub(crate) fn new(placement: SymbolPlacement<'data>, name: &'data [u8]) -> Self {
+    pub(crate) fn new(placement: SymbolPlacement<'data, P>, name: &'data [u8]) -> Self {
         Self {
             placement,
             name,
@@ -249,6 +249,10 @@ impl<'data, P: Platform> Prelude<'data, P> {
         let def = &self.symbol_definitions[symbol_id.as_usize()];
         UnversionedSymbolName::new(def.name)
     }
+
+    pub(crate) fn symbol_def(&self, symbol_id: SymbolId) -> &InternalSymDefInfo<'data, P> {
+        &self.symbol_definitions[symbol_id.as_usize()]
+    }
 }
 
 #[derive(Default)]
@@ -299,12 +303,13 @@ impl<'data, P: Platform> InternalSymbolsBuilder<'data, P> {
         ))
     }
 
-    pub(crate) fn linker_defined(
+    pub(crate) fn platform_specific(
         &mut self,
         name: &'static [u8],
+        specific: P::PlatformSpecificSymbol,
     ) -> &mut InternalSymDefInfo<'data, P> {
         self.add_symbol(InternalSymDefInfo::new(
-            SymbolPlacement::LinkerDefined,
+            SymbolPlacement::PlatformSpecific(specific),
             name,
         ))
     }

--- a/libwild/src/parsing.rs
+++ b/libwild/src/parsing.rs
@@ -98,6 +98,9 @@ pub(crate) enum SymbolPlacement<'data> {
 
     /// Symbol will point to the start of the first loadable segment.
     LoadBaseAddress,
+
+    /// A symbol defined by the linker.
+    LinkerDefined,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -293,6 +296,16 @@ impl<'data, P: Platform> InternalSymbolsBuilder<'data, P> {
         self.add_symbol(InternalSymDefInfo::new(
             SymbolPlacement::SectionGroupEnd(section_id),
             name.as_bytes(),
+        ))
+    }
+
+    pub(crate) fn linker_defined(
+        &mut self,
+        name: &'static [u8],
+    ) -> &mut InternalSymDefInfo<'data, P> {
+        self.add_symbol(InternalSymDefInfo::new(
+            SymbolPlacement::LinkerDefined,
+            name,
         ))
     }
 }

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -246,6 +246,7 @@ pub(crate) trait Platform:
     type File<'data>: ObjectFile<'data, Platform = Self>;
     type FileFlags;
     type SymtabEntry: Symbol;
+    type PlatformSpecificSymbol: Copy + PartialEq + Eq + std::fmt::Debug + Send + Sync + 'static;
     type SectionHeader: SectionHeader;
     type SectionFlags: SectionFlags;
     type SectionAttributes: SectionAttributes<Platform = Self>;

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -2060,6 +2060,10 @@ impl<'data, P: Platform> Prelude<'data, P> {
                     outputs.add_non_versioned(PendingSymbol::new(symbol_id, definition.name));
                     ValueFlags::NON_INTERPOSABLE
                 }
+                SymbolPlacement::LinkerDefined => {
+                    outputs.add_non_versioned(PendingSymbol::new(symbol_id, definition.name));
+                    ValueFlags::NON_INTERPOSABLE | ValueFlags::ABSOLUTE
+                }
                 SymbolPlacement::Redirect(redirect) => {
                     outputs.add_non_versioned(PendingSymbol::new(symbol_id, definition.name));
                     if matches!(redirect.loc, SymbolLoc::None) {
@@ -2095,7 +2099,8 @@ impl<P: Platform> InternalSymDefInfo<'_, P> {
             }) => Some(i),
             SymbolPlacement::Undefined
             | SymbolPlacement::ForceUndefined
-            | SymbolPlacement::Redirect(_) => None,
+            | SymbolPlacement::Redirect(_)
+            | SymbolPlacement::LinkerDefined => None,
             SymbolPlacement::SectionStart(i) => Some(i),
             SymbolPlacement::SectionEnd(i) => Some(i),
             SymbolPlacement::SectionGroupEnd(i) => Some(i),

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -684,6 +684,21 @@ impl<'data, P: Platform> SymbolDb<'data, P> {
         }
     }
 
+    /// Returns the prelude definition for `symbol_id` when it belongs to the prelude.
+    pub(crate) fn prelude_symbol_def(
+        &self,
+        symbol_id: SymbolId,
+    ) -> Option<&InternalSymDefInfo<'data, P>> {
+        let file_id = self.file_id_for_symbol(symbol_id);
+        if file_id != PRELUDE_FILE_ID {
+            return None;
+        }
+        match &self.groups[file_id.group()] {
+            Group::Prelude(prelude) => Some(prelude.symbol_def(symbol_id)),
+            _ => None,
+        }
+    }
+
     /// Get the version of a symbol. Only intended for diagnostic purposes.
     pub(crate) fn symbol_version_debug(&self, symbol_id: SymbolId) -> Option<String> {
         let file_id = self.file_id_for_symbol(symbol_id);
@@ -2060,7 +2075,7 @@ impl<'data, P: Platform> Prelude<'data, P> {
                     outputs.add_non_versioned(PendingSymbol::new(symbol_id, definition.name));
                     ValueFlags::NON_INTERPOSABLE
                 }
-                SymbolPlacement::LinkerDefined => {
+                SymbolPlacement::PlatformSpecific(_) => {
                     outputs.add_non_versioned(PendingSymbol::new(symbol_id, definition.name));
                     ValueFlags::NON_INTERPOSABLE | ValueFlags::ABSOLUTE
                 }
@@ -2100,7 +2115,7 @@ impl<P: Platform> InternalSymDefInfo<'_, P> {
             SymbolPlacement::Undefined
             | SymbolPlacement::ForceUndefined
             | SymbolPlacement::Redirect(_)
-            | SymbolPlacement::LinkerDefined => None,
+            | SymbolPlacement::PlatformSpecific(_) => None,
             SymbolPlacement::SectionStart(i) => Some(i),
             SymbolPlacement::SectionEnd(i) => Some(i),
             SymbolPlacement::SectionGroupEnd(i) => Some(i),

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -7,6 +7,7 @@ use crate::bail;
 use crate::ensure;
 use crate::error::Context as _;
 use crate::error::Result;
+use crate::input_data::PRELUDE_FILE_ID;
 use crate::layout;
 use crate::layout_rules::SectionKind;
 use crate::layout_rules::SectionRule;
@@ -2441,10 +2442,6 @@ impl<'data> WasmObjectLayoutInput<'data> {
         for (i, import) in self.function_imports.iter().enumerate() {
             match resolutions.function_resolutions[i] {
                 ImportResolution::Unresolved => {
-                    if let Some(index) = indices.function_index(import.name) {
-                        index_map.function_indices.push(index);
-                        continue;
-                    }
                     let output_type_index = index_bases
                         .type_index_base
                         .checked_add(import.type_index)
@@ -2462,6 +2459,12 @@ impl<'data> WasmObjectLayoutInput<'data> {
                             type_index: output_type_index,
                         },
                     });
+                }
+                ImportResolution::LinkerDefined(known) => {
+                    let index = indices.function_index(known).ok_or_else(|| {
+                        crate::error!("missing reserved Wasm function for {known:?}")
+                    })?;
+                    index_map.function_indices.push(index);
                 }
                 ImportResolution::ResolvedFunction {
                     object_index,
@@ -2489,10 +2492,6 @@ impl<'data> WasmObjectLayoutInput<'data> {
         for (i, import) in self.global_imports.iter().enumerate() {
             match resolutions.global_resolutions[i] {
                 ImportResolution::Unresolved => {
-                    if let Some(index) = indices.global_index(import.name) {
-                        index_map.global_indices.push(index);
-                        continue;
-                    }
                     let output_global_index = index_bases
                         .global_import_base
                         .checked_add(unresolved_global_count)
@@ -2504,6 +2503,12 @@ impl<'data> WasmObjectLayoutInput<'data> {
                         name: import.name,
                         entity: OutputImportEntity::Global(import.ty),
                     });
+                }
+                ImportResolution::LinkerDefined(known) => {
+                    let index = indices.global_index(known).ok_or_else(|| {
+                        crate::error!("missing reserved Wasm global for {known:?}")
+                    })?;
+                    index_map.global_indices.push(index);
                 }
                 ImportResolution::ResolvedGlobal {
                     object_index,
@@ -2608,6 +2613,8 @@ enum ImportResolution {
         object_index: usize,
         local_defined_index: u32,
     },
+    /// Resolved to a linker-synthesized function or global.
+    LinkerDefined(WasmLinkerSymbol),
 }
 
 #[derive(Debug, Default)]
@@ -2706,6 +2713,21 @@ fn resolve_import_symbols<'data>(
         }
     }
 
+    let import_names: Vec<&str> = match kind {
+        WasmSymbolKind::Func => input.function_imports.iter().map(|i| i.name).collect(),
+        WasmSymbolKind::Global => input.global_imports.iter().map(|i| i.name).collect(),
+        _ => Vec::new(),
+    };
+    for (import_idx, name) in import_names.iter().enumerate() {
+        if !matches!(resolutions[import_idx], ImportResolution::Unresolved) {
+            continue;
+        }
+        if let Some(resolution) = linker_defined_import_resolution(name, kind, symbol_db) {
+            unresolved_count -= 1;
+            resolutions[import_idx] = resolution;
+        }
+    }
+
     Ok((resolutions, unresolved_count))
 }
 
@@ -2724,6 +2746,14 @@ fn resolve_one_import<'data>(
         return Ok(ImportResolution::Unresolved);
     }
     let def_file_id = symbol_db.file_id_for_symbol(def_id);
+
+    if def_file_id == PRELUDE_FILE_ID {
+        return Ok(
+            linker_defined_from_prelude_def(def_id, expected_kind, symbol_db)
+                .unwrap_or(ImportResolution::Unresolved),
+        );
+    }
+
     let Some(&def_obj_idx) = file_id_to_index.get(&def_file_id) else {
         return Ok(ImportResolution::Unresolved);
     };
@@ -2759,6 +2789,36 @@ fn resolve_one_import<'data>(
     }
 }
 
+fn linker_defined_from_prelude_def(
+    def_id: crate::symbol_db::SymbolId,
+    expected_kind: WasmSymbolKind,
+    symbol_db: &SymbolDb<'_, Wasm>,
+) -> Option<ImportResolution> {
+    let name = symbol_db.symbol_name(def_id).ok()?;
+    let known = WasmLinkerSymbol::parse_bytes(name.bytes())?;
+    known
+        .matches_import_kind(expected_kind)
+        .then_some(ImportResolution::LinkerDefined(known))
+}
+
+/// Resolve an import name to a prelude linker definition, if present in [`SymbolDb`].
+fn linker_defined_import_resolution(
+    import_name: &str,
+    expected_kind: WasmSymbolKind,
+    symbol_db: &SymbolDb<'_, Wasm>,
+) -> Option<ImportResolution> {
+    let known = WasmLinkerSymbol::parse(import_name)?;
+    if !known.matches_import_kind(expected_kind) {
+        return None;
+    }
+    let symbol_id = symbol_db.get_unversioned(&UnversionedSymbolName::prehashed(known.name()))?;
+    let def_id = symbol_db.definition(symbol_id);
+    if symbol_db.file_id_for_symbol(def_id) != PRELUDE_FILE_ID {
+        return None;
+    }
+    Some(ImportResolution::LinkerDefined(known))
+}
+
 fn object_needs_linker_memory(input: &WasmObjectLayoutInput<'_>) -> bool {
     !input.memory_imports.is_empty() || !input.memories.is_empty()
 }
@@ -2769,8 +2829,6 @@ fn any_object_needs_linker_memory(inputs: &[WasmObjectLayoutInput<'_>]) -> bool 
 
 #[derive(Debug, Clone, Copy, Default)]
 struct LinkerImportAbsorption {
-    absorbed_functions: u32,
-    absorbed_globals: u32,
     needs_memory_base: bool,
     needs_stack_pointer: bool,
     needs_tls_base: bool,
@@ -2779,64 +2837,30 @@ struct LinkerImportAbsorption {
 }
 
 impl LinkerImportAbsorption {
-    fn for_object(
-        input: &WasmObjectLayoutInput<'_>,
-        resolutions: &ObjectImportResolutions,
-    ) -> Self {
+    fn from_resolutions(resolutions: &ObjectImportResolutions) -> Self {
         let mut absorption = Self::default();
-        for (i, import) in input.function_imports.iter().enumerate() {
-            if !matches!(
-                resolutions.function_resolutions.get(i),
-                Some(ImportResolution::Unresolved)
-            ) {
-                continue;
-            }
-            match WasmLinkerSymbol::parse(import.name) {
-                Some(WasmLinkerSymbol::CallCtors) => {
-                    absorption.needs_ctors = true;
-                    absorption.absorbed_functions += 1;
+        for resolution in &resolutions.function_resolutions {
+            if let ImportResolution::LinkerDefined(known) = *resolution {
+                match known {
+                    WasmLinkerSymbol::CallCtors => absorption.needs_ctors = true,
+                    WasmLinkerSymbol::CallDtors => absorption.needs_dtors = true,
+                    _ => {}
                 }
-                Some(WasmLinkerSymbol::CallDtors) => {
-                    absorption.needs_dtors = true;
-                    absorption.absorbed_functions += 1;
-                }
-                _ => {}
             }
         }
-        for (i, import) in input.global_imports.iter().enumerate() {
-            if !matches!(
-                resolutions.global_resolutions.get(i),
-                Some(ImportResolution::Unresolved)
-            ) {
-                continue;
-            }
-            match WasmLinkerSymbol::parse(import.name) {
-                Some(WasmLinkerSymbol::MemoryBase) => {
-                    absorption.needs_memory_base = true;
-                    absorption.absorbed_globals += 1;
+        for resolution in &resolutions.global_resolutions {
+            if let ImportResolution::LinkerDefined(known) = *resolution {
+                match known {
+                    WasmLinkerSymbol::MemoryBase => absorption.needs_memory_base = true,
+                    WasmLinkerSymbol::StackPointer => absorption.needs_stack_pointer = true,
+                    // Single-threaded. Immutable base (no TLS segment yet).
+                    WasmLinkerSymbol::TlsBase => absorption.needs_tls_base = true,
+                    _ => {}
                 }
-                Some(WasmLinkerSymbol::StackPointer) => {
-                    absorption.needs_stack_pointer = true;
-                    absorption.absorbed_globals += 1;
-                }
-                // Single-threaded. Immutable base (no TLS segment yet).
-                Some(WasmLinkerSymbol::TlsBase) => {
-                    absorption.needs_tls_base = true;
-                    absorption.absorbed_globals += 1;
-                }
-                _ => {}
             }
         }
         absorption
     }
-}
-
-fn remaining_unresolved_imports(unresolved: u32, absorbed: u32) -> Result<u32> {
-    unresolved.checked_sub(absorbed).ok_or_else(|| {
-        crate::error!(
-            "Wasm linker absorption count ({absorbed}) exceeds unresolved imports ({unresolved})"
-        )
-    })
 }
 
 /// Reserved Wasm index-space slots for linker-defined globals/functions.
@@ -2858,13 +2882,17 @@ struct LinkerDefinedIndices {
 /// True if inputs import or export `__wasm_call_ctors`.
 fn call_ctors_used_in_objects(inputs: &[WasmObjectLayoutInput<'_>]) -> bool {
     inputs.iter().any(|input| {
-        input
-            .function_imports
-            .iter()
-            .any(|imp| matches!(WasmLinkerSymbol::parse(imp.name), Some(WasmLinkerSymbol::CallCtors)))
-            || input.exports.iter().any(|exp| {
-                matches!(WasmLinkerSymbol::parse(exp.name), Some(WasmLinkerSymbol::CallCtors))
-            })
+        input.function_imports.iter().any(|imp| {
+            matches!(
+                WasmLinkerSymbol::parse(imp.name),
+                Some(WasmLinkerSymbol::CallCtors)
+            )
+        }) || input.exports.iter().any(|exp| {
+            matches!(
+                WasmLinkerSymbol::parse(exp.name),
+                Some(WasmLinkerSymbol::CallCtors)
+            )
+        })
     })
 }
 
@@ -2902,7 +2930,7 @@ impl LinkerDefinedIndices {
         let mut global_import_count = 0u32;
 
         for (input, resolutions) in inputs.iter().zip(import_resolutions) {
-            let absorption = LinkerImportAbsorption::for_object(input, resolutions);
+            let absorption = LinkerImportAbsorption::from_resolutions(resolutions);
             needs_ctors |= absorption.needs_ctors;
             needs_dtors |= absorption.needs_dtors;
             needs_memory_base |= absorption.needs_memory_base;
@@ -2910,17 +2938,11 @@ impl LinkerDefinedIndices {
             needs_tls_base |= absorption.needs_tls_base;
 
             function_import_count = function_import_count
-                .checked_add(remaining_unresolved_imports(
-                    resolutions.unresolved_function_count,
-                    absorption.absorbed_functions,
-                )?)
+                .checked_add(resolutions.unresolved_function_count)
                 .ok_or_else(|| crate::error!("Wasm function index overflow"))?;
 
             global_import_count = global_import_count
-                .checked_add(remaining_unresolved_imports(
-                    resolutions.unresolved_global_count,
-                    absorption.absorbed_globals,
-                )?)
+                .checked_add(resolutions.unresolved_global_count)
                 .ok_or_else(|| crate::error!("Wasm global index overflow"))?;
 
             if !needs_memory_base
@@ -2988,8 +3010,8 @@ impl LinkerDefinedIndices {
         })
     }
 
-    fn global_index(&self, name: &str) -> Option<u32> {
-        match WasmLinkerSymbol::parse(name)? {
+    fn global_index(&self, known: WasmLinkerSymbol) -> Option<u32> {
+        match known {
             WasmLinkerSymbol::MemoryBase => self.memory_base_global,
             WasmLinkerSymbol::StackPointer => self.stack_pointer_global,
             WasmLinkerSymbol::TlsBase => self.tls_base_global,
@@ -2997,8 +3019,8 @@ impl LinkerDefinedIndices {
         }
     }
 
-    fn function_index(&self, name: &str) -> Option<u32> {
-        match WasmLinkerSymbol::parse(name)? {
+    fn function_index(&self, known: WasmLinkerSymbol) -> Option<u32> {
+        match known {
             WasmLinkerSymbol::CallCtors => self.call_ctors_func,
             WasmLinkerSymbol::CallDtors => self.call_dtors_func,
             _ => None,
@@ -4050,18 +4072,11 @@ fn allocate_wasm_object_index_bases(
             .checked_add(u32::try_from(input.types.len()).context("too many Wasm types")?)
             .ok_or_else(|| crate::error!("Wasm type index overflow"))?;
 
-        let absorption = LinkerImportAbsorption::for_object(input, resolutions);
         next_function_import_index = next_function_import_index
-            .checked_add(remaining_unresolved_imports(
-                resolutions.unresolved_function_count,
-                absorption.absorbed_functions,
-            )?)
+            .checked_add(resolutions.unresolved_function_count)
             .ok_or_else(|| crate::error!("Wasm function index overflow"))?;
         next_global_import_index = next_global_import_index
-            .checked_add(remaining_unresolved_imports(
-                resolutions.unresolved_global_count,
-                absorption.absorbed_globals,
-            )?)
+            .checked_add(resolutions.unresolved_global_count)
             .ok_or_else(|| crate::error!("Wasm global index overflow"))?;
     }
 

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -3872,24 +3872,57 @@ struct LinkerDefinedDataAddress {
     address: u32,
 }
 
-/// Absolute addresses for linker-defined data symbols.
+/// Wasm data symbols synthesized by the linker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumIter)]
+enum WasmLinkerDataSymbol {
+    DataEnd,
+    HeapBase,
+    HeapEnd,
+    WasmFirstPageEnd,
+}
+
+impl WasmLinkerDataSymbol {
+    fn name(self) -> &'static [u8] {
+        match self {
+            Self::DataEnd => b"__data_end",
+            Self::HeapBase => b"__heap_base",
+            Self::HeapEnd => b"__heap_end",
+            Self::WasmFirstPageEnd => b"__wasm_first_page_end",
+        }
+    }
+
+    fn parse(name: &[u8]) -> Option<Self> {
+        match name {
+            b"__data_end" => Some(Self::DataEnd),
+            b"__heap_base" => Some(Self::HeapBase),
+            b"__heap_end" => Some(Self::HeapEnd),
+            b"__wasm_first_page_end" => Some(Self::WasmFirstPageEnd),
+            _ => None,
+        }
+    }
+
+    fn address(self, data_end: u32, stack_size: u32, heap_end: Option<u32>) -> Result<Option<u32>> {
+        Ok(match self {
+            Self::DataEnd => Some(data_end),
+            Self::HeapBase => Some(stack_high_after_data(data_end, stack_size)?),
+            Self::WasmFirstPageEnd => Some(u32::try_from(wasm_page_size())?),
+            Self::HeapEnd => heap_end,
+        })
+    }
+}
+
 fn linker_defined_data_symbol_address(
     name: &[u8],
     data_end: u32,
     stack_size: u32,
     heap_end: Option<u32>,
 ) -> Result<Option<LinkerDefinedDataAddress>> {
-    match name {
-        b"__data_end" => Ok(Some(LinkerDefinedDataAddress { address: data_end })),
-        b"__heap_base" => Ok(Some(LinkerDefinedDataAddress {
-            address: stack_high_after_data(data_end, stack_size)?,
-        })),
-        b"__wasm_first_page_end" => Ok(Some(LinkerDefinedDataAddress {
-            address: u32::try_from(wasm_page_size())?,
-        })),
-        b"__heap_end" => Ok(heap_end.map(|address| LinkerDefinedDataAddress { address })),
-        _ => Ok(None),
-    }
+    let Some(sym) = WasmLinkerDataSymbol::parse(name) else {
+        return Ok(None);
+    };
+    Ok(sym
+        .address(data_end, stack_size, heap_end)?
+        .map(|address| LinkerDefinedDataAddress { address }))
 }
 
 fn compute_data_addresses(
@@ -3920,39 +3953,32 @@ fn compute_data_addresses(
             }
             let symbol_id = layout_inputs[obj_idx].symbol_id_range.offset_to_id(sym_idx);
 
-            // Resolve to the canonical definition when this is an undefined reference.
-            let (def_obj_idx, def_sym, name_symbol_id) = if sym.is_undefined() {
-                let def_id = symbol_db.definition(symbol_id);
-                let def_file_id = symbol_db.file_id_for_symbol(def_id);
-                let Some(&def_obj_idx) = file_id_to_index.get(&def_file_id) else {
-                    continue;
-                };
-                let def_input = &layout_inputs[def_obj_idx];
-                let def_sym_offset = def_id.to_offset(def_input.symbol_id_range);
-                (
-                    def_obj_idx,
-                    per_object_symbols[def_obj_idx][def_sym_offset],
-                    def_id,
-                )
-            } else {
-                (obj_idx, *sym, symbol_id)
-            };
-
-            if def_sym.is_undefined() {
-                let name = symbol_db.symbol_name(name_symbol_id)?;
-                if let Some(resolved) = linker_defined_data_symbol_address(
-                    name.bytes(),
-                    data_end,
-                    stack_size,
-                    heap_end,
-                )? {
-                    data_addresses[sym_idx] = resolved.address;
-                }
+            if !sym.is_undefined() {
+                data_addresses[sym_idx] =
+                    data_symbol_memory_address(&object_data_layouts[obj_idx], sym)?;
                 continue;
             }
 
-            data_addresses[sym_idx] =
-                data_symbol_memory_address(&object_data_layouts[def_obj_idx], &def_sym)?;
+            let def_id = symbol_db.definition(symbol_id);
+            let def_file_id = symbol_db.file_id_for_symbol(def_id);
+
+            if let Some(&def_obj_idx) = file_id_to_index.get(&def_file_id) {
+                let def_input = &layout_inputs[def_obj_idx];
+                let def_sym =
+                    per_object_symbols[def_obj_idx][def_id.to_offset(def_input.symbol_id_range)];
+                if !def_sym.is_undefined() {
+                    data_addresses[sym_idx] =
+                        data_symbol_memory_address(&object_data_layouts[def_obj_idx], &def_sym)?;
+                    continue;
+                }
+            }
+
+            let name = symbol_db.symbol_name(def_id)?;
+            if let Some(resolved) =
+                linker_defined_data_symbol_address(name.bytes(), data_end, stack_size, heap_end)?
+            {
+                data_addresses[sym_idx] = resolved.address;
+            }
         }
         index_map.data_addresses = data_addresses;
     }
@@ -4278,6 +4304,10 @@ impl platform::Platform for Wasm {
                 b"",
             ))
             .hide();
+
+        for sym in <WasmLinkerDataSymbol as strum::IntoEnumIterator>::iter() {
+            symbols.linker_defined(sym.name()).hide();
+        }
     }
 
     fn built_in_section_infos<'data>()

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -3894,54 +3894,44 @@ struct LinkerDefinedDataAddress {
 }
 
 /// Wasm symbols synthesized by the linker.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumIter)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, strum::EnumIter, strum::EnumString, strum::IntoStaticStr,
+)]
 enum WasmLinkerSymbol {
     // Data
+    #[strum(serialize = "__data_end")]
     DataEnd,
+    #[strum(serialize = "__heap_base")]
     HeapBase,
+    #[strum(serialize = "__heap_end")]
     HeapEnd,
+    #[strum(serialize = "__wasm_first_page_end")]
     WasmFirstPageEnd,
     // Globals
+    #[strum(serialize = "__memory_base")]
     MemoryBase,
+    #[strum(serialize = "__stack_pointer")]
     StackPointer,
+    #[strum(serialize = "__tls_base")]
     TlsBase,
     // Functions
+    #[strum(serialize = "__wasm_call_ctors")]
     CallCtors,
+    #[strum(serialize = "__wasm_call_dtors")]
     CallDtors,
 }
 
 impl WasmLinkerSymbol {
     fn name(self) -> &'static [u8] {
-        match self {
-            Self::DataEnd => b"__data_end",
-            Self::HeapBase => b"__heap_base",
-            Self::HeapEnd => b"__heap_end",
-            Self::WasmFirstPageEnd => b"__wasm_first_page_end",
-            Self::MemoryBase => b"__memory_base",
-            Self::StackPointer => b"__stack_pointer",
-            Self::TlsBase => b"__tls_base",
-            Self::CallCtors => b"__wasm_call_ctors",
-            Self::CallDtors => b"__wasm_call_dtors",
-        }
+        <&'static str>::from(self).as_bytes()
     }
 
     fn parse_bytes(name: &[u8]) -> Option<Self> {
-        match name {
-            b"__data_end" => Some(Self::DataEnd),
-            b"__heap_base" => Some(Self::HeapBase),
-            b"__heap_end" => Some(Self::HeapEnd),
-            b"__wasm_first_page_end" => Some(Self::WasmFirstPageEnd),
-            b"__memory_base" => Some(Self::MemoryBase),
-            b"__stack_pointer" => Some(Self::StackPointer),
-            b"__tls_base" => Some(Self::TlsBase),
-            b"__wasm_call_ctors" => Some(Self::CallCtors),
-            b"__wasm_call_dtors" => Some(Self::CallDtors),
-            _ => None,
-        }
+        std::str::from_utf8(name).ok()?.parse().ok()
     }
 
     fn parse(name: &str) -> Option<Self> {
-        Self::parse_bytes(name.as_bytes())
+        name.parse().ok()
     }
 
     fn matches_import_kind(self, kind: WasmSymbolKind) -> bool {

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -2794,29 +2794,25 @@ fn linker_defined_from_prelude_def(
     expected_kind: WasmSymbolKind,
     symbol_db: &SymbolDb<'_, Wasm>,
 ) -> Option<ImportResolution> {
-    let name = symbol_db.symbol_name(def_id).ok()?;
-    let known = WasmLinkerSymbol::parse_bytes(name.bytes())?;
+    let def_info = symbol_db.prelude_symbol_def(def_id)?;
+    let crate::parsing::SymbolPlacement::PlatformSpecific(known) = &def_info.placement else {
+        return None;
+    };
     known
         .matches_import_kind(expected_kind)
-        .then_some(ImportResolution::LinkerDefined(known))
+        .then_some(ImportResolution::LinkerDefined(*known))
 }
 
-/// Resolve an import name to a prelude linker definition, if present in [`SymbolDb`].
+/// Resolve an import name to a prelude platform-specific definition, if present in `SymbolDb`.
 fn linker_defined_import_resolution(
     import_name: &str,
     expected_kind: WasmSymbolKind,
     symbol_db: &SymbolDb<'_, Wasm>,
 ) -> Option<ImportResolution> {
-    let known = WasmLinkerSymbol::parse(import_name)?;
-    if !known.matches_import_kind(expected_kind) {
-        return None;
-    }
-    let symbol_id = symbol_db.get_unversioned(&UnversionedSymbolName::prehashed(known.name()))?;
+    let symbol_id =
+        symbol_db.get_unversioned(&UnversionedSymbolName::prehashed(import_name.as_bytes()))?;
     let def_id = symbol_db.definition(symbol_id);
-    if symbol_db.file_id_for_symbol(def_id) != PRELUDE_FILE_ID {
-        return None;
-    }
-    Some(ImportResolution::LinkerDefined(known))
+    linker_defined_from_prelude_def(def_id, expected_kind, symbol_db)
 }
 
 fn object_needs_linker_memory(input: &WasmObjectLayoutInput<'_>) -> bool {
@@ -3897,7 +3893,7 @@ struct LinkerDefinedDataAddress {
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, strum::EnumIter, strum::EnumString, strum::IntoStaticStr,
 )]
-enum WasmLinkerSymbol {
+pub(crate) enum WasmLinkerSymbol {
     // Data
     #[strum(serialize = "__data_end")]
     DataEnd,
@@ -4025,11 +4021,12 @@ fn compute_data_addresses(
                 }
             }
 
-            let name = symbol_db.symbol_name(def_id)?;
-            if let Some(resolved) =
-                linker_defined_data_symbol_address(name.bytes(), data_end, stack_size, heap_end)?
+            if let Some(def_info) = symbol_db.prelude_symbol_def(def_id)
+                && let crate::parsing::SymbolPlacement::PlatformSpecific(known) =
+                    &def_info.placement
+                && let Some(address) = known.data_address(data_end, stack_size, heap_end)?
             {
-                data_addresses[sym_idx] = resolved.address;
+                data_addresses[sym_idx] = address;
             }
         }
         index_map.data_addresses = data_addresses;
@@ -4141,6 +4138,7 @@ impl platform::Platform for Wasm {
     type File<'data> = File<'data>;
     type FileFlags = u32;
     type SymtabEntry = WasmSymbol;
+    type PlatformSpecificSymbol = WasmLinkerSymbol;
     type SectionHeader = SectionHeader;
     type SectionFlags = SectionFlags;
     type SectionAttributes = SectionAttributes;
@@ -4351,7 +4349,7 @@ impl platform::Platform for Wasm {
             .hide();
 
         for sym in <WasmLinkerSymbol as strum::IntoEnumIterator>::iter() {
-            symbols.linker_defined(sym.name()).hide();
+            symbols.platform_specific(sym.name(), sym).hide();
         }
     }
 

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -2791,12 +2791,12 @@ impl LinkerImportAbsorption {
             ) {
                 continue;
             }
-            match import.name {
-                "__wasm_call_ctors" => {
+            match WasmLinkerSymbol::parse(import.name) {
+                Some(WasmLinkerSymbol::CallCtors) => {
                     absorption.needs_ctors = true;
                     absorption.absorbed_functions += 1;
                 }
-                "__wasm_call_dtors" => {
+                Some(WasmLinkerSymbol::CallDtors) => {
                     absorption.needs_dtors = true;
                     absorption.absorbed_functions += 1;
                 }
@@ -2810,17 +2810,17 @@ impl LinkerImportAbsorption {
             ) {
                 continue;
             }
-            match import.name {
-                "__memory_base" => {
+            match WasmLinkerSymbol::parse(import.name) {
+                Some(WasmLinkerSymbol::MemoryBase) => {
                     absorption.needs_memory_base = true;
                     absorption.absorbed_globals += 1;
                 }
-                "__stack_pointer" => {
+                Some(WasmLinkerSymbol::StackPointer) => {
                     absorption.needs_stack_pointer = true;
                     absorption.absorbed_globals += 1;
                 }
                 // Single-threaded. Immutable base (no TLS segment yet).
-                "__tls_base" => {
+                Some(WasmLinkerSymbol::TlsBase) => {
                     absorption.needs_tls_base = true;
                     absorption.absorbed_globals += 1;
                 }
@@ -2861,11 +2861,10 @@ fn call_ctors_used_in_objects(inputs: &[WasmObjectLayoutInput<'_>]) -> bool {
         input
             .function_imports
             .iter()
-            .any(|imp| imp.name == "__wasm_call_ctors")
-            || input
-                .exports
-                .iter()
-                .any(|exp| exp.name == "__wasm_call_ctors")
+            .any(|imp| matches!(WasmLinkerSymbol::parse(imp.name), Some(WasmLinkerSymbol::CallCtors)))
+            || input.exports.iter().any(|exp| {
+                matches!(WasmLinkerSymbol::parse(exp.name), Some(WasmLinkerSymbol::CallCtors))
+            })
     })
 }
 
@@ -2990,18 +2989,18 @@ impl LinkerDefinedIndices {
     }
 
     fn global_index(&self, name: &str) -> Option<u32> {
-        match name {
-            "__memory_base" => self.memory_base_global,
-            "__stack_pointer" => self.stack_pointer_global,
-            "__tls_base" => self.tls_base_global,
+        match WasmLinkerSymbol::parse(name)? {
+            WasmLinkerSymbol::MemoryBase => self.memory_base_global,
+            WasmLinkerSymbol::StackPointer => self.stack_pointer_global,
+            WasmLinkerSymbol::TlsBase => self.tls_base_global,
             _ => None,
         }
     }
 
     fn function_index(&self, name: &str) -> Option<u32> {
-        match name {
-            "__wasm_call_ctors" => self.call_ctors_func,
-            "__wasm_call_dtors" => self.call_dtors_func,
+        match WasmLinkerSymbol::parse(name)? {
+            WasmLinkerSymbol::CallCtors => self.call_ctors_func,
+            WasmLinkerSymbol::CallDtors => self.call_dtors_func,
             _ => None,
         }
     }
@@ -3872,41 +3871,82 @@ struct LinkerDefinedDataAddress {
     address: u32,
 }
 
-/// Wasm data symbols synthesized by the linker.
+/// Wasm symbols synthesized by the linker.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumIter)]
-enum WasmLinkerDataSymbol {
+enum WasmLinkerSymbol {
+    // Data
     DataEnd,
     HeapBase,
     HeapEnd,
     WasmFirstPageEnd,
+    // Globals
+    MemoryBase,
+    StackPointer,
+    TlsBase,
+    // Functions
+    CallCtors,
+    CallDtors,
 }
 
-impl WasmLinkerDataSymbol {
+impl WasmLinkerSymbol {
     fn name(self) -> &'static [u8] {
         match self {
             Self::DataEnd => b"__data_end",
             Self::HeapBase => b"__heap_base",
             Self::HeapEnd => b"__heap_end",
             Self::WasmFirstPageEnd => b"__wasm_first_page_end",
+            Self::MemoryBase => b"__memory_base",
+            Self::StackPointer => b"__stack_pointer",
+            Self::TlsBase => b"__tls_base",
+            Self::CallCtors => b"__wasm_call_ctors",
+            Self::CallDtors => b"__wasm_call_dtors",
         }
     }
 
-    fn parse(name: &[u8]) -> Option<Self> {
+    fn parse_bytes(name: &[u8]) -> Option<Self> {
         match name {
             b"__data_end" => Some(Self::DataEnd),
             b"__heap_base" => Some(Self::HeapBase),
             b"__heap_end" => Some(Self::HeapEnd),
             b"__wasm_first_page_end" => Some(Self::WasmFirstPageEnd),
+            b"__memory_base" => Some(Self::MemoryBase),
+            b"__stack_pointer" => Some(Self::StackPointer),
+            b"__tls_base" => Some(Self::TlsBase),
+            b"__wasm_call_ctors" => Some(Self::CallCtors),
+            b"__wasm_call_dtors" => Some(Self::CallDtors),
             _ => None,
         }
     }
 
-    fn address(self, data_end: u32, stack_size: u32, heap_end: Option<u32>) -> Result<Option<u32>> {
+    fn parse(name: &str) -> Option<Self> {
+        Self::parse_bytes(name.as_bytes())
+    }
+
+    fn matches_import_kind(self, kind: WasmSymbolKind) -> bool {
+        match self {
+            Self::CallCtors | Self::CallDtors => kind == WasmSymbolKind::Func,
+            Self::MemoryBase | Self::StackPointer | Self::TlsBase => kind == WasmSymbolKind::Global,
+            Self::DataEnd | Self::HeapBase | Self::HeapEnd | Self::WasmFirstPageEnd => false,
+        }
+    }
+
+    /// Data-symbol address after memory layout. `None` for non-data variants or absent memory.
+    fn data_address(
+        self,
+        data_end: u32,
+        stack_size: u32,
+        heap_end: Option<u32>,
+    ) -> Result<Option<u32>> {
         Ok(match self {
             Self::DataEnd => Some(data_end),
             Self::HeapBase => Some(stack_high_after_data(data_end, stack_size)?),
             Self::WasmFirstPageEnd => Some(u32::try_from(wasm_page_size())?),
             Self::HeapEnd => heap_end,
+            Self::MemoryBase
+            | Self::StackPointer
+            | Self::TlsBase
+            | Self::CallCtors
+            | Self::CallDtors => None,
         })
     }
 }
@@ -3917,11 +3957,11 @@ fn linker_defined_data_symbol_address(
     stack_size: u32,
     heap_end: Option<u32>,
 ) -> Result<Option<LinkerDefinedDataAddress>> {
-    let Some(sym) = WasmLinkerDataSymbol::parse(name) else {
+    let Some(sym) = WasmLinkerSymbol::parse_bytes(name) else {
         return Ok(None);
     };
     Ok(sym
-        .address(data_end, stack_size, heap_end)?
+        .data_address(data_end, stack_size, heap_end)?
         .map(|address| LinkerDefinedDataAddress { address }))
 }
 
@@ -4305,7 +4345,7 @@ impl platform::Platform for Wasm {
             ))
             .hide();
 
-        for sym in <WasmLinkerDataSymbol as strum::IntoEnumIterator>::iter() {
+        for sym in <WasmLinkerSymbol as strum::IntoEnumIterator>::iter() {
             symbols.linker_defined(sym.name()).hide();
         }
     }


### PR DESCRIPTION
Register Wasm linker-synthesized symbols in SymbolDb and resolve reserved imports from those definitions.

Part of #1431