### PR TITLE
feat: implement `SORT_BY_NAME` and `SORT_BY_ALIGNMENT`

### DIFF
--- a/LINKER_SCRIPT_SUPPORT.md
+++ b/LINKER_SCRIPT_SUPPORT.md
@@ -53,7 +53,9 @@ end lists the features required to link the Linux kernel.
 | `=fillexp` | ✅ | |
 | `AT(addr)` load-address specifier on output sections | ✅ | |
 | Numeric address between section name and `:` (e.g. `name 0 : { ... }`) | 🧪 | Only numeric literals are currently supported |
-| `SORT_BY_NAME(...)`, `SORT_BY_ALIGNMENT(...)`, `SORT_BY_INIT_PRIORITY(...)` | 📅 | |
+| `SORT(...)`, `SORT_BY_NAME(...)` | ✅ | |
+| `SORT_BY_ALIGNMENT(...)` | ✅ | Parsed and ignored, as sections are sorted by alignment by default |
+| `SORT_BY_INIT_PRIORITY(...)` | 📅 | |
 | `EXCLUDE_FILE(...)` inside input section matchers | 📅 | |
 | `BYTE(expr)`, `SHORT(expr)`, `LONG(expr)`, `QUAD(expr)` output data | ❌ | |
 | `SUBALIGN(n)` forced input alignment | ❌ | |
@@ -119,7 +121,8 @@ see at a glance what remains before Wild can link the kernel.
 | `=fillexp` | ✅ | |
 | `AT(addr)` load-address specifier on output sections | ✅ | |
 | `>region` and `AT>region` memory region placement | 📅 | |
-| `SORT_BY_NAME(...)`, `SORT_BY_ALIGNMENT(...)`, `SORT_BY_INIT_PRIORITY(...)` | 📅 | |
+| `SORT(...)`, `SORT_BY_NAME(...)` | ✅ | |
+| `SORT_BY_ALIGNMENT(...)` | ✅ | Parsed and ignored, as sections are sorted by alignment by default |
 | `EXCLUDE_FILE(...)` inside input section matchers | 📅 | |
 | `CONSTRUCTORS` command | ✅ | Parsed and ignored, it is a nop for ELF.  |
 | `PHDRS` command for explicit program header definition | 🧪 | The FILEHDR and PHDRS keywords aren't yet supported. |

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -1315,32 +1315,29 @@ fn parse_matcher_pattern<'input>(input: &mut &'input BStr) -> winnow::Result<Mat
 }
 
 fn parse_pattern<'input>(input: &mut &'input BStr) -> winnow::Result<SectionPattern<'input>> {
-    // Handling SORT(...) wrapper: SORT is an alias for SORT_BY_NAME in GNU ld.
-    use winnow::combinator::opt;
-    use winnow::token::literal;
-    if opt(literal(b"SORT")).parse_next(input)?.is_some() {
-        skip_comments_and_whitespace(input)?;
+    let sort_kw = opt(alt((
+        "SORT_BY_NAME".map(|_| true),
+        "SORT_BY_ALIGNMENT".map(|_| false),
+        "SORT".map(|_| true),
+    )))
+    .parse_next(input)?;
+    let sorted = sort_kw.unwrap_or(false);
 
+    if sort_kw.is_some() {
+        skip_comments_and_whitespace(input)?;
         '('.parse_next(input)?;
-        skip_comments_and_whitespace(input)?;
+    }
 
-        // Inside SORT(...), accept a single wildcard pattern up to ')'
-        let name =
-            take_while(1.., |b: u8| b != b')' && !b.is_ascii_whitespace()).parse_next(input)?;
-        skip_comments_and_whitespace(input)?;
+    skip_comments_and_whitespace(input)?;
+    let name = take_while(1.., |b: u8| b != b')' && !b.is_ascii_whitespace()).parse_next(input)?;
+    skip_comments_and_whitespace(input)?;
+
+    if sort_kw.is_some() {
         ')'.parse_next(input)?;
         skip_comments_and_whitespace(input)?;
-
-        Ok(SectionPattern { name, sorted: true })
-    } else {
-        let name =
-            take_while(1.., |b: u8| b != b')' && !b.is_ascii_whitespace()).parse_next(input)?;
-        skip_comments_and_whitespace(input)?;
-        Ok(SectionPattern {
-            name,
-            sorted: false,
-        })
     }
+
+    Ok(SectionPattern { name, sorted })
 }
 
 /// Call `cb` for each input file requested by `commands`.

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -1314,18 +1314,28 @@ fn parse_matcher_pattern<'input>(input: &mut &'input BStr) -> winnow::Result<Mat
     })
 }
 
