### PR TITLE
refactor: Declare `--fork` and `--no-fork` as common args

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -1436,6 +1436,24 @@ fn declare_common_args<T: platform::Args>(parser: &mut ArgumentParser<T>) {
             args.common_mut().num_threads = Some(NonZeroUsize::new(1).unwrap());
             Ok(())
         });
+
+    parser
+        .declare()
+        .long("no-fork")
+        .help("Do not fork while linking")
+        .execute(|args, _modifier_stack| {
+            args.common_mut().should_fork = false;
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("fork")
+        .help("Spawn a child process to link (default)")
+        .execute(|args, _modifier_stack| {
+            args.common_mut().should_fork = true;
+            Ok(())
+        });
 }
 
 #[cfg(test)]

--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -1651,15 +1651,6 @@ fn setup_argument_parser() -> ArgumentParser<ElfArgs> {
 
     parser
         .declare()
-        .long("no-fork")
-        .help("Do not fork while linking")
-        .execute(|args, _modifier_stack| {
-            args.common_mut().should_fork = false;
-            Ok(())
-        });
-
-    parser
-        .declare()
         .long("no-update-in-place")
         .help("Delete and recreate the file")
         .execute(|args, _modifier_stack| {


### PR DESCRIPTION
This enables accurate measurement for some metrics such as RSS for platforms other than ELF.