### PR TITLE
ci: test-build images for PRs

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -89,8 +89,8 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
-          name: myimage
-          path: ${{ runner.temp }}/myimage.tar
+          name: base_image
+          path: ${{ runner.temp }}/base_image.tar
 
   # Build images that depend on other images.
   build-dependent:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -76,7 +76,7 @@ jobs:
           cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=ghcr.io/{0}/{1}:buildcache,mode=max', github.repository, matrix.container) || '' }}
 
       - name: Export base image
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && contains(matrix.file, 'base')
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -86,7 +86,7 @@ jobs:
           outputs: type=docker,dest=${{ runner.temp }}/base_image.tar
 
       - name: Upload base image archive
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && contains(matrix.file, 'base')
         uses: actions/upload-artifact@v4
         with:
           name: base_image-${{ matrix.container }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -79,6 +79,9 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: docker/build-push-action@v7
         with:
+          context: .
+          file: ${{ matrix.file }}
+          platforms: ${{ matrix.platform }}
           tags: ghcr.io/${{ github.repository }}/${{ matrix.container }}:latest
           outputs: type=docker,dest=${{ runner.temp }}/base_image.tar
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -92,6 +92,7 @@ jobs:
           name: base_image-${{ matrix.container }}
           path: ${{ runner.temp }}/base_image.tar
           retention-days: 1
+          if-no-files-found: error
 
   # Build images that depend on other images.
   build-dependent:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -75,7 +75,7 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.container }}:buildcache
           cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=ghcr.io/{0}/{1}:buildcache,mode=max', github.repository, matrix.container) || '' }}
 
-      - name: Export base image (OCI layout)
+      - name: Export base image
         if: github.event_name == 'pull_request' && contains(matrix.file, 'base')
         uses: docker/build-push-action@v7
         with:
@@ -83,7 +83,7 @@ jobs:
           file: ${{ matrix.file }}
           platforms: ${{ matrix.platform }}
           tags: ghcr.io/${{ github.repository }}/${{ matrix.container }}:sha-${{ github.sha }}
-          outputs: type=oci,dest=${{ runner.temp }}/base_image.tar
+          outputs: type=docker,dest=${{ runner.temp }}/base_image.tar
 
       - name: Upload base image archive
         if: github.event_name == 'pull_request' && contains(matrix.file, 'base')
@@ -145,11 +145,11 @@ jobs:
           name: base_image-${{ matrix.base_image_container }}
           path: ${{ runner.temp }}
 
-      - name: Unpack base image OCI layout
+      - name: Load base image archive
         if: github.event_name == 'pull_request'
         run: |
-          mkdir -p ${{ runner.temp }}/base_image_oci
-          tar -xf ${{ runner.temp }}/base_image.tar -C ${{ runner.temp }}/base_image_oci
+          docker load --input ${{ runner.temp }}/base_image.tar
+          docker image ls -a
 
       - name: Build and push dependent image
         uses: docker/build-push-action@v7
@@ -160,10 +160,9 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: |
             BASE_IMAGE=${{ matrix.base_image }}
-          build-contexts: |
-            ${{ github.event_name == 'pull_request' && format('{0}=oci-layout://{1}/base_image_oci', matrix.base_image, runner.temp) || '' }}
           tags: |
             ghcr.io/${{ github.repository }}/${{ matrix.container }}:latest
             ghcr.io/${{ github.repository }}/${{ matrix.container }}:sha-${{ github.sha }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.container }}:buildcache
           cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=ghcr.io/{0}/{1}:buildcache,mode=max', github.repository, matrix.container) || '' }}
+          load: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -129,6 +129,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          # `docker` supports local images, `docker-container` supports caching, and neither fits all...
+          # For PRs, we don't push images and loading base image is important.
+          driver: ${{ github.event_name == 'pull_request' && 'docker' || 'docker-container' }}
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'
@@ -165,4 +169,3 @@ jobs:
             ghcr.io/${{ github.repository }}/${{ matrix.container }}:sha-${{ github.sha }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.container }}:buildcache
           cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=ghcr.io/{0}/{1}:buildcache,mode=max', github.repository, matrix.container) || '' }}
-          load: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -85,6 +85,13 @@ jobs:
           tags: ghcr.io/${{ github.repository }}/${{ matrix.container }}:latest
           outputs: type=docker,dest=${{ runner.temp }}/base_image.tar
 
+      - name: Upload base image archive
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: myimage
+          path: ${{ runner.temp }}/myimage.tar
+
   # Build images that depend on other images.
   build-dependent:
     name: ${{ matrix.container }}
