### PR TITLE
refactor: Move link_for_arch off Platform

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -168,6 +168,35 @@ type SymbolTable<'data> = object::read::elf::SymbolTable<'data, FileHeader>;
 #[derive(Debug, Copy, Clone, Default)]
 pub(crate) struct Elf;
 
+pub(crate) fn link_for_arch<'data, F: FileSystem>(
+    linker: &'data crate::Linker<F>,
+    args: &'data ElfArgs,
+) -> Result<crate::LinkerOutput<'data>> {
+    match args.arch {
+        crate::arch::Architecture::X86_64 => {
+            linker.link_for_arch::<Elf, crate::elf_x86_64::ElfX86_64>(args)
+        }
+        crate::arch::Architecture::AArch64 => {
+            linker.link_for_arch::<Elf, crate::elf_aarch64::ElfAArch64>(args)
+        }
+        crate::arch::Architecture::RiscV64 => {
+            linker.link_for_arch::<Elf, crate::elf_riscv64::ElfRiscV64>(args)
+        }
+        crate::arch::Architecture::LoongArch64 => {
+            linker.link_for_arch::<Elf, crate::elf_loongarch64::ElfLoongArch64>(args)
+        }
+        crate::arch::Architecture::Ppc64 => {
+            linker.link_for_arch::<Elf, crate::elf_ppc64::ElfPpc64>(args)
+        }
+        crate::arch::Architecture::Unsupported => {
+            bail!(
+                "No default target architecture known for host platform. \
+                    Please specify an architecture with -m"
+            )
+        }
+    }
+}
+
 #[repr(u32)]
 #[derive(Clone, Copy)]
 enum SinglePartSectionId {
@@ -586,35 +615,6 @@ impl platform::Platform for Elf {
     type ResolutionExt = ResolutionExt;
     type SymtabShndxEntry = SymtabShndxEntry;
     type ResolvedObjectExt<'data> = ResolvedObjectExt<'data>;
-
-    fn link_for_arch<'data, F: FileSystem>(
-        linker: &'data crate::Linker<F>,
-        args: &'data Self::Args,
-    ) -> Result<crate::LinkerOutput<'data>> {
-        match args.arch {
-            crate::arch::Architecture::X86_64 => {
-                linker.link_for_arch::<Elf, crate::elf_x86_64::ElfX86_64>(args)
-            }
-            crate::arch::Architecture::AArch64 => {
-                linker.link_for_arch::<Elf, crate::elf_aarch64::ElfAArch64>(args)
-            }
-            crate::arch::Architecture::RiscV64 => {
-                linker.link_for_arch::<Elf, crate::elf_riscv64::ElfRiscV64>(args)
-            }
-            crate::arch::Architecture::LoongArch64 => {
-                linker.link_for_arch::<Elf, crate::elf_loongarch64::ElfLoongArch64>(args)
-            }
-            crate::arch::Architecture::Ppc64 => {
-                linker.link_for_arch::<Elf, crate::elf_ppc64::ElfPpc64>(args)
-            }
-            crate::arch::Architecture::Unsupported => {
-                bail!(
-                    "No default target architecture known for host platform. \
-                    Please specify an architecture with -m"
-                )
-            }
-        }
-    }
 
     fn write_output_file<'data, A: Arch<Platform = Self>, F: FileSystem>(
         output: &crate::file_writer::Output<F>,

--- a/libwild/src/lib.rs
+++ b/libwild/src/lib.rs
@@ -94,11 +94,9 @@ pub(crate) mod wasm;
 pub(crate) mod wasm_wasm32;
 pub(crate) mod wasm_writer;
 
-use crate::elf::Elf;
 use crate::error::Context;
 use crate::error::Result;
 use crate::layout_rules::LayoutRulesBuilder;
-use crate::macho::MachO;
 use crate::output_kind::OutputKind;
 use crate::platform::Arch;
 use crate::platform::Args as _;
@@ -267,9 +265,9 @@ impl<F: FileSystem> Linker<F> {
         }
 
         match args {
-            Args::Elf(elf_args) => Elf::link_for_arch(self, elf_args),
-            Args::MachO(macho_args) => MachO::link_for_arch(self, macho_args),
-            Args::Wasm(wasm_args) => crate::wasm::Wasm::link_for_arch(self, wasm_args),
+            Args::Elf(elf_args) => crate::elf::link_for_arch(self, elf_args),
+            Args::MachO(macho_args) => crate::macho::link_for_arch(self, macho_args),
+            Args::Wasm(wasm_args) => crate::wasm::link_for_arch(self, wasm_args),
         }
     }
 

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -66,6 +66,19 @@ use std::num::NonZeroU64;
 #[derive(Debug, Copy, Clone, Default)]
 pub(crate) struct MachO;
 
