### PR TITLE
refactor:  Split ELF relocation GC into classify, materialize, and edges

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -5614,175 +5614,270 @@ fn process_relocation<'data, 'scope, A: Arch<Platform = Elf>, R: Relocation<Plat
     scope: &Scope<'scope>,
     relr_writer: &mut RelrEncoder,
 ) -> Result<RelocationModifier> {
+    let Some(local_sym_index) = rel.symbol() else {
+        return Ok(RelocationModifier::Normal);
+    };
+
+    let mut classified =
+        classify_symbol_relocation::<A, R>(object, rel, section, local_sym_index, resources)?;
+
+    materialize_relocation_requirements::<A, R>(
+        common,
+        rel,
+        section,
+        resources,
+        is_debug_section,
+        relr_writer,
+        &mut classified,
+    )?;
+
+    let previous_flags =
+        note_relocation_symbol_reference::<A>(&classified, resources, queue, scope);
+
+    if !is_debug_section {
+        crate::thunks::handle_thunk_extensions_for_relocation::<A>(
+            section_part_id,
+            resources,
+            classified.local_symbol_id,
+            classified.symbol_id,
+            classified.r_type,
+        );
+    }
+
+    layout::check_for_undefined::<A>(
+        object,
+        section,
+        classified.rel_offset,
+        local_sym_index,
+        classified.flags,
+        classified.symbol_id,
+        resources,
+    )?;
+
+    if classified.flags_to_add.needs_copy_relocation() && !previous_flags.needs_copy_relocation() {
+        queue.send_copy_relocation_request::<A>(classified.symbol_id, resources, scope);
+    }
+
+    Ok(classified.next_modifier)
+}
+
+/// Symbol and relocation-kind info needed for both GC edges and output accounting.
+struct ClassifiedSymbolRelocation {
+    local_symbol_id: SymbolId,
+    symbol_id: SymbolId,
+    /// Definition (and local) value flags before this relocation's contributions.
+    flags: ValueFlags,
+    flags_to_add: ValueFlags,
+    rel_offset: u64,
+    r_type: u32,
+    rel_kind: linker_utils::elf::RelocationKind,
+    next_modifier: RelocationModifier,
+    section_is_writable: bool,
+}
+
+/// Resolve the relocated symbol and determine the effective relocation kind / initial flags.
+#[inline(always)]
+fn classify_symbol_relocation<'data, A: Arch<Platform = Elf>, R: Relocation<Platform = Elf>>(
+    object: &ObjectLayoutState<'data, Elf>,
+    rel: &R,
+    section: &<A::Platform as Platform>::SectionHeader,
+    local_sym_index: object::SymbolIndex,
+    resources: &layout::GraphResources<'data, '_, Elf>,
+) -> Result<ClassifiedSymbolRelocation> {
     let args = resources.symbol_db.args;
+    let symbol_db = resources.symbol_db;
+    let local_symbol_id = object.symbol_id_range.input_to_id(local_sym_index);
+    let symbol_id = symbol_db.definition(local_symbol_id);
+    let mut flags = resources.local_flags_for_symbol(symbol_id);
+    flags.merge(resources.local_flags_for_symbol(local_symbol_id));
+    let rel_offset = rel.offset();
+    let r_type = rel.raw_type();
+    let section_flags = section.sh_flags(LittleEndian);
+
     let mut next_modifier = RelocationModifier::Normal;
-    if let Some(local_sym_index) = rel.symbol() {
-        let symbol_db = resources.symbol_db;
-        let local_symbol_id = object.symbol_id_range.input_to_id(local_sym_index);
-        let symbol_id = symbol_db.definition(local_symbol_id);
-        let mut flags = resources.local_flags_for_symbol(symbol_id);
-        flags.merge(resources.local_flags_for_symbol(local_symbol_id));
-        let rel_offset = rel.offset();
-        let r_type = rel.raw_type();
-        let section_flags = section.sh_flags(LittleEndian);
+    let rel_info = if let Some(relaxation) = A::new_relaxation(
+        r_type,
+        object.object.raw_section_data(section)?,
+        rel_offset,
+        flags,
+        symbol_db.output_kind,
+        section_flags,
+        true,
+        None,
+    )
+    .filter(|relaxation| args.should_relax() || relaxation.is_mandatory())
+    {
+        next_modifier = relaxation.next_modifier();
+        relaxation.rel_info()
+    } else {
+        A::relocation_from_raw(r_type)?
+    };
 
-        let rel_info = if let Some(relaxation) = A::new_relaxation(
-            r_type,
-            object.object.raw_section_data(section)?,
-            rel_offset,
-            flags,
-            symbol_db.output_kind,
-            section_flags,
-            true,
-            None,
-        )
-        .filter(|relaxation| args.should_relax() || relaxation.is_mandatory())
+    Ok(ClassifiedSymbolRelocation {
+        local_symbol_id,
+        symbol_id,
+        flags,
+        flags_to_add: layout::resolution_flags(rel_info.kind),
+        rel_offset,
+        r_type,
+        rel_kind: rel_info.kind,
+        next_modifier,
+        section_is_writable: section.is_writable(),
+    })
+}
+
+/// Account for GOT/PLT/dynamic-reloc/TLS sizes implied by this relocation.
+#[inline(always)]
+fn materialize_relocation_requirements<
+    'data,
+    A: Arch<Platform = Elf>,
+    R: Relocation<Platform = Elf>,
+>(
+    common: &mut CommonGroupState<'data, Elf>,
+    rel: &R,
+    section: &<A::Platform as Platform>::SectionHeader,
+    resources: &layout::GraphResources<'data, '_, Elf>,
+    is_debug_section: bool,
+    relr_writer: &mut RelrEncoder,
+    classified: &mut ClassifiedSymbolRelocation,
+) -> Result {
+    let args = resources.symbol_db.args;
+    let symbol_db = resources.symbol_db;
+    let section_flags = section.sh_flags(LittleEndian);
+    let flags = classified.flags;
+    let symbol_id = classified.symbol_id;
+    let r_type = classified.r_type;
+    let section_is_writable = classified.section_is_writable;
+    let flags_to_add = &mut classified.flags_to_add;
+    let rel_kind = classified.rel_kind;
+
+    if !section_flags.is_alloc() {
+        // Non-alloc sections never get dynamic relocations, so there's nothing to do here.
+    } else if rel_kind.is_tls() {
+        if does_relocation_require_static_tls(rel_kind) {
+            resources
+                .has_static_tls
+                .store(true, atomic::Ordering::Relaxed);
+        }
+
+        if layout::needs_tlsld(rel_kind)
+            && !resources
+                .layout_resources_ext
+                .uses_tlsld
+                .load(atomic::Ordering::Relaxed)
         {
-            next_modifier = relaxation.next_modifier();
-            relaxation.rel_info()
-        } else {
-            A::relocation_from_raw(r_type)?
-        };
-
-        let section_is_writable = section.is_writable();
-        let mut flags_to_add = layout::resolution_flags(rel_info.kind);
-
-        if !section_flags.is_alloc() {
-            // Non-alloc sections never get dynamic relocations, so there's nothing to do here.
-        } else if rel_info.kind.is_tls() {
-            if does_relocation_require_static_tls(rel_info.kind) {
-                resources
-                    .has_static_tls
-                    .store(true, atomic::Ordering::Relaxed);
-            }
-
-            if layout::needs_tlsld(rel_info.kind)
-                && !resources
-                    .layout_resources_ext
-                    .uses_tlsld
-                    .load(atomic::Ordering::Relaxed)
-            {
-                resources
-                    .layout_resources_ext
-                    .uses_tlsld
-                    .store(true, atomic::Ordering::Relaxed);
-            }
-        } else if flags_to_add.needs_direct() && flags.is_interposable() {
-            if symbol_db.output_kind.is_shared_object()
-                && A::is_disallowed_for_interposable_symbols(r_type)
-            {
-                bail!(
-                    "relocation {} cannot be used when making a shared object; \
-                    recompile with -fPIC",
-                    A::rel_type_to_string(r_type),
-                );
-            }
-            if section_is_writable {
-                common.allocate(part_id::RELA_DYN_GENERAL, elf::RELA_ENTRY_SIZE);
-            } else if flags.is_function() {
-                // Create a PLT entry for the function and refer to that instead.
-                flags_to_add.remove(ValueFlags::DIRECT);
-                flags_to_add |= ValueFlags::PLT | ValueFlags::GOT;
-            } else if !flags.is_absolute() {
-                match args.copy_relocations_enabled() {
-                    crate::args::CopyRelocations::Allowed => {
-                        flags_to_add |= ValueFlags::COPY_RELOCATION;
-                    }
-                    crate::args::CopyRelocations::Disallowed(reason) => {
-                        // We don't at present support text relocations, so if we can't apply a copy
-                        // relocation, we error instead.
-                        bail!(
-                            "Direct relocation ({}) to dynamic symbol from non-writable section, \
-                            but copy relocations are disabled because {reason}. {}",
-                            A::rel_type_to_string(r_type),
-                            resources.symbol_debug(symbol_id),
-                        );
-                    }
-                }
-            }
-        } else if flags.is_ifunc()
-            && rel_info.kind == RelocationKind::Absolute
-            && section_is_writable
-            && symbol_db.output_kind.is_relocatable()
+            resources
+                .layout_resources_ext
+                .uses_tlsld
+                .store(true, atomic::Ordering::Relaxed);
+        }
+    } else if flags_to_add.needs_direct() && flags.is_interposable() {
+        if symbol_db.output_kind.is_shared_object()
+            && A::is_disallowed_for_interposable_symbols(r_type)
         {
-            common.allocate(part_id::RELA_DYN_GENERAL, elf::RELA_ENTRY_SIZE);
-        } else if symbol_db.output_kind.is_relocatable()
-            && rel_info.kind == RelocationKind::Absolute
-            && flags.is_address()
-        {
-            if section_is_writable {
-                // Odd offsets can't be encoded as RELR address entries (LSB used as
-                // bitmap marker), so fall back to RELA for them.
-                if resources.symbol_db.args.is_relr_enabled() && rel.offset().is_multiple_of(2) {
-                    relr_writer.encode(rel.offset(), |_, encoding| {
-                        if matches!(encoding, RelrEntryEncoding::New) {
-                            common.allocate(part_id::RELR_DYN, elf::RELR_ENTRY_SIZE);
-                        }
-                        Ok(())
-                    })?;
-                } else {
-                    common.allocate(part_id::RELA_DYN_RELATIVE, elf::RELA_ENTRY_SIZE);
-                }
-            } else if !is_debug_section {
-                bail!(
-                    "Cannot apply relocation {} to read-only section. \
-                    Please recompile with -fPIC or link with -no-pie",
-                    A::rel_type_to_string(r_type),
-                );
-            }
-        }
-
-        // For ifunc symbols with GOT-relative references (like R_X86_64_GOTPCRELX), we need a
-        // separate GOT entry for address equality. The main GOT entry will be used by the PLT stub
-        // with an IRELATIVE relocation, while this extra entry will contain the PLT stub address so
-        // that all references to the ifunc return the same address.
-
-        let relocation_needs_got = flags_to_add.needs_got();
-
-        if flags.is_ifunc() && !symbol_db.output_kind.is_static_executable() {
-            flags_to_add |= ValueFlags::GOT | ValueFlags::PLT;
-        }
-
-        if flags.is_ifunc() && relocation_needs_got && !symbol_db.output_kind.is_relocatable() {
-            flags_to_add |= ValueFlags::IFUNC_GOT_FOR_ADDRESS;
-        }
-
-        let atomic_flags = &resources.per_symbol_flags.get_atomic(symbol_id);
-        let previous_flags = atomic_flags.fetch_or(flags_to_add);
-
-        if !previous_flags.has_resolution() {
-            if flags.is_ifunc() && symbol_db.output_kind.is_static_executable() {
-                atomic_flags.fetch_or(ValueFlags::GOT | ValueFlags::PLT);
-            }
-
-            queue.send_symbol_request::<A>(symbol_id, resources, scope);
-        }
-
-        if !is_debug_section {
-            crate::thunks::handle_thunk_extensions_for_relocation::<A>(
-                section_part_id,
-                resources,
-                local_symbol_id,
-                symbol_id,
-                r_type,
+            bail!(
+                "relocation {} cannot be used when making a shared object; \
+                recompile with -fPIC",
+                A::rel_type_to_string(r_type),
             );
         }
-
-        layout::check_for_undefined::<A>(
-            object,
-            section,
-            rel_offset,
-            local_sym_index,
-            flags,
-            symbol_id,
-            resources,
-        )?;
-
-        if flags_to_add.needs_copy_relocation() && !previous_flags.needs_copy_relocation() {
-            queue.send_copy_relocation_request::<A>(symbol_id, resources, scope);
+        if section_is_writable {
+            common.allocate(part_id::RELA_DYN_GENERAL, elf::RELA_ENTRY_SIZE);
+        } else if flags.is_function() {
+            // Create a PLT entry for the function and refer to that instead.
+            flags_to_add.remove(ValueFlags::DIRECT);
+            *flags_to_add |= ValueFlags::PLT | ValueFlags::GOT;
+        } else if !flags.is_absolute() {
+            match args.copy_relocations_enabled() {
+                crate::args::CopyRelocations::Allowed => {
+                    *flags_to_add |= ValueFlags::COPY_RELOCATION;
+                }
+                crate::args::CopyRelocations::Disallowed(reason) => {
+                    // We don't at present support text relocations, so if we can't apply a copy
+                    // relocation, we error instead.
+                    bail!(
+                        "Direct relocation ({}) to dynamic symbol from non-writable section, \
+                        but copy relocations are disabled because {reason}. {}",
+                        A::rel_type_to_string(r_type),
+                        resources.symbol_debug(symbol_id),
+                    );
+                }
+            }
+        }
+    } else if flags.is_ifunc()
+        && rel_kind == RelocationKind::Absolute
+        && section_is_writable
+        && symbol_db.output_kind.is_relocatable()
+    {
+        common.allocate(part_id::RELA_DYN_GENERAL, elf::RELA_ENTRY_SIZE);
+    } else if symbol_db.output_kind.is_relocatable()
+        && rel_kind == RelocationKind::Absolute
+        && flags.is_address()
+    {
+        if section_is_writable {
+            // Odd offsets can't be encoded as RELR address entries (LSB used as
+            // bitmap marker), so fall back to RELA for them.
+            if resources.symbol_db.args.is_relr_enabled() && rel.offset().is_multiple_of(2) {
+                relr_writer.encode(rel.offset(), |_, encoding| {
+                    if matches!(encoding, RelrEntryEncoding::New) {
+                        common.allocate(part_id::RELR_DYN, elf::RELR_ENTRY_SIZE);
+                    }
+                    Ok(())
+                })?;
+            } else {
+                common.allocate(part_id::RELA_DYN_RELATIVE, elf::RELA_ENTRY_SIZE);
+            }
+        } else if !is_debug_section {
+            bail!(
+                "Cannot apply relocation {} to read-only section. \
+                Please recompile with -fPIC or link with -no-pie",
+                A::rel_type_to_string(r_type),
+            );
         }
     }
-    Ok(next_modifier)
+
+    // For ifunc symbols with GOT-relative references (like R_X86_64_GOTPCRELX), we need a
+    // separate GOT entry for address equality. The main GOT entry will be used by the PLT stub
+    // with an IRELATIVE relocation, while this extra entry will contain the PLT stub address so
+    // that all references to the ifunc return the same address.
+
+    let relocation_needs_got = flags_to_add.needs_got();
+
+    if flags.is_ifunc() && !symbol_db.output_kind.is_static_executable() {
+        *flags_to_add |= ValueFlags::GOT | ValueFlags::PLT;
+    }
+
+    if flags.is_ifunc() && relocation_needs_got && !symbol_db.output_kind.is_relocatable() {
+        *flags_to_add |= ValueFlags::IFUNC_GOT_FOR_ADDRESS;
+    }
+
+    Ok(())
+}
+
+/// Record that a live section references `classified.symbol_id` and enqueue graph work if needed.
+#[inline(always)]
+fn note_relocation_symbol_reference<'data, 'scope, A: Arch<Platform = Elf>>(
+    classified: &ClassifiedSymbolRelocation,
+    resources: &'scope layout::GraphResources<'data, '_, Elf>,
+    queue: &mut layout::LocalWorkQueue,
+    scope: &Scope<'scope>,
+) -> ValueFlags {
+    let symbol_id = classified.symbol_id;
+    let flags = classified.flags;
+    let flags_to_add = classified.flags_to_add;
+
+    let atomic_flags = &resources.per_symbol_flags.get_atomic(symbol_id);
+    let previous_flags = atomic_flags.fetch_or(flags_to_add);
+
+    if !previous_flags.has_resolution() {
+        if flags.is_ifunc() && resources.symbol_db.output_kind.is_static_executable() {
+            atomic_flags.fetch_or(ValueFlags::GOT | ValueFlags::PLT);
+        }
+
+        queue.send_symbol_request::<A>(symbol_id, resources, scope);
+    }
+
+    previous_flags
 }
 
 /// Returns whether the supplied relocation type requires static TLS. If true and we're writing a


### PR DESCRIPTION
Split the existing ELF GC relocation path into smaller steps so other formats (especially Wasm) can reuse the edge-discovery half without taking on ELF materialize (GOT/PLT/sizes) or the section work queue.