@@ -128,7 +135,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Load base image
+      - name: Download base image archive
+        if: github.event_name == 'pull_request'
+        uses: actions/download-artifact@v4
+        with:
+          name: base_image
+          path: ${{ runner.temp }}
+
+      - name: Load base image archive
         if: github.event_name == 'pull_request'
         run: |
           docker load --input ${{ runner.temp }}/base_image.tar

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -91,6 +91,7 @@ jobs:
         with:
           name: base_image-${{ matrix.container }}
           path: ${{ runner.temp }}/base_image.tar
+          retention-days: 1
 
   # Build images that depend on other images.
   build-dependent:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -129,10 +129,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-        with:
+          # with:
           # `docker` supports local images, `docker-container` supports caching, and neither fits all...
           # For PRs, we don't push images and loading base image is important.
-          driver: ${{ github.event_name == 'pull_request' && 'docker' || 'docker-container' }}
+        # driver: ${{ github.event_name == 'pull_request' && 'docker' || 'docker-container' }}
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -82,7 +82,7 @@ jobs:
           context: .
           file: ${{ matrix.file }}
           platforms: ${{ matrix.platform }}
-          tags: ghcr.io/${{ github.repository }}/${{ matrix.container }}:latest
+          tags: ghcr.io/${{ github.repository }}/${{ matrix.container }}:sha-${{ github.sha }}
           outputs: type=docker,dest=${{ runner.temp }}/base_image.tar
 
       - name: Upload base image archive

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -3,9 +3,14 @@
 name: Build images
 
 # Since there are manual steps involved in switching to new images, we don't want to automatically
-# build new ones. So for now, we only build when someone triggers the workflow.
+# push new ones. So for now, we only push when someone triggers the workflow.
+# We also want to test-build them for relevant pull requests.
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - 'docker/ci/**'
+      - '.github/workflows/build-images.yml'
 
 permissions:
   packages: write
@@ -50,6 +55,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -61,13 +67,13 @@ jobs:
         with:
           context: .
           file: ${{ matrix.file }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           platforms: ${{ matrix.platform }}
           tags: |
             ghcr.io/${{ github.repository }}/${{ matrix.container }}:latest
             ghcr.io/${{ github.repository }}/${{ matrix.container }}:sha-${{ github.sha }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.container }}:buildcache
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.container }}:buildcache,mode=max
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=ghcr.io/{0}/{1}:buildcache,mode=max', github.repository, matrix.container) || '' }}
 
   # Build images that depend on other images.
   build-dependent:
@@ -105,6 +111,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -116,7 +123,7 @@ jobs:
         with:
           context: .
           file: ${{ matrix.file }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           platforms: ${{ matrix.platform }}
           build-args: |
             BASE_IMAGE=${{ matrix.base_image }}
@@ -124,4 +131,4 @@ jobs:
             ghcr.io/${{ github.repository }}/${{ matrix.container }}:latest
             ghcr.io/${{ github.repository }}/${{ matrix.container }}:sha-${{ github.sha }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.container }}:buildcache
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.container }}:buildcache,mode=max
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=ghcr.io/{0}/{1}:buildcache,mode=max', github.repository, matrix.container) || '' }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -126,6 +126,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          # `docker` supports local images, `docker-container` supports caching, and neither fits all...
+          # For PRs, we don't push images and loading base image is important.
+          driver: ${{ github.event_name == 'pull_request' && 'docker' || 'docker-container' }}
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -75,7 +75,7 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.container }}:buildcache
           cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=ghcr.io/{0}/{1}:buildcache,mode=max', github.repository, matrix.container) || '' }}
 
-      - name: Export base image
+      - name: Export base image (OCI layout)
         if: github.event_name == 'pull_request' && contains(matrix.file, 'base')
         uses: docker/build-push-action@v7
         with:
@@ -83,7 +83,7 @@ jobs:
           file: ${{ matrix.file }}
           platforms: ${{ matrix.platform }}
           tags: ghcr.io/${{ github.repository }}/${{ matrix.container }}:sha-${{ github.sha }}
-          outputs: type=docker,dest=${{ runner.temp }}/base_image.tar
+          outputs: type=oci,dest=${{ runner.temp }}/base_image.tar
 
       - name: Upload base image archive
         if: github.event_name == 'pull_request' && contains(matrix.file, 'base')
@@ -145,11 +145,11 @@ jobs:
           name: base_image-${{ matrix.base_image_container }}
           path: ${{ runner.temp }}
 
-      - name: Load base image archive
+      - name: Unpack base image OCI layout
         if: github.event_name == 'pull_request'
         run: |
-          docker load --input ${{ runner.temp }}/base_image.tar
-          docker image ls -a
+          mkdir -p ${{ runner.temp }}/base_image_oci
+          tar -xf ${{ runner.temp }}/base_image.tar -C ${{ runner.temp }}/base_image_oci
 
       - name: Build and push dependent image
         uses: docker/build-push-action@v7
