### PR TITLE
fix: Avoid applying ELF-specific entry behaviour to other platforms

### DIFF
--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -1914,16 +1914,19 @@ impl platform::Args for ElfArgs {
         &self.wrap
     }
 
-    fn entry_symbol_name<'a>(&'a self, linker_script_entry: Option<&'a [u8]>) -> Option<&'a [u8]> {
+    fn entry_point<'a>(
+        &'a self,
+        linker_script_entry: Option<&'a [u8]>,
+    ) -> platform::EntryPoint<'a> {
         // The --entry flag is used first, falling back to what the linker script says, or otherwise
         // defaults to `_start`.
-        Some(
-            self.entry
-                .as_ref()
-                .map(|n| n.as_bytes())
-                .or(linker_script_entry)
-                .unwrap_or(b"_start"),
-        )
+        if let Some(entry) = self.entry.as_deref() {
+            return parse_number(entry).map_or_else(
+                |_| platform::EntryPoint::Symbol(entry.as_bytes()),
+                platform::EntryPoint::Address,
+            );
+        }
+        platform::EntryPoint::Symbol(linker_script_entry.unwrap_or(b"_start"))
     }
 
     fn start_address_for_section(&self, section_name: SectionName) -> Option<u64> {

--- a/libwild/src/args/macho.rs
+++ b/libwild/src/args/macho.rs
@@ -26,6 +26,7 @@ pub struct MachOArgs {
     pub(crate) lib_search_path: Vec<Box<Path>>,
     pub(crate) plugin_path: Option<String>,
     pub(crate) dead_strip_dylibs: bool,
+    pub(crate) entry: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -77,7 +78,6 @@ impl MachOArgs {
     }
 }
 
-#[expect(clippy::derivable_impls)]
 impl Default for MachOArgs {
     fn default() -> Self {
         Self {
@@ -87,6 +87,7 @@ impl Default for MachOArgs {
             lib_search_path: Vec::new(),
             plugin_path: None,
             dead_strip_dylibs: false,
+            entry: "_main".to_owned(),
         }
     }
 }
@@ -108,9 +109,11 @@ impl platform::Args for MachOArgs {
         false
     }
 
-    fn entry_symbol_name<'a>(&'a self, _linker_script_entry: Option<&'a [u8]>) -> Option<&'a [u8]> {
-        // TODO: probably add option
-        Some(b"_main")
+    fn entry_point<'a>(
+        &'a self,
+        _linker_script_entry: Option<&'a [u8]>,
+    ) -> platform::EntryPoint<'a> {
+        platform::EntryPoint::Symbol(self.entry.as_bytes())
     }
 
     fn lib_search_path(&self) -> &[Box<std::path::Path>] {
@@ -182,6 +185,15 @@ pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(
 // variants.
 fn setup_argument_parser() -> ArgumentParser<MachOArgs> {
     let mut parser = ArgumentParser::<MachOArgs>::new();
+
+    parser
+        .declare_with_param()
+        .short("e")
+        .help("Set the entry point symbol")
+        .execute(|args, _modifier_stack, value| {
+            args.entry = value.to_owned();
+            Ok(())
+        });
 
     parser
         .declare_with_param()

--- a/libwild/src/args/wasm.rs
+++ b/libwild/src/args/wasm.rs
@@ -84,8 +84,15 @@ impl platform::Args for WasmArgs {
         false
     }
 
-    fn entry_symbol_name<'a>(&'a self, _linker_script_entry: Option<&'a [u8]>) -> Option<&'a [u8]> {
-        self.entry.as_deref().map(str::as_bytes)
+    fn entry_point<'a>(
+        &'a self,
+        _linker_script_entry: Option<&'a [u8]>,
+    ) -> platform::EntryPoint<'a> {
+        self.entry
+            .as_deref()
+            .map_or(platform::EntryPoint::None, |entry| {
+                platform::EntryPoint::Symbol(entry.as_bytes())
+            })
     }
 
     fn force_export_symbol_names(&self) -> &[String] {

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -440,7 +440,7 @@ fn populate_file_header<A: Arch<Platform = Elf>>(
     header.e_type.set(e, ty);
     header.e_machine.set(e, A::arch_identifier());
     header.e_version.set(e, object::elf::EV_CURRENT.0.into());
-    header.e_entry.set(e, layout.entry_symbol_address()?);
+    header.e_entry.set(e, elf_entry_address(layout)?);
     header.e_phoff.set(
         e,
         if output_kind.is_partial_object() {
@@ -484,6 +484,40 @@ fn populate_file_header<A: Arch<Platform = Elf>>(
         .e_shstrndx
         .set(e, object::elf::SymbolSection::new(shstrndx));
     Ok(())
+}
+
+fn elf_entry_address(layout: &ElfLayout) -> Result<u64> {
+    if layout.args().should_output_partial_object() {
+        return Ok(0);
+    }
+
+    let entry_name = match layout.symbol_db.entry_point() {
+        crate::platform::EntryPoint::None => return Ok(0),
+        crate::platform::EntryPoint::Address(address) => return Ok(address),
+        crate::platform::EntryPoint::Symbol(name) => name,
+    };
+
+    if let Some(address) = layout.resolved_entry_symbol_address()? {
+        return Ok(address);
+    }
+    if layout.symbol_db.output_kind == OutputKind::SharedObject {
+        return Ok(0);
+    }
+
+    let entry_name = String::from_utf8_lossy(entry_name);
+    let text_layout = layout.section_layouts.get(output_section_id::TEXT);
+    if text_layout.mem_size == 0 {
+        layout.symbol_db.warning(format!(
+            "cannot find entry symbol `{entry_name}` and .text is empty, not setting entry point"
+        ));
+        return Ok(0);
+    }
+
+    layout.symbol_db.warning(format!(
+        "cannot find entry symbol `{entry_name}`, defaulting to 0x{}",
+        text_layout.mem_offset
+    ));
+    Ok(text_layout.mem_offset)
 }
 
 fn write_file<'data, A: Arch<Platform = Elf>>(

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -514,7 +514,7 @@ fn elf_entry_address(layout: &ElfLayout) -> Result<u64> {
     }
 
     layout.symbol_db.warning(format!(
-        "cannot find entry symbol `{entry_name}`, defaulting to 0x{}",
+        "cannot find entry symbol `{entry_name}`, defaulting to 0x{:x}",
         text_layout.mem_offset
     ));
     Ok(text_layout.mem_offset)

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -1573,34 +1573,10 @@ impl<'data, P: Platform> Layout<'data, P> {
             .map(move |(i, res)| (range.offset_to_id(i), res.as_ref()))
     }
 
-    pub(crate) fn entry_symbol_address(&self) -> Result<u64> {
-        if self.symbol_db.args.should_output_partial_object() {
-            return Ok(0);
-        }
+    pub(crate) fn resolved_entry_symbol_address(&self) -> Result<Option<u64>> {
         let Some(symbol_id) = self.prelude().entry_symbol_id else {
-            if self.symbol_db.output_kind == OutputKind::SharedObject {
-                // Shared objects don't have an implicit entry point.
-                return Ok(0);
-            }
-
-            // There's no entry point specified, set it to the start of .text. This is pretty weird,
-            // but it's what GNU ld does.
-            let text_layout = self.section_layouts.get(output_section_id::TEXT);
-            if text_layout.mem_size == 0 {
-                self.symbol_db.warning(
-                    "cannot find entry symbol `_start` and .text is empty, not setting entry point",
-                );
-
-                return Ok(0);
-            }
-
-            self.symbol_db.warning(format!(
-                "cannot find entry symbol `_start`, defaulting to 0x{}",
-                text_layout.mem_offset
-            ));
-            return Ok(text_layout.mem_offset);
+            return Ok(None);
         };
-
         let resolution = self.local_symbol_resolution(symbol_id).with_context(|| {
             format!(
                 "Entry point symbol was defined, but didn't get loaded. {}",
@@ -1615,7 +1591,7 @@ impl<'data, P: Platform> Layout<'data, P> {
             );
         }
 
-        Ok(resolution.value())
+        Ok(Some(resolution.value()))
     }
 
     pub(crate) fn tls_start_address(&self) -> u64 {

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -1400,7 +1400,9 @@ impl platform::Platform for MachO {
             );
         }
         allocate_load_cmd(size_of::<SegmentCommand>());
-        allocate_load_cmd(size_of::<EntryPointCommand>());
+        if resources.symbol_db.output_kind.is_executable() {
+            allocate_load_cmd(size_of::<EntryPointCommand>());
+        }
         allocate_load_cmd(
             (size_of::<DylinkerCommand>() + DYLINKER_PATH.len())
                 .next_multiple_of(MACHO_COMMAND_ALIGNMENT),

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -43,7 +43,6 @@ use crate::macho::PROGRAM_SEGMENT_DEFS;
 use crate::macho::SEG_DATA_CONST;
 use crate::macho::SectionEntry;
 use crate::macho::SegmentCommand;
-use crate::macho::SegmentSectionsInfo;
 use crate::macho::SegmentType;
 use crate::macho::SymtabCommand;
 use crate::macho::UuidCommand;
@@ -220,7 +219,9 @@ fn write_prelude<'data>(
     let mut load_command_buffer = slice_from_all_bytes_mut(buffers.get_mut(part_id::LOAD_COMMANDS));
     write_segment_commands(layout, &mut load_command_buffer)?;
 
-    write_entry_point_command(layout, take_mut(&mut load_command_buffer)?)?;
+    if layout.symbol_db.output_kind.is_executable() {
+        write_entry_point_command(layout, take_mut(&mut load_command_buffer)?)?;
+    }
 
     write_uuid_command(take_mut(&mut load_command_buffer)?);
 
@@ -741,15 +742,31 @@ fn get_resolution<'data>(
 }
 
 fn write_entry_point_command(layout: &MachOLayout, command: &mut EntryPointCommand) -> Result {
-    let SegmentSectionsInfo { segment_size, .. } =
-        get_segment_sections(layout, SegmentType::TextSections)
-            .ok_or_else(|| error!("TextSections segment is mandatory"))?;
+    let entry_name = match layout.symbol_db.entry_point() {
+        crate::platform::EntryPoint::Symbol(name) => String::from_utf8_lossy(name),
+        crate::platform::EntryPoint::None | crate::platform::EntryPoint::Address(_) => {
+            bail!("Mach-O executable entry point must be a symbol")
+        }
+    };
+
+    let entry_address = layout
+        .resolved_entry_symbol_address()?
+        .with_context(|| format!("entry symbol `{entry_name}` is not defined"))?;
+
+    let image_base = layout
+        .section_layouts
+        .get(output_section_id::FILE_HEADER)
+        .mem_offset;
+
+    let entry_offset = entry_address
+        .checked_sub(image_base)
+        .context("entry point is before the Mach-O image base")?;
 
     command.cmd.set(LE, LC_MAIN);
     command
         .cmdsize
         .set(LE, size_of::<EntryPointCommand>() as u32);
-    command.entryoff.set(LE, segment_size.file_offset as u64);
+    command.entryoff.set(LE, entry_offset);
     command.stacksize.set(LE, 0);
     Ok(())
 }

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -1319,6 +1319,13 @@ pub(crate) trait ProgramSegmentDef: Copy + Send + Sync + Display + 'static {
 
 pub(crate) trait BuiltInSectionDetails: Send + Sync + 'static {}
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum EntryPoint<'a> {
+    None,
+    Symbol(&'a [u8]),
+    Address(u64),
+}
+
 pub(crate) trait Args: std::fmt::Debug + Send + Sync + 'static {
     fn parse<S, I>(&mut self, input: I) -> Result
     where
@@ -1360,7 +1367,7 @@ pub(crate) trait Args: std::fmt::Debug + Send + Sync + 'static {
         &[]
     }
 
-    fn entry_symbol_name<'a>(&'a self, linker_script_entry: Option<&'a [u8]>) -> Option<&'a [u8]>;
+    fn entry_point<'a>(&'a self, linker_script_entry: Option<&'a [u8]>) -> EntryPoint<'a>;
 
     fn version_script_path(&self) -> Option<&Path> {
         None

--- a/libwild/src/symbol_db.rs
+++ b/libwild/src/symbol_db.rs
@@ -944,8 +944,15 @@ impl<'data, P: Platform> SymbolDb<'data, P> {
         header.is_group()
     }
 
+    pub(crate) fn entry_point(&self) -> crate::platform::EntryPoint<'_> {
+        self.args.entry_point(self.entry)
+    }
+
     pub(crate) fn entry_symbol_name(&self) -> Option<&[u8]> {
-        self.args.entry_symbol_name(self.entry)
+        match self.entry_point() {
+            crate::platform::EntryPoint::Symbol(name) => Some(name),
+            crate::platform::EntryPoint::None | crate::platform::EntryPoint::Address(_) => None,
+        }
     }
 
     fn apply_linker_script(&mut self, script: &InputLinkerScript<'data>) {

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -50,6 +50,10 @@
 //!
 //! NoDynSym:symbol-name Checks that the specified symbol name is not defined in .dynsym.
 //!
+//! ExpectEntry:symbol-name|address Checks that the executable entry point refers to the specified
+//! symbol or numeric address. Symbols are supported for ELF and Mach-O. Numeric addresses are
+//! supported for ELF.
+//!
 //! ExpectDynamic:tag-name Checks that the specified dynamic entry (e.g. DT_RUNPATH, DT_FLAGS) is
 //! present in the .dynamic section.
 //!
@@ -1648,6 +1652,7 @@ struct Dep {
 struct Assertions {
     expected_symtab_entries: Vec<ExpectedSymtabEntry>,
     expected_dynsym_entries: Vec<ExpectedSymtabEntry>,
+    expected_entry: Option<String>,
     expected_comments: Vec<String>,
     no_sym: HashSet<String>,
     no_dynsym: HashSet<String>,
@@ -2061,6 +2066,7 @@ fn process_directive(
         "ExpectDynSym" => config.assertions.expected_dynsym_entries.push(
             ExpectedSymtabEntry::parse(arg).context("Failed to parse ExpectDynSym arguments")?,
         ),
+        "ExpectEntry" => config.assertions.expected_entry = Some(arg.to_owned()),
         "ExpectComment" => config.assertions.expected_comments.push(arg.to_owned()),
         "NoSym" => {
             config.assertions.no_sym.insert(arg.to_owned());
@@ -2155,16 +2161,8 @@ fn process_directive(
             .push(arg.to_owned()),
         "ExpectLoadAlignment" => {
             let alignment_strs = arg.split(" ").map(str::trim);
-            let alignments = alignment_strs.map(|alignment_str| {
-                if let Some(hex) = alignment_str.strip_prefix("0x") {
-                    u64::from_str_radix(hex, 16)
-                        .with_context(|| format!("Invalid hex alignment: {alignment_str}"))
-                } else {
-                    alignment_str
-                        .parse::<u64>()
-                        .with_context(|| format!("Invalid alignment: {alignment_str}"))
-                }
-            });
+            let alignments = alignment_strs
+                .map(|alignment_str| parse_number(alignment_str).context("Invalid alignment"));
             config.assertions.expected_load_alignments =
                 alignments.collect::<Result<Vec<u64>>>()?;
         }
@@ -4428,6 +4426,7 @@ impl Assertions {
             obj.dynamic_symbols(),
             "dynsym",
         )?;
+        self.verify_elf_entry(&obj)?;
         self.verify_symbols_absent(&self.no_sym, obj.symbols(), "symtab")?;
         self.verify_expected_sections(&obj)?;
         self.verify_absent_sections(&obj)?;
@@ -4465,6 +4464,7 @@ impl Assertions {
         let supported = Assertions {
             expected_symtab_entries: self.expected_symtab_entries.clone(),
             expected_dynsym_entries: self.expected_dynsym_entries.clone(),
+            expected_entry: self.expected_entry.clone(),
             no_sym: self.no_sym.clone(),
             does_not_contain: self.does_not_contain.clone(),
             contains_strings: self.contains_strings.clone(),
@@ -4488,6 +4488,7 @@ impl Assertions {
             obj.dynamic_symbols(),
             "dynsym",
         )?;
+        self.verify_macho_entry(obj)?;
         self.verify_symbols_absent(&self.no_sym, obj.symbols(), "symtab")?;
         self.verify_expected_sections(obj)?;
         self.verify_absent_sections(obj)?;
@@ -4540,6 +4541,100 @@ impl Assertions {
         info.ensure_func_types_unique(linker_name)?;
         info.ensure_exports(&self.expected_symtab_entries, &self.no_sym, linker_name)?;
         self.verify_strings(&info.bytes)?;
+        Ok(())
+    }
+
+    fn expected_entry_address(&self, obj: &object::File) -> Result<Option<u64>> {
+        let Some(expected_entry) = &self.expected_entry else {
+            return Ok(None);
+        };
+
+        if let Ok(num) = parse_number(expected_entry) {
+            return Ok(Some(num));
+        }
+
+        let symbol = obj
+            .symbols()
+            .find(|symbol| symbol.name() == Ok(expected_entry))
+            .with_context(|| format!("Entry symbol `{expected_entry}` is not defined"))?;
+
+        Ok(Some(symbol.address()))
+    }
+
+    fn verify_elf_entry(&self, obj: &object::File) -> Result {
+        let Some(expected_address) = self.expected_entry_address(obj)? else {
+            return Ok(());
+        };
+
+        let object::File::Elf64(file) = obj else {
+            bail!("ExpectEntry is only supported for 64-bit ELF and Mach-O");
+        };
+
+        let actual_address = file.elf_header().e_entry.get(file.endianness());
+        ensure!(
+            actual_address == expected_address,
+            "Expected entry point `{}` at {expected_address:#x}, but ELF e_entry was {actual_address:#x}",
+            self.expected_entry.as_deref().unwrap()
+        );
+
+        Ok(())
+    }
+
+    fn verify_macho_entry(&self, obj: &object::File) -> Result {
+        let Some(expected_address) = self.expected_entry_address(obj)? else {
+            return Ok(());
+        };
+
+        let object::File::MachO64(file) = obj else {
+            bail!("ExpectEntry is only supported for 64-bit ELF and Mach-O");
+        };
+
+        let e = file.endianness();
+        let mut segments = Vec::new();
+        let mut entryoff = None;
+        let mut commands = file.macho_load_commands()?;
+
+        while let Some(command) = commands.next()? {
+            match command.variant()? {
+                LoadCommandVariant::Segment64(segment, _) => {
+                    segments.push((
+                        segment.vmaddr.get(e),
+                        segment.vmsize.get(e),
+                        segment.fileoff.get(e),
+                        String::from_utf8_lossy(segment.name()).into_owned(),
+                    ));
+                }
+                LoadCommandVariant::EntryPoint(entry) => {
+                    entryoff = Some(entry.entryoff.get(e));
+                }
+                _ => {}
+            }
+        }
+
+        let entryoff = entryoff.context("Missing LC_MAIN")?;
+        let (text_vmaddr, _, text_fileoff, _) = segments
+            .iter()
+            .find(|(_, _, _, name)| name == object::macho::SEG_TEXT)
+            .context("Missing __TEXT segment")?;
+
+        let image_base = text_vmaddr
+            .checked_sub(*text_fileoff)
+            .context("__TEXT file offset is greater than its VM address")?;
+
+        let actual_address = image_base + entryoff;
+        let (_, _, _, segment_name) = segments
+            .iter()
+            .find(|(vmaddr, vmsize, _, _)| (*vmaddr..vmaddr + vmsize).contains(&actual_address))
+            .with_context(|| {
+                format!("LC_MAIN refers to unmapped virtual address {actual_address:#x}")
+            })?;
+
+        ensure!(
+            actual_address == expected_address,
+            "Expected entry point `{}` at {expected_address:#x}, but LC_MAIN refers to {actual_address:#x} in segment `{segment_name}`",
+            self.expected_entry.as_deref().unwrap()
+        );
+
         Ok(())
     }
 
@@ -5131,6 +5226,18 @@ impl Assertions {
         // won't be checked for the test that writes the output to /dev/null.
         self.max_thunks > 0
     }
+}
+
+fn parse_number(s: &str) -> Result<u64> {
+    if let Some(hex) = s.strip_prefix("0x") {
+        return Ok(u64::from_str_radix(hex, 16)?);
+    }
+
+    if s.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Ok(s.parse()?);
+    }
+
+    bail!("Failed to parse `{s}` as a number");
 }
 
 /// Parsed offsets from a `.gdb_index` header, version-agnostic.

--- a/wild/tests/sources/elf/entry-arg/entry-arg.c
+++ b/wild/tests/sources/elf/entry-arg/entry-arg.c
@@ -4,7 +4,13 @@
 //#Config:custom-entry:default
 //#LinkArgs:--entry=custom_entry
 //#ExpectSym:custom_entry section=".text"
+//#ExpectEntry:custom_entry
 //#TestUpdateInPlace:true
+
+//#Config:numeric-entry:default
+//#LinkArgs:--entry=0x1234
+//#ExpectEntry:0x1234
+//#RunEnabled:false
 
 #include "../common/runtime.h"
 

--- a/wild/tests/sources/elf/missing-custom-entry/missing-custom-entry.c
+++ b/wild/tests/sources/elf/missing-custom-entry/missing-custom-entry.c
@@ -1,0 +1,7 @@
+//#Config:default
+//#LinkArgs:--entry=missing --no-gc-sections
+//#ExpectWarning:cannot find entry symbol .*missing
+//#ExpectEntry:first_function
+//#RunEnabled:false
+
+void first_function(void) {}

--- a/wild/tests/sources/elf/no-start-empty-text/no-start-empty-text.c
+++ b/wild/tests/sources/elf/no-start-empty-text/no-start-empty-text.c
@@ -1,0 +1,11 @@
+//#Config:default
+//#SkipArch:ppc64le
+//#RunEnabled:false
+//#ExpectWarning:cannot find entry symbol
+//#ExpectEntry:0
+//#DiffIgnore:file-header.*
+//#DiffIgnore:riscv_attributes.stack_align
+//#DiffIgnore:segment.RISCV_ATTRIBUTES.*
+//#DiffIgnore:riscv_attributes.*
+
+int data = 42;

--- a/wild/tests/sources/elf/no-start/no-start.c
+++ b/wild/tests/sources/elf/no-start/no-start.c
@@ -1,6 +1,7 @@
 //#AbstractConfig:default
 //#Object:runtime.c
 //#ExpectWarning:cannot find entry symbol
+//#ExpectEntry:this_is_the_entry_point
 
 //#Config:no-gc:default
 //#LinkArgs:-z now --no-gc-sections

--- a/wild/tests/sources/macho/default-entry/default-entry.c
+++ b/wild/tests/sources/macho/default-entry/default-entry.c
@@ -1,0 +1,10 @@
+//#Config:default
+//#Object:runtime.c
+//#ExpectEntry:_main
+//#DiffIgnore:section.__unwind_info
+
+#include "../common/runtime.h"
+
+__attribute__((used, noinline)) void not_the_entry_point(void) { exit_syscall(1); }
+
+void main(void) { exit_syscall(42); }

--- a/wild/tests/sources/macho/entry/entry.c
+++ b/wild/tests/sources/macho/entry/entry.c
@@ -1,0 +1,11 @@
+//#Config:default
+//#Object:runtime.c
+//#LinkArgs:-e _custom_entry
+//#ExpectEntry:_custom_entry
+//#DiffIgnore:section.__unwind_info
+
+#include "../common/runtime.h"
+
+void main(void) { exit_syscall(1); }
+
+void custom_entry(void) { exit_syscall(42); }

--- a/wild/tests/sources/macho/missing-entry/missing-entry.c
+++ b/wild/tests/sources/macho/missing-entry/missing-entry.c
@@ -1,0 +1,7 @@
+//#Config:default
+//#RunEnabled:false
+//#DiffEnabled:false
+//#LinkArgs:-e _missing
+//#ExpectErrorWild:entry symbol `_missing` is not defined
+
+void not_main(void) {}


### PR DESCRIPTION
For ELF, we duplicate some of the dubious behaviours of GNU ld - e.g. if the entry symbol isn't defined, we warn, then use the start of the .text section or otherwise 0. We don't want to duplicate such behaviours to other platforms, so this PR moves this behaviour to be ELF-specific. In order to properly test the entry behaviour of the other platforms I needed to implement the `-e` flag for mac. A bunch of new tests were added to check the corner cases around entry handlings. Many of these fail without the rest of the change.