### PR TITLE
refactor: use Platform::RelocationInfo for relocation types

### DIFF
--- a/libwild/src/dwarf_address_info.rs
+++ b/libwild/src/dwarf_address_info.rs
@@ -130,7 +130,10 @@ fn section_data_with_relocations<A: Arch<Platform = crate::elf::Elf>>(
     Ok(data)
 }
 
-fn apply_section_relocations<A: Arch<Platform = crate::elf::Elf>, R: Relocation>(
+fn apply_section_relocations<
+    A: Arch<Platform = crate::elf::Elf>,
+    R: Relocation<Platform = crate::elf::Elf>,
+>(
     object: &File<'_>,
     section_of_interest: &object::elf::SectionHeader64<LittleEndian>,
     section_data: &mut [u8],

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -196,6 +196,7 @@ pub(crate) struct File<'data> {
 
 impl Relocation for Rela {
     type Sequence<'data> = &'data [Rela];
+    type Platform = Elf;
 
     fn symbol(&self) -> Option<object::SymbolIndex> {
         object::read::elf::Rela::symbol(self, LittleEndian, false)
@@ -216,6 +217,7 @@ impl Relocation for Rela {
 
 impl Relocation for Crel {
     type Sequence<'data> = Vec<Crel>;
+    type Platform = Elf;
 
     fn symbol(&self) -> Option<object::SymbolIndex> {
         object::read::elf::Crel::symbol(self)
@@ -2834,7 +2836,12 @@ impl DynamicLayoutStateExt<'_> {
     }
 }
 
-fn process_eh_frame_relocations<'data, 'scope, A: Arch<Platform = Elf>, R: Relocation>(
+fn process_eh_frame_relocations<
+    'data,
+    'scope,
+    A: Arch<Platform = Elf>,
+    R: Relocation<Platform = Elf>,
+>(
     object: &mut layout::ObjectLayoutState<'data, Elf>,
     common: &mut layout::CommonGroupState<'data, Elf>,
     resources: &'scope layout::GraphResources<'data, '_, Elf>,
@@ -2970,7 +2977,12 @@ fn process_eh_frame_relocations<'data, 'scope, A: Arch<Platform = Elf>, R: Reloc
 }
 
 /// Processes the exception frames for a section that we're loading.
-fn process_section_exception_frames<'data, 'scope, A: Arch<Platform = Elf>, R: Relocation>(
+fn process_section_exception_frames<
+    'data,
+    'scope,
+    A: Arch<Platform = Elf>,
+    R: Relocation<Platform = Elf>,
+>(
     object: &layout::ObjectLayoutState<'data, Elf>,
     frame_index: Option<FrameIndex>,
     common: &mut layout::CommonGroupState<'data, Elf>,
@@ -5054,7 +5066,12 @@ pub(crate) struct DynamicSymbolDefinitionExt {
     pub(crate) version: object::elf::VersymIndex,
 }
 
-fn load_section_relocations<'scope, 'data, A: Arch<Platform = Elf>, R: Relocation>(
+fn load_section_relocations<
+    'scope,
+    'data,
+    A: Arch<Platform = Elf>,
+    R: Relocation<Platform = Elf>,
+>(
     state: &layout::ObjectLayoutState<'data, Elf>,
     common: &mut CommonGroupState<'data, Elf>,
     queue: &mut layout::LocalWorkQueue,
@@ -5218,7 +5235,7 @@ impl RelrEncoder {
 }
 
 #[inline(always)]
-fn process_relocation<'data, 'scope, A: Arch<Platform = Elf>, R: Relocation>(
+fn process_relocation<'data, 'scope, A: Arch<Platform = Elf>, R: Relocation<Platform = Elf>>(
     object: &ObjectLayoutState<'data, Elf>,
     common: &mut CommonGroupState<'data, Elf>,
     rel: &R,

--- a/libwild/src/elf_riscv64.rs
+++ b/libwild/src/elf_riscv64.rs
@@ -389,7 +389,7 @@ impl crate::platform::Relaxation for Relaxation {
 /// `section_output_address` is the output address of the section being scanned. `existing_deltas`,
 /// if present, is used to skip calls that were already relaxed in a previous pass. `resolve_symbol`
 /// returns the output address and interposability of a symbol.
-fn collect_relaxation_deltas<R: Relocation>(
+fn collect_relaxation_deltas<R: Relocation<Platform = Elf>>(
     section_output_address: u64,
     section_bytes: &[u8],
     relocations: impl Iterator<Item = R>,

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2353,7 +2353,7 @@ fn write_symbols<'data>(
 fn apply_relocations<
     'data,
     A: Arch<Platform = Elf>,
-    R: Relocation,
+    R: Relocation<Platform = Elf>,
     I: Iterator<Item = object::Result<R>> + Clone,
 >(
     object: &ObjectLayout<'data, Elf>,
@@ -2439,7 +2439,7 @@ fn apply_relocations<
 pub(crate) fn apply_debug_relocations<
     'data,
     A: Arch<Platform = Elf>,
-    R: Relocation,
+    R: Relocation<Platform = Elf>,
     I: Iterator<Item = object::Result<R>> + Clone,
 >(
     object: &ObjectLayout<'data, Elf>,
@@ -2526,7 +2526,7 @@ fn write_eh_frame_data<'data, A: Arch<Platform = Elf>>(
     }
 }
 
-fn write_eh_frame_relocations<'data, A: Arch<Platform = Elf>, R: Relocation>(
+fn write_eh_frame_relocations<'data, A: Arch<Platform = Elf>, R: Relocation<Platform = Elf>>(
     object: &ObjectLayout<'data, Elf>,
     layout: &ElfLayout<'data>,
     table_writer: &mut TableWriter<'_, '_>,
@@ -2725,7 +2725,7 @@ struct DisplayRelocation<'a, 'data, A: Arch<Platform = Elf>, R: Relocation> {
     phantom: PhantomData<A>,
 }
 
-impl<'a, 'data, A: Arch<Platform = Elf>, R: Relocation> Display
+impl<'a, 'data, A: Arch<Platform = Elf>, R: Relocation<Platform = Elf>> Display
     for DisplayRelocation<'a, 'data, A, R>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -2912,7 +2912,11 @@ fn adjust_relocation_based_on_value(
 }
 
 #[inline(always)]
-fn get_pair_subtraction_relocation_value<'data, A: Arch<Platform = Elf>, R: Relocation>(
+fn get_pair_subtraction_relocation_value<
+    'data,
+    A: Arch<Platform = Elf>,
+    R: Relocation<Platform = Elf>,
+>(
     object_layout: &ObjectLayout<'data, Elf>,
     rel: &R,
     layout: &ElfLayout,
@@ -2960,7 +2964,7 @@ fn get_pair_subtraction_relocation_value<'data, A: Arch<Platform = Elf>, R: Relo
 fn apply_relocation<
     'data,
     A: Arch<Platform = Elf>,
-    R: Relocation,
+    R: Relocation<Platform = Elf>,
     I: Iterator<Item = object::Result<R>> + Clone,
 >(
     object_layout: &ObjectLayout<'data, Elf>,
@@ -3544,7 +3548,7 @@ fn maybe_get_thunk_for_relocation<A: Arch<Platform = Elf>>(
     );
 }
 
-fn apply_debug_relocation<'data, A: Arch<Platform = Elf>, R: Relocation>(
+fn apply_debug_relocation<'data, A: Arch<Platform = Elf>, R: Relocation<Platform = Elf>>(
     object_layout: &ObjectLayout<'data, Elf>,
     offset_in_section: u64,
     rel: &R,

--- a/libwild/src/macho_aarch64.rs
+++ b/libwild/src/macho_aarch64.rs
@@ -64,7 +64,9 @@ impl crate::platform::Arch for MachOAArch64 {
         todo!()
     }
 
-    fn get_dynamic_relocation_type(relocation: linker_utils::elf::DynamicRelocationKind) -> u32 {
+    fn get_dynamic_relocation_type(
+        relocation: linker_utils::elf::DynamicRelocationKind,
+    ) -> object::macho::RelocationInfo {
         todo!()
     }
 
@@ -172,8 +174,9 @@ impl crate::platform::Arch for MachOAArch64 {
         })
     }
 
-    fn rel_type_to_string(r_type: u32) -> Cow<'static, str> {
-        if let Some(name) = object::macho::NAMES_ARM64_RELOC.name(r_type as u8) {
+    fn rel_type_to_string(info: object::macho::RelocationInfo) -> Cow<'static, str> {
+        let r_type = info.r_type;
+        if let Some(name) = object::macho::NAMES_ARM64_RELOC.name(r_type) {
             Cow::Borrowed(name)
         } else {
             Cow::Owned(format!("Unknown arm64 relocation type 0x{r_type:x}"))
@@ -192,7 +195,7 @@ impl crate::platform::Arch for MachOAArch64 {
         todo!()
     }
 
-    fn high_part_relocations() -> &'static [u32] {
+    fn high_part_relocations() -> &'static [object::macho::RelocationInfo] {
         todo!()
     }
 
@@ -206,7 +209,7 @@ impl crate::platform::Arch for MachOAArch64 {
     }
 
     fn new_relaxation(
-        relocation_kind: u32,
+        relocation_kind: object::macho::RelocationInfo,
         section_bytes: &[u8],
         offset_in_section: u64,
         flags: crate::value_flags::ValueFlags,

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -665,7 +665,7 @@ fn apply_relocation<'data, A: Arch<Platform = MachO>>(
         .with_context(|| {
             format!(
                 "Failed to apply relocation {} to {}",
-                A::rel_type_to_string(rel.r_type.into()),
+                A::rel_type_to_string(rel),
                 layout.symbol_debug(local_symbol_id)
             )
         })?;

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -85,7 +85,9 @@ pub(crate) trait Arch: Send + Sync + 'static {
     fn arch_identifier() -> <Self::Platform as Platform>::ArchIdentifier;
 
     /// Get dynamic relocation value specific for the architecture.
-    fn get_dynamic_relocation_type(relocation: DynamicRelocationKind) -> u32;
+    fn get_dynamic_relocation_type(
+        relocation: DynamicRelocationKind,
+    ) -> <Self::Platform as Platform>::RelocationInfo;
 
     /// Write PLT entry for the architecture.
     fn write_plt_entry(plt_entry: &mut [u8], got_address: u64, plt_address: u64) -> Result;
@@ -96,7 +98,9 @@ pub(crate) trait Arch: Send + Sync + 'static {
     ) -> Result<RelocationKindInfo>;
 
     /// Get string representation of a relocation specific for the architecture.
-    fn rel_type_to_string(r_type: u32) -> Cow<'static, str>;
+    fn rel_type_to_string(
+        r_type: <Self::Platform as Platform>::RelocationInfo,
+    ) -> Cow<'static, str>;
 
     /// Get DTV OFFSET.
     fn get_dtv_offset() -> u64 {
@@ -118,7 +122,7 @@ pub(crate) trait Arch: Send + Sync + 'static {
     ) -> Result<<Self::Platform as Platform>::FileFlags>;
 
     /// A list of high-part relocations that need to be tracked in a relocation cache
-    fn high_part_relocations() -> &'static [u32];
+    fn high_part_relocations() -> &'static [<Self::Platform as Platform>::RelocationInfo];
 
     /// Whether the platform supports relaxations that reduce the sizes of function.
     fn supports_size_reduction_relaxations() -> bool {
@@ -128,7 +132,7 @@ pub(crate) trait Arch: Send + Sync + 'static {
     /// Returns true if the given relocation type cannot be used when making a shared object.
     /// On 64-bit architectures, sub-pointer-size absolute relocations cannot be represented
     /// as dynamic relocations and must be rejected. Default is false (allow).
-    fn is_illegal_in_shared_object(_r_type: u32) -> bool {
+    fn is_illegal_in_shared_object(_r_type: <Self::Platform as Platform>::RelocationInfo) -> bool {
         false
     }
 
@@ -176,7 +180,7 @@ pub(crate) trait Arch: Send + Sync + 'static {
     /// Tries to create a relaxation for the relocation of the specified kind, to be applied at the
     /// specified offset in the supplied section.
     fn new_relaxation(
-        relocation_kind: u32,
+        relocation_kind: <Self::Platform as Platform>::RelocationInfo,
         section_bytes: &[u8],
         offset_in_section: u64,
         flags: ValueFlags,
@@ -1170,11 +1174,12 @@ pub(crate) struct CommonSymbol {
 }
 
 pub(crate) trait Relocation: Send + Sync + Copy + 'static {
-    type Sequence<'data>: RelocationSequence<'data>;
+    type Sequence<'data>: RelocationSequence<'data, Rel = Self>;
+    type Platform: Platform;
 
     fn symbol(&self) -> Option<object::SymbolIndex>;
 
-    fn raw_type(&self) -> u32;
+    fn raw_type(&self) -> <Self::Platform as Platform>::RelocationInfo;
 
     fn offset(&self) -> u64;
 


### PR DESCRIPTION
Make the `Relocation` trait generic over the platform and replace relocation type values with `Platform::RelocationInfo` instead of `u32`.

This is preparation for updating the `object` crate to use newtypes for relocation types. For ELF, the u32 will become `object::elf::RelocationType`.

Mach-O is already using `object::macho::RelocationInfo`. There will be a new `object::macho::RelocationType` as well, but it's simpler to use `Platform::RelocationInfo` everywhere rather than adding a new associated type.