### PR TITLE
fix: Error on R_AARCH64_ABS32/ABS16 against symbols in shared objects

### DIFF
--- a/libwild/src/elf_aarch64.rs
+++ b/libwild/src/elf_aarch64.rs
@@ -79,6 +79,13 @@ impl crate::platform::Arch for ElfAArch64 {
         )
     }
 
+    fn is_disallowed_in_shared_object(r_type: u32) -> bool {
+        matches!(
+            r_type,
+            object::elf::R_AARCH64_ABS32 | object::elf::R_AARCH64_ABS16
+        )
+    }
+
     fn get_dynamic_relocation_type(relocation: DynamicRelocationKind) -> u32 {
         relocation.aarch64_r_type()
     }

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -3013,13 +3013,7 @@ fn apply_relocation<
         }
         RelocationKind::Absolute
             if layout.symbol_db.output_kind.is_shared_object()
-                && matches!(
-                    r_type,
-                    object::elf::R_X86_64_32
-                        | object::elf::R_X86_64_32S
-                        | object::elf::R_X86_64_8
-                        | object::elf::R_X86_64_16
-                ) =>
+                && A::is_disallowed_in_shared_object(r_type) =>
         {
             bail!(
                 "relocation type {} cannot be used when making a shared object; \

--- a/libwild/src/elf_x86_64.rs
+++ b/libwild/src/elf_x86_64.rs
@@ -80,6 +80,16 @@ impl crate::platform::Arch for ElfX86_64 {
         )
     }
 
+    fn is_disallowed_in_shared_object(r_type: u32) -> bool {
+        matches!(
+            r_type,
+            object::elf::R_X86_64_32
+                | object::elf::R_X86_64_32S
+                | object::elf::R_X86_64_8
+                | object::elf::R_X86_64_16
+        )
+    }
+
     fn get_dynamic_relocation_type(relocation: DynamicRelocationKind) -> u32 {
         relocation.x86_64_r_type()
     }

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -132,6 +132,12 @@ pub(crate) trait Arch: Send + Sync + 'static {
         false
     }
 
+    /// Returns true if the given relocation type cannot be used when making a shared object,
+    /// regardless of whether the symbol is interposable. Default is false (allow).
+    fn is_disallowed_in_shared_object(_r_type: u32) -> bool {
+        false
+    }
+
     /// Uses debug info, if available, to get information about where in the source code a
     /// particular offset in a particular section came from.
     fn get_source_info<'data>(

--- a/wild/tests/sources/elf/aarch64-abs32-dyn/aarch64-abs32-dyn.s
+++ b/wild/tests/sources/elf/aarch64-abs32-dyn/aarch64-abs32-dyn.s
@@ -1,0 +1,10 @@
+//#Arch:aarch64
+//#Mode:dynamic
+//#LinkArgs:-shared --no-gc-sections
+//#ExpectError:R_AARCH64_ABS32
+//#ExpectErrorWild:R_AARCH64_ABS32.*cannot be used when making a shared object
+.globl hidden
+.hidden hidden
+hidden:
+.data
+.long hidden


### PR DESCRIPTION
Wild silently accepted R_AARCH64_ABS32 and R_AARCH64_ABS16 relocations when linking a shared object, producing a broken output -- these fields are too narrow to hold a runtime-resolved address.

This adds a check erroring with "recompile with -fPIC" when these relocation types are used against a shared object, matching lld and GNU ld's behavior.  implemented as a new is_disallowed_in_shared_object method on the Arch trait, shared between x86_64 and aarch64, rather than per-architecture matches in elf_writer.rs.

Issue #2247 