### PR TITLE
ci: add Arch Linux cross CI image

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -28,6 +28,10 @@ jobs:
             container: ci-alpine-amd64
             runs-on: ubuntu-24.04
             platform: linux/amd64
+          - file: docker/ci/arch.Dockerfile
+            container: ci-arch-cross-amd64
+            runs-on: ubuntu-24.04
+            platform: linux/amd64
           - file: docker/ci/opensuse.Dockerfile
             container: ci-opensuse-amd64
             runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
           - runs-on: ubuntu-24.04
             container: ci-ubuntu-cross-amd64
             cross: all
-#          - runs-on: ubuntu-24.04
-#            container: ci-arch-cross-amd64
-#            cross: aarch64,riscv64
+            #          - runs-on: ubuntu-24.04
+            #            container: ci-arch-cross-amd64
+            #            cross: aarch64,riscv64
           - runs-on: ubuntu-24.04-arm
             container: ci-ubuntu-arm64
           - runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
           - runs-on: ubuntu-24.04
             container: ci-ubuntu-cross-amd64
             cross: all
-            #          - runs-on: ubuntu-24.04
-            #            container: ci-arch-cross-amd64
-            #            cross: aarch64,riscv64
+          - runs-on: ubuntu-24.04
+            container: ci-arch-cross-amd64
+            cross: aarch64,riscv64
           - runs-on: ubuntu-24.04-arm
             container: ci-ubuntu-arm64
           - runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,6 @@ jobs:
         include:
           - runs-on: ubuntu-24.04
             container: ci-ubuntu-cross-amd64
-            cross: all
-          - runs-on: ubuntu-24.04
-            container: ci-arch-cross-amd64
-            cross: aarch64,riscv64
           - runs-on: ubuntu-24.04-arm
             container: ci-ubuntu-arm64
           - runs-on: ubuntu-24.04
@@ -49,7 +45,7 @@ jobs:
       - run: echo "$PATH" >> "$GITHUB_PATH"
         if: ${{ contains(matrix.container, 'opensuse') }}
       - run: echo "WILD_TEST_CONFIG=test-config-ci.toml" >> $GITHUB_ENV
-      - run: echo "WILD_TEST_CROSS=${{ matrix.cross }}" >> $GITHUB_ENV
+      - run: echo "WILD_TEST_CROSS=all" >> $GITHUB_ENV
         if: ${{ contains(matrix.container, '-cross') }}
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
           - runs-on: ubuntu-24.04
             container: ci-ubuntu-cross-amd64
             cross: all
-          - runs-on: ubuntu-24.04
-            container: ci-arch-cross-amd64
-            cross: aarch64,riscv64
+#          - runs-on: ubuntu-24.04
+#            container: ci-arch-cross-amd64
+#            cross: aarch64,riscv64
           - runs-on: ubuntu-24.04-arm
             container: ci-ubuntu-arm64
           - runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
         include:
           - runs-on: ubuntu-24.04
             container: ci-ubuntu-cross-amd64
+            cross: all
+          - runs-on: ubuntu-24.04
+            container: ci-arch-cross-amd64
+            cross: aarch64,riscv64
           - runs-on: ubuntu-24.04-arm
             container: ci-ubuntu-arm64
           - runs-on: ubuntu-24.04
@@ -45,7 +49,7 @@ jobs:
       - run: echo "$PATH" >> "$GITHUB_PATH"
         if: ${{ contains(matrix.container, 'opensuse') }}
       - run: echo "WILD_TEST_CONFIG=test-config-ci.toml" >> $GITHUB_ENV
-      - run: echo "WILD_TEST_CROSS=all" >> $GITHUB_ENV
+      - run: echo "WILD_TEST_CROSS=${{ matrix.cross }}" >> $GITHUB_ENV
         if: ${{ contains(matrix.container, '-cross') }}
       - uses: actions/checkout@v7
         with:

--- a/docker/ci/arch.Dockerfile
+++ b/docker/ci/arch.Dockerfile
@@ -1,0 +1,25 @@
+FROM archlinux:base
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN pacman --noconfirm -Syu \        
+        base-devel \
+        clang \
+        curl \
+        git \
+        lld \
+        qemu-user \
+        aarch64-linux-gnu-gcc \
+        riscv64-linux-gnu-gcc \
+        taplo-cli \
+        wget
+RUN pacman --noconfirm -Scc
+RUN wget https://sh.rustup.rs -O rustup-installer && \
+    chmod +x rustup-installer && \
+    ./rustup-installer -y --default-toolchain 1.94.0
+RUN rustup toolchain install nightly \
+        --allow-downgrade \
+        --target x86_64-unknown-linux-musl,aarch64-unknown-linux-gnu,aarch64-unknown-linux-musl,riscv64gc-unknown-linux-gnu,riscv64gc-unknown-linux-musl \
+        --component rustc-codegen-cranelift-preview


### PR DESCRIPTION
There are a new CI failures related to updated GCC 16.1 aarch64 cross compiler and thus I would like to have the platform in CI.
Note the `loongarch64` cross compiler in unavailable on the Arch distro.