### PR TITLE
chore: tweak gitignore so that test build dir can be symlink

### DIFF
--- a/wild/tests/.gitignore
+++ b/wild/tests/.gitignore
@@ -1,3 +1,2 @@
-build/
+build
 target/
-


### PR DESCRIPTION
I've started making wild/tests/build be a symlink to somewhere else. There are a few use cases for this. One is to put it on tmpfs to reduce wear on the SSD. Another is that it makes it easier to work with docker images when you mount the repo into the docker image, since the docker image generally needs a separate test build directory, otherwise weird failures can happen.