### PR TITLE
port(wasm): Support `--entry` / `--no-entry`

### DIFF
--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -1914,14 +1914,16 @@ impl platform::Args for ElfArgs {
         &self.wrap
     }
 
-    fn entry_symbol_name<'a>(&'a self, linker_script_entry: Option<&'a [u8]>) -> &'a [u8] {
+    fn entry_symbol_name<'a>(&'a self, linker_script_entry: Option<&'a [u8]>) -> Option<&'a [u8]> {
         // The --entry flag is used first, falling back to what the linker script says, or otherwise
         // defaults to `_start`.
-        self.entry
-            .as_ref()
-            .map(|n| n.as_bytes())
-            .or(linker_script_entry)
-            .unwrap_or(b"_start")
+        Some(
+            self.entry
+                .as_ref()
+                .map(|n| n.as_bytes())
+                .or(linker_script_entry)
+                .unwrap_or(b"_start"),
+        )
     }
 
     fn start_address_for_section(&self, section_name: SectionName) -> Option<u64> {

--- a/libwild/src/args/macho.rs
+++ b/libwild/src/args/macho.rs
@@ -108,9 +108,9 @@ impl platform::Args for MachOArgs {
         false
     }
 
-    fn entry_symbol_name<'a>(&'a self, _linker_script_entry: Option<&'a [u8]>) -> &'a [u8] {
+    fn entry_symbol_name<'a>(&'a self, _linker_script_entry: Option<&'a [u8]>) -> Option<&'a [u8]> {
         // TODO: probably add option
-        b"_main"
+        Some(b"_main")
     }
 
     fn lib_search_path(&self) -> &[Box<std::path::Path>] {

--- a/libwild/src/args/wasm.rs
+++ b/libwild/src/args/wasm.rs
@@ -31,6 +31,9 @@ pub(crate) const WASM_PAGE_SIZE: u64 = WASM_PAGE_ALIGNMENT.value();
 /// Default main stack size.
 pub(crate) const DEFAULT_STACK_SIZE: u32 = 64 * 1024;
 
+/// Default entry symbol for Wasm command modules.
+pub(crate) const DEFAULT_ENTRY: &str = "_start";
+
 #[derive(Debug)]
 pub struct WasmArgs {
     pub(crate) common: super::CommonArgs,
@@ -38,6 +41,8 @@ pub struct WasmArgs {
     pub(crate) export_symbols: Vec<String>,
     pub(crate) z_stack_size: u32,
     pub(crate) stack_first: bool,
+    // Entry symbol name. Defaults to `DEFAULT_ENTRY`.
+    pub(crate) entry: Option<String>,
 }
 
 impl WasmArgs {
@@ -57,6 +62,7 @@ impl Default for WasmArgs {
             export_symbols: Vec::new(),
             z_stack_size: DEFAULT_STACK_SIZE,
             stack_first: false,
+            entry: Some(DEFAULT_ENTRY.to_owned()),
         }
     }
 }
@@ -78,10 +84,8 @@ impl platform::Args for WasmArgs {
         false
     }
 
-    fn entry_symbol_name<'a>(&'a self, linker_script_entry: Option<&'a [u8]>) -> &'a [u8] {
-        // TODO: probably add option. wasm-ld defaults to `_start` for command
-        // modules and no entry for reactor modules.
-        b"_start"
+    fn entry_symbol_name<'a>(&'a self, _linker_script_entry: Option<&'a [u8]>) -> &'a [u8] {
+        self.entry.as_deref().map_or(b"", str::as_bytes)
     }
 
     fn force_export_symbol_names(&self) -> &[String] {
@@ -202,6 +206,25 @@ fn setup_argument_parser() -> ArgumentParser<WasmArgs> {
         .help("Force a symbol to be exported")
         .execute(|args, _modifier_stack, value| {
             args.export_symbols.push(value.to_owned());
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("no-entry")
+        .help("Do not output any entry point (reactor module)")
+        .execute(|args, _modifier_stack| {
+            args.entry = None;
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("entry")
+        .short("e")
+        .help("Name of entry point symbol")
+        .execute(|args, _modifier_stack, value| {
+            args.entry = Some(value.to_owned());
             Ok(())
         });
 

--- a/libwild/src/args/wasm.rs
+++ b/libwild/src/args/wasm.rs
@@ -84,8 +84,8 @@ impl platform::Args for WasmArgs {
         false
     }
 
-    fn entry_symbol_name<'a>(&'a self, _linker_script_entry: Option<&'a [u8]>) -> &'a [u8] {
-        self.entry.as_deref().map_or(b"", str::as_bytes)
+    fn entry_symbol_name<'a>(&'a self, _linker_script_entry: Option<&'a [u8]>) -> Option<&'a [u8]> {
+        self.entry.as_deref().map(str::as_bytes)
     }
 
     fn force_export_symbol_names(&self) -> &[String] {

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -3144,12 +3144,12 @@ impl<'data, P: Platform> PreludeLayoutState<'data, P> {
         queue: &mut LocalWorkQueue,
         scope: &Scope<'scope>,
     ) {
-        let Some(symbol_id) =
-            resources
-                .symbol_db
-                .get_unversioned(&UnversionedSymbolName::prehashed(
-                    resources.symbol_db.entry_symbol_name(),
-                ))
+        let Some(entry_name) = resources.symbol_db.entry_symbol_name() else {
+            return;
+        };
+        let Some(symbol_id) = resources
+            .symbol_db
+            .get_unversioned(&UnversionedSymbolName::prehashed(entry_name))
         else {
             // We'll emit a warning when writing the file if it's an executable.
             return;

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -1360,7 +1360,7 @@ pub(crate) trait Args: std::fmt::Debug + Send + Sync + 'static {
         &[]
     }
 
-    fn entry_symbol_name<'a>(&'a self, linker_script_entry: Option<&'a [u8]>) -> &'a [u8];
+    fn entry_symbol_name<'a>(&'a self, linker_script_entry: Option<&'a [u8]>) -> Option<&'a [u8]>;
 
     fn version_script_path(&self) -> Option<&Path> {
         None

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -940,19 +940,16 @@ fn load_prelude<'scope, 'data, P: Platform>(
 ) {
     // The start symbol could be defined within an archive entry. If it is, then we need to load
     // it. We don't currently store the resulting SymbolId, but instead look it up again during
-    // layout.
-    let symbol_id = load_symbol_named(
-        resources,
-        &mut SymbolId::undefined(),
-        resources.symbol_db.entry_symbol_name(),
-        scope,
-    );
+    // layout. Skip when there is no entry (e.g. Wasm `--no-entry`).
+    if let Some(entry_name) = resources.symbol_db.entry_symbol_name() {
+        let symbol_id = load_symbol_named(resources, &mut SymbolId::undefined(), entry_name, scope);
 
-    if let Some(symbol_id) = symbol_id {
-        resources
-            .per_symbol_flags
-            .get_atomic(symbol_id)
-            .fetch_or(ValueFlags::HAS_NON_IR_REF);
+        if let Some(symbol_id) = symbol_id {
+            resources
+                .per_symbol_flags
+                .get_atomic(symbol_id)
+                .fetch_or(ValueFlags::HAS_NON_IR_REF);
+        }
     }
 
     // Try to resolve any symbols that the user requested be undefined (e.g. via --undefined). If an

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -944,7 +944,7 @@ impl<'data, P: Platform> SymbolDb<'data, P> {
         header.is_group()
     }
 
-    pub(crate) fn entry_symbol_name(&self) -> &[u8] {
+    pub(crate) fn entry_symbol_name(&self) -> Option<&[u8]> {
         self.args.entry_symbol_name(self.entry)
     }
 

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -3503,10 +3503,14 @@ fn resolve_entry_function<'data>(
     let Some(entry_name_bytes) = symbol_db.entry_symbol_name() else {
         return Ok(None);
     };
+    let entry_display = String::from_utf8_lossy(entry_name_bytes);
+    let not_defined =
+        || crate::error!("entry symbol not defined (pass --no-entry to suppress): {entry_display}");
+
     let Some(symbol_id) =
         symbol_db.get_unversioned(&UnversionedSymbolName::prehashed(entry_name_bytes))
     else {
-        return Ok(None);
+        return Err(not_defined());
     };
     let def_id = symbol_db.definition(symbol_id);
     let def_file_id = symbol_db.file_id_for_symbol(def_id);
@@ -3515,12 +3519,12 @@ fn resolve_entry_function<'data>(
         .iter()
         .position(|input| input.file_id == def_file_id)
     else {
-        return Ok(None);
+        return Err(not_defined());
     };
     let def_input = &layout_inputs[def_obj_idx];
     let def_sym = &def_input.symbols[def_input.symbol_id_range.id_to_offset(def_id)];
     if def_sym.is_undefined() || def_sym.kind != WasmSymbolKind::Func {
-        return Ok(None);
+        return Err(not_defined());
     }
 
     let index_map = object_index_maps

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -2973,7 +2973,9 @@ fn entry_is_defined_function(
     layout_inputs: &[WasmObjectLayoutInput<'_>],
     symbol_db: &SymbolDb<'_, Wasm>,
 ) -> bool {
-    let entry_name = symbol_db.entry_symbol_name();
+    let Some(entry_name) = symbol_db.entry_symbol_name() else {
+        return false;
+    };
     let Some(symbol_id) = symbol_db.get_unversioned(&UnversionedSymbolName::prehashed(entry_name))
     else {
         return false;
@@ -3498,7 +3500,9 @@ fn resolve_entry_function<'data>(
     object_index_maps: &[WasmObjectIndexMap],
     symbol_db: &SymbolDb<'data, Wasm>,
 ) -> Result<Option<ResolvedEntry<'data>>> {
-    let entry_name_bytes = symbol_db.entry_symbol_name();
+    let Some(entry_name_bytes) = symbol_db.entry_symbol_name() else {
+        return Ok(None);
+    };
     let Some(symbol_id) =
         symbol_db.get_unversioned(&UnversionedSymbolName::prehashed(entry_name_bytes))
     else {

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -3887,15 +3887,15 @@ impl LinkCommand {
                             }
                         }
                         PlatformKind::Wasm => {
-                            // TODO(wasm): Drop once Wild accepts the same flags as wasm-ld.
                             let primary_wat = config
                                 .test_src_dir
                                 .join(format!("{}.wat", config.test_name));
-                            if !linker.is_wild() && primary_wat.exists() {
-                                command
-                                    .arg("--no-entry")
-                                    .arg("--export-all")
-                                    .arg("--no-check-features");
+                            if primary_wat.exists() {
+                                command.arg("--no-entry");
+                                if !linker.is_wild() {
+                                    // TODO(wasm): Support these options
+                                    command.arg("--export-all").arg("--no-check-features");
+                                }
                             }
                         }
                     }

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -505,193 +505,183 @@ fn for_each_test_dir(platform_name: &str, mut cb: impl FnMut(&str, PathBuf) -> R
     Ok(())
 }
 
-/// Section names present in a Wasm module for `ExpectSection` / `NoSection`.
-fn wasm_section_names(wasm_file: &Path) -> Result<HashSet<String>> {
-    use wasmparser::Parser;
-    use wasmparser::Payload;
-
-    let bytes = std::fs::read(wasm_file)
-        .with_context(|| format!("Failed to read wasm file {}", wasm_file.display()))?;
-    let mut sections = HashSet::new();
-    for payload in Parser::new(0).parse_all(&bytes) {
-        match payload? {
-            Payload::TypeSection(_) => {
-                sections.insert("Type".to_owned());
-            }
-            Payload::ImportSection(_) => {
-                sections.insert("Import".to_owned());
-            }
-            Payload::FunctionSection(_) => {
-                sections.insert("Function".to_owned());
-            }
-            Payload::TableSection(_) => {
-                sections.insert("Table".to_owned());
-            }
-            Payload::MemorySection(_) => {
-                sections.insert("Memory".to_owned());
-            }
-            Payload::GlobalSection(_) => {
-                sections.insert("Global".to_owned());
-            }
-            Payload::ExportSection(_) => {
-                sections.insert("Export".to_owned());
-            }
-            Payload::StartSection { .. } => {
-                sections.insert("Start".to_owned());
-            }
-            Payload::ElementSection(_) => {
-                sections.insert("Element".to_owned());
-            }
-            Payload::CodeSectionStart { .. } => {
-                sections.insert("Code".to_owned());
-            }
-            Payload::DataSection(_) => {
-                sections.insert("Data".to_owned());
-            }
-            Payload::DataCountSection { .. } => {
-                sections.insert("DataCount".to_owned());
-            }
-            Payload::CustomSection(reader) => {
-                sections.insert(reader.name().to_owned());
-            }
-            _ => {}
-        }
-    }
-    Ok(sections)
+struct WasmModuleInfo {
+    path: PathBuf,
+    bytes: Vec<u8>,
+    section_names: HashSet<String>,
+    export_names: HashSet<String>,
+    func_types: Vec<wasmparser::FuncType>,
 }
 
-fn wasm_export_names(wasm_file: &Path) -> Result<HashSet<String>> {
-    use wasmparser::Parser;
-    use wasmparser::Payload;
+impl WasmModuleInfo {
+    fn parse(path: &Path) -> Result<Self> {
+        use wasmparser::CompositeInnerType;
+        use wasmparser::Parser;
+        use wasmparser::Payload;
 
-    let bytes = std::fs::read(wasm_file)
-        .with_context(|| format!("Failed to read Wasm file {}", wasm_file.display()))?;
-    let mut exports = HashSet::new();
-    for payload in Parser::new(0).parse_all(&bytes) {
-        let Payload::ExportSection(section) = payload? else {
-            continue;
-        };
-        for export in section {
-            let export = export
-                .with_context(|| format!("Invalid export entry in {}", wasm_file.display()))?;
-            exports.insert(export.name.to_owned());
-        }
-    }
-    Ok(exports)
-}
+        let bytes = std::fs::read(path)
+            .with_context(|| format!("Failed to read Wasm file {}", path.display()))?;
+        let mut section_names = HashSet::new();
+        let mut export_names = HashSet::new();
+        let mut func_types = Vec::new();
 
-fn ensure_wasm_exports(
-    wasm_file: &Path,
-    expected: &[ExpectedSymtabEntry],
-    absent: &HashSet<String>,
-    linker_name: &str,
-) -> Result<()> {
-    for exp in expected {
-        ensure!(
-            exp.assertions == SymtabAssertions::default(),
-            "Symbol property assertions are not supported for Wasm (on `{}`)",
-            exp.name
-        );
-    }
-
-    let exports = wasm_export_names(wasm_file)?;
-    let format_exports = || {
-        let mut names: Vec<_> = exports.iter().cloned().collect();
-        names.sort();
-        names.join(", ")
-    };
-
-    for exp in expected {
-        ensure!(
-            exports.contains(&exp.name),
-            "Expected export `{}` in {linker_name} output ({}), found: [{}]",
-            exp.name,
-            wasm_file.display(),
-            format_exports()
-        );
-    }
-    for name in absent {
-        ensure!(
-            !exports.contains(name),
-            "Export `{name}` should not exist in {linker_name} output ({}), found: [{}]",
-            wasm_file.display(),
-            format_exports()
-        );
-    }
-    Ok(())
-}
-
-fn ensure_wasm_sections(
-    wasm_file: &Path,
-    section_names: &[String],
-    linker_name: &str,
-) -> Result<()> {
-    let sections = wasm_section_names(wasm_file)?;
-    for section_name in section_names {
-        ensure!(
-            sections.contains(section_name),
-            "Expected section `{section_name}` in {linker_name} output ({}), found: {}",
-            wasm_file.display(),
-            {
-                let mut names: Vec<_> = sections.iter().cloned().collect();
-                names.sort();
-                names.join(", ")
-            }
-        );
-    }
-    Ok(())
-}
-
-/// Collect function types from a linked Wasm module's type section, in section order.
-fn wasm_func_types(wasm_file: &Path) -> Result<Vec<wasmparser::FuncType>> {
-    use wasmparser::CompositeInnerType;
-    use wasmparser::Parser;
-    use wasmparser::Payload;
-
-    let bytes = std::fs::read(wasm_file)
-        .with_context(|| format!("Failed to read wasm file {}", wasm_file.display()))?;
-    let mut types = Vec::new();
-    for payload in Parser::new(0).parse_all(&bytes) {
-        let Payload::TypeSection(section) = payload? else {
-            continue;
-        };
-        for group in section {
-            for ty in group
-                .with_context(|| format!("Invalid type group in {}", wasm_file.display()))?
-                .into_types()
-            {
-                match ty.composite_type.inner {
-                    CompositeInnerType::Func(func) => types.push(func),
-                    other => bail!(
-                        "Unsupported non-function type in {}: {other:?}",
-                        wasm_file.display()
-                    ),
+        for payload in Parser::new(0).parse_all(&bytes) {
+            match payload? {
+                Payload::TypeSection(section) => {
+                    section_names.insert("Type".to_owned());
+                    for group in section {
+                        for ty in group
+                            .with_context(|| format!("Invalid type group in {}", path.display()))?
+                            .into_types()
+                        {
+                            match ty.composite_type.inner {
+                                CompositeInnerType::Func(func) => func_types.push(func),
+                                other => bail!(
+                                    "Unsupported non-function type in {}: {other:?}",
+                                    path.display()
+                                ),
+                            }
+                        }
+                    }
                 }
+                Payload::ImportSection(_) => {
+                    section_names.insert("Import".to_owned());
+                }
+                Payload::FunctionSection(_) => {
+                    section_names.insert("Function".to_owned());
+                }
+                Payload::TableSection(_) => {
+                    section_names.insert("Table".to_owned());
+                }
+                Payload::MemorySection(_) => {
+                    section_names.insert("Memory".to_owned());
+                }
+                Payload::GlobalSection(_) => {
+                    section_names.insert("Global".to_owned());
+                }
+                Payload::ExportSection(section) => {
+                    section_names.insert("Export".to_owned());
+                    for export in section {
+                        let export = export.with_context(|| {
+                            format!("Invalid export entry in {}", path.display())
+                        })?;
+                        export_names.insert(export.name.to_owned());
+                    }
+                }
+                Payload::StartSection { .. } => {
+                    section_names.insert("Start".to_owned());
+                }
+                Payload::ElementSection(_) => {
+                    section_names.insert("Element".to_owned());
+                }
+                Payload::CodeSectionStart { .. } => {
+                    section_names.insert("Code".to_owned());
+                }
+                Payload::DataSection(_) => {
+                    section_names.insert("Data".to_owned());
+                }
+                Payload::DataCountSection { .. } => {
+                    section_names.insert("DataCount".to_owned());
+                }
+                Payload::CustomSection(reader) => {
+                    section_names.insert(reader.name().to_owned());
+                }
+                _ => {}
             }
         }
-    }
-    Ok(types)
-}
 
-/// Linked modules must not repeat identical function types.
-fn ensure_wasm_func_types_unique(wasm_file: &Path, linker_name: &str) -> Result {
-    let types = wasm_func_types(wasm_file)?;
-    let mut seen = HashSet::new();
-    for (index, ty) in types.iter().enumerate() {
-        ensure!(
-            seen.insert(ty.clone()),
-            "Duplicate Wasm function type at type index {index} in {linker_name} output ({}): {ty}\n\
-             All entries: [{}]",
-            wasm_file.display(),
-            types
-                .iter()
-                .enumerate()
-                .map(|(i, t)| format!("{i}:{t}"))
-                .collect::<Vec<_>>()
-                .join(", ")
-        );
+        Ok(Self {
+            path: path.to_owned(),
+            bytes,
+            section_names,
+            export_names,
+            func_types,
+        })
     }
-    Ok(())
+
+    fn format_sorted(names: &HashSet<String>) -> String {
+        let mut sorted: Vec<_> = names.iter().cloned().collect();
+        sorted.sort();
+        sorted.join(", ")
+    }
+
+    fn ensure_sections(&self, expected: &[String], linker_name: &str) -> Result {
+        for section_name in expected {
+            ensure!(
+                self.section_names.contains(section_name),
+                "Expected section `{section_name}` in {linker_name} output ({}), found: {}",
+                self.path.display(),
+                Self::format_sorted(&self.section_names)
+            );
+        }
+        Ok(())
+    }
+
+    fn ensure_absent_sections(&self, absent: &[String], linker_name: &str) -> Result {
+        for name in absent {
+            ensure!(
+                !self.section_names.contains(name),
+                "Section `{name}` should not exist but was found in {linker_name} output ({})",
+                self.path.display()
+            );
+        }
+        Ok(())
+    }
+
+    fn ensure_exports(
+        &self,
+        expected: &[ExpectedSymtabEntry],
+        absent: &HashSet<String>,
+        linker_name: &str,
+    ) -> Result {
+        for exp in expected {
+            ensure!(
+                exp.assertions == SymtabAssertions::default(),
+                "Symbol property assertions are not supported for Wasm (on `{}`)",
+                exp.name
+            );
+        }
+
+        let found = || Self::format_sorted(&self.export_names);
+        for exp in expected {
+            ensure!(
+                self.export_names.contains(&exp.name),
+                "Expected export `{}` in {linker_name} output ({}), found: [{}]",
+                exp.name,
+                self.path.display(),
+                found()
+            );
+        }
+        for name in absent {
+            ensure!(
+                !self.export_names.contains(name),
+                "Export `{name}` should not exist in {linker_name} output ({}), found: [{}]",
+                self.path.display(),
+                found()
+            );
+        }
+        Ok(())
+    }
+
+    // Linked modules must not repeat identical function types.
+    fn ensure_func_types_unique(&self, linker_name: &str) -> Result {
+        let mut seen = HashSet::new();
+        for (index, ty) in self.func_types.iter().enumerate() {
+            ensure!(
+                seen.insert(ty.clone()),
+                "Duplicate Wasm function type at type index {index} in {linker_name} output ({}): {ty}\n\
+                 All entries: [{}]",
+                self.path.display(),
+                self.func_types
+                    .iter()
+                    .enumerate()
+                    .map(|(i, t)| format!("{i}:{t}"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+        Ok(())
+    }
 }
 
 fn validate_wasm(wasm_file: &Path, linker_name: &str) -> Result {
@@ -4531,33 +4521,19 @@ impl Assertions {
                 .all(|s| s.assertions == SectionAssertions::default()),
             "Section property assertions are not supported for Wasm"
         );
-        let section_names: Vec<String> = self
+
+        let info = WasmModuleInfo::parse(path)?;
+        let linker_name = linker_used.name();
+        let expected_sections: Vec<String> = self
             .expected_sections
             .iter()
             .map(|s| s.section_name.clone())
             .collect();
-        ensure_wasm_sections(path, &section_names, linker_used.name())?;
-        ensure_wasm_func_types_unique(path, linker_used.name())?;
-        ensure_wasm_exports(
-            path,
-            &self.expected_symtab_entries,
-            &self.no_sym,
-            linker_used.name(),
-        )?;
-
-        let sections = wasm_section_names(path)?;
-        for name in &self.absent_sections {
-            ensure!(
-                !sections.contains(name),
-                "Section `{name}` should not exist but was found in {} output ({})",
-                linker_used.name(),
-                path.display()
-            );
-        }
-
-        let bytes =
-            std::fs::read(path).with_context(|| format!("Failed to read {}", path.display()))?;
-        self.verify_strings(&bytes)?;
+        info.ensure_sections(&expected_sections, linker_name)?;
+        info.ensure_absent_sections(&self.absent_sections, linker_name)?;
+        info.ensure_func_types_unique(linker_name)?;
+        info.ensure_exports(&self.expected_symtab_entries, &self.no_sym, linker_name)?;
+        self.verify_strings(&info.bytes)?;
         Ok(())
     }
 

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -40,11 +40,13 @@
 //!
 //! ExpectSym:symbol-name [Symbol properties...] Checks that the specified symbol is defined in the
 //! output file. Can also assert some properties of that symbol. See Symbol properties below.
+//! For Wasm modules, this checks that the name is present in the export section. Symbol properties
+//! are not yet supported for Wasm.
 //!
 //! ExpectDynSym:symbol-name As for ExpectSym, but for dynamic symbols.
 //!
 //! NoSym:symbol-name Checks that the specified symbol name is not defined in either .symtab or
-//! .dynsym.
+//! .dynsym. For Wasm modules, checks that the name is not present in the export section.
 //!
 //! NoDynSym:symbol-name Checks that the specified symbol name is not defined in .dynsym.
 //!
@@ -556,6 +558,67 @@ fn wasm_section_names(wasm_file: &Path) -> Result<HashSet<String>> {
         }
     }
     Ok(sections)
+}
+
+fn wasm_export_names(wasm_file: &Path) -> Result<HashSet<String>> {
+    use wasmparser::Parser;
+    use wasmparser::Payload;
+
+    let bytes = std::fs::read(wasm_file)
+        .with_context(|| format!("Failed to read Wasm file {}", wasm_file.display()))?;
+    let mut exports = HashSet::new();
+    for payload in Parser::new(0).parse_all(&bytes) {
+        let Payload::ExportSection(section) = payload? else {
+            continue;
+        };
+        for export in section {
+            let export = export
+                .with_context(|| format!("Invalid export entry in {}", wasm_file.display()))?;
+            exports.insert(export.name.to_owned());
+        }
+    }
+    Ok(exports)
+}
+
+fn ensure_wasm_exports(
+    wasm_file: &Path,
+    expected: &[ExpectedSymtabEntry],
+    absent: &HashSet<String>,
+    linker_name: &str,
+) -> Result<()> {
+    for exp in expected {
+        ensure!(
+            exp.assertions == SymtabAssertions::default(),
+            "Symbol property assertions are not supported for Wasm (on `{}`)",
+            exp.name
+        );
+    }
+
+    let exports = wasm_export_names(wasm_file)?;
+    let format_exports = || {
+        let mut names: Vec<_> = exports.iter().cloned().collect();
+        names.sort();
+        names.join(", ")
+    };
+
+    for exp in expected {
+        ensure!(
+            exports.contains(&exp.name),
+            "Expected export `{}` in {linker_name} output ({}), found: [{}]",
+            exp.name,
+            wasm_file.display(),
+            format_exports()
+        );
+    }
+    for name in absent {
+        ensure!(
+            !exports.contains(name),
+            "Export `{name}` should not exist in {linker_name} output ({}), found: [{}]",
+            wasm_file.display(),
+            format_exports()
+        );
+    }
+    Ok(())
 }
 
 fn ensure_wasm_sections(
@@ -4452,6 +4515,8 @@ impl Assertions {
             does_not_contain: self.does_not_contain.clone(),
             contains_strings: self.contains_strings.clone(),
             output_file_matches: self.output_file_matches.clone(),
+            expected_symtab_entries: self.expected_symtab_entries.clone(),
+            no_sym: self.no_sym.clone(),
             ..Default::default()
         };
         ensure!(
@@ -4473,6 +4538,12 @@ impl Assertions {
             .collect();
         ensure_wasm_sections(path, &section_names, linker_used.name())?;
         ensure_wasm_func_types_unique(path, linker_used.name())?;
+        ensure_wasm_exports(
+            path,
+            &self.expected_symtab_entries,
+            &self.no_sym,
+            linker_used.name(),
+        )?;
 
         let sections = wasm_section_names(path)?;
         for name in &self.absent_sections {

--- a/wild/tests/sources/wasm/export/export.c
+++ b/wild/tests/sources/wasm/export/export.c
@@ -1,8 +1,10 @@
 //#Config:export-functions
 //#LinkArgs: --export=foo
-//#Contains: foo
 //#ExpectSection: name
-// TODO(wasm): verify that `not_exported` is actually not exported
+//#ExpectSym: foo
+//#ExpectSym: _start
+//#ExpectSym: memory
+//#NoSym: not_exported
 
 //#Config:missing-export
 //#LinkArgs: --export does_not_exist

--- a/wild/tests/sources/wasm/no-entry/no-entry.c
+++ b/wild/tests/sources/wasm/no-entry/no-entry.c
@@ -1,17 +1,26 @@
 //#Config:no-entry
 //#LinkArgs: --no-entry --export=foo
 //#RunEnabled:false
-//#Contains: foo
+//#ExpectSym: foo
+//#ExpectSym: memory
+//#NoSym: _start
+//#NoSym: custom_entry
 
 //#Config:custom-entry
 //#LinkArgs: --entry=custom_entry
 //#RunEnabled:false
-//#Contains: custom_entry
+//#ExpectSym: custom_entry
+//#ExpectSym: memory
+//#NoSym: _start
+//#NoSym: foo
 
 //#Config:entry-then-no-entry
 //#LinkArgs: --entry=custom_entry --no-entry --export=foo
 //#RunEnabled:false
-//#Contains: foo
+//#ExpectSym: foo
+//#ExpectSym: memory
+//#NoSym: _start
+//#NoSym: custom_entry
 
 int foo(void) { return 7; }
 

--- a/wild/tests/sources/wasm/no-entry/no-entry.c
+++ b/wild/tests/sources/wasm/no-entry/no-entry.c
@@ -1,0 +1,24 @@
+//#Config:no-entry
+//#LinkArgs: --no-entry --export=foo
+//#RunEnabled:false
+//#Contains: foo
+
+//#Config:custom-entry
+//#LinkArgs: --entry=custom_entry
+//#RunEnabled:false
+//#Contains: custom_entry
+
+//#Config:entry-then-no-entry
+//#LinkArgs: --entry=custom_entry --no-entry --export=foo
+//#RunEnabled:false
+//#Contains: foo
+
+int foo(void) { return 7; }
+
+void custom_entry(void) {}
+
+void _start(void) {
+  if (foo() != 7) {
+    __builtin_trap();
+  }
+}

--- a/wild/tests/sources/wasm/no-entry/no-entry.c
+++ b/wild/tests/sources/wasm/no-entry/no-entry.c
@@ -22,6 +22,10 @@
 //#NoSym: _start
 //#NoSym: custom_entry
 
+//#Config:missing-entry
+//#LinkArgs: --entry=does_not_exist
+//#ExpectError: entry symbol not defined
+
 int foo(void) { return 7; }
 
 void custom_entry(void) {}


### PR DESCRIPTION
`--no-entry` is commonly seen with targets like wasm32-unknown-unknown.

Additionally, this patch makes `ExpectSym` and `NoSym` test directives for ELF also usable for Wasm. This was necessary to improve the robustness of the tests added in this patch.

Part of #1431