### PR TITLE
test: Fix race condition in Rust LTO support detection, try 2

### DIFF
--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -6731,6 +6731,7 @@ fn verify_linker_plugin_requirements(
                 verifier_path.display()
             );
 
+            let tmp_dir = tempfile::tempdir()?;
             // Check that rustc can use linker-plugin-lto with the installed clang. This eliminates
             // platforms where the LLVM version used by clang doesn't match the version used by
             // rustc.
@@ -6742,7 +6743,7 @@ fn verify_linker_plugin_requirements(
                 "-Clinker-plugin-lto",
                 "-Clink-arg=-flto",
                 "-o",
-                &format!("/tmp/rust-{}.out", config.arch),
+                &format!("{}/rust.out", tmp_dir.path().display()),
             ]);
             verify_command_success(&mut command).context(
                 "Can't use rust+clang with linker plugin. LLVM version mismatch? \


### PR DESCRIPTION
Previously running this loop in fish shell would fail in a few seconds:
```
❯ while true
      cargo t lto 2>&1 | rg -A10 'LLVM version' && break
  end
```
After this change and over 13 minutes of the torture loop I got no failures.

Fixes #2290