### PR TITLE
fix: Skip mapping symbols in unloaded sections during relocatable link

### DIFF
--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -2302,10 +2302,15 @@ fn write_symbols<'data>(
                             .section_part_id(section_index, &layout.symbol_db.section_part_ids)
                             .output_section_id::<Elf>(),
                         SectionSlot::FrameData(..) => output_section_id::EH_FRAME,
-                        _ => bail!(
-                            "Tried to copy a symbol in a section we didn't load. {}",
-                            layout.symbol_debug(symbol_id)
-                        ),
+                        _ => {
+                            if layout.symbol_db.is_mapping_symbol(symbol_id) {
+                                continue;
+                            }
+                            bail!(
+                                "Tried to copy a symbol in a section we didn't load. {}",
+                                layout.symbol_debug(symbol_id)
+                            )
+                        }
                     }
                 } else if sym.is_common(e) {
                     if sym.st_type() == STT_TLS {

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -1674,7 +1674,10 @@ impl<'data, P: Platform> std::fmt::Display for ResolvedFile<'data, P> {
 
 impl SectionSlot {
     pub(crate) fn is_loaded(&self) -> bool {
-        !matches!(self, SectionSlot::Discard | SectionSlot::Unloaded(..))
+        !matches!(
+            self,
+            SectionSlot::Discard | SectionSlot::Unloaded(..) | SectionSlot::NoteGnuProperty(..)
+        )
     }
 
     pub(crate) fn unloaded_mut(&mut self) -> Option<&mut UnloadedSection> {

--- a/wild/tests/sources/elf/aarch64-property-relocatable/aarch64-property-relocatable-input.s
+++ b/wild/tests/sources/elf/aarch64-property-relocatable/aarch64-property-relocatable-input.s
@@ -1,0 +1,13 @@
+.text
+ret
+.section ".note.gnu.property", "a"
+.p2align 3
+.long 4
+.long 0x10
+.long 5
+.asciz "GNU"
+.p2align 3
+.long 0xc0000000
+.long 4
+.long 3
+.p2align 3

--- a/wild/tests/sources/elf/aarch64-property-relocatable/aarch64-property-relocatable.s
+++ b/wild/tests/sources/elf/aarch64-property-relocatable/aarch64-property-relocatable.s
@@ -1,0 +1,13 @@
+// Test that Wild doesn't panic when doing a relocatable link with an object
+// containing .note.gnu.property section (which has $d mapping symbol).
+// Previously Wild panicked with "Tried to copy a symbol in a section we didn't load"
+// for the $d mapping symbol in the .note.gnu.property section.
+//#Arch:aarch64
+//#Mode:static
+//#LinkArgs:--no-gc-sections
+//#Relocatable:aarch64-property-relocatable-input.s
+//#RunEnabled:false
+
+.globl _start
+_start:
+    ret


### PR DESCRIPTION
Wild reads `.note.gnu.property` specially but doesn't load it as a regular section. The `$d` mapping symbol inside it had no output section.

1. `elf_writer.rs`: Skip mapping symbols whose section is not loaded
2. `resolution.rs`: Mark `NoteGnuProperty` as not loaded in `is_loaded()`

Both are needed — Fix 1 alone causes `validate_empty` error.

Wild drops `.note.gnu.property` in relocatable output while lld and GNU ld preserve it. This silently removes BTI/PAC security features in two-step builds. Will be fixed in a follow-up PR.

Issue https://github.com/wild-linker/wild/issues/2247