### PR TITLE
ci: build ubuntu-cross image natively

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -89,7 +89,7 @@ jobs:
           - file: docker/ci/ubuntu-cross.Dockerfile
             container: ci-ubuntu-cross-amd64
             platform: linux/amd64
-            runs-on: ubuntu-24.04-arm
+            runs-on: ubuntu-24.04
             base_image: ghcr.io/${{ github.repository }}/ci-ubuntu-base-amd64:sha-${{ github.sha }}
 
     runs-on: ${{ matrix.runs-on }}


### PR DESCRIPTION
It's a typo from https://github.com/wild-linker/wild/pull/2046