@@ -160,9 +160,10 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: |
             BASE_IMAGE=${{ matrix.base_image }}
+          build-contexts: |
+            ${{ github.event_name == 'pull_request' && format('{0}=oci-layout://{1}/base_image_oci', matrix.base_image, runner.temp) || '' }}
           tags: |
             ghcr.io/${{ github.repository }}/${{ matrix.container }}:latest
             ghcr.io/${{ github.repository }}/${{ matrix.container }}:sha-${{ github.sha }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.container }}:buildcache
           cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=ghcr.io/{0}/{1}:buildcache,mode=max', github.repository, matrix.container) || '' }}
-          load: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -129,10 +129,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-          # with:
+        with:
           # `docker` supports local images, `docker-container` supports caching, and neither fits all...
           # For PRs, we don't push images and loading base image is important.
-        # driver: ${{ github.event_name == 'pull_request' && 'docker' || 'docker-container' }}
+          driver: ${{ github.event_name == 'pull_request' && 'docker' || 'docker-container' }}
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -89,7 +89,7 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
-          name: base_image
+          name: base_image-${{ matrix.container }}
           path: ${{ runner.temp }}/base_image.tar
 
   # Build images that depend on other images.
@@ -104,16 +104,19 @@ jobs:
             platform: linux/amd64
             runs-on: ubuntu-24.04
             base_image: ghcr.io/${{ github.repository }}/ci-ubuntu-base-amd64:sha-${{ github.sha }}
+            base_image_container: ci-ubuntu-base-amd64
           - file: docker/ci/ubuntu.Dockerfile
             container: ci-ubuntu-arm64
             runs-on: ubuntu-24.04-arm
             platform: linux/arm64
             base_image: ghcr.io/${{ github.repository }}/ci-ubuntu-base-arm64:sha-${{ github.sha }}
+            base_image_container: ci-ubuntu-base-arm64
           - file: docker/ci/ubuntu-cross.Dockerfile
             container: ci-ubuntu-cross-amd64
             platform: linux/amd64
             runs-on: ubuntu-24.04-arm
             base_image: ghcr.io/${{ github.repository }}/ci-ubuntu-base-amd64:sha-${{ github.sha }}
+            base_image_container: ci-ubuntu-base-amd64
 
     runs-on: ${{ matrix.runs-on }}
 
@@ -143,7 +146,7 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/download-artifact@v4
         with:
-          name: base_image
+          name: base_image-${{ matrix.base_image_container }}
           path: ${{ runner.temp }}
 
       - name: Load base image archive

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -129,10 +129,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-        with:
-          # `docker` supports local images, `docker-container` supports caching, and neither fits all...
-          # For PRs, we don't push images and loading base image is important.
-          driver: ${{ github.event_name == 'pull_request' && 'docker' || 'docker-container' }}
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'
@@ -169,3 +165,4 @@ jobs:
             ghcr.io/${{ github.repository }}/${{ matrix.container }}:sha-${{ github.sha }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.container }}:buildcache
           cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=ghcr.io/{0}/{1}:buildcache,mode=max', github.repository, matrix.container) || '' }}
+          load: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -75,6 +75,13 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/${{ matrix.container }}:buildcache
           cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref=ghcr.io/{0}/{1}:buildcache,mode=max', github.repository, matrix.container) || '' }}
 
+      - name: Export base image
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v7
+        with:
+          tags: ghcr.io/${{ github.repository }}/${{ matrix.container }}:latest
+          outputs: type=docker,dest=${{ runner.temp }}/base_image.tar
+
   # Build images that depend on other images.
   build-dependent:
     name: ${{ matrix.container }}
@@ -117,6 +124,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Load base image
+        if: github.event_name == 'pull_request'
+        run: |
+          docker load --input ${{ runner.temp }}/base_image.tar
+          docker image ls -a
 
       - name: Build and push dependent image
         uses: docker/build-push-action@v7

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -114,7 +114,7 @@ jobs:
           - file: docker/ci/ubuntu-cross.Dockerfile
             container: ci-ubuntu-cross-amd64
             platform: linux/amd64
-            runs-on: ubuntu-24.04-arm
+            runs-on: ubuntu-24.04
             base_image: ghcr.io/${{ github.repository }}/ci-ubuntu-base-amd64:sha-${{ github.sha }}
             base_image_container: ci-ubuntu-base-amd64
 


### PR DESCRIPTION
Every time I interact with GitHub Actions they prove to be insaner than I previously though. I used LLMs to make conditional `cache-to` and still could not come up with anything sane.
My idea is to make sure the images build (and in the future pass tests) on PR, before merging changes to them.

This got complicated a lot with base images being built in a distinct job. For PRs we really don't want to push untrusted stuff, so I followed https://docs.docker.com/build/ci/github-actions/share-image-jobs/ on how to move them between jobs.