-fn parse_pattern<'input>(input: &mut &'input BStr) -> winnow::Result<SectionPattern<'input>> {
-    let sort_kw = opt(alt((
+fn parse_sort(input: &mut &BStr) -> winnow::Result<bool> {
+    let sort_kw = alt((
         "SORT_BY_NAME".map(|_| true),
         "SORT_BY_ALIGNMENT".map(|_| false),
         "SORT".map(|_| true),
-    )))
+    ))
     .parse_next(input)?;
+    Ok(sort_kw)
+}
+
+fn parse_pattern<'input>(input: &mut &'input BStr) -> winnow::Result<SectionPattern<'input>> {
+    let sort_kw = opt(parse_sort).parse_next(input)?;
     let sorted = sort_kw.unwrap_or(false);
 
     if sort_kw.is_some() {
         skip_comments_and_whitespace(input)?;
         '('.parse_next(input)?;
+        winnow::combinator::not(parse_sort)
+            .parse_next(input)
+            .map_err(|_: ContextError| {
+                ContextError::from_external_error(input, LinkerScriptError::UnsupportedNestedSort)
+            })?;
     }
 
     skip_comments_and_whitespace(input)?;
@@ -1384,6 +1394,7 @@ fn to_str(bytes: &[u8]) -> Result<&str> {
 enum LinkerScriptError {
     InvalidAlignment,
     UnclosedComment,
+    UnsupportedNestedSort,
 }
 
 impl std::error::Error for LinkerScriptError {}
@@ -1393,6 +1404,10 @@ impl std::fmt::Display for LinkerScriptError {
         match self {
             LinkerScriptError::InvalidAlignment => write!(f, "Invalid alignment"),
             LinkerScriptError::UnclosedComment => write!(f, "Unclosed comment"),
+            LinkerScriptError::UnsupportedNestedSort => write!(
+                f,
+                "Nested sorting commands in linker scripts is not supported"
+            ),
         }
     }
 }
@@ -2289,5 +2304,19 @@ mod tests {
         .unwrap();
 
         assert_eq!(unquoted, quoted);
+    }
+
+    #[test]
+    fn test_nested_sort_is_unsupported() {
+        let script = parse_script(
+            r"
+            SECTIONS {
+                .text : {
+                    *(SORT(SORT_BY_ALIGNMENT(.text.*)))
+                }
+            }
+            ",
+        );
+        assert!(script.is_err());
     }
 }

--- a/wild/tests/sources/elf/script-sort/script-sort-2.c
+++ b/wild/tests/sources/elf/script-sort/script-sort-2.c
@@ -1,4 +1,9 @@
 __attribute__((used, section(".text.sort.b"))) int func_b() { return 2; }
 
+__attribute__((used, aligned(16), section(".text.align.16"))) int align_16() { return 16; }
+__attribute__((used, aligned(64), section(".text.align.64"))) int align_64() { return 64; }
+__attribute__((used, aligned(4), section(".text.align.4"))) int align_4() { return 4; }
+__attribute__((used, aligned(32), section(".text.align.32"))) int align_32() { return 32; }
+
 __attribute__((section(".text.kept.func"))) int func_kept() { return 4; }
 __attribute__((section(".text.drop.func"))) int func_drop() { return 5; }

--- a/wild/tests/sources/elf/script-sort/script-sort.c
+++ b/wild/tests/sources/elf/script-sort/script-sort.c
@@ -15,6 +15,11 @@ extern int func_a();
 extern int func_b();
 extern int func_c();
 
+extern int align_16();
+extern int align_64();
+extern int align_4();
+extern int align_32();
+
 void _start(void) {
   runtime_init();
 
@@ -31,6 +36,16 @@ void _start(void) {
 
   if (func_a() != 1 || func_b() != 2 || func_c() != 3) {
     exit_syscall(103);
+  }
+
+  size_t align_16_addr = ptr_to_int(&align_16);
+  size_t align_64_addr = ptr_to_int(&align_64);
+  size_t align_4_addr = ptr_to_int(&align_4);
+  size_t align_32_addr = ptr_to_int(&align_32);
+
+  if (align_64_addr >= align_32_addr || align_32_addr >= align_16_addr ||
+      align_16_addr >= align_4_addr) {
+    exit_syscall(104);
   }
 
   exit_syscall(42);

--- a/wild/tests/sources/elf/script-sort/script-sort.ld
+++ b/wild/tests/sources/elf/script-sort/script-sort.ld
@@ -9,7 +9,8 @@ SECTIONS
         
         *(SORT(.text.sort.*))
         KEEP(*(SORT(.text.kept.*)))
-        *(SORT(.text.drop.*))
+        *(SORT_BY_NAME(.text.drop.*))
+        *(SORT_BY_ALIGNMENT(.text.align.*))
     }
 
     /* Ensure valid alignment for subsequent sections */


### PR DESCRIPTION
`SORT_BY_NAME` is an alias of `SORT`, and sorts by section names.
`SORT_BY_ALIGNMENT` sorts sections in decreasing order of alignment. Since wild already does this by default, it is ignored.