### PR TITLE
port(wasm): change default to --stack-first

### DIFF
--- a/libwild/src/args/wasm.rs
+++ b/libwild/src/args/wasm.rs
@@ -40,6 +40,7 @@ pub struct WasmArgs {
     pub(crate) lib_search_path: Vec<Box<Path>>,
     pub(crate) export_symbols: Vec<String>,
     pub(crate) z_stack_size: u32,
+    // Since LLVM 22, the default option is true.
     pub(crate) stack_first: bool,
     // Entry symbol name. Defaults to `DEFAULT_ENTRY`.
     pub(crate) entry: Option<String>,
@@ -61,7 +62,7 @@ impl Default for WasmArgs {
             lib_search_path: Vec::new(),
             export_symbols: Vec::new(),
             z_stack_size: DEFAULT_STACK_SIZE,
-            stack_first: false,
+            stack_first: true,
             entry: Some(DEFAULT_ENTRY.to_owned()),
         }
     }
@@ -253,6 +254,15 @@ fn setup_argument_parser() -> ArgumentParser<WasmArgs> {
         .help("Place stack at start of linear memory rather than after data")
         .execute(|args, _modifier_stack| {
             args.stack_first = true;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("no-stack-first")
+        .help("Place stack at the end of linear memory after data")
+        .execute(|args, _modifier_stack| {
+            args.stack_first = false;
             Ok(())
         });
 

--- a/wild/tests/sources/wasm/data-end-heap-base/data-end-heap-base.c
+++ b/wild/tests/sources/wasm/data-end-heap-base/data-end-heap-base.c
@@ -1,4 +1,5 @@
 //#Object:data-end-heap-base2.c
+//#LinkArgs:--no-stack-first
 
 extern char __data_end;
 extern char __heap_base;

--- a/wild/tests/sources/wasm/data-end-heap-base/data-end-heap-base.c
+++ b/wild/tests/sources/wasm/data-end-heap-base/data-end-heap-base.c
@@ -1,5 +1,6 @@
 //#Object:data-end-heap-base2.c
 //#LinkArgs:--no-stack-first
+//#RequiresLinkerFlags: --no-stack-first
 
 extern char __data_end;
 extern char __heap_base;

--- a/wild/tests/sources/wasm/stack-size/stack-size.c
+++ b/wild/tests/sources/wasm/stack-size/stack-size.c
@@ -1,6 +1,7 @@
 //#Config:stack-size
 //#CompArgs:-DNO_STACK_FIRST
 //#LinkArgs: -z stack-size=1048576 --no-stack-first
+//#RequiresLinkerFlags: --no-stack-first
 
 //#Config:stack-first
 //#LinkArgs: -z stack-size=1048576 --stack-first

--- a/wild/tests/sources/wasm/stack-size/stack-size.c
+++ b/wild/tests/sources/wasm/stack-size/stack-size.c
@@ -1,5 +1,9 @@
 //#Config:stack-size
-//#LinkArgs: -z stack-size=1048576
+//#CompArgs:-DNO_STACK_FIRST
+//#LinkArgs: -z stack-size=1048576 --no-stack-first
+
+//#Config:stack-first
+//#LinkArgs: -z stack-size=1048576 --stack-first
 
 //#Config:invalid-stack-size
 //#LinkArgs:-z stack-size=3
@@ -11,9 +15,15 @@ extern char __heap_base;
 void _start(void) {
   unsigned long data_end = (unsigned long)&__data_end;
   unsigned long heap_base = (unsigned long)&__heap_base;
-  unsigned long stack_base = (data_end + 15) & ~15UL;
 
+#ifdef NO_STACK_FIRST
+  unsigned long stack_base = (data_end + 15) & ~15UL;
   if (heap_base != stack_base + 1048576) {
     __builtin_trap();
   }
+#else
+  if (heap_base < 1048576 || data_end < 1048576) {
+    __builtin_trap();
+  }
+#endif
 }


### PR DESCRIPTION
I noticed some failure tests on my Arch Linux system and apparently, starting with LLVM 22
(https://github.com/llvm/llvm-project/pull/166998), the default got adjusted to `--stack-first`. Given that, I am changing the default.