### PR TITLE
 fix: do not retain a linker script output section if a symbol is defined after it

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -4622,12 +4622,10 @@ fn get_symbol_attributes(
                     .output_sections
                     .output_index_of_nearest_section(section_id)
             } else {
-                def_info
-                    .section_id()
-                    .and_then(|section_id| {
-                        let section_id = layout.output_sections.primary_output_section(section_id);
-                        layout.output_sections.output_index_of_section(section_id)
-                    })
+                def_info.section_id().and_then(|section_id| {
+                    let section_id = layout.output_sections.primary_output_section(section_id);
+                    layout.output_sections.output_index_of_section(section_id)
+                })
             }
             .map_or(object::elf::SHN_ABS.into(), SymbolSection::Index);
 

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -4613,19 +4613,21 @@ fn get_symbol_attributes(
         FileLayout::LinkerScript(script) => {
             let local_index = symbol_id.to_input(script.symbol_id_range);
             let def_info = &script.internal_symbols.symbol_definitions[local_index.0];
-            let shndx = match &def_info.placement {
-                crate::parsing::SymbolPlacement::Redirect(redirect)
-                    if let SymbolLoc::SectionEnd(section_id) = redirect.loc =>
-                {
-                    let section_id = layout.output_sections.primary_output_section(section_id);
-                    layout
-                        .output_sections
-                        .output_index_of_nearest_section(section_id)
-                }
-                _ => def_info.section_id().and_then(|section_id| {
-                    let section_id = layout.output_sections.primary_output_section(section_id);
-                    layout.output_sections.output_index_of_section(section_id)
-                }),
+            let shndx = if let crate::parsing::SymbolPlacement::Redirect(redirect) =
+                &def_info.placement
+                && let SymbolLoc::SectionEnd(section_id) = redirect.loc
+            {
+                let section_id = layout.output_sections.primary_output_section(section_id);
+                layout
+                    .output_sections
+                    .output_index_of_nearest_section(section_id)
+            } else {
+                script.internal_symbols.symbol_definitions[local_index.0]
+                    .section_id()
+                    .and_then(|section_id| {
+                        let section_id = layout.output_sections.primary_output_section(section_id);
+                        layout.output_sections.output_index_of_section(section_id)
+                    })
             }
             .map_or(object::elf::SHN_ABS.into(), SymbolSection::Index);
 

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -4622,7 +4622,7 @@ fn get_symbol_attributes(
                     .output_sections
                     .output_index_of_nearest_section(section_id)
             } else {
-                script.internal_symbols.symbol_definitions[local_index.0]
+                def_info
                     .section_id()
                     .and_then(|section_id| {
                         let section_id = layout.output_sections.primary_output_section(section_id);

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -4612,13 +4612,22 @@ fn get_symbol_attributes(
         }
         FileLayout::LinkerScript(script) => {
             let local_index = symbol_id.to_input(script.symbol_id_range);
-            let shndx = script.internal_symbols.symbol_definitions[local_index.0]
-                .section_id()
-                .and_then(|section_id| {
+            let def_info = &script.internal_symbols.symbol_definitions[local_index.0];
+            let shndx = match &def_info.placement {
+                crate::parsing::SymbolPlacement::Redirect(redirect)
+                    if let SymbolLoc::SectionEnd(section_id) = redirect.loc =>
+                {
+                    let section_id = layout.output_sections.primary_output_section(section_id);
+                    layout
+                        .output_sections
+                        .output_index_of_nearest_section(section_id)
+                }
+                _ => def_info.section_id().and_then(|section_id| {
                     let section_id = layout.output_sections.primary_output_section(section_id);
                     layout.output_sections.output_index_of_section(section_id)
-                })
-                .map_or(object::elf::SHN_ABS.into(), SymbolSection::Index);
+                }),
+            }
+            .map_or(object::elf::SHN_ABS.into(), SymbolSection::Index);
 
             Ok((shndx, object::elf::STT_NOTYPE))
         }
@@ -4668,30 +4677,32 @@ fn get_defsym_attributes(
         }
     } else {
         let shndx = match redirect.loc {
-            SymbolLoc::SectionStartRelative(os)
-            | SymbolLoc::SectionEndRelative(os)
-            | SymbolLoc::SectionEnd(os) => {
+            SymbolLoc::SectionEnd(os) => {
                 let os = layout.output_sections.primary_output_section(os);
-                layout
-                    .output_sections
-                    .output_index_of_section(os)
-                    .unwrap_or(0)
+                layout.output_sections.output_index_of_nearest_section(os)
             }
-            SymbolLoc::FirstSection => 1,
+            SymbolLoc::SectionStartRelative(os) | SymbolLoc::SectionEndRelative(os) => {
+                let os = layout.output_sections.primary_output_section(os);
+                layout.output_sections.output_index_of_section(os)
+            }
+            SymbolLoc::FirstSection => Some(1),
             SymbolLoc::LocationCounter(_, os) => {
                 if let Some(os) = os {
                     let os = layout.output_sections.primary_output_section(os);
-                    layout
-                        .output_sections
-                        .output_index_of_section(os)
-                        .unwrap_or(0)
+                    layout.output_sections.output_index_of_section(os)
                 } else {
-                    1
+                    Some(1)
                 }
             }
             SymbolLoc::None => return Ok((object::elf::SHN_ABS.into(), object::elf::STT_NOTYPE)),
         };
-        Ok((SymbolSection::Index(shndx), object::elf::STT_NOTYPE))
+        Ok((
+            shndx.map_or(
+                SymbolSection::Raw(object::elf::SHN_ABS),
+                SymbolSection::Index,
+            ),
+            object::elf::STT_NOTYPE,
+        ))
     }
 }
 

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -33,6 +33,7 @@ use crate::output_section_id::OutputSections;
 use crate::output_section_map::OutputSectionMap;
 use crate::output_section_part_map::OutputSectionPartMap;
 use crate::parsing::InternalSymDefInfo;
+use crate::parsing::Redirect;
 use crate::parsing::SymbolLoc;
 use crate::parsing::SymbolPlacement;
 use crate::part_id;
@@ -3534,9 +3535,20 @@ impl<'data, P: Platform> InternalSymbols<'data, P> {
                 continue;
             }
 
-            // Mark the section referenced by this symbol so that empty sections
-            // defined by the linker script are still emitted.
-            if let Some(section_id) = def_info.section_id() {
+            // Mark the section referenced by this symbol so that empty sections defined by the
+            // linker script are still emitted. Symbols defined within an output-section body keep
+            // that section alive. Symbols between output sections instead belong to the preceding
+            // emitted section, so they must not retain an otherwise discarded section.
+            let section_id = match &def_info.placement {
+                SymbolPlacement::Redirect(Redirect {
+                    loc:
+                        SymbolLoc::SectionStartRelative(section_id)
+                        | SymbolLoc::SectionEndRelative(section_id),
+                    ..
+                }) => Some(*section_id),
+                _ => None,
+            };
+            if let Some(section_id) = section_id {
                 resources
                     .must_keep_sections
                     .get(section_id)

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -999,6 +999,17 @@ impl<'data, P: Platform> OutputSections<'data, P> {
             .flatten()
     }
 
+    pub(crate) fn output_index_of_nearest_section(&self, id: OutputSectionId) -> Option<u32> {
+        let sections = self.output_section_indexes[..=id.as_usize()].iter().rev();
+
+        for section in sections {
+            if section.is_some() {
+                return *section;
+            }
+        }
+        None
+    }
+
     /// Returns whether we're going to emit the specified section.
     pub(crate) fn will_emit_section(&self, id: OutputSectionId) -> bool {
         self.output_index_of_section(id).is_some()

--- a/wild/tests/sources/elf/linker-script-symbols/linker-script-symbols.c
+++ b/wild/tests/sources/elf/linker-script-symbols/linker-script-symbols.c
@@ -1,6 +1,8 @@
 //#Config:default
 //#AugmentLinkerScript:script.ld
 //#Object:runtime.c
+//#NoSection:.rodata
+//#ExpectSym:value3
 
 //#Config:lto:default
 //#RequiresLinkerPlugin:true

--- a/wild/tests/sources/elf/linker-script-symbols/script.ld
+++ b/wild/tests/sources/elf/linker-script-symbols/script.ld
@@ -1,3 +1,15 @@
 PROVIDE(value1a = value1);
 PROVIDE(value2a = value2);
 PROVIDE(foo_alias = foo);
+
+SECTIONS {
+    .text : {
+        *(.text)
+    }
+
+    .rodata : {
+        *(.rodata)
+    }
+
+    value3 = .;
+}


### PR DESCRIPTION
When defining a symbol between two output sections in a linker script, the symbol should reference any preceding section before it, that is retained. An empty section that would otherwise get discarded shouldn't be retained.