### PR TITLE
port(wasm): Avoid cloning symbol tables during module layout

### DIFF
--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -1675,7 +1675,7 @@ pub(crate) struct WasmLayout<'data> {
     pub(crate) unsupported_output: Vec<&'static str>,
     pub(crate) object_index_maps: Vec<WasmObjectIndexMap>,
     pub(crate) object_data_layouts: Vec<WasmObjectDataLayout<'data>>,
-    pub(crate) per_object_symbols: Vec<Vec<WasmSymbol>>,
+    pub(crate) per_object_symbols: Vec<&'data [WasmSymbol]>,
     pub(crate) encoded_sections: WasmEncodedSections,
     pub(crate) code_section_size: u64,
     pub(crate) data_section_size: u64,
@@ -1807,7 +1807,7 @@ fn build_name_section<'data>(
         let Some(index_map) = layout.object_index_maps.get(obj_idx) else {
             continue;
         };
-        for sym in &input.symbols {
+        for sym in input.symbols {
             let Some(name) = wasm_symbol_name_str(input.data, sym) else {
                 continue;
             };
@@ -2394,8 +2394,8 @@ struct WasmObjectLayoutInput<'data> {
     data_segments: Vec<WasmDataSegment<'data>>,
     segment_alignments: Vec<Alignment>,
     data_relocations: Vec<WasmRelocation>,
-    symbols: Vec<WasmSymbol>,
-    init_funcs: Vec<WasmInitFunc>,
+    symbols: &'data [WasmSymbol],
+    init_funcs: &'data [WasmInitFunc],
     symbol_id_range: crate::symbol_db::SymbolIdRange,
     file_id: crate::input_data::FileId,
 }
@@ -2425,7 +2425,7 @@ struct WasmObjectOutputLayout<'data> {
 
 impl<'data> WasmObjectLayoutInput<'data> {
     fn from_file(
-        file: &File<'data>,
+        file: &'data File<'data>,
         symbol_id_range: crate::symbol_db::SymbolIdRange,
         file_id: crate::input_data::FileId,
     ) -> Result<Self> {
@@ -2586,8 +2586,8 @@ impl<'data> WasmObjectLayoutInput<'data> {
             data_segments,
             segment_alignments: file.segments.iter().map(|s| s.alignment).collect(),
             data_relocations,
-            symbols: file.symbols.clone(),
-            init_funcs: file.init_funcs.clone(),
+            symbols: file.symbols.as_slice(),
+            init_funcs: file.init_funcs.as_slice(),
             symbol_id_range,
             file_id,
         })
@@ -3791,7 +3791,7 @@ fn collect_sorted_init_function_calls(
     let mut items = Vec::new();
     for (obj_idx, input) in inputs.iter().enumerate() {
         let index_map = &object_index_maps[obj_idx];
-        for init in &input.init_funcs {
+        for init in input.init_funcs {
             let sym = &input.symbols[init.symbol_index as usize];
             ensure!(
                 sym.kind == WasmSymbolKind::Func && !sym.is_undefined(),
@@ -4307,9 +4307,8 @@ where
             apply_got_mem_to_index_maps(&mut layout.object_index_maps, got_mem);
         }
         {
-            timing_phase!("Clone Wasm symbol tables");
             for input in &layout_inputs {
-                layout.per_object_symbols.push(input.symbols.clone());
+                layout.per_object_symbols.push(input.symbols);
             }
         }
         {
@@ -4663,7 +4662,7 @@ fn linker_defined_data_symbol_address(
 
 fn compute_data_addresses(
     object_index_maps: &mut [WasmObjectIndexMap],
-    per_object_symbols: &[Vec<WasmSymbol>],
+    per_object_symbols: &[&[WasmSymbol]],
     object_data_layouts: &[WasmObjectDataLayout<'_>],
     layout_inputs: &[WasmObjectLayoutInput<'_>],
     symbol_db: &SymbolDb<'_, Wasm>,


### PR DESCRIPTION
Borrow linking symbols and init funcs from each input File as slices instead of cloning them into `WasmObjectLayoutInput` and again into `WasmLayout`. This contributes to a slight reduction in RSS.

```
Benchmark 1 (116 runs): /home/lapla/wild-rg/save/0/run-with /tmp/wild-symclone/wild-before --no-fork
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          43.2ms ± 2.33ms    37.5ms … 47.1ms          0 ( 0%)        0%
  peak_rss           85.6MB ±  453KB    84.3MB … 86.7MB          4 ( 3%)        0%
  cpu_cycles         38.8M  ± 21.8M     14.3M  … 83.9M           0 ( 0%)        0%
  instructions       75.7M  ± 40.7M     27.3M  …  166M           0 ( 0%)        0%
  cache_references    803K  ±  552K      262K  … 1.78M           0 ( 0%)        0%
  cache_misses        448K  ±  299K      157K  …  930K           0 ( 0%)        0%
  branch_misses       258K  ±  134K      114K  …  558K           0 ( 0%)        0%
Benchmark 2 (118 runs): /home/lapla/wild-rg/save/0/run-with /tmp/wild-symclone/wild-after --no-fork
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          42.6ms ± 2.41ms    37.2ms … 49.1ms          0 ( 0%)          -  1.4% ±  1.4%
  peak_rss           83.2MB ±  421KB    81.7MB … 84.3MB          3 ( 3%)        ⚡-  2.7% ±  0.1%
  cpu_cycles         37.5M  ± 20.6M     10.6M  … 77.5M           0 ( 0%)          -  3.4% ± 14.0%
  instructions       74.6M  ± 39.2M     20.9M  …  150M           0 ( 0%)          -  1.6% ± 13.5%
  cache_references    759K  ±  527K      182K  … 1.70M           0 ( 0%)          -  5.5% ± 17.2%
  cache_misses        415K  ±  276K      125K  …  872K           0 ( 0%)          -  7.4% ± 16.4%
  branch_misses       254K  ±  129K     83.7K  …  494K           0 ( 0%)          -  1.6% ± 13.1%
```

Part of #1431 