### PR TITLE
port(MachO): Add `__const` section to output order

### DIFF
--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -812,9 +812,10 @@ impl platform::ProgramSegmentDef for ProgramSegmentDef {
         let mapped_segment = match section_id {
             output_section_id::FILE_HEADER => SegmentType::Text,
             output_section_id::LOAD_COMMANDS => SegmentType::LoadCommands,
-            output_section_id::TEXT | output_section_id::CSTRING | output_section_id::PLT_GOT => {
-                SegmentType::TextSections
-            }
+            output_section_id::TEXT
+            | output_section_id::CSTRING
+            | output_section_id::CONST
+            | output_section_id::PLT_GOT => SegmentType::TextSections,
             output_section_id::DATA => SegmentType::DataSections,
             output_section_id::GOT => SegmentType::DataConstSections,
             output_section_id::CHAINED_FIXUP_TABLE
@@ -1603,6 +1604,7 @@ impl platform::Platform for MachO {
         // Content of the sections (e.g. __text, __data).
         builder.add_section(output_section_id::TEXT);
         builder.add_section(output_section_id::CSTRING);
+        builder.add_section(output_section_id::CONST);
         builder.add_section(output_section_id::PLT_GOT);
         builder.add_section(output_section_id::DATA);
         builder.add_section(output_section_id::GOT);
@@ -1759,6 +1761,11 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         section_flags: macho::S_CSTRING_LITERALS.to_flags(),
         ..DEFAULT_DEFS
     };
+    defs[output_section_id::CONST.as_usize()] = BuiltInSectionDetails {
+        kind: SectionKind::Primary(SectionName(b"__const")),
+        section_flags: macho::S_REGULAR.to_flags(),
+        ..DEFAULT_DEFS
+    };
     defs[output_section_id::DATA.as_usize()] = BuiltInSectionDetails {
         kind: SectionKind::Primary(SectionName(b"__data")),
         section_flags: macho::S_REGULAR.to_flags(),
@@ -1806,6 +1813,7 @@ fn allocate_plt(memory_offsets: &mut OutputSectionPartMap<u64>) -> NonZeroU64 {
 const DEFAULT_SECTION_RULES: &[SectionRule<'static>] = &[
     SectionRule::exact_section_keep(b"__text", crate::output_section_id::TEXT),
     SectionRule::exact_section_keep(b"__cstring", crate::output_section_id::CSTRING),
+    SectionRule::exact_section_keep(b"__const", crate::output_section_id::CONST),
     SectionRule::exact_section_keep(b"__data", crate::output_section_id::DATA),
     // SectionRule::exact_section_keep(b"__compact_unwind", crate::output_section_id::EH_FRAME),
 ];

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -148,8 +148,9 @@ pub(crate) const NOTE_ABI_TAG: OutputSectionId = OutputSectionId::regular(13);
 pub(crate) const DATA_REL_RO: OutputSectionId = OutputSectionId::regular(14);
 // Mach-O specific sections
 pub(crate) const CSTRING: OutputSectionId = OutputSectionId::regular(15);
+pub(crate) const CONST: OutputSectionId = OutputSectionId::regular(16);
 
-pub(crate) const NUM_BUILT_IN_REGULAR_SECTIONS: usize = 16;
+pub(crate) const NUM_BUILT_IN_REGULAR_SECTIONS: usize = 17;
 
 #[derive(Debug)]
 pub(crate) struct OutputSections<'data, P: Platform> {

--- a/libwild/src/output_section_part_map.rs
+++ b/libwild/src/output_section_part_map.rs
@@ -227,7 +227,7 @@ fn test_merge_parts() {
     );
 
     // Subtract the Mach-O specific sections.
-    let num_regular_sections = output_sections.num_regular_sections() - 1;
+    let num_regular_sections = output_sections.num_regular_sections() - 2;
     let mut num_sections_with_17 = 0;
 
     let mut sum_of_1s = output_sections.new_section_map::<u32>();
@@ -239,6 +239,7 @@ fn test_merge_parts() {
     const SKIP_SECTIONS: &[OutputSectionId] = &[
         crate::part_id::UNMAPPED.output_section_id(),
         output_section_id::CSTRING,
+        output_section_id::CONST,
         output_section_id::LINK_EDIT_SEGMENT,
         output_section_id::LOAD_COMMANDS,
         output_section_id::CHAINED_FIXUP_TABLE,

--- a/wild/tests/sources/macho/archive/archive.c
+++ b/wild/tests/sources/macho/archive/archive.c
@@ -1,7 +1,6 @@
 //#Object:runtime.c
 //#Archive:from_archive.c
 //#ExpectSym:_main
-//#DiffIgnore:section.__const
 //#DiffIgnore:section.__unwind_info
 
 #include "../common/runtime.h"

--- a/wild/tests/sources/macho/fat/fat.c
+++ b/wild/tests/sources/macho/fat/fat.c
@@ -1,6 +1,5 @@
 //#AbstractConfig:default
 //#Object:runtime.c
-//#DiffIgnore:section.__const
 //#DiffIgnore:section.__unwind_info
 // TODO: Add support for fat objects to linker-diff.
 //#DiffEnabled:false

--- a/wild/tests/sources/macho/trivial-dynamic/trivial-dynamic.c
+++ b/wild/tests/sources/macho/trivial-dynamic/trivial-dynamic.c
@@ -2,7 +2,6 @@
 //#LinkerDriver:clang
 //#SoSingleLinker:lld
 //#DiffIgnore:section.__unwind_info
-//#DiffIgnore:section.__const
 
 //#Config:dylib:default
 //#TestUpdateInPlace:true

--- a/wild/tests/sources/macho/trivial-multiple/trivial-multiple.c
+++ b/wild/tests/sources/macho/trivial-multiple/trivial-multiple.c
@@ -2,7 +2,6 @@
 //#Object:lib.c
 //#ExpectSym:_main
 //#TestUpdateInPlace:true
-//#DiffIgnore:section.__const
 //#DiffIgnore:section.__unwind_info
 
 #include "../common/runtime.h"

--- a/wild/tests/sources/macho/trivial/trivial.c
+++ b/wild/tests/sources/macho/trivial/trivial.c
@@ -1,7 +1,6 @@
 //#Object:runtime.c
 //#ExpectSym:_main
 //#TestUpdateInPlace:true
-//#DiffIgnore:section.__const
 //#DiffIgnore:section.__unwind_info
 
 #include "../common/runtime.h"


### PR DESCRIPTION
From my understanding, it looks like Mach-O identifies sections by (segment name, section name). Currently, we resolve Mach-O input sections by only the section name, then map each resulting `OutputSectionId` to a fixed output segment. I was looking into implementing this but wasn’t sure whether we wanted to completely refactor this right now, so I submitted that as a separate issue here: #2248. 

For now, following the current implementation, I added `__const` as a section mapped to `__TEXT` and added this to the output order, since that’s what #2236’s code snippet produces. However, we should note that `__const` can actually be found in segments other than `__TEXT` (such as `__DATA_CONST`), which is why Mach-O identifies sections by segment name and section name. 

I also tried linking again with `tramp3d-v4.cpp` and got a similar error back: `wild: error: Internal error: Section 72 (__bss) has non-zero allocation, but isn't in output order`. It seems like we might be missing more sections, but I didn’t open an issue for this one since I think refactoring to support (segment name, section name) could potentially help here. 

For testing, I was manually able to test with the code snippet that `wild: error: Internal error: Section 67 (__const) has non-zero allocation, but isn't in output order` does not reappear with our fix. I also removed `//DiffIgnore:section.__const` in the Mach-O files.

Resolves #2236 
