### PR TITLE
chore: Trim whitespace from output in malfunction tests

### DIFF
--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -6011,7 +6011,7 @@ fn normalise_report(report: &linker_diff::Report) -> String {
         } else {
             Cow::Borrowed(line)
         };
-        out.push_str(&line_out);
+        out.push_str(line_out.trim());
         out.push('\n');
     }
     out

--- a/wild/tests/sources/elf/linker-diff-trivial/malfunction-elf-incorrect-type.x86_64.exp
+++ b/wild/tests/sources/elf/linker-diff-trivial/malfunction-elf-incorrect-type.x86_64.exp
@@ -1,6 +1,6 @@
 wild: elf/x86_64/linker-diff-trivial/malfunction-elf-incorrect-type/linker-diff-trivial.c.wild
 ld: elf/x86_64/linker-diff-trivial/malfunction-elf-incorrect-type/linker-diff-trivial.c.ld
 file-header.type
-  wild 0x4
-  ld 0x2
+wild 0x4
+ld 0x2
 

--- a/wild/tests/sources/elf/mov-indirect-to-absolute/malfunction-no-mov-indirect-to-absolute.x86_64.exp
+++ b/wild/tests/sources/elf/mov-indirect-to-absolute/malfunction-no-mov-indirect-to-absolute.x86_64.exp
@@ -1,11 +1,11 @@
 wild: elf/x86_64/mov-indirect-to-absolute/malfunction-no-mov-indirect-to-absolute/mov-indirect-to-absolute.s.wild
 ld: elf/x86_64/mov-indirect-to-absolute/malfunction-no-mov-indirect-to-absolute/mov-indirect-to-absolute.s.ld
 rel.missing-opt.R_X86_64_GOTPCRELX.MovIndirectToAbsolute.static-non-pie
-  `elf/x86_64/mov-indirect-to-absolute/malfunction-no-mov-indirect-to-absolute/mov-indirect-to-absolute.s.o` .text _start
- R_X86_64_GOTPCRELX 
-  ORIG .Ldata0 -4
- R_X86_64_GOTPCRELX NoOp 
-  wild TRACE: relocation applied flags=NON_INTERPOSABLE | GOT,
-  wild TRACE: rel_kind=GotRelative,
- R_X86_64_32 MovIndirectToAbsolute 
+`elf/x86_64/mov-indirect-to-absolute/malfunction-no-mov-indirect-to-absolute/mov-indirect-to-absolute.s.o` .text _start
+R_X86_64_GOTPCRELX
+ORIG .Ldata0 -4
+R_X86_64_GOTPCRELX NoOp
+wild TRACE: relocation applied flags=NON_INTERPOSABLE | GOT,
+wild TRACE: rel_kind=GotRelative,
+R_X86_64_32 MovIndirectToAbsolute
 

--- a/wild/tests/sources/elf/tls-local-dynamic/malfunction-no-movzx0lsl16.aarch64.exp
+++ b/wild/tests/sources/elf/tls-local-dynamic/malfunction-no-movzx0lsl16.aarch64.exp
@@ -1,30 +1,30 @@
 wild: elf/aarch64/tls-local-dynamic/malfunction-no-movzx0lsl16/tls-local-dynamic.c.wild
 ld: elf/aarch64/tls-local-dynamic/malfunction-no-movzx0lsl16/tls-local-dynamic.c.ld
 rel.R_AARCH64_NONE.R_AARCH64_TLSLE_MOVW_TPREL_G1
