### PR TITLE
fix: Error on non-PIC AArch64 relocations against preemptible symbols in shared objects

### DIFF
--- a/libwild/src/elf_aarch64.rs
+++ b/libwild/src/elf_aarch64.rs
@@ -75,7 +75,12 @@ impl crate::platform::Arch for ElfAArch64 {
     fn is_illegal_in_shared_object(r_type: u32) -> bool {
         matches!(
             r_type,
-            object::elf::R_AARCH64_ABS32 | object::elf::R_AARCH64_ABS16
+            object::elf::R_AARCH64_ABS32
+                | object::elf::R_AARCH64_ABS16
+                | object::elf::R_AARCH64_ADD_ABS_LO12_NC
+                | object::elf::R_AARCH64_LDST8_ABS_LO12_NC
+                | object::elf::R_AARCH64_LDST32_ABS_LO12_NC
+                | object::elf::R_AARCH64_LDST64_ABS_LO12_NC
         )
     }
 

--- a/wild/tests/sources/elf/aarch64-fpic-illegal-shared/aarch64-fpic-illegal-shared.s
+++ b/wild/tests/sources/elf/aarch64-fpic-illegal-shared/aarch64-fpic-illegal-shared.s
@@ -3,7 +3,7 @@
 // GNU ld cross linker silently succeeds so we skip it.
 //#Arch:aarch64
 //#Mode:dynamic
-//#SkipLinker:ld
+//#ReferenceLinkers:lld
 //#LinkArgs:-shared --no-gc-sections
 //#ExpectError:recompile with -fPIC
 //#RunEnabled:false

--- a/wild/tests/sources/elf/aarch64-fpic-illegal-shared/aarch64-fpic-illegal-shared.s
+++ b/wild/tests/sources/elf/aarch64-fpic-illegal-shared/aarch64-fpic-illegal-shared.s
@@ -1,0 +1,18 @@
+// Test that non-PIC AArch64 relocations error in shared objects.
+// Wild errors with "recompile with -fPIC" matching lld behavior.
+// GNU ld cross linker silently succeeds so we skip it.
+//#Arch:aarch64
+//#Mode:dynamic
+//#SkipLinker:ld
+//#LinkArgs:-shared --no-gc-sections
+//#ExpectError:recompile with -fPIC
+//#RunEnabled:false
+
+.globl dat
+dat:
+    .word 0
+
+.text
+.globl _start
+_start:
+    add x0, x0, :lo12:dat


### PR DESCRIPTION
Wild silently accepted these AArch64 relocations when linking a shared  object, producing broken output:

- `R_AARCH64_ADD_ABS_LO12_NC`
- `R_AARCH64_LDST8_ABS_LO12_NC`
- `R_AARCH64_LDST32_ABS_LO12_NC`
- `R_AARCH64_LDST64_ABS_LO12_NC`

These relocations store absolute addresses in fixed-size 12-bit fields  that cannot hold runtime-resolved addresses in a shared object.

Issue #2247 