### PR TITLE
port(wasm): Speed up data symbol address lookup with O(1) segment indexing

### DIFF
--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -3857,8 +3857,8 @@ fn data_symbol_memory_address(
     );
     let segment = object_data_layout
         .segments
-        .iter()
-        .find(|segment| segment.segment_index == sym.index)
+        .get(sym.index as usize)
+        .filter(|segment| segment.segment_index == sym.index)
         .ok_or_else(|| crate::error!("Wasm data symbol segment {} not found", sym.index))?;
     segment
         .output_memory_offset


### PR DESCRIPTION
Data symbol memory addresses were resolved by linearly scanning an object's data segments. This can dominate link time on large Wasm objects.

Part of #1431