### PR TITLE
chore: update object dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,7 +863,7 @@ dependencies = [
  "memchr",
  "memmap2",
  "nix",
- "object 0.39.1",
+ "object 0.40.0",
  "perf-event",
  "perfetto-recorder",
  "rayon",
@@ -905,7 +905,7 @@ dependencies = [
  "linker-utils",
  "memchr",
  "memmap2",
- "object 0.39.1",
+ "object 0.40.0",
  "symbolic-demangle",
  "tabled",
  "tempfile",
@@ -939,7 +939,7 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "leb128",
- "object 0.39.1",
+ "object 0.40.0",
  "paste",
 ]
 
@@ -1229,8 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.39.1"
-source = "git+https://github.com/gimli-rs/object?rev=a0bfa322#a0bfa322b6b01bcd4dc8c24eacaac1e8fad80d1d"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd229a0361b9d0d4396176e02d65897f487eebeab7caa6d443855ee152ca0b9c"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -1554,9 +1555,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ruzstd"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ff0cc5e135c8870a775d3320910cd9b564ec036b4dc0b8741629020be63f01"
+checksum = "a252f5e20f038fe7b4ea53e073e65398d652c864cc162fc77c56c2f13717b888"
 dependencies = [
  "twox-hash",
 ]
@@ -2170,7 +2171,7 @@ dependencies = [
  "linker-diff",
  "linker-layout",
  "mimalloc",
- "object 0.39.1",
+ "object 0.40.0",
  "os_info",
  "rand",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ nix = { version = "0.31.1", default-features = false, features = [
   "resource",
   "fs",
 ] }
-object = { git = "https://github.com/gimli-rs/object", rev = "a0bfa322", default-features = false, features = [
+object = { version = "0.40.0", default-features = false, features = [
   # Note that compression is only actually needed for linker-diff
   "compression",
   "elf",

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -412,7 +412,7 @@ impl Relocation for Rela {
         object::read::elf::Rela::symbol(self, LittleEndian, false)
     }
 
-    fn raw_type(&self) -> u32 {
+    fn raw_type(&self) -> object::elf::RelocationType {
         object::read::elf::Rela::r_type(self, LittleEndian, false)
     }
 
@@ -433,7 +433,7 @@ impl Relocation for Crel {
         object::read::elf::Crel::symbol(self)
     }
 
-    fn raw_type(&self) -> u32 {
+    fn raw_type(&self) -> object::elf::RelocationType {
         self.r_type
     }
 
@@ -593,7 +593,7 @@ impl platform::Platform for Elf {
     type RelocationSections = RelocationSections;
     type DynamicEntry = DynamicEntry;
     type DynamicSymbolDefinitionExt = DynamicSymbolDefinitionExt;
-    type RelocationInfo = u32;
+    type RelocationInfo = object::elf::RelocationType;
     type FinaliseSizesExt<'data> = LayoutExt;
     type LayoutExt<'data> = LayoutExt;
     type SymbolVersionIndex = Versym;
@@ -998,7 +998,7 @@ impl platform::Platform for Elf {
                 .version_script
                 .version_for_symbol(&UnversionedSymbolName::prehashed(name), version_name)?
         {
-            version = object::elf::VersymIndex::new(v, !is_default);
+            version = v.versym(!is_default);
         }
         Ok(layout::DynamicSymbolDefinition {
             symbol_id,
@@ -5674,7 +5674,7 @@ struct ClassifiedSymbolRelocation {
     flags: ValueFlags,
     flags_to_add: ValueFlags,
     rel_offset: u64,
-    r_type: u32,
+    r_type: object::elf::RelocationType,
     rel_kind: linker_utils::elf::RelocationKind,
     next_modifier: RelocationModifier,
     section_is_writable: bool,

--- a/libwild/src/elf_aarch64.rs
+++ b/libwild/src/elf_aarch64.rs
@@ -63,7 +63,7 @@ impl crate::platform::Arch for ElfAArch64 {
     // The table of the relocations is documented here:
     // https://github.com/ARM-software/abi-aa/blob/main/aaelf64/aaelf64.rst.
     #[inline(always)]
-    fn relocation_from_raw(r_type: u32) -> Result<RelocationKindInfo> {
+    fn relocation_from_raw(r_type: object::elf::RelocationType) -> Result<RelocationKindInfo> {
         linker_utils::aarch64::relocation_type_from_raw(r_type).ok_or_else(|| {
             error!(
                 "Unsupported relocation type {}",
@@ -72,7 +72,7 @@ impl crate::platform::Arch for ElfAArch64 {
         })
     }
 
-    fn is_disallowed_for_interposable_symbols(r_type: u32) -> bool {
+    fn is_disallowed_for_interposable_symbols(r_type: object::elf::RelocationType) -> bool {
         matches!(
             r_type,
             object::elf::R_AARCH64_ABS32
@@ -87,18 +87,20 @@ impl crate::platform::Arch for ElfAArch64 {
         )
     }
 
-    fn is_disallowed_in_shared_object(r_type: u32) -> bool {
+    fn is_disallowed_in_shared_object(r_type: object::elf::RelocationType) -> bool {
         matches!(
             r_type,
             object::elf::R_AARCH64_ABS32 | object::elf::R_AARCH64_ABS16
         )
     }
 
-    fn get_dynamic_relocation_type(relocation: DynamicRelocationKind) -> u32 {
+    fn get_dynamic_relocation_type(
+        relocation: DynamicRelocationKind,
+    ) -> object::elf::RelocationType {
         relocation.aarch64_r_type()
     }
 
-    fn rel_type_to_string(r_type: u32) -> std::borrow::Cow<'static, str> {
+    fn rel_type_to_string(r_type: object::elf::RelocationType) -> std::borrow::Cow<'static, str> {
         aarch64_rel_type_to_string(r_type)
     }
 
@@ -147,13 +149,13 @@ impl crate::platform::Arch for ElfAArch64 {
         Ok(object::elf::FileFlags(0))
     }
 
-    fn high_part_relocations() -> &'static [u32] {
+    fn high_part_relocations() -> &'static [object::elf::RelocationType] {
         &[]
     }
 
     #[inline(always)]
     fn new_relaxation(
-        relocation_kind: u32,
+        relocation_kind: object::elf::RelocationType,
         section_bytes: &[u8],
         offset_in_section: u64,
         flags: crate::value_flags::ValueFlags,

--- a/libwild/src/elf_loongarch64.rs
+++ b/libwild/src/elf_loongarch64.rs
@@ -38,7 +38,7 @@ impl crate::platform::Arch for ElfLoongArch64 {
     }
 
     #[inline(always)]
-    fn relocation_from_raw(r_type: u32) -> Result<RelocationKindInfo> {
+    fn relocation_from_raw(r_type: object::elf::RelocationType) -> Result<RelocationKindInfo> {
         linker_utils::loongarch64::relocation_type_from_raw(r_type).ok_or_else(|| {
             error!(
                 "Unsupported relocation type {}",
@@ -47,15 +47,17 @@ impl crate::platform::Arch for ElfLoongArch64 {
         })
     }
 
-    fn is_disallowed_for_interposable_symbols(r_type: u32) -> bool {
+    fn is_disallowed_for_interposable_symbols(r_type: object::elf::RelocationType) -> bool {
         matches!(r_type, object::elf::R_LARCH_32)
     }
 
-    fn get_dynamic_relocation_type(relocation: DynamicRelocationKind) -> u32 {
+    fn get_dynamic_relocation_type(
+        relocation: DynamicRelocationKind,
+    ) -> object::elf::RelocationType {
         relocation.loongarch64_r_type()
     }
 
-    fn rel_type_to_string(r_type: u32) -> std::borrow::Cow<'static, str> {
+    fn rel_type_to_string(r_type: object::elf::RelocationType) -> std::borrow::Cow<'static, str> {
         loongarch64_rel_type_to_string(r_type)
     }
 
@@ -101,14 +103,14 @@ impl crate::platform::Arch for ElfLoongArch64 {
         }
     }
 
-    fn high_part_relocations() -> &'static [u32] {
+    fn high_part_relocations() -> &'static [object::elf::RelocationType] {
         &[]
     }
 
     #[allow(unused_variables)]
     #[inline(always)]
     fn new_relaxation(
-        relocation_kind: u32,
+        relocation_kind: object::elf::RelocationType,
         section_bytes: &[u8],
         offset_in_section: u64,
         flags: crate::value_flags::ValueFlags,

--- a/libwild/src/elf_ppc64.rs
+++ b/libwild/src/elf_ppc64.rs
@@ -21,7 +21,7 @@ impl crate::platform::Arch for ElfPpc64 {
     }
 
     #[inline(always)]
-    fn relocation_from_raw(r_type: u32) -> Result<RelocationKindInfo> {
+    fn relocation_from_raw(r_type: object::elf::RelocationType) -> Result<RelocationKindInfo> {
         linker_utils::ppc64::relocation_type_from_raw(r_type).ok_or_else(|| {
             error!(
                 "Unsupported relocation type {}",
@@ -30,15 +30,17 @@ impl crate::platform::Arch for ElfPpc64 {
         })
     }
 
-    fn is_disallowed_for_interposable_symbols(r_type: u32) -> bool {
+    fn is_disallowed_for_interposable_symbols(r_type: object::elf::RelocationType) -> bool {
         matches!(r_type, object::elf::R_PPC64_ADDR32)
     }
 
-    fn get_dynamic_relocation_type(relocation: DynamicRelocationKind) -> u32 {
+    fn get_dynamic_relocation_type(
+        relocation: DynamicRelocationKind,
+    ) -> object::elf::RelocationType {
         relocation.ppc64_r_type()
     }
 
-    fn rel_type_to_string(r_type: u32) -> std::borrow::Cow<'static, str> {
+    fn rel_type_to_string(r_type: object::elf::RelocationType) -> std::borrow::Cow<'static, str> {
         ppc64_rel_type_to_string(r_type)
     }
 
@@ -70,7 +72,7 @@ impl crate::platform::Arch for ElfPpc64 {
         Ok(eflags.fold(object::elf::FileFlags(0), |merged, flags| merged | flags))
     }
 
-    fn high_part_relocations() -> &'static [u32] {
+    fn high_part_relocations() -> &'static [object::elf::RelocationType] {
         &[]
     }
 
@@ -85,7 +87,7 @@ impl crate::platform::Arch for ElfPpc64 {
     #[allow(unused_variables)]
     #[inline(always)]
     fn new_relaxation(
-        relocation_kind: u32,
+        relocation_kind: object::elf::RelocationType,
         section_bytes: &[u8],
         offset_in_section: u64,
         flags: crate::value_flags::ValueFlags,

--- a/libwild/src/elf_riscv64.rs
+++ b/libwild/src/elf_riscv64.rs
@@ -56,7 +56,7 @@ impl crate::platform::Arch for ElfRiscV64 {
     }
 
     #[inline(always)]
-    fn relocation_from_raw(r_type: u32) -> Result<RelocationKindInfo> {
+    fn relocation_from_raw(r_type: object::elf::RelocationType) -> Result<RelocationKindInfo> {
         linker_utils::riscv64::relocation_type_from_raw(r_type).ok_or_else(|| {
             error!(
                 "Unsupported relocation type {}",
@@ -65,15 +65,17 @@ impl crate::platform::Arch for ElfRiscV64 {
         })
     }
 
-    fn is_disallowed_for_interposable_symbols(r_type: u32) -> bool {
+    fn is_disallowed_for_interposable_symbols(r_type: object::elf::RelocationType) -> bool {
         matches!(r_type, object::elf::R_RISCV_32)
     }
 
-    fn get_dynamic_relocation_type(relocation: DynamicRelocationKind) -> u32 {
+    fn get_dynamic_relocation_type(
+        relocation: DynamicRelocationKind,
+    ) -> object::elf::RelocationType {
         relocation.riscv64_r_type()
     }
 
-    fn rel_type_to_string(r_type: u32) -> std::borrow::Cow<'static, str> {
+    fn rel_type_to_string(r_type: object::elf::RelocationType) -> std::borrow::Cow<'static, str> {
         riscv64_rel_type_to_string(r_type)
     }
 
@@ -146,7 +148,7 @@ impl crate::platform::Arch for ElfRiscV64 {
         Ok(or_eflags)
     }
 
-    fn high_part_relocations() -> &'static [u32] {
+    fn high_part_relocations() -> &'static [object::elf::RelocationType] {
         &[
             object::elf::R_RISCV_HI20,
             object::elf::R_RISCV_PCREL_HI20,
@@ -183,7 +185,7 @@ impl crate::platform::Arch for ElfRiscV64 {
 
     #[inline(always)]
     fn new_relaxation(
-        relocation_kind: u32,
+        relocation_kind: object::elf::RelocationType,
         section_bytes: &[u8],
         offset_in_section: u64,
         flags: crate::value_flags::ValueFlags,

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -1098,11 +1098,11 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
             .context("Missing GOT entry for ifunc")?
             .get();
         out.r_offset.set(e, got_address);
-        out.r_info.set(
+        out.set_r_info(
             e,
-            u64::from(A::get_dynamic_relocation_type(
-                DynamicRelocationKind::Irelative,
-            )),
+            false,
+            0,
+            A::get_dynamic_relocation_type(DynamicRelocationKind::Irelative),
         );
         Ok(())
     }
@@ -1188,9 +1188,11 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
                 .ok_or_else(|| insufficient_allocation(".rela.dyn (relative)"))?;
             rela.r_offset.set(e, place);
             rela.r_addend.set(e, relative_address as i64);
-            rela.r_info.set(
+            rela.set_r_info(
                 e,
-                A::get_dynamic_relocation_type(DynamicRelocationKind::Relative).into(),
+                false,
+                0,
+                A::get_dynamic_relocation_type(DynamicRelocationKind::Relative),
             );
             Ok(0)
         }
@@ -1240,9 +1242,11 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
                 .ok_or_else(|| insufficient_allocation(".rela.dyn (relative)"))?;
             rela.r_offset.set(e, place);
             rela.r_addend.set(e, relative_address as i64);
-            rela.r_info.set(
+            rela.set_r_info(
                 e,
-                A::get_dynamic_relocation_type(DynamicRelocationKind::Relative).into(),
+                false,
+                0,
+                A::get_dynamic_relocation_type(DynamicRelocationKind::Relative),
             );
             Ok(0)
         }
@@ -1292,7 +1296,7 @@ impl<'layout, 'out> TableWriter<'layout, 'out> {
         &mut self,
         place: u64,
         dynamic_symbol_index: u32,
-        r_type: u32,
+        r_type: object::elf::RelocationType,
         addend: i64,
     ) -> Result {
         debug_assert_bail!(
@@ -1960,7 +1964,10 @@ fn write_rela_sections<'data>(
         let out_relas: &mut [elf::Rela] = slice_from_all_bytes_mut(out_buf);
         let mut rela_iter = out_relas.iter_mut();
 
-        let mut write_one = |offset: u64, sym: Option<SymbolIndex>, r_type: u32, addend: i64| {
+        let mut write_one = |offset: u64,
+                             sym: Option<SymbolIndex>,
+                             r_type: object::elf::RelocationType,
+                             addend: i64| {
             let Some(out) = rela_iter.next() else {
                 return;
             };
@@ -2966,7 +2973,7 @@ fn get_pair_subtraction_relocation_value<
     symbol_index: SymbolIndex,
     addend: i64,
     set_rel: &R,
-    expected_r_type: u32,
+    expected_r_type: object::elf::RelocationType,
 ) -> Result<u64> {
     ensure!(
         set_rel.offset() == rel.offset(),

--- a/libwild/src/elf_x86_64.rs
+++ b/libwild/src/elf_x86_64.rs
@@ -58,7 +58,7 @@ impl crate::platform::Arch for ElfX86_64 {
     }
 
     #[inline(always)]
-    fn relocation_from_raw(r_type: u32) -> Result<RelocationKindInfo> {
+    fn relocation_from_raw(r_type: object::elf::RelocationType) -> Result<RelocationKindInfo> {
         linker_utils::x86_64::relocation_from_raw(r_type).ok_or_else(|| {
             error!(
                 "Unsupported relocation type {}",
@@ -67,7 +67,7 @@ impl crate::platform::Arch for ElfX86_64 {
         })
     }
 
-    fn is_disallowed_for_interposable_symbols(r_type: u32) -> bool {
+    fn is_disallowed_for_interposable_symbols(r_type: object::elf::RelocationType) -> bool {
         matches!(
             r_type,
             object::elf::R_X86_64_32
@@ -80,7 +80,7 @@ impl crate::platform::Arch for ElfX86_64 {
         )
     }
 
-    fn is_disallowed_in_shared_object(r_type: u32) -> bool {
+    fn is_disallowed_in_shared_object(r_type: object::elf::RelocationType) -> bool {
         matches!(
             r_type,
             object::elf::R_X86_64_32
@@ -90,7 +90,9 @@ impl crate::platform::Arch for ElfX86_64 {
         )
     }
 
-    fn get_dynamic_relocation_type(relocation: DynamicRelocationKind) -> u32 {
+    fn get_dynamic_relocation_type(
+        relocation: DynamicRelocationKind,
+    ) -> object::elf::RelocationType {
         relocation.x86_64_r_type()
     }
 
@@ -107,7 +109,7 @@ impl crate::platform::Arch for ElfX86_64 {
         Ok(())
     }
 
-    fn rel_type_to_string(r_type: u32) -> std::borrow::Cow<'static, str> {
+    fn rel_type_to_string(r_type: object::elf::RelocationType) -> std::borrow::Cow<'static, str> {
         x86_64_rel_type_to_string(r_type)
     }
 
@@ -138,13 +140,13 @@ impl crate::platform::Arch for ElfX86_64 {
         Ok(object::elf::FileFlags(0))
     }
 
-    fn high_part_relocations() -> &'static [u32] {
+    fn high_part_relocations() -> &'static [object::elf::RelocationType] {
         &[]
     }
 
     #[inline(always)]
     fn new_relaxation(
-        relocation_kind: u32,
+        relocation_kind: object::elf::RelocationType,
         section_bytes: &[u8],
         offset_in_section: u64,
         flags: ValueFlags,
@@ -583,7 +585,12 @@ fn test_relaxation() {
     use crate::platform::Relaxation as _;
 
     #[track_caller]
-    fn check(relocation_kind: u32, bytes_in: &[u8], address: &[u8], absolute: &[u8]) {
+    fn check(
+        relocation_kind: object::elf::RelocationType,
+        bytes_in: &[u8],
+        address: &[u8],
+        absolute: &[u8],
+    ) {
         let mut out = bytes_in.to_owned();
         let mut offset = bytes_in.len() as u64;
         if let Some(r) = ElfX86_64::new_relaxation(

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -477,7 +477,7 @@ impl<'data> platform::ObjectFile<'data> for File<'data> {
 
     fn copy_section_data(&self, section: &SectionHeader, out: &mut [u8]) -> Result {
         let data = section
-            .data(LE, self.data)
+            .data(LE, self.data, section.offset(LE).into())
             .map_err(|_e| error!("cannot get section data"))?;
         copy_section_data(data, out);
 

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -145,7 +145,9 @@ pub(crate) trait Arch: Send + Sync + 'static {
 
     /// Returns true if the given relocation type cannot be used when making a shared object,
     /// regardless of whether the symbol is interposable. Default is false (allow).
-    fn is_disallowed_in_shared_object(_r_type: u32) -> bool {
+    fn is_disallowed_in_shared_object(
+        _r_type: <Self::Platform as Platform>::RelocationInfo,
+    ) -> bool {
         false
     }
 

--- a/linker-diff/src/aarch64.rs
+++ b/linker-diff/src/aarch64.rs
@@ -508,10 +508,10 @@ fn equal_with_mask(a: &[u8], b: &[u8], mask: &[u8]) -> bool {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct RType(u32);
+pub(crate) struct RType(object::elf::RelocationType);
 
 impl crate::arch::RType for RType {
-    fn from_raw(raw: u32) -> Self {
+    fn from_raw(raw: object::elf::RelocationType) -> Self {
         RType(raw)
     }
 

--- a/linker-diff/src/arch.rs
+++ b/linker-diff/src/arch.rs
@@ -147,7 +147,7 @@ pub(crate) trait Arch: Clone + Copy + Eq + PartialEq + Debug {
 }
 
 pub(crate) trait RType: Copy + Debug + Display + Eq + PartialEq {
-    fn from_raw(raw: u32) -> Self;
+    fn from_raw(raw: object::elf::RelocationType) -> Self;
 
     fn from_dynamic_relocation_kind(kind: DynamicRelocationKind) -> Self;
 

--- a/linker-diff/src/loongarch64.rs
+++ b/linker-diff/src/loongarch64.rs
@@ -384,10 +384,10 @@ fn decode_plt_entry_pcalau12i(
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct RType(u32);
+pub(crate) struct RType(object::elf::RelocationType);
 
 impl crate::arch::RType for RType {
-    fn from_raw(raw: u32) -> Self {
+    fn from_raw(raw: object::elf::RelocationType) -> Self {
         RType(raw)
     }
 

--- a/linker-diff/src/ppc64.rs
+++ b/linker-diff/src/ppc64.rs
@@ -113,10 +113,10 @@ impl Arch for Ppc64 {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct RType(u32);
+pub(crate) struct RType(object::elf::RelocationType);
 
 impl crate::arch::RType for RType {
-    fn from_raw(raw: u32) -> Self {
+    fn from_raw(raw: object::elf::RelocationType) -> Self {
         RType(raw)
     }
 

--- a/linker-diff/src/riscv64.rs
+++ b/linker-diff/src/riscv64.rs
@@ -264,10 +264,10 @@ fn decode_plt_entry_riscv(
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct RType(u32);
+pub(crate) struct RType(object::elf::RelocationType);
 
 impl crate::arch::RType for RType {
-    fn from_raw(raw: u32) -> Self {
+    fn from_raw(raw: object::elf::RelocationType) -> Self {
         RType(raw)
     }
 

--- a/linker-diff/src/x86_64.rs
+++ b/linker-diff/src/x86_64.rs
@@ -452,10 +452,10 @@ impl<'data> AsmDecoder<'data> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct RType(u32);
+pub(crate) struct RType(object::elf::RelocationType);
 
 impl crate::arch::RType for RType {
-    fn from_raw(raw: u32) -> Self {
+    fn from_raw(raw: object::elf::RelocationType) -> Self {
         RType(raw)
     }
 

--- a/linker-utils/src/aarch64.rs
+++ b/linker-utils/src/aarch64.rs
@@ -115,7 +115,9 @@ impl RelaxationKind {
 }
 
 #[must_use]
-pub const fn relocation_type_from_raw(r_type: u32) -> Option<RelocationKindInfo> {
+pub const fn relocation_type_from_raw(
+    r_type: object::elf::RelocationType,
+) -> Option<RelocationKindInfo> {
     let (kind, size, mask, range, alignment) = match r_type {
         // 5.7.4   Static miscellaneous relocations
         object::elf::R_AARCH64_NONE => (

--- a/linker-utils/src/elf.rs
+++ b/linker-utils/src/elf.rs
@@ -122,7 +122,7 @@ elf_constant_newtype!(
 elf_constant_newtype!(SymbolType, object::elf::SymbolType, stt, STT, NOTYPE, TLS);
 
 #[must_use]
-pub fn x86_64_rel_type_to_string(r_type: u32) -> Cow<'static, str> {
+pub fn x86_64_rel_type_to_string(r_type: object::elf::RelocationType) -> Cow<'static, str> {
     if let Some(name) = object::elf::NAMES_R_X86_64.name(r_type) {
         Cow::Borrowed(name)
     } else {
@@ -131,7 +131,7 @@ pub fn x86_64_rel_type_to_string(r_type: u32) -> Cow<'static, str> {
 }
 
 #[must_use]
-pub fn aarch64_rel_type_to_string(r_type: u32) -> Cow<'static, str> {
+pub fn aarch64_rel_type_to_string(r_type: object::elf::RelocationType) -> Cow<'static, str> {
     if let Some(name) = object::elf::NAMES_R_AARCH64.name(r_type) {
         Cow::Borrowed(name)
     } else {
@@ -140,7 +140,7 @@ pub fn aarch64_rel_type_to_string(r_type: u32) -> Cow<'static, str> {
 }
 
 #[must_use]
-pub fn riscv64_rel_type_to_string(r_type: u32) -> Cow<'static, str> {
+pub fn riscv64_rel_type_to_string(r_type: object::elf::RelocationType) -> Cow<'static, str> {
     if let Some(name) = object::elf::NAMES_R_RISCV.name(r_type) {
         Cow::Borrowed(name)
     } else {
@@ -149,7 +149,7 @@ pub fn riscv64_rel_type_to_string(r_type: u32) -> Cow<'static, str> {
 }
 
 #[must_use]
-pub fn loongarch64_rel_type_to_string(r_type: u32) -> Cow<'static, str> {
+pub fn loongarch64_rel_type_to_string(r_type: object::elf::RelocationType) -> Cow<'static, str> {
     if let Some(name) = object::elf::NAMES_R_LARCH.name(r_type) {
         Cow::Borrowed(name)
     } else {
@@ -158,7 +158,7 @@ pub fn loongarch64_rel_type_to_string(r_type: u32) -> Cow<'static, str> {
 }
 
 #[must_use]
-pub fn ppc64_rel_type_to_string(r_type: u32) -> Cow<'static, str> {
+pub fn ppc64_rel_type_to_string(r_type: object::elf::RelocationType) -> Cow<'static, str> {
     if let Some(name) = object::elf::NAMES_R_PPC64.name(r_type) {
         Cow::Borrowed(name)
     } else {
@@ -441,7 +441,7 @@ pub enum RelocationKind {
     /// R_RISCV_SET_ULEB128 and R_RISCV_SUB_ULEB128 relocation pair and fill the space with a
     /// single ULEB128-encoded value. This is achieved by prepending the redundant 0x80 byte as
     /// necessary. The linker must not alter the length of the ULEB128-encoded value.
-    PairSubtractionULEB128(u32),
+    PairSubtractionULEB128(object::elf::RelocationType),
 
     /// The address of the symbol, relative to the place of the relocation.
     Relative,
@@ -587,7 +587,7 @@ pub enum DynamicRelocationKind {
 
 impl DynamicRelocationKind {
     #[must_use]
-    pub fn from_x86_64_r_type(r_type: u32) -> Option<Self> {
+    pub fn from_x86_64_r_type(r_type: object::elf::RelocationType) -> Option<Self> {
         let kind = match r_type {
             object::elf::R_X86_64_COPY => DynamicRelocationKind::Copy,
             object::elf::R_X86_64_IRELATIVE => DynamicRelocationKind::Irelative,
@@ -606,7 +606,7 @@ impl DynamicRelocationKind {
     }
 
     #[must_use]
-    pub fn x86_64_r_type(self) -> u32 {
+    pub fn x86_64_r_type(self) -> object::elf::RelocationType {
         match self {
             DynamicRelocationKind::Copy => object::elf::R_X86_64_COPY,
             DynamicRelocationKind::Irelative => object::elf::R_X86_64_IRELATIVE,
@@ -622,7 +622,7 @@ impl DynamicRelocationKind {
     }
 
     #[must_use]
-    pub fn from_aarch64_r_type(r_type: u32) -> Option<Self> {
+    pub fn from_aarch64_r_type(r_type: object::elf::RelocationType) -> Option<Self> {
         let kind = match r_type {
             object::elf::R_AARCH64_COPY => DynamicRelocationKind::Copy,
             object::elf::R_AARCH64_IRELATIVE => DynamicRelocationKind::Irelative,
@@ -641,7 +641,7 @@ impl DynamicRelocationKind {
     }
 
     #[must_use]
-    pub fn aarch64_r_type(&self) -> u32 {
+    pub fn aarch64_r_type(&self) -> object::elf::RelocationType {
         match self {
             DynamicRelocationKind::Copy => object::elf::R_AARCH64_COPY,
             DynamicRelocationKind::Irelative => object::elf::R_AARCH64_IRELATIVE,
@@ -657,7 +657,7 @@ impl DynamicRelocationKind {
     }
 
     #[must_use]
-    pub fn from_riscv64_r_type(r_type: u32) -> Option<Self> {
+    pub fn from_riscv64_r_type(r_type: object::elf::RelocationType) -> Option<Self> {
         let kind = match r_type {
             object::elf::R_RISCV_COPY => DynamicRelocationKind::Copy,
             object::elf::R_RISCV_IRELATIVE => DynamicRelocationKind::Irelative,
@@ -674,7 +674,7 @@ impl DynamicRelocationKind {
     }
 
     #[must_use]
-    pub fn riscv64_r_type(&self) -> u32 {
+    pub fn riscv64_r_type(&self) -> object::elf::RelocationType {
         match self {
             DynamicRelocationKind::Copy => object::elf::R_RISCV_COPY,
             DynamicRelocationKind::Irelative => object::elf::R_RISCV_IRELATIVE,
@@ -690,7 +690,7 @@ impl DynamicRelocationKind {
     }
 
     #[must_use]
-    pub fn from_loongarch64_r_type(r_type: u32) -> Option<Self> {
+    pub fn from_loongarch64_r_type(r_type: object::elf::RelocationType) -> Option<Self> {
         let kind = match r_type {
             object::elf::R_LARCH_COPY => DynamicRelocationKind::Copy,
             object::elf::R_LARCH_IRELATIVE => DynamicRelocationKind::Irelative,
@@ -707,7 +707,7 @@ impl DynamicRelocationKind {
     }
 
     #[must_use]
-    pub fn loongarch64_r_type(&self) -> u32 {
+    pub fn loongarch64_r_type(&self) -> object::elf::RelocationType {
         match self {
             DynamicRelocationKind::Copy => object::elf::R_LARCH_COPY,
             DynamicRelocationKind::Irelative => object::elf::R_LARCH_IRELATIVE,
@@ -723,7 +723,7 @@ impl DynamicRelocationKind {
     }
 
     #[must_use]
-    pub fn ppc64_r_type(&self) -> u32 {
+    pub fn ppc64_r_type(&self) -> object::elf::RelocationType {
         match self {
             DynamicRelocationKind::Copy => object::elf::R_PPC64_COPY,
             DynamicRelocationKind::Irelative => object::elf::R_PPC64_IRELATIVE,
@@ -740,7 +740,7 @@ impl DynamicRelocationKind {
     }
 
     #[must_use]
-    pub fn from_ppc64_r_type(r_type: u32) -> Option<Self> {
+    pub fn from_ppc64_r_type(r_type: object::elf::RelocationType) -> Option<Self> {
         let kind = match r_type {
             object::elf::R_PPC64_COPY => DynamicRelocationKind::Copy,
             object::elf::R_PPC64_IRELATIVE => DynamicRelocationKind::Irelative,
@@ -1161,12 +1161,12 @@ mod tests {
             stringify!(R_X86_64_GOTPC32_TLSDESC)
         );
         assert_eq!(
-            &x86_64_rel_type_to_string(64),
+            &x86_64_rel_type_to_string(object::elf::RelocationType(64)),
             "Unknown x86_64 relocation type 0x40"
         );
 
         assert_eq!(
-            &aarch64_rel_type_to_string(64),
+            &aarch64_rel_type_to_string(object::elf::RelocationType(64)),
             "Unknown aarch64 relocation type 0x40"
         );
     }

--- a/linker-utils/src/loongarch64.rs
+++ b/linker-utils/src/loongarch64.rs
@@ -45,7 +45,9 @@ impl RelaxationKind {
 }
 
 #[must_use]
-pub const fn relocation_type_from_raw(r_type: u32) -> Option<RelocationKindInfo> {
+pub const fn relocation_type_from_raw(
+    r_type: object::elf::RelocationType,
+) -> Option<RelocationKindInfo> {
     // The relocation listing following the order defined in the standard:
     // https://github.com/loongson/la-abi-specs/blob/release/laelf.adoc#relocation-types
     let (kind, size, mask, range, alignment, bias) = match r_type {

--- a/linker-utils/src/ppc64.rs
+++ b/linker-utils/src/ppc64.rs
@@ -37,7 +37,9 @@ impl RelaxationKind {
 }
 
 #[must_use]
-pub const fn relocation_type_from_raw(r_type: u32) -> Option<RelocationKindInfo> {
+pub const fn relocation_type_from_raw(
+    r_type: object::elf::RelocationType,
+) -> Option<RelocationKindInfo> {
     let (kind, size, range, alignment, bias) = match r_type {
         // Absolute addresses.
         object::elf::R_PPC64_ADDR64 => (

--- a/linker-utils/src/riscv64.rs
+++ b/linker-utils/src/riscv64.rs
@@ -125,7 +125,9 @@ impl RelaxationKind {
 }
 
 #[must_use]
-pub const fn relocation_type_from_raw(r_type: u32) -> Option<RelocationKindInfo> {
+pub const fn relocation_type_from_raw(
+    r_type: object::elf::RelocationType,
+) -> Option<RelocationKindInfo> {
     // The relocation listing following the order defined in the standard:
     // https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc#relocations
     let (kind, size, mask, range, alignment) = match r_type {

--- a/linker-utils/src/x86_64.rs
+++ b/linker-utils/src/x86_64.rs
@@ -319,7 +319,9 @@ const RELOC_NONE: RelocSizeAndRange = (RelocationSize::ByteSize(0), AllowedRange
 /// recognised.
 #[must_use]
 #[inline(always)]
-pub const fn relocation_from_raw(r_type: u32) -> Option<RelocationKindInfo> {
+pub const fn relocation_from_raw(
+    r_type: object::elf::RelocationType,
+) -> Option<RelocationKindInfo> {
     let (kind, (size, range)) = match r_type {
         object::elf::R_X86_64_64 => (RelocationKind::Absolute, RELOC_8_BYTE_UNSIGNED),
         object::elf::R_X86_64_PC32 => (RelocationKind::Relative, RELOC_4_BYTE_SIGNED),


### PR DESCRIPTION
There's a few breaking changes. Most of this commit is handling the change from `u32` to `object::elf::RelocationType`, but also:

- `elf::VersymIndex::new` replaced with `elf::VersionIndex::versym`
- `read::macho::SectionHeader::data` now takes the section offset (fix handles 32-bit file offsets only, which is fine for object files)