### PR TITLE
port(wasm): Support `--stack-first` for Wasm

### DIFF
--- a/libwild/src/args/wasm.rs
+++ b/libwild/src/args/wasm.rs
@@ -37,6 +37,7 @@ pub struct WasmArgs {
     pub(crate) lib_search_path: Vec<Box<Path>>,
     pub(crate) export_symbols: Vec<String>,
     pub(crate) z_stack_size: u32,
+    pub(crate) stack_first: bool,
 }
 
 impl WasmArgs {
@@ -55,6 +56,7 @@ impl Default for WasmArgs {
             lib_search_path: Vec::new(),
             export_symbols: Vec::new(),
             z_stack_size: DEFAULT_STACK_SIZE,
+            stack_first: false,
         }
     }
 }
@@ -219,6 +221,15 @@ fn setup_argument_parser() -> ArgumentParser<WasmArgs> {
         )
         .execute(|args, _modifier_stack, value| {
             args.warn_unsupported(&(format!("-z {value}")))?;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("stack-first")
+        .help("Place stack at start of linear memory rather than after data")
+        .execute(|args, _modifier_stack| {
+            args.stack_first = true;
             Ok(())
         });
 

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -1989,6 +1989,39 @@ fn stack_high_after_data(data_end: u32, stack_size: u32) -> Result<u32> {
         .ok_or_else(|| crate::error!("Wasm stack pointer overflow"))
 }
 
+/// Align the end of static data for `__heap_base`.
+fn heap_base_after_data(data_end: u32) -> Result<u32> {
+    u32::try_from(crate::alignment::STACK_ALIGNMENT.align_up(u64::from(data_end)))
+        .map_err(|_| crate::error!("Wasm heap base overflow"))
+}
+
+/// Initial `__stack_pointer` value for the chosen stack layout.
+fn stack_pointer_init(data_end: u32, stack_size: u32, stack_first: bool) -> Result<u32> {
+    ensure_stack_size_aligned(stack_size)?;
+    if stack_first {
+        Ok(stack_size)
+    } else {
+        stack_high_after_data(data_end, stack_size)
+    }
+}
+
+fn heap_base_address(data_end: u32, stack_size: u32, stack_first: bool) -> Result<u32> {
+    if stack_first {
+        heap_base_after_data(data_end)
+    } else {
+        stack_high_after_data(data_end, stack_size)
+    }
+}
+
+fn ensure_stack_size_aligned(stack_size: u32) -> Result {
+    let align = crate::alignment::STACK_ALIGNMENT.value();
+    ensure!(
+        u64::from(stack_size).is_multiple_of(align),
+        "stack size must be {align}-byte aligned"
+    );
+    Ok(())
+}
+
 fn layout_object_data<'data>(
     input: &WasmObjectLayoutInput<'data>,
     index_map: &WasmObjectIndexMap,
@@ -3322,11 +3355,11 @@ fn wasm_page_size() -> u64 {
 fn ensure_memory_covers(
     layout: &mut WasmLayout<'_>,
     stack_size: u32,
-    reserve_post_data_stack: bool,
+    stack_first: bool,
 ) -> Result<u64> {
     let page = wasm_page_size();
     let mut bytes_needed = u64::from(layout.data_end.max(layout.memory_base));
-    if reserve_post_data_stack && stack_size > 0 {
+    if !stack_first && stack_size > 0 {
         bytes_needed = bytes_needed.max(u64::from(stack_high_after_data(
             layout.data_end,
             stack_size,
@@ -3352,11 +3385,12 @@ fn fill_stack_pointer_init(
     layout: &mut WasmLayout<'_>,
     indices: &LinkerDefinedIndices,
     stack_size: u32,
+    stack_first: bool,
 ) -> Result {
     let Some(defined_slot) = indices.stack_pointer_defined_slot else {
         return Ok(());
     };
-    let sp = stack_high_after_data(layout.data_end, stack_size)?;
+    let sp = stack_pointer_init(layout.data_end, stack_size, stack_first)?;
     let global = layout
         .globals
         .get_mut(defined_slot as usize)
@@ -3625,6 +3659,11 @@ where
     };
 
     let linker_memory = any_object_needs_linker_memory(&layout_inputs);
+    let stack_size = symbol_db.args.z_stack_size;
+    let stack_first = symbol_db.args.stack_first;
+    if stack_size > 0 {
+        ensure_stack_size_aligned(stack_size)?;
+    }
     let mut layout = WasmLayout {
         memory_base: if linker_memory || indices.memory_base_global.is_some() {
             LINKER_MEMORY_BASE
@@ -3633,7 +3672,11 @@ where
         },
         ..WasmLayout::default()
     };
-    let mut memory_cursor = layout.memory_base;
+    let mut memory_cursor = if stack_first {
+        stack_size
+    } else {
+        layout.memory_base
+    };
     let mut section_cursor = 0u32;
     {
         timing_phase!("Merge Wasm object layouts");
@@ -3737,8 +3780,7 @@ where
             ensure_memory_export(&mut layout.exports);
         }
         layout.data_end = memory_cursor;
-        let stack_size = symbol_db.args.z_stack_size;
-        let initial_pages = ensure_memory_covers(&mut layout, stack_size, stack_size > 0)?;
+        let initial_pages = ensure_memory_covers(&mut layout, stack_size, stack_first)?;
         // wasm-ld only defines `__heap_end` when linear memory exists (end of `memory.initial`).
         let heap_end = if layout.memories.is_empty() {
             None
@@ -3754,8 +3796,9 @@ where
             layout.data_end,
             stack_size,
             heap_end,
+            stack_first,
         )?;
-        fill_stack_pointer_init(&mut layout, &indices, stack_size)?;
+        fill_stack_pointer_init(&mut layout, &indices, stack_size, stack_first)?;
         ensure_entry_export(
             &mut layout.exports,
             entry.as_ref(),
@@ -4016,10 +4059,11 @@ impl WasmLinkerSymbol {
         data_end: u32,
         stack_size: u32,
         heap_end: Option<u32>,
+        stack_first: bool,
     ) -> Result<Option<u32>> {
         Ok(match self {
             Self::DataEnd => Some(data_end),
-            Self::HeapBase => Some(stack_high_after_data(data_end, stack_size)?),
+            Self::HeapBase => Some(heap_base_address(data_end, stack_size, stack_first)?),
             Self::WasmFirstPageEnd => Some(u32::try_from(wasm_page_size())?),
             Self::HeapEnd => heap_end,
             Self::MemoryBase
@@ -4037,12 +4081,13 @@ fn linker_defined_data_symbol_address(
     data_end: u32,
     stack_size: u32,
     heap_end: Option<u32>,
+    stack_first: bool,
 ) -> Result<Option<LinkerDefinedDataAddress>> {
     let Some(sym) = WasmLinkerSymbol::parse_bytes(name) else {
         return Ok(None);
     };
     Ok(sym
-        .data_address(data_end, stack_size, heap_end)?
+        .data_address(data_end, stack_size, heap_end, stack_first)?
         .map(|address| LinkerDefinedDataAddress { address }))
 }
 
@@ -4055,6 +4100,7 @@ fn compute_data_addresses(
     data_end: u32,
     stack_size: u32,
     heap_end: Option<u32>,
+    stack_first: bool,
 ) -> Result {
     let file_id_to_index: HashMap<crate::input_data::FileId, usize> = layout_inputs
         .iter()
@@ -4097,7 +4143,8 @@ fn compute_data_addresses(
             if let Some(def_info) = symbol_db.prelude_symbol_def(def_id)
                 && let crate::parsing::SymbolPlacement::PlatformSpecific(known) =
                     &def_info.placement
-                && let Some(address) = known.data_address(data_end, stack_size, heap_end)?
+                && let Some(address) =
+                    known.data_address(data_end, stack_size, heap_end, stack_first)?
             {
                 data_addresses[sym_idx] = address;
             }
@@ -5000,6 +5047,7 @@ mod tests {
             data_end,
             DEFAULT_STACK_SIZE,
             Some(heap_end),
+            false,
         )
         .unwrap()
         .expect("__data_end");
@@ -5010,6 +5058,7 @@ mod tests {
             data_end,
             DEFAULT_STACK_SIZE,
             Some(heap_end),
+            false,
         )
         .unwrap()
         .expect("__heap_base");
@@ -5023,6 +5072,7 @@ mod tests {
             data_end,
             DEFAULT_STACK_SIZE,
             Some(heap_end),
+            false,
         )
         .unwrap()
         .expect("__wasm_first_page_end");
@@ -5033,6 +5083,7 @@ mod tests {
             data_end,
             DEFAULT_STACK_SIZE,
             Some(heap_end),
+            false,
         )
         .unwrap()
         .expect("__heap_end");
@@ -5042,9 +5093,15 @@ mod tests {
 
         // If there is no output memory, `__heap_end` is not synthesised.
         assert!(
-            linker_defined_data_symbol_address(b"__heap_end", data_end, DEFAULT_STACK_SIZE, None,)
-                .unwrap()
-                .is_none()
+            linker_defined_data_symbol_address(
+                b"__heap_end",
+                data_end,
+                DEFAULT_STACK_SIZE,
+                None,
+                false,
+            )
+            .unwrap()
+            .is_none()
         );
         assert!(
             linker_defined_data_symbol_address(
@@ -5052,10 +5109,46 @@ mod tests {
                 data_end,
                 DEFAULT_STACK_SIZE,
                 None,
+                false,
             )
             .unwrap()
             .is_some()
         );
+    }
+
+    #[test]
+    fn stack_first_heap_base_follows_data_not_stack() {
+        let data_end = 1_048_576 + 100;
+        let stack_size = 1_048_576u32;
+        let hb = linker_defined_data_symbol_address(
+            b"__heap_base",
+            data_end,
+            stack_size,
+            Some(2 * 65_536),
+            true,
+        )
+        .unwrap()
+        .expect("__heap_base");
+        assert_eq!(hb.address, heap_base_after_data(data_end).unwrap());
+        assert!(hb.address - data_end < 16);
+        // Without stack-first, heap would be roughly data_end + stack_size.
+        let post_data = stack_high_after_data(data_end, stack_size).unwrap();
+        assert!(post_data > hb.address + stack_size / 2);
+    }
+
+    #[test]
+    fn stack_pointer_init_stack_first_is_stack_size() {
+        let sp = stack_pointer_init(2_000_000, 1_048_576, true).unwrap();
+        assert_eq!(sp, 1_048_576);
+        let sp = stack_pointer_init(1024, DEFAULT_STACK_SIZE, false).unwrap();
+        assert_eq!(sp, stack_high_after_data(1024, DEFAULT_STACK_SIZE).unwrap());
+    }
+
+    #[test]
+    fn unaligned_stack_size_is_rejected() {
+        assert!(ensure_stack_size_aligned(1000).is_err());
+        assert!(ensure_stack_size_aligned(1024).is_ok());
+        assert!(stack_pointer_init(0, 1000, true).is_err());
     }
 
     #[test]
@@ -5083,11 +5176,11 @@ mod tests {
             ..Default::default()
         };
 
-        let pages = ensure_memory_covers(&mut layout, DEFAULT_STACK_SIZE, false).unwrap();
+        let pages = ensure_memory_covers(&mut layout, DEFAULT_STACK_SIZE, true).unwrap();
         assert_eq!(pages, 1);
         assert_eq!(layout.memories[0].initial, 1);
 
-        let pages = ensure_memory_covers(&mut layout, DEFAULT_STACK_SIZE, true).unwrap();
+        let pages = ensure_memory_covers(&mut layout, DEFAULT_STACK_SIZE, false).unwrap();
         let expected_pages = (u64::from(data_end) + u64::from(DEFAULT_STACK_SIZE))
             .div_ceil(wasm_page_size())
             .max(1);

--- a/wild/tests/sources/wasm/stack-first/stack-first.c
+++ b/wild/tests/sources/wasm/stack-first/stack-first.c
@@ -1,0 +1,28 @@
+//#LinkArgs: -z stack-size=1048576 --stack-first
+
+int payload[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+
+extern char __data_end;
+extern char __heap_base;
+
+void _start(void) {
+  unsigned long data_end = (unsigned long)&__data_end;
+  unsigned long heap_base = (unsigned long)&__heap_base;
+  unsigned long stack_size = 1048576;
+
+  // With --stack-first, static data starts at stack_size.
+  if (data_end <= stack_size) {
+    __builtin_trap();
+  }
+  // Heap immediately follows data (at most 16-byte alignment padding).
+  if (heap_base < data_end || heap_base > data_end + 16) {
+    __builtin_trap();
+  }
+  // payload must be reachable inside the data region.
+  if ((unsigned long)&payload[0] < stack_size) {
+    __builtin_trap();
+  }
+  if (payload[0] != 1 || payload[7] != 8) {
+    __builtin_trap();
+  }
+}

--- a/wild/tests/sources/wasm/stack-size/stack-size.c
+++ b/wild/tests/sources/wasm/stack-size/stack-size.c
@@ -1,4 +1,9 @@
+//#Config:stack-size
 //#LinkArgs: -z stack-size=1048576
+
+//#Config:invalid-stack-size
+//#LinkArgs:-z stack-size=3
+//#ExpectError: stack size must be 16-byte aligned
 
 extern char __data_end;
 extern char __heap_base;


### PR DESCRIPTION
This option is passed by rustc.

Part of #1431