### PR TITLE
chore: address cargo clippy issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -272,6 +272,10 @@ too_many_lines = "allow"
 # Some of our tests do this and there doesn't seem to be much value in changing them.
 unreadable_literal = "allow"
 
+# Sometimes explicit if/else branches are clearer, even when the if branch always returns,
+# because the reader doesn't have to recognize that the fallthrough is an implicit else branch.
+redundant_else = "allow"
+
 trivially_copy_pass_by_ref = "warn"
 uninlined_format_args = "warn"
 unnecessary_wraps = "warn"
@@ -285,7 +289,6 @@ inconsistent_struct_constructor = "warn"
 map_unwrap_or = "warn"
 match_wildcard_for_single_variants = "warn"
 needless_pass_by_value = "warn"
-redundant_else = "warn"
 semicolon_if_nothing_returned = "warn"
 range_plus_one = "warn"
 must_use_candidate = "warn"

--- a/linker-diff/src/init_order.rs
+++ b/linker-diff/src/init_order.rs
@@ -7,6 +7,7 @@ use crate::arch::RType as _;
 use crate::get_r_type;
 use crate::header_diff::ResolvedValue;
 use anyhow::Context;
+use anyhow::ensure;
 use linker_utils::elf::DynamicRelocationKind;
 use linker_utils::elf::secnames;
 use object::Object;
@@ -44,7 +45,12 @@ fn get_pointer_list<A: Arch>(bin: &Binary, section_name: &str) -> Result<Vec<Res
 
     let mut names = Vec::with_capacity(data.len() / ADDRESS_SIZE);
 
-    for (entry_num, address_bytes) in data.chunks_exact(ADDRESS_SIZE).enumerate() {
+    let chunks = data.as_chunks::<ADDRESS_SIZE>();
+    ensure!(
+        chunks.1.is_empty(),
+        "data must be a multiple of ADDRESS_SIZE"
+    );
+    for (entry_num, address_bytes) in chunks.0.iter().enumerate() {
         let mut address = u64::from_le_bytes(*address_bytes.first_chunk::<ADDRESS_SIZE>().unwrap());
         let entry_address = section_address + (entry_num * ADDRESS_SIZE) as u64;
         let mut symbol_names = Vec::new();

--- a/linker-diff/src/sysv_hash.rs
+++ b/linker-diff/src/sysv_hash.rs
@@ -57,9 +57,12 @@ pub(crate) fn check_object(obj: &Binary) -> Result {
         data.len() >= offset + bucket_len,
         "Insufficient data for .hash buckets"
     );
-    let buckets = data[offset..offset + bucket_len]
-        .chunks_exact(4)
-        .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()))
+    let chunks = data[offset..offset + bucket_len].as_chunks::<4>();
+    ensure!(chunks.1.is_empty(), "data size must be a multiple of 4");
+    let buckets = chunks
+        .0
+        .iter()
+        .map(|chunk| u32::from_le_bytes(*chunk))
         .collect_vec();
     offset += bucket_len;
 
@@ -68,9 +71,12 @@ pub(crate) fn check_object(obj: &Binary) -> Result {
         data.len() >= offset + chain_len,
         "Insufficient data for .hash chains"
     );
-    let chains = data[offset..offset + chain_len]
-        .chunks_exact(4)
-        .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()))
+    let chunks = data[offset..offset + chain_len].as_chunks::<4>();
+    ensure!(chunks.1.is_empty(), "data size must be a multiple of 4");
+    let chains = chunks
+        .0
+        .iter()
+        .map(|chunk| u32::from_le_bytes(*chunk))
         .collect_vec();
 
     for sym in obj.file.dynamic_symbols() {

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -5240,8 +5240,14 @@ fn verify_chained_fixups_segment_offsets(obj: &object::File, bytes: &[u8]) -> Re
     let seg_count = usize::try_from(u32::from_le_bytes(starts_in_image[..4].try_into()?))?;
     let seg_info_offsets = &starts_in_image[4..];
 
-    for (i, offset_bytes) in seg_info_offsets.chunks_exact(4).take(seg_count).enumerate() {
-        let seg_info_offset = usize::try_from(u32::from_le_bytes(offset_bytes.try_into()?))?;
+    for (i, offset_bytes) in seg_info_offsets
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .take(seg_count)
+        .enumerate()
+    {
+        let seg_info_offset = usize::try_from(u32::from_le_bytes(*offset_bytes))?;
         if seg_info_offset == 0 {
             continue;
         }


### PR DESCRIPTION
The spotted redundant_else issues are:
```
warning: redundant else block
  --> linker-diff/src/bin/linker-diff.rs:10:6
   |
10 |       } else {
   |  ______^
11 | |         println!("No differences or validation failures detected");
12 | |     }
   | |_____^

   --> libwild/src/save_dir.rs:121:6
    |
121 |       } else {
    |  ______^
122 | |         Ok(None)
123 | |     }
    | |_____^
```