+pub(crate) fn link_for_arch<'data, F: FileSystem>(
+    linker: &'data crate::Linker<F>,
+    args: &'data MachOArgs,
+) -> crate::error::Result<crate::LinkerOutput<'data>> {
+    if !cfg!(feature = "macho") {
+        crate::bail!(
+            "Mach-O support is still experimental. Rebuild with `--features macho` to enable it."
+        );
+    }
+
+    linker.link_for_arch::<MachO, crate::macho_aarch64::MachOAArch64>(args)
+}
+
 #[repr(u32)]
 #[derive(Clone, Copy)]
 enum SinglePartSectionId {
@@ -1045,19 +1058,6 @@ impl platform::Platform for MachO {
     type ResolvedObjectExt<'data> = ();
 
     const HAS_NULL_SYMBOL_ENTRY: bool = true;
-
-    fn link_for_arch<'data, F: FileSystem>(
-        linker: &'data crate::Linker<F>,
-        args: &'data Self::Args,
-    ) -> crate::error::Result<crate::LinkerOutput<'data>> {
-        if !cfg!(feature = "macho") {
-            crate::bail!(
-                "Mach-O support is still experimental. Rebuild with `--features macho` to enable it."
-            );
-        }
-
-        linker.link_for_arch::<MachO, crate::macho_aarch64::MachOAArch64>(args)
-    }
 
     fn write_output_file<'data, A: platform::Arch<Platform = Self>, F: FileSystem>(
         output: &crate::file_writer::Output<F>,

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -363,12 +363,6 @@ pub(crate) trait Platform:
     /// For platforms that don't support symbol versioning, this can just be the unit type.
     type VerneedTable<'data>: VerneedTable<'data>;
 
-    /// Invoke the linker for requested architecture.
-    fn link_for_arch<'data, F: FileSystem>(
-        linker: &'data crate::Linker<F>,
-        args: &'data Self::Args,
-    ) -> Result<crate::LinkerOutput<'data>>;
-
     fn write_output_file<'data, A: Arch<Platform = Self>, F: FileSystem>(
         output: &crate::file_writer::Output<F>,
         layout: &Layout<'data, Self>,

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -64,6 +64,17 @@ use wasmparser::TypeSectionReader;
 #[derive(Debug, Copy, Clone, Default)]
 pub(crate) struct Wasm;
 
+pub(crate) fn link_for_arch<'data, F: FileSystem>(
+    linker: &'data crate::Linker<F>,
+    args: &'data WasmArgs,
+) -> crate::error::Result<crate::LinkerOutput<'data>> {
+    if !cfg!(feature = "wasm") {
+        bail!("Wasm support is still experimental. Rebuild with `--features wasm` to enable it.");
+    }
+
+    linker.link_for_arch::<Wasm, crate::wasm_wasm32::WasmWasm32>(args)
+}
+
 #[repr(u32)]
 #[derive(Clone, Copy)]
 enum SinglePartSectionId {
@@ -4869,19 +4880,6 @@ impl platform::Platform for Wasm {
     type VersionNames<'data> = ();
     type VerneedTable<'data> = VerneedTable<'data>;
     type ResolvedObjectExt<'data> = WasmObjectLayout<'data>;
-
-    fn link_for_arch<'data, F: FileSystem>(
-        linker: &'data crate::Linker<F>,
-        args: &'data Self::Args,
-    ) -> crate::error::Result<crate::LinkerOutput<'data>> {
-        if !cfg!(feature = "wasm") {
-            bail!(
-                "Wasm support is still experimental. Rebuild with `--features wasm` to enable it."
-            );
-        }
-
-        linker.link_for_arch::<Wasm, crate::wasm_wasm32::WasmWasm32>(args)
-    }
 
     fn write_output_file<'data, A: platform::Arch<Platform = Self>, F: FileSystem>(
         output: &crate::file_writer::Output<F>,


### PR DESCRIPTION
It doesn't need to be on `Platform` and having it there was getting in the way of making the Elf platform generic over 32/64 bits, since there would be more than one Elf platform.

Issue #2287