### PR TITLE
feat: parse an optional comma after output sections in linker scripts

### DIFF
--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -1140,6 +1140,8 @@ fn parse_section_command<'input>(
     }
 
     skip_comments_and_whitespace(input)?;
+    opt(',').parse_next(input)?;
+    skip_comments_and_whitespace(input)?;
 
     Ok(SectionCommand::Section(Section {
         output_section_name: name,

--- a/wild/tests/sources/elf/linker-script/linker-script.ld
+++ b/wild/tests/sources/elf/linker-script/linker-script.ld
@@ -7,7 +7,7 @@ SECTIONS {
         start_aaa = .;
         KEEP(*(.data.aaa));
         end_bar = .;
-    }
+    },
     sections_end = 0xcdef;
 }
 defsym_start_aaa = start_aaa;


### PR DESCRIPTION
An output section's definition in a linker script may have a trailing comma.