### PR TITLE
fix: Avoid range error for aarch64 TPOFF rel against undefined weak tls

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -3411,6 +3411,16 @@ fn apply_relocation<
             .wrapping_add(bias)
             .bitand(mask.got_entry)
             .wrapping_sub(layout.got_base().bitand(mask.got)),
+        RelocationKind::TpOff
+            if layout
+                .symbol_db
+                .is_undefined(layout.symbol_db.definition(local_symbol_id)) =>
+        {
+            // An undefined weak TLS symbol has no offset within the TLS block, so we somewhat
+            // arbitrarily give the 0 offset which at least some other linkers also do and most
+            // importantly is a value guaranteed to fit within the range of any relocation.
+            (addend as u64).wrapping_add(bias)
+        }
         RelocationKind::TpOff => resolution
             .value()
             .wrapping_add(addend as u64)

--- a/wild/tests/sources/elf/undefined-weak-tls/undefined-weak-tls.c
+++ b/wild/tests/sources/elf/undefined-weak-tls/undefined-weak-tls.c
@@ -1,0 +1,23 @@
+//#CompArgs:-ftls-model=local-exec
+//#LinkArgs:-z now --no-gc-sections
+//#Object:runtime.c
+//#Object:ptr_black_box.c
+//#ReferenceLinkers:bfd,lld
+//#SkipArch:ppc64le
+//#ExpectSym:undefined_tls_address
+
+#include "../common/runtime.h"
+
+extern __thread int undefined_tls __attribute__((weak, visibility("hidden")));
+
+// There's not really any way to check any property of this symbol, so we pretty much just make sure
+// that we can link and that the function that references the symbol was included.
+void* undefined_tls_address(void) { return &undefined_tls; }
+
+// Make sure the TLS segment isn't empty.
+__thread int defined_tls;
+
+void _start(void) {
+  runtime_init();
+  exit_syscall(42);
+}


### PR DESCRIPTION
Fixes #2283