-  `elf/aarch64/tls-local-dynamic/malfunction-no-movzx0lsl16/tls-local-dynamic.c.o` .text.startup main
- R_AARCH64_TLSDESC_ADR_PAGE21 
- R_AARCH64_TLSDESC_LD64_LO12 
- R_AARCH64_TLSDESC_ADD_LO12 
- R_AARCH64_TLSDESC_CALL 
-  ORIG foo
- R_AARCH64_NONE ReplaceWithNop 
- R_AARCH64_NONE ReplaceWithNop 
- R_AARCH64_TLSDESC_ADD_LO12 NoOp 
- R_AARCH64_TLSLE_MOVW_TPREL_G0_NC MovkX0 
-  wild TRACE: relaxation applied relaxation=ReplaceWithNop, flags=NON_INTERPOSABLE | DIRECT | GOT_TLS_DESCRIPTOR,
-  wild TRACE: rel_kind=None,
-  wild TRACE: value=0x0, symbol_name=foo
-  wild TRACE: relaxation applied relaxation=ReplaceWithNop, flags=NON_INTERPOSABLE | DIRECT | GOT_TLS_DESCRIPTOR,
-  wild TRACE: rel_kind=None,
-  wild TRACE: value=0x0, symbol_name=foo
-  wild TRACE: relocation applied flags=NON_INTERPOSABLE | DIRECT | GOT_TLS_DESCRIPTOR,
-  wild TRACE: rel_kind=TlsDescGot,
-  wild TRACE: relaxation applied relaxation=MovkX0, flags=NON_INTERPOSABLE | DIRECT | GOT_TLS_DESCRIPTOR,
-  wild TRACE: rel_kind=TpOff,
-  wild TRACE: value=0x10, symbol_name=foo
- R_AARCH64_TLSLE_MOVW_TPREL_G1 MovzX0Lsl16 
- R_AARCH64_TLSLE_MOVW_TPREL_G0_NC MovkX0 
- R_AARCH64_NONE ReplaceWithNop 
- R_AARCH64_NONE ReplaceWithNop 
-  ld   foo
+`elf/aarch64/tls-local-dynamic/malfunction-no-movzx0lsl16/tls-local-dynamic.c.o` .text.startup main
+R_AARCH64_TLSDESC_ADR_PAGE21
+R_AARCH64_TLSDESC_LD64_LO12
+R_AARCH64_TLSDESC_ADD_LO12
+R_AARCH64_TLSDESC_CALL
+ORIG foo
+R_AARCH64_NONE ReplaceWithNop
+R_AARCH64_NONE ReplaceWithNop
+R_AARCH64_TLSDESC_ADD_LO12 NoOp
+R_AARCH64_TLSLE_MOVW_TPREL_G0_NC MovkX0
+wild TRACE: relaxation applied relaxation=ReplaceWithNop, flags=NON_INTERPOSABLE | DIRECT | GOT_TLS_DESCRIPTOR,
+wild TRACE: rel_kind=None,
+wild TRACE: value=0x0, symbol_name=foo
+wild TRACE: relaxation applied relaxation=ReplaceWithNop, flags=NON_INTERPOSABLE | DIRECT | GOT_TLS_DESCRIPTOR,
+wild TRACE: rel_kind=None,
+wild TRACE: value=0x0, symbol_name=foo
+wild TRACE: relocation applied flags=NON_INTERPOSABLE | DIRECT | GOT_TLS_DESCRIPTOR,
+wild TRACE: rel_kind=TlsDescGot,
+wild TRACE: relaxation applied relaxation=MovkX0, flags=NON_INTERPOSABLE | DIRECT | GOT_TLS_DESCRIPTOR,
+wild TRACE: rel_kind=TpOff,
+wild TRACE: value=0x10, symbol_name=foo
+R_AARCH64_TLSLE_MOVW_TPREL_G1 MovzX0Lsl16
+R_AARCH64_TLSLE_MOVW_TPREL_G0_NC MovkX0
+R_AARCH64_NONE ReplaceWithNop
+R_AARCH64_NONE ReplaceWithNop
+ld   foo
 


### PR DESCRIPTION
Some lines have whitespace at the start that depends on the width of an address or similar on the previous line. Removing that whitespace makes these cases more robust. My immediate motivation is to unblock #2281, which hit such a difference on openSUSE.