### PR TITLE
fix: Error on R_AARCH64_PREL16/32/64 against preemptible symbols in shared objects

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -5421,7 +5421,9 @@ fn process_relocation<'data, 'scope, A: Arch<Platform = Elf>, R: Relocation<Plat
                     .store(true, atomic::Ordering::Relaxed);
             }
         } else if flags_to_add.needs_direct() && flags.is_interposable() {
-            if symbol_db.output_kind.is_shared_object() && A::is_illegal_in_shared_object(r_type) {
+            if symbol_db.output_kind.is_shared_object()
+                && A::is_disallowed_for_interposable_symbols(r_type)
+            {
                 bail!(
                     "relocation {} cannot be used when making a shared object; \
                     recompile with -fPIC",

--- a/libwild/src/elf_aarch64.rs
+++ b/libwild/src/elf_aarch64.rs
@@ -72,7 +72,7 @@ impl crate::platform::Arch for ElfAArch64 {
         })
     }
 
-    fn is_illegal_in_shared_object(r_type: u32) -> bool {
+    fn is_disallowed_for_interposable_symbols(r_type: u32) -> bool {
         matches!(
             r_type,
             object::elf::R_AARCH64_ABS32

--- a/libwild/src/elf_aarch64.rs
+++ b/libwild/src/elf_aarch64.rs
@@ -81,6 +81,9 @@ impl crate::platform::Arch for ElfAArch64 {
                 | object::elf::R_AARCH64_LDST8_ABS_LO12_NC
                 | object::elf::R_AARCH64_LDST32_ABS_LO12_NC
                 | object::elf::R_AARCH64_LDST64_ABS_LO12_NC
+                | object::elf::R_AARCH64_PREL16
+                | object::elf::R_AARCH64_PREL32
+                | object::elf::R_AARCH64_PREL64
         )
     }
 

--- a/libwild/src/elf_loongarch64.rs
+++ b/libwild/src/elf_loongarch64.rs
@@ -47,7 +47,7 @@ impl crate::platform::Arch for ElfLoongArch64 {
         })
     }
 
-    fn is_illegal_in_shared_object(r_type: u32) -> bool {
+    fn is_disallowed_for_interposable_symbols(r_type: u32) -> bool {
         matches!(r_type, object::elf::R_LARCH_32)
     }
 

--- a/libwild/src/elf_ppc64.rs
+++ b/libwild/src/elf_ppc64.rs
@@ -30,7 +30,7 @@ impl crate::platform::Arch for ElfPpc64 {
         })
     }
 
-    fn is_illegal_in_shared_object(r_type: u32) -> bool {
+    fn is_disallowed_for_interposable_symbols(r_type: u32) -> bool {
         matches!(r_type, object::elf::R_PPC64_ADDR32)
     }
 

--- a/libwild/src/elf_riscv64.rs
+++ b/libwild/src/elf_riscv64.rs
@@ -65,7 +65,7 @@ impl crate::platform::Arch for ElfRiscV64 {
         })
     }
 
-    fn is_illegal_in_shared_object(r_type: u32) -> bool {
+    fn is_disallowed_for_interposable_symbols(r_type: u32) -> bool {
         matches!(r_type, object::elf::R_RISCV_32)
     }
 

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -3035,7 +3035,7 @@ fn apply_relocation<
         && (flags.is_interposable() || flags.is_dynamic())
         && !flags.needs_copy_relocation()
         && !flags.needs_plt()
-        && A::is_illegal_in_shared_object(r_type)
+        && A::is_disallowed_for_interposable_symbols(r_type)
     {
         bail!(
             "relocation {} cannot be used against symbol; recompile with -fPIC",

--- a/libwild/src/elf_x86_64.rs
+++ b/libwild/src/elf_x86_64.rs
@@ -67,7 +67,7 @@ impl crate::platform::Arch for ElfX86_64 {
         })
     }
 
-    fn is_illegal_in_shared_object(r_type: u32) -> bool {
+    fn is_disallowed_for_interposable_symbols(r_type: u32) -> bool {
         matches!(
             r_type,
             object::elf::R_X86_64_32

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -129,10 +129,13 @@ pub(crate) trait Arch: Send + Sync + 'static {
         false
     }
 
-    /// Returns true if the given relocation type cannot be used when making a shared object.
-    /// On 64-bit architectures, sub-pointer-size absolute relocations cannot be represented
-    /// as dynamic relocations and must be rejected. Default is false (allow).
-    fn is_illegal_in_shared_object(_r_type: <Self::Platform as Platform>::RelocationInfo) -> bool {
+    /// Returns true if the given relocation type cannot be used against interposable symbols.
+    /// This includes preemptible symbols in shared objects and DSO-provided symbols in
+    /// executables. On 64-bit architectures, sub-pointer-size absolute and PC-relative
+    /// relocations cannot hold runtime-resolved addresses. Default is false (allow).
+    fn is_disallowed_for_interposable_symbols(
+        _r_type: <Self::Platform as Platform>::RelocationInfo,
+    ) -> bool {
         false
     }
 

--- a/wild/tests/sources/elf/aarch64-prel-shared/aarch64-prel-shared.s
+++ b/wild/tests/sources/elf/aarch64-prel-shared/aarch64-prel-shared.s
@@ -6,7 +6,6 @@
 //#ReferenceLinkers:lld
 //#LinkArgs:-shared --no-gc-sections
 //#ExpectError:recompile with -fPIC
-//#RunEnabled:false
 
 .globl foo
 foo:

--- a/wild/tests/sources/elf/aarch64-prel-shared/aarch64-prel-shared.s
+++ b/wild/tests/sources/elf/aarch64-prel-shared/aarch64-prel-shared.s
@@ -1,0 +1,16 @@
+// Test that R_AARCH64_PREL32 to a preemptible symbol errors in shared objects.
+// lld errors with "cannot be used against symbol; recompile with -fPIC"
+// GNU ld silently succeeds on this relocation.
+//#Arch:aarch64
+//#Mode:dynamic
+//#ReferenceLinkers:lld
+//#LinkArgs:-shared --no-gc-sections
+//#ExpectError:recompile with -fPIC
+//#RunEnabled:false
+
+.globl foo
+foo:
+    .word 0
+
+.data
+    .word foo - .


### PR DESCRIPTION
Wild was producing an internal `validate_empty` error instead of a proper error message when these relocations were used against preemptible  symbols in shared objects:

- `R_AARCH64_PREL16`
- `R_AARCH64_PREL32`  
- `R_AARCH64_PREL64`

These are PC-relative relocations that store `symbol_address - place`.  In a shared object, the symbol may be preemptible (overridden at runtime by another library), so its address isn't known at link time and can't  be computed correctly.

Issue https://github.com/wild-linker/wild/issues/2247
