### PR TITLE
refactor: Introduce and use some type aliases with suffix '64'

### DIFF
--- a/libwild/src/dwarf_address_info.rs
+++ b/libwild/src/dwarf_address_info.rs
@@ -1,7 +1,8 @@
 //! Uses DWARF debug info, if available, to find file and line number information for a particular
 //! offset in an input section.
 
-use crate::elf::File;
+use crate::elf::Elf64;
+use crate::elf::File64;
 use crate::elf::Rela;
 use crate::error::Result;
 use crate::fs::path_from_bytes;
@@ -26,8 +27,8 @@ use std::path::PathBuf;
 const SECTION_LOAD_ADDRESS: u64 = 0x1_000_000_000;
 
 /// Attempts to locate source info for `offset_in_section` within `section`.
-pub(crate) fn get_source_info<A: Arch<Platform = crate::elf::Elf>>(
-    object: &File,
+pub(crate) fn get_source_info<A: Arch<Platform = Elf64>>(
+    object: &File64,
     relocations: &RelocationSections,
     section: &object::elf::SectionHeader64<LittleEndian>,
     offset_in_section: u64,
@@ -92,8 +93,8 @@ pub(crate) fn get_source_info<A: Arch<Platform = crate::elf::Elf>>(
 }
 
 /// Gets the data for section `id` from `object` and applies relocations to it.
-fn section_data_with_relocations<A: Arch<Platform = crate::elf::Elf>>(
-    object: &File,
+fn section_data_with_relocations<A: Arch<Platform = Elf64>>(
+    object: &File64,
     relocations: &RelocationSections,
     id: gimli::SectionId,
     section_of_interest: &object::elf::SectionHeader64<LittleEndian>,
@@ -130,11 +131,8 @@ fn section_data_with_relocations<A: Arch<Platform = crate::elf::Elf>>(
     Ok(data)
 }
 
-fn apply_section_relocations<
-    A: Arch<Platform = crate::elf::Elf>,
-    R: Relocation<Platform = crate::elf::Elf>,
->(
-    object: &File<'_>,
+fn apply_section_relocations<A: Arch<Platform = Elf64>, R: Relocation<Platform = Elf64>>(
+    object: &File64,
     section_of_interest: &object::elf::SectionHeader64<LittleEndian>,
     section_data: &mut [u8],
     relocations: impl Iterator<Item = R>,

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -169,25 +169,30 @@ type SymbolTable<'data> = object::read::elf::SymbolTable<'data, FileHeader>;
 #[derive(Debug, Copy, Clone, Default)]
 pub(crate) struct Elf;
 
+pub(crate) type Elf64 = Elf;
+pub(crate) type File64<'data> = File<'data>;
+pub(crate) type FileHeader64 = FileHeader;
+pub(crate) type RelocationList64<'data> = RelocationList<'data>;
+
 pub(crate) fn link_for_arch<'data, F: FileSystem>(
     linker: &'data crate::Linker<F>,
     args: &'data ElfArgs,
 ) -> Result<crate::LinkerOutput<'data>> {
     match args.arch {
         crate::arch::Architecture::X86_64 => {
-            linker.link_for_arch::<Elf, crate::elf_x86_64::ElfX86_64>(args)
+            linker.link_for_arch::<Elf64, crate::elf_x86_64::ElfX86_64>(args)
         }
         crate::arch::Architecture::AArch64 => {
-            linker.link_for_arch::<Elf, crate::elf_aarch64::ElfAArch64>(args)
+            linker.link_for_arch::<Elf64, crate::elf_aarch64::ElfAArch64>(args)
         }
         crate::arch::Architecture::RiscV64 => {
-            linker.link_for_arch::<Elf, crate::elf_riscv64::ElfRiscV64>(args)
+            linker.link_for_arch::<Elf64, crate::elf_riscv64::ElfRiscV64>(args)
         }
         crate::arch::Architecture::LoongArch64 => {
-            linker.link_for_arch::<Elf, crate::elf_loongarch64::ElfLoongArch64>(args)
+            linker.link_for_arch::<Elf64, crate::elf_loongarch64::ElfLoongArch64>(args)
         }
         crate::arch::Architecture::Ppc64 => {
-            linker.link_for_arch::<Elf, crate::elf_ppc64::ElfPpc64>(args)
+            linker.link_for_arch::<Elf64, crate::elf_ppc64::ElfPpc64>(args)
         }
         crate::arch::Architecture::Unsupported => {
             bail!(

--- a/libwild/src/elf_aarch64.rs
+++ b/libwild/src/elf_aarch64.rs
@@ -1,5 +1,5 @@
 use crate::alignment::Alignment;
-use crate::elf::Elf;
+use crate::elf::Elf64;
 use crate::elf::PLT_ENTRY_SIZE;
 use crate::elf::PropertyClass;
 use crate::elf::output_section_id;
@@ -54,7 +54,7 @@ macro_rules! rel_info_from_type {
 
 impl crate::platform::Arch for ElfAArch64 {
     type Relaxation = Relaxation;
-    type Platform = Elf;
+    type Platform = Elf64;
 
     fn arch_identifier() -> <Self::Platform as Platform>::ArchIdentifier {
         object::elf::EM_AARCH64
@@ -130,7 +130,7 @@ impl crate::platform::Arch for ElfAArch64 {
         Ok(())
     }
 
-    fn tp_offset_start(layout: &Layout<Elf>) -> u64 {
+    fn tp_offset_start(layout: &Layout<Elf64>) -> u64 {
         layout.tls_start_address_aarch64()
     }
 
@@ -338,8 +338,7 @@ impl crate::platform::Arch for ElfAArch64 {
     fn thunk_config() -> Option<crate::platform::ThunkConfig> {
         Some(crate::platform::ThunkConfig {
             primary_function_part_id: const {
-                output_section_id::TEXT
-                    .part_id_with_alignment::<crate::elf::Elf>(Alignment { exponent: 2 })
+                output_section_id::TEXT.part_id_with_alignment::<Elf64>(Alignment { exponent: 2 })
             },
             min_branch_range: MIN_BRANCH_RANGE,
             thunk_size: THUNK_TEMPLATE.len() as u64,

--- a/libwild/src/elf_loongarch64.rs
+++ b/libwild/src/elf_loongarch64.rs
@@ -1,4 +1,4 @@
-use crate::elf::Elf;
+use crate::elf::Elf64;
 use crate::elf::PLT_ENTRY_SIZE;
 use crate::error;
 use crate::error::Result;
@@ -31,7 +31,7 @@ const _ASSERTS: () = {
 
 impl crate::platform::Arch for ElfLoongArch64 {
     type Relaxation = Relaxation;
-    type Platform = Elf;
+    type Platform = Elf64;
 
     fn arch_identifier() -> <Self::Platform as Platform>::ArchIdentifier {
         object::elf::EM_LOONGARCH
@@ -82,7 +82,7 @@ impl crate::platform::Arch for ElfLoongArch64 {
         0
     }
 
-    fn tp_offset_start(layout: &crate::layout::Layout<Elf>) -> u64 {
+    fn tp_offset_start(layout: &crate::layout::Layout<Elf64>) -> u64 {
         layout.tls_start_address_aligned()
     }
 

--- a/libwild/src/elf_ppc64.rs
+++ b/libwild/src/elf_ppc64.rs
@@ -1,5 +1,5 @@
 use crate::bail;
-use crate::elf::Elf;
+use crate::elf::Elf64;
 use crate::error;
 use crate::error::Result;
 use crate::platform::Platform;
@@ -14,7 +14,7 @@ pub(crate) struct ElfPpc64;
 
 impl crate::platform::Arch for ElfPpc64 {
     type Relaxation = Relaxation;
-    type Platform = Elf;
+    type Platform = Elf64;
 
     fn arch_identifier() -> <Self::Platform as Platform>::ArchIdentifier {
         object::elf::EM_PPC64
@@ -51,7 +51,7 @@ impl crate::platform::Arch for ElfPpc64 {
     }
 
     /// The thread pointer (`r13`) points 0x7000 bytes past the start of the static TLS block.
-    fn tp_offset_start(layout: &crate::layout::Layout<Elf>) -> u64 {
+    fn tp_offset_start(layout: &crate::layout::Layout<Elf64>) -> u64 {
         layout.tls_start_address() + 0x7000
     }
 

--- a/libwild/src/elf_riscv64.rs
+++ b/libwild/src/elf_riscv64.rs
@@ -1,6 +1,6 @@
-use crate::elf::Elf;
+use crate::elf::Elf64;
 use crate::elf::PLT_ENTRY_SIZE;
-use crate::elf::RelocationList;
+use crate::elf::RelocationList64;
 use crate::ensure;
 use crate::error;
 use crate::error::Context as _;
@@ -48,7 +48,7 @@ macro_rules! rel_info_from_type {
 
 impl crate::platform::Arch for ElfRiscV64 {
     type Relaxation = Relaxation;
-    type Platform = Elf;
+    type Platform = Elf64;
     const DEFAULT_LOAD_ADDRESS: u64 = 0x10000;
 
     fn arch_identifier() -> <Self::Platform as Platform>::ArchIdentifier {
@@ -99,7 +99,7 @@ impl crate::platform::Arch for ElfRiscV64 {
         RISCV_TLS_DTV_OFFSET
     }
 
-    fn tp_offset_start(layout: &crate::layout::Layout<Elf>) -> u64 {
+    fn tp_offset_start(layout: &crate::layout::Layout<Elf64>) -> u64 {
         layout.tls_start_address_aligned()
     }
 
@@ -290,19 +290,19 @@ impl crate::platform::Arch for ElfRiscV64 {
     fn collect_relaxation_deltas(
         section_output_address: u64,
         section_bytes: &[u8],
-        relocations: RelocationList,
+        relocations: RelocationList64,
         existing_deltas: Option<&SectionRelaxDeltas>,
         mut resolve_symbol: impl FnMut(object::SymbolIndex) -> Option<RelaxSymbolInfo>,
     ) -> (Vec<(u64, u32)>, Option<u64>) {
         match relocations {
-            RelocationList::Rela(rela_list) => collect_relaxation_deltas(
+            RelocationList64::Rela(rela_list) => collect_relaxation_deltas(
                 section_output_address,
                 section_bytes,
                 rela_list.rel_iter(),
                 existing_deltas,
                 &mut resolve_symbol,
             ),
-            RelocationList::Crel(crel_iter) => collect_relaxation_deltas(
+            RelocationList64::Crel(crel_iter) => collect_relaxation_deltas(
                 section_output_address,
                 section_bytes,
                 crel_iter.flatten(),
@@ -389,7 +389,7 @@ impl crate::platform::Relaxation for Relaxation {
 /// `section_output_address` is the output address of the section being scanned. `existing_deltas`,
 /// if present, is used to skip calls that were already relaxed in a previous pass. `resolve_symbol`
 /// returns the output address and interposability of a symbol.
-fn collect_relaxation_deltas<R: Relocation<Platform = Elf>>(
+fn collect_relaxation_deltas<R: Relocation<Platform = Elf64>>(
     section_output_address: u64,
     section_bytes: &[u8],
     relocations: impl Iterator<Item = R>,

--- a/libwild/src/elf_x86_64.rs
+++ b/libwild/src/elf_x86_64.rs
@@ -4,7 +4,7 @@
 //! static-PIE binary because dynamic relocations haven't yet been applied to the GOT yet.
 
 use crate::OutputKind;
-use crate::elf::Elf;
+use crate::elf::Elf64;
 use crate::elf::PLT_ENTRY_SIZE;
 use crate::elf::PropertyClass;
 use crate::error;
@@ -51,7 +51,7 @@ macro_rules! rel_info_from_type {
 
 impl crate::platform::Arch for ElfX86_64 {
     type Relaxation = Relaxation;
-    type Platform = Elf;
+    type Platform = Elf64;
 
     fn arch_identifier() -> <Self::Platform as Platform>::ArchIdentifier {
         object::elf::EM_X86_64
@@ -111,7 +111,7 @@ impl crate::platform::Arch for ElfX86_64 {
         x86_64_rel_type_to_string(r_type)
     }
 
-    fn tp_offset_start(layout: &crate::layout::Layout<Elf>) -> u64 {
+    fn tp_offset_start(layout: &crate::layout::Layout<Elf64>) -> u64 {
         layout.tls_end_address()
     }
 

--- a/libwild/src/expression_eval.rs
+++ b/libwild/src/expression_eval.rs
@@ -436,7 +436,7 @@ fn section_load_address<'data, P: Platform>(
 mod tests {
     use super::*;
     use crate::OsFileSystem;
-    use crate::elf::Elf;
+    use crate::elf::Elf64;
     use crate::grouping::Group;
     use crate::grouping::SequencedLinkerScript;
     use crate::input_data::FileId;
@@ -450,11 +450,11 @@ mod tests {
     fn with_dummy_context<R>(
         f: impl for<'test> FnOnce(
             &OutputSectionMap<OutputRecordLayout>,
-            &OutputSections<'test, Elf>,
-            &mut SymbolDb<'test, Elf>,
+            &OutputSections<'test, Elf64>,
+            &mut SymbolDb<'test, Elf64>,
         ) -> R,
     ) -> R {
-        let sections = OutputSections::<Elf>::for_testing();
+        let sections = OutputSections::<Elf64>::for_testing();
         let layouts = sections.new_section_map::<OutputRecordLayout>();
         let args = crate::args::elf::ElfArgs::new().unwrap();
         let output_kind = crate::output_kind::OutputKind::Relocatable;
@@ -462,13 +462,13 @@ mod tests {
         let auxiliary =
             crate::input_data::AuxiliaryFiles::new(&args, &arena, &OsFileSystem).unwrap();
         let herd = Default::default();
-        let mut symbol_db = SymbolDb::<Elf>::new(&args, output_kind, &auxiliary, &herd).unwrap();
+        let mut symbol_db = SymbolDb::<Elf64>::new(&args, output_kind, &auxiliary, &herd).unwrap();
         f(&layouts, &sections, &mut symbol_db)
     }
 
     fn eval_const(expr: &Expression<'static>) -> Result<u64> {
         with_dummy_context(|layouts, sections, symbol_db| {
-            evaluate_expression::<Elf>(
+            evaluate_expression::<Elf64>(
                 expr,
                 &SymbolLoc::None,
                 layouts,
@@ -791,7 +791,7 @@ mod tests {
         );
     }
 
-    fn make_group<'data>(assertions: Vec<AssertCommand<'static>>) -> Group<'data, Elf> {
+    fn make_group<'data>(assertions: Vec<AssertCommand<'static>>) -> Group<'data, Elf64> {
         let script = SequencedLinkerScript {
             parsed: ProcessedLinkerScript {
                 input: crate::input_data::InputRef {
@@ -826,7 +826,7 @@ mod tests {
             }]);
             symbol_db.add_group(group);
             assert!(
-                evaluate_assertions::<Elf>(
+                evaluate_assertions::<Elf64>(
                     symbol_db,
                     layouts,
                     sections,
@@ -849,7 +849,7 @@ mod tests {
                 remainder: b"",
             }]);
             symbol_db.add_group(group);
-            let err = evaluate_assertions::<Elf>(
+            let err = evaluate_assertions::<Elf64>(
                 symbol_db,
                 layouts,
                 sections,
@@ -885,7 +885,7 @@ mod tests {
                 ),
             ]);
             let eval = |expr: &Expression<'static>| {
-                evaluate_expression::<Elf>(
+                evaluate_expression::<Elf64>(
                     expr,
                     &SymbolLoc::None,
                     layouts,

--- a/libwild/src/file_kind.rs
+++ b/libwild/src/file_kind.rs
@@ -36,11 +36,11 @@ impl FileKind {
         } else if bytes.starts_with(&object::archive::THIN_MAGIC) {
             Ok(FileKind::ThinArchive)
         } else if bytes.starts_with(&object::elf::ELFMAG) {
-            const HEADER_LEN: usize = size_of::<elf::FileHeader>();
+            const HEADER_LEN: usize = size_of::<elf::FileHeader64>();
             if bytes.len() < HEADER_LEN {
                 bail!("Invalid ELF file");
             }
-            let header: &elf::FileHeader = object::from_bytes(&bytes[..HEADER_LEN]).unwrap().0;
+            let header: &elf::FileHeader64 = object::from_bytes(&bytes[..HEADER_LEN]).unwrap().0;
             ensure!(
                 header.e_ident.class == object::elf::ELFCLASS64,
                 "Only 64 bit ELF is currently supported"
@@ -115,7 +115,7 @@ fn determine_macho_kind(bytes: &[u8]) -> Result<FileKind> {
 /// expensive. Instead, we assume that we'll find a GCC LTO section within the first few sections,
 /// so just scan part of the section header strings table. It's unfortunate that GCC didn't tag
 /// these objects in some fast-to-check way.
-fn is_gcc_bitcode(data: &[u8], header: &crate::elf::FileHeader) -> Option<bool> {
+fn is_gcc_bitcode(data: &[u8], header: &crate::elf::FileHeader64) -> Option<bool> {
     // If we don't have plugin support, then we skip checking if the file contains GCC IR. If it is,
     // then we'll figure that out later on and report an error. We do this because this code has a
     // measurable performance impact.

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -5881,13 +5881,13 @@ impl<'data, P: Platform> ObjectLayout<'data, P> {
 #[test]
 fn test_no_disallowed_overlaps() {
     use crate::OsFileSystem;
-    use crate::elf::Elf;
+    use crate::elf::Elf64;
     use crate::output_section_id::OrderEvent;
 
     let output_kind = crate::output_kind::OutputKind::StaticExecutable(
         crate::args::RelocationModel::NonRelocatable,
     );
-    let mut output_sections = OutputSections::<Elf>::with_base_address(0x1000, output_kind);
+    let mut output_sections = OutputSections::<Elf64>::with_base_address(0x1000, output_kind);
     let (output_order, program_segments) =
         output_sections.output_order(output_kind, &[], &[]).unwrap();
     let mut args = crate::args::elf::ElfArgs::default();
@@ -5907,7 +5907,7 @@ fn test_no_disallowed_overlaps() {
         .collect();
 
     let section_part_sizes = output_sections.new_part_map::<u64>().map(|part_id, _| {
-        if sections_to_output.contains(&part_id.output_section_id::<crate::elf::Elf>()) {
+        if sections_to_output.contains(&part_id.output_section_id::<Elf64>()) {
             7
         } else {
             0
@@ -5921,9 +5921,9 @@ fn test_no_disallowed_overlaps() {
     let auxiliary = crate::input_data::AuxiliaryFiles::new(&args, &arena, &OsFileSystem).unwrap();
     let herd = Default::default();
     let symbol_db =
-        crate::symbol_db::SymbolDb::<Elf>::new(&args, output_kind, &auxiliary, &herd).unwrap();
+        crate::symbol_db::SymbolDb::<Elf64>::new(&args, output_kind, &auxiliary, &herd).unwrap();
 
-    let (_, section_layouts, _) = compute_layout_sections::<Elf>(
+    let (_, section_layouts, _) = compute_layout_sections::<Elf64>(
         &section_part_sizes,
         &output_sections,
         &program_segments,
@@ -5990,7 +5990,7 @@ fn test_no_disallowed_overlaps() {
         }
     });
 
-    let segment_layouts = compute_segment_layout::<Elf>(
+    let segment_layouts = compute_segment_layout::<Elf64>(
         &section_layouts,
         &output_sections,
         &output_order,

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -714,10 +714,10 @@ fn regular_section_or_discard(section_id: Option<OutputSectionId>) -> SectionRul
 
 #[test]
 fn test_section_mapping() {
-    let rules = SectionRules::from_rules(&crate::elf::Elf::default_layout_rules(
+    let rules = SectionRules::from_rules(&crate::elf::Elf64::default_layout_rules(
         &crate::args::elf::ElfArgs::new().unwrap(),
     ));
-    let header = crate::elf::SectionHeader {
+    let header = object::elf::SectionHeader64::<object::LittleEndian> {
         sh_name: Default::default(),
         sh_type: Default::default(),
         sh_flags: Default::default(),
@@ -729,7 +729,8 @@ fn test_section_mapping() {
         sh_addralign: Default::default(),
         sh_entsize: Default::default(),
     };
-    let lookup_name = |name: &str| rules.lookup::<crate::elf::Elf>(name.as_bytes(), None, &header);
+    let lookup_name =
+        |name: &str| rules.lookup::<crate::elf::Elf64>(name.as_bytes(), None, &header);
 
     assert_eq!(
         lookup_name(".comment"),

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -1050,13 +1050,13 @@ impl<'data, P: Platform> OutputSections<'data, P> {
     }
 
     #[cfg(test)]
-    pub(crate) fn for_testing() -> OutputSections<'static, crate::elf::Elf> {
-        use crate::elf::Elf;
+    pub(crate) fn for_testing() -> OutputSections<'static, crate::elf::Elf64> {
+        use crate::elf::Elf64;
 
         let output_kind = crate::output_kind::OutputKind::StaticExecutable(
             crate::args::RelocationModel::NonRelocatable,
         );
-        let mut output_sections = OutputSections::<Elf>::with_base_address(0x1000, output_kind);
+        let mut output_sections = OutputSections::<Elf64>::with_base_address(0x1000, output_kind);
         let mut add_name = |name: &'static str| {
             output_sections.add_named_section(
                 SectionName(name.as_bytes()),

--- a/libwild/src/output_section_part_map.rs
+++ b/libwild/src/output_section_part_map.rs
@@ -202,8 +202,9 @@ impl<'out> OutputSectionPartMap<&'out mut [u8]> {
 
 #[test]
 fn test_merge_parts() {
-    let output_sections =
-        crate::output_section_id::OutputSections::<crate::elf::Elf>::for_testing();
+    use crate::elf::Elf64;
+
+    let output_sections = crate::output_section_id::OutputSections::<Elf64>::for_testing();
     let (output_order, _program_segments) = output_sections
         .output_order(
             crate::output_kind::OutputKind::StaticExecutable(
@@ -228,12 +229,12 @@ fn test_merge_parts() {
 
     let mut sum_of_1s = output_sections.new_section_map::<u32>();
     sum_of_1s.for_each_mut(|section_id, sum| {
-        if !section_id.is_regular::<crate::elf::Elf>()
-            && <crate::elf::Elf as crate::platform::Platform>::single_part_id(section_id).is_none()
+        if !section_id.is_regular::<Elf64>()
+            && <Elf64 as crate::platform::Platform>::single_part_id(section_id).is_none()
         {
             return;
         }
-        let range = section_id.part_id_range::<crate::elf::Elf>();
+        let range = section_id.part_id_range::<Elf64>();
         *sum = all_1[range].iter().sum();
     });
 
@@ -243,8 +244,8 @@ fn test_merge_parts() {
         if *sum == 17 {
             num_sections_with_17 += 1;
         }
-        let unsupported_single_part = !section_id.is_regular::<crate::elf::Elf>()
-            && <crate::elf::Elf as crate::platform::Platform>::single_part_id(section_id).is_none();
+        let unsupported_single_part = !section_id.is_regular::<Elf64>()
+            && <Elf64 as crate::platform::Platform>::single_part_id(section_id).is_none();
         if section_id == crate::output_section_id::UNMAPPED || unsupported_single_part {
             assert!(*sum == 0, "Expected zero sum for section {section_id:?}");
         } else {
@@ -259,12 +260,12 @@ fn test_merge_parts() {
 
     let mut merged = output_sections.new_section_map::<u32>();
     merged.for_each_mut(|section_id, sum| {
-        if !section_id.is_regular::<crate::elf::Elf>()
-            && <crate::elf::Elf as crate::platform::Platform>::single_part_id(section_id).is_none()
+        if !section_id.is_regular::<Elf64>()
+            && <Elf64 as crate::platform::Platform>::single_part_id(section_id).is_none()
         {
             return;
         }
-        let range = section_id.part_id_range::<crate::elf::Elf>();
+        let range = section_id.part_id_range::<Elf64>();
         *sum = headers_only[range].iter().sum();
     });
 
@@ -276,7 +277,7 @@ fn test_merge_parts() {
 #[test]
 fn test_mut_with_map() {
     let output_sections =
-        crate::output_section_id::OutputSections::<crate::elf::Elf>::for_testing();
+        crate::output_section_id::OutputSections::<crate::elf::Elf64>::for_testing();
     let mut input1 = output_sections.new_part_map::<u32>().map(|_, _| 1);
     let input2 = output_sections.new_part_map::<u32>().map(|_, _| 2);
     let expected = output_sections.new_part_map::<u32>().map(|_, _| 3);
@@ -287,7 +288,7 @@ fn test_mut_with_map() {
 #[test]
 fn test_merge() {
     let output_sections =
-        crate::output_section_id::OutputSections::<crate::elf::Elf>::for_testing();
+        crate::output_section_id::OutputSections::<crate::elf::Elf64>::for_testing();
     let mut input1 = output_sections.new_part_map::<u32>().map(|_, _| 1);
     let input2 = output_sections.new_part_map::<u32>().map(|_, _| 2);
     let expected = output_sections.new_part_map::<u32>().map(|_, _| 3);
@@ -298,7 +299,7 @@ fn test_merge() {
 #[test]
 fn test_merge_with_custom_sections() {
     let output_sections =
-        crate::output_section_id::OutputSections::<crate::elf::Elf>::for_testing();
+        crate::output_section_id::OutputSections::<crate::elf::Elf64>::for_testing();
     let mut m1 = output_sections.new_part_map::<u32>();
     let mut m2 = output_sections.new_part_map::<u32>();
     assert_eq!(m2.num_parts(), output_sections.num_parts());
@@ -312,10 +313,11 @@ fn test_merge_with_custom_sections() {
 /// latter, so this test is less important. It's kept for the time being anyway.
 #[test]
 fn test_output_order_map_consistent() {
+    use crate::elf::Elf64;
     use itertools::Itertools;
 
     let output_sections =
-        crate::output_section_id::OutputSections::<crate::elf::Elf>::for_testing();
+        crate::output_section_id::OutputSections::<crate::elf::Elf64>::for_testing();
     let (output_order, _program_segments) = output_sections
         .output_order(
             crate::output_kind::OutputKind::StaticExecutable(
@@ -330,7 +332,7 @@ fn test_output_order_map_consistent() {
     // First, make sure that all our built-in part-ids are here. If they're not, we'd fail anyway,
     // but we can give a much better failure message if we check first.
     let mut missing: hashbrown::HashSet<PartId> =
-        crate::part_id::built_in_part_ids::<crate::elf::Elf>().collect();
+        crate::part_id::built_in_part_ids::<Elf64>().collect();
     part_map.map(|part_id, _| {
         missing.remove(&part_id);
     });
@@ -342,7 +344,7 @@ fn test_output_order_map_consistent() {
             .iter()
             .map(|id| format!(
                 "{id} (in {})",
-                output_sections.display_name(id.output_section_id::<crate::elf::Elf>())
+                output_sections.display_name(id.output_section_id::<Elf64>())
             ))
             .collect_vec()
             .join(", ")
@@ -350,7 +352,7 @@ fn test_output_order_map_consistent() {
 
     let mut ordering_a = Vec::new();
     part_map.output_order_map(&output_order, &output_sections, |part_id, _, _| {
-        let section_id = part_id.output_section_id::<crate::elf::Elf>();
+        let section_id = part_id.output_section_id::<Elf64>();
         if ordering_a.last() != Some(&section_id.as_usize()) {
             ordering_a.push(section_id.as_usize());
         }
@@ -371,10 +373,10 @@ fn test_output_order_map_consistent() {
 
 #[test]
 fn test_output_order_map() {
+    use crate::elf::Elf64;
     use crate::elf::output_section_id;
 
-    let output_sections =
-        crate::output_section_id::OutputSections::<crate::elf::Elf>::for_testing();
+    let output_sections = crate::output_section_id::OutputSections::<Elf64>::for_testing();
     let (output_order, _program_segments) = output_sections
         .output_order(
             crate::output_kind::OutputKind::StaticExecutable(
@@ -387,11 +389,11 @@ fn test_output_order_map() {
     let mut part_map = output_sections.new_part_map::<u32>();
 
     const PART_ID1: PartId =
-        output_section_id::DATA.part_id_with_alignment::<crate::elf::Elf>(alignment::USIZE);
+        output_section_id::DATA.part_id_with_alignment::<Elf64>(alignment::USIZE);
     *part_map.get_mut(PART_ID1) += 32;
 
     const PART_ID2: PartId =
-        output_section_id::DATA.part_id_with_alignment::<crate::elf::Elf>(alignment::MIN);
+        output_section_id::DATA.part_id_with_alignment::<Elf64>(alignment::MIN);
     *part_map.get_mut(PART_ID2) += 5;
 
     part_map.output_order_map(
@@ -407,7 +409,7 @@ fn test_output_order_map() {
                 assert_eq!(value, 5);
             }
             _ => {
-                if part_id.output_section_id::<crate::elf::Elf>() == output_section_id::DATA {
+                if part_id.output_section_id::<Elf64>() == output_section_id::DATA {
                     assert!(
                         alignment <= alignment::USIZE,
                         "Unexpected alignment {alignment}"
@@ -421,31 +423,31 @@ fn test_output_order_map() {
 
 #[test]
 fn test_max_alignment() {
+    use crate::elf::Elf64;
     use crate::elf::output_section_id;
 
-    let output_sections =
-        crate::output_section_id::OutputSections::<crate::elf::Elf>::for_testing();
+    let output_sections = crate::output_section_id::OutputSections::<Elf64>::for_testing();
     let mut part_map = output_sections.new_part_map::<u32>();
 
     assert_eq!(
         part_map.max_alignment(
-            output_section_id::DATA.part_id_range::<crate::elf::Elf>(),
+            output_section_id::DATA.part_id_range::<Elf64>(),
             &output_sections,
         ),
         alignment::MIN
     );
 
     const PART_ID1: PartId =
-        output_section_id::DATA.part_id_with_alignment::<crate::elf::Elf>(alignment::USIZE);
+        output_section_id::DATA.part_id_with_alignment::<Elf64>(alignment::USIZE);
     *part_map.get_mut(PART_ID1) += 32;
 
     const PART_ID2: PartId =
-        output_section_id::DATA.part_id_with_alignment::<crate::elf::Elf>(alignment::MIN);
+        output_section_id::DATA.part_id_with_alignment::<Elf64>(alignment::MIN);
     *part_map.get_mut(PART_ID2) += 5;
 
     assert_eq!(
         part_map.max_alignment(
-            output_section_id::DATA.part_id_range::<crate::elf::Elf>(),
+            output_section_id::DATA.part_id_range::<Elf64>(),
             &output_sections,
         ),
         alignment::USIZE

--- a/libwild/src/part_id.rs
+++ b/libwild/src/part_id.rs
@@ -176,7 +176,7 @@ mod tests {
 
     #[test]
     fn test_platform_part_id_invariants() {
-        check_platform_part_ids::<crate::elf::Elf>();
+        check_platform_part_ids::<crate::elf::Elf64>();
         check_platform_part_ids::<crate::macho::MachO>();
         check_platform_part_ids::<crate::wasm::Wasm>();
     }


### PR DESCRIPTION
This is mostly to reduce the diff of a later PR.

Issue #2287