### PR TITLE
port(MachO): Introduce `SectionIdentity`

### DIFF
--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -42,6 +42,7 @@ use crate::output_section_id::OutputOrder;
 use crate::output_section_id::OutputOrderBuilder;
 use crate::output_section_id::OutputSectionId;
 use crate::output_section_id::OutputSections;
+use crate::output_section_id::SectionIdentity;
 use crate::output_section_id::SectionName;
 use crate::output_section_id::SectionOutputInfo;
 use crate::output_section_map::OutputSectionMap;
@@ -621,6 +622,7 @@ impl platform::Platform for Elf {
     type ResolutionExt = ResolutionExt;
     type SymtabShndxEntry = SymtabShndxEntry;
     type ResolvedObjectExt<'data> = ResolvedObjectExt<'data>;
+    type SectionIdentityExt = ();
 
     fn write_output_file<'data, A: Arch<Platform = Self>, F: FileSystem>(
         output: &crate::file_writer::Output<F>,
@@ -2174,8 +2176,8 @@ impl platform::Platform for Elf {
             .ids_with_info()
             .filter(|(id, _info)| output_sections.output_index_of_section(*id).is_some())
             .map(|(_id, info)| {
-                if let SectionKind::Primary(name) = info.kind {
-                    name.len() as u64 + 1
+                if let SectionKind::Primary(identity) = info.kind {
+                    identity.section_name().len() as u64 + 1
                 } else {
                     0
                 }
@@ -2667,6 +2669,19 @@ impl platform::Platform for Elf {
 
     fn is_allowed_in_archive(kind: crate::file_kind::FileKind) -> bool {
         kind == FileKind::ElfObject
+    }
+
+    fn section_identity<'data>(
+        name: SectionName<'data>,
+        _section: &Self::SectionHeader,
+    ) -> SectionIdentity<'data, Self> {
+        SectionIdentity::new(name, ())
+    }
+
+    fn section_identity_from_name<'data>(
+        name: SectionName<'data>,
+    ) -> Option<SectionIdentity<'data, Self>> {
+        Some(SectionIdentity::new(name, ()))
     }
 }
 
@@ -5060,9 +5075,9 @@ impl std::fmt::Display for ProgramSegmentDef {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub(crate) struct BuiltInSectionDetails {
-    pub(crate) kind: SectionKind<'static>,
+    pub(crate) kind: SectionKind<'static, Elf>,
     pub(crate) section_flags: SectionFlags,
     /// Sections to try to link to. The first section that we're outputting is the one used.
     pub(crate) link: &'static [OutputSectionId],
@@ -5074,7 +5089,7 @@ pub(crate) struct BuiltInSectionDetails {
 }
 
 const DEFAULT_DEFS: BuiltInSectionDetails = BuiltInSectionDetails {
-    kind: SectionKind::Primary(SectionName(&[])),
+    kind: SectionKind::Primary(SectionIdentity::new(SectionName(&[]), ())),
     section_flags: SectionFlags(0),
     link: &[],
     min_alignment: alignment::MIN,
@@ -5091,34 +5106,40 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
 
     // A section into which we write headers.
     defs[crate::output_section_id::FILE_HEADER.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b""), ())),
         section_flags: shf::ALLOC,
         ..DEFAULT_DEFS
     };
     defs[output_section_id::PROGRAM_HEADERS.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(PROGRAM_HEADERS_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(
+            SectionName(PROGRAM_HEADERS_SECTION_NAME),
+            (),
+        )),
         section_flags: shf::ALLOC,
         min_alignment: alignment::PROGRAM_HEADER_ENTRY,
         target_segment_type: Some(pt::PHDR),
         ..DEFAULT_DEFS
     };
     defs[output_section_id::SECTION_HEADERS.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(SECTION_HEADERS_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(
+            SectionName(SECTION_HEADERS_SECTION_NAME),
+            (),
+        )),
         section_flags: shf::ALLOC,
         ..DEFAULT_DEFS
     };
     defs[output_section_id::SHSTRTAB.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(SHSTRTAB_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(SHSTRTAB_SECTION_NAME), ())),
         ty: sht::STRTAB,
         ..DEFAULT_DEFS
     };
     defs[output_section_id::STRTAB.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(STRTAB_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(STRTAB_SECTION_NAME), ())),
         ty: sht::STRTAB,
         ..DEFAULT_DEFS
     };
     defs[output_section_id::GOT.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(GOT_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(GOT_SECTION_NAME), ())),
         ty: sht::PROGBITS,
         section_flags: shf::WRITE.with(shf::ALLOC),
         element_size: crate::elf::GOT_ENTRY_SIZE,
@@ -5133,7 +5154,7 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         ..DEFAULT_DEFS
     };
     defs[output_section_id::PLT_GOT.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(PLT_GOT_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(PLT_GOT_SECTION_NAME), ())),
         ty: sht::PROGBITS,
         section_flags: shf::ALLOC.with(shf::EXECINSTR),
         element_size: crate::elf::PLT_ENTRY_SIZE,
@@ -5141,7 +5162,7 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         ..DEFAULT_DEFS
     };
     defs[output_section_id::RELA_PLT.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(RELA_PLT_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(RELA_PLT_SECTION_NAME), ())),
         ty: sht::RELA,
         section_flags: shf::ALLOC.with(shf::INFO_LINK),
         element_size: RELA_ENTRY_SIZE,
@@ -5150,14 +5171,17 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         ..DEFAULT_DEFS
     };
     defs[output_section_id::EH_FRAME.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(EH_FRAME_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(EH_FRAME_SECTION_NAME), ())),
         ty: sht::PROGBITS,
         section_flags: shf::ALLOC,
         min_alignment: alignment::USIZE,
         ..DEFAULT_DEFS
     };
     defs[output_section_id::EH_FRAME_HDR.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(EH_FRAME_HDR_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(
+            SectionName(EH_FRAME_HDR_SECTION_NAME),
+            (),
+        )),
         ty: sht::PROGBITS,
         section_flags: shf::ALLOC,
         min_alignment: alignment::EH_FRAME_HDR,
@@ -5165,7 +5189,7 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         ..DEFAULT_DEFS
     };
     defs[output_section_id::SFRAME.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(SFRAME_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(SFRAME_SECTION_NAME), ())),
         ty: sht::GNU_SFRAME,
         section_flags: shf::ALLOC,
         min_alignment: alignment::USIZE,
@@ -5173,7 +5197,7 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         ..DEFAULT_DEFS
     };
     defs[output_section_id::DYNAMIC.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(DYNAMIC_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(DYNAMIC_SECTION_NAME), ())),
         ty: sht::DYNAMIC,
         section_flags: shf::ALLOC.with(shf::WRITE),
         element_size: size_of::<DynamicEntry>() as u64,
@@ -5184,7 +5208,7 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         ..DEFAULT_DEFS
     };
     defs[output_section_id::HASH.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(HASH_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(HASH_SECTION_NAME), ())),
         ty: sht::HASH,
         section_flags: shf::ALLOC,
         link: &[output_section_id::DYNSYM],
@@ -5192,7 +5216,7 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         ..DEFAULT_DEFS
     };
     defs[output_section_id::GNU_HASH.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(GNU_HASH_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(GNU_HASH_SECTION_NAME), ())),
         ty: sht::GNU_HASH,
         section_flags: shf::ALLOC,
         link: &[output_section_id::DYNSYM],
@@ -5200,7 +5224,7 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         ..DEFAULT_DEFS
     };
     defs[output_section_id::DYNSYM.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(DYNSYM_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(DYNSYM_SECTION_NAME), ())),
         ty: sht::DYNSYM,
         section_flags: shf::ALLOC,
         element_size: size_of::<elf::SymtabEntry>() as u64,
@@ -5209,21 +5233,24 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         ..DEFAULT_DEFS
     };
     defs[output_section_id::DYNSTR.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(DYNSTR_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(DYNSTR_SECTION_NAME), ())),
         ty: sht::STRTAB,
         section_flags: shf::ALLOC,
         min_alignment: alignment::MIN,
         ..DEFAULT_DEFS
     };
     defs[output_section_id::INTERP.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(INTERP_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(INTERP_SECTION_NAME), ())),
         ty: sht::PROGBITS,
         section_flags: shf::ALLOC,
         target_segment_type: Some(pt::INTERP),
         ..DEFAULT_DEFS
     };
     defs[output_section_id::GNU_VERSION.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(GNU_VERSION_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(
+            SectionName(GNU_VERSION_SECTION_NAME),
+            (),
+        )),
         ty: sht::GNU_VERSYM,
         section_flags: shf::ALLOC,
         element_size: size_of::<Versym>() as u64,
@@ -5232,7 +5259,10 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         ..DEFAULT_DEFS
     };
     defs[output_section_id::GNU_VERSION_D.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(GNU_VERSION_D_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(
+            SectionName(GNU_VERSION_D_SECTION_NAME),
+            (),
+        )),
         ty: sht::GNU_VERDEF,
         section_flags: shf::ALLOC,
         min_alignment: alignment::VERSION_D,
@@ -5240,7 +5270,10 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         ..DEFAULT_DEFS
     };
     defs[output_section_id::GNU_VERSION_R.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(GNU_VERSION_R_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(
+            SectionName(GNU_VERSION_R_SECTION_NAME),
+            (),
+        )),
         ty: sht::GNU_VERNEED,
         section_flags: shf::ALLOC,
         min_alignment: alignment::VERSION_R,
@@ -5248,7 +5281,10 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         ..DEFAULT_DEFS
     };
     defs[output_section_id::NOTE_GNU_PROPERTY.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(NOTE_GNU_PROPERTY_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(
+            SectionName(NOTE_GNU_PROPERTY_SECTION_NAME),
+            (),
+        )),
         ty: sht::NOTE,
         section_flags: shf::ALLOC,
         min_alignment: alignment::NOTE_GNU_PROPERTY,
@@ -5256,7 +5292,10 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         ..DEFAULT_DEFS
     };
     defs[output_section_id::NOTE_GNU_BUILD_ID.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(NOTE_GNU_BUILD_ID_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(
+            SectionName(NOTE_GNU_BUILD_ID_SECTION_NAME),
+            (),
+        )),
         ty: sht::NOTE,
         section_flags: shf::ALLOC,
         min_alignment: alignment::NOTE_GNU_BUILD_ID,
@@ -5264,7 +5303,7 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
     };
     // Multi-part generated sections
     defs[output_section_id::SYMTAB_LOCAL.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(SYMTAB_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(SYMTAB_SECTION_NAME), ())),
         ty: sht::SYMTAB,
         element_size: size_of::<SymtabEntry>() as u64,
         min_alignment: alignment::SYMTAB_ENTRY,
@@ -5276,7 +5315,7 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         ..DEFAULT_DEFS
     };
     defs[output_section_id::RELA_DYN_RELATIVE.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(RELA_DYN_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(RELA_DYN_SECTION_NAME), ())),
         ty: sht::RELA,
         section_flags: shf::ALLOC,
         element_size: RELA_ENTRY_SIZE,
@@ -5289,7 +5328,7 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         ..DEFAULT_DEFS
     };
     defs[output_section_id::RELR_DYN.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(RELR_DYN_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(RELR_DYN_SECTION_NAME), ())),
         ty: sht::RELR,
         section_flags: shf::ALLOC,
         element_size: RELR_ENTRY_SIZE,
@@ -5297,20 +5336,29 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         ..DEFAULT_DEFS
     };
     defs[output_section_id::RISCV_ATTRIBUTES.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(RISCV_ATTRIBUTES_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(
+            SectionName(RISCV_ATTRIBUTES_SECTION_NAME),
+            (),
+        )),
         ty: sht::RISCV_ATTRIBUTES,
         target_segment_type: Some(pt::RISCV_ATTRIBUTES),
         ..DEFAULT_DEFS
     };
     defs[output_section_id::RELRO_PADDING.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(RELRO_PADDING_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(
+            SectionName(RELRO_PADDING_SECTION_NAME),
+            (),
+        )),
         ty: sht::NOBITS,
         section_flags: shf::ALLOC.with(shf::WRITE),
         is_relro: true,
         ..DEFAULT_DEFS
     };
     defs[output_section_id::SYMTAB_SHNDX_LOCAL.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(SYMTAB_SHNDX_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(
+            SectionName(SYMTAB_SHNDX_SECTION_NAME),
+            (),
+        )),
         ty: sht::SYMTAB_SHNDX,
         element_size: SYMTAB_SHNDX_ENTRY_SIZE,
         min_alignment: alignment::SYMTAB_SHNDX_ENTRY,
@@ -5322,19 +5370,25 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         ..DEFAULT_DEFS
     };
     defs[output_section_id::GDB_INDEX.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(GDB_INDEX_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(
+            SectionName(GDB_INDEX_SECTION_NAME),
+            (),
+        )),
         ty: sht::PROGBITS,
         ..DEFAULT_DEFS
     };
     // Start of regular sections
     defs[output_section_id::RODATA.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(RODATA_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(RODATA_SECTION_NAME), ())),
         ty: sht::PROGBITS,
         section_flags: shf::ALLOC,
         ..DEFAULT_DEFS
     };
     defs[output_section_id::INIT_ARRAY.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(INIT_ARRAY_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(
+            SectionName(INIT_ARRAY_SECTION_NAME),
+            (),
+        )),
         ty: sht::INIT_ARRAY,
         section_flags: shf::ALLOC.with(shf::WRITE),
         element_size: size_of::<u64>() as u64,
@@ -5343,7 +5397,10 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         ..DEFAULT_DEFS
     };
     defs[output_section_id::FINI_ARRAY.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(FINI_ARRAY_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(
+            SectionName(FINI_ARRAY_SECTION_NAME),
+            (),
+        )),
         ty: sht::FINI_ARRAY,
         section_flags: shf::ALLOC.with(shf::WRITE),
         element_size: size_of::<u64>() as u64,
@@ -5352,75 +5409,87 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         ..DEFAULT_DEFS
     };
     defs[output_section_id::PREINIT_ARRAY.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(PREINIT_ARRAY_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(
+            SectionName(PREINIT_ARRAY_SECTION_NAME),
+            (),
+        )),
         ty: sht::PREINIT_ARRAY,
         section_flags: shf::ALLOC.with(shf::WRITE),
         is_relro: true,
         ..DEFAULT_DEFS
     };
     defs[output_section_id::TEXT.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(TEXT_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(TEXT_SECTION_NAME), ())),
         ty: sht::PROGBITS,
         section_flags: shf::ALLOC.with(shf::EXECINSTR),
         ..DEFAULT_DEFS
     };
     defs[output_section_id::INIT.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(INIT_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(INIT_SECTION_NAME), ())),
         ty: sht::PROGBITS,
         section_flags: shf::ALLOC.with(shf::EXECINSTR),
         ..DEFAULT_DEFS
     };
     defs[output_section_id::FINI.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(FINI_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(FINI_SECTION_NAME), ())),
         ty: sht::PROGBITS,
         section_flags: shf::ALLOC.with(shf::EXECINSTR),
         ..DEFAULT_DEFS
     };
     defs[output_section_id::DATA.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(DATA_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(DATA_SECTION_NAME), ())),
         ty: sht::PROGBITS,
         section_flags: shf::ALLOC.with(shf::WRITE),
         ..DEFAULT_DEFS
     };
     defs[output_section_id::TDATA.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(TDATA_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(TDATA_SECTION_NAME), ())),
         ty: sht::PROGBITS,
         section_flags: shf::WRITE.with(shf::ALLOC).with(shf::TLS),
         ..DEFAULT_DEFS
     };
     defs[output_section_id::TBSS.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(TBSS_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(TBSS_SECTION_NAME), ())),
         ty: sht::NOBITS,
         section_flags: shf::WRITE.with(shf::ALLOC).with(shf::TLS),
         ..DEFAULT_DEFS
     };
     defs[output_section_id::BSS.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(BSS_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(BSS_SECTION_NAME), ())),
         ty: sht::NOBITS,
         section_flags: shf::ALLOC.with(shf::WRITE),
         ..DEFAULT_DEFS
     };
     defs[output_section_id::COMMENT.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(COMMENT_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(COMMENT_SECTION_NAME), ())),
         ty: sht::PROGBITS,
         section_flags: shf::STRINGS.with(shf::MERGE),
         element_size: 1,
         ..DEFAULT_DEFS
     };
     defs[output_section_id::GCC_EXCEPT_TABLE.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(GCC_EXCEPT_TABLE_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(
+            SectionName(GCC_EXCEPT_TABLE_SECTION_NAME),
+            (),
+        )),
         ty: sht::PROGBITS,
         section_flags: shf::ALLOC,
         ..DEFAULT_DEFS
     };
     defs[output_section_id::NOTE_ABI_TAG.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(NOTE_ABI_TAG_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(
+            SectionName(NOTE_ABI_TAG_SECTION_NAME),
+            (),
+        )),
         ty: sht::NOTE,
         section_flags: shf::ALLOC,
         ..DEFAULT_DEFS
     };
     defs[output_section_id::DATA_REL_RO.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(DATA_REL_RO_SECTION_NAME)),
+        kind: SectionKind::Primary(SectionIdentity::new(
+            SectionName(DATA_REL_RO_SECTION_NAME),
+            (),
+        )),
         ty: sht::PROGBITS,
         section_flags: shf::ALLOC.with(shf::WRITE),
         is_relro: true,

--- a/libwild/src/elf_writer.rs
+++ b/libwild/src/elf_writer.rs
@@ -65,6 +65,7 @@ use crate::output_section_id::OrderEvent;
 use crate::output_section_id::OutputOrder;
 use crate::output_section_id::OutputSectionId;
 use crate::output_section_id::OutputSections;
+use crate::output_section_id::SectionIdentity;
 use crate::output_section_id::SectionName;
 use crate::output_section_id::SectionOutputInfo;
 use crate::output_section_map::OutputSectionMap;
@@ -1949,7 +1950,7 @@ fn write_rela_sections<'data>(
 
         let Some(section_id) = layout
             .output_sections
-            .custom_name_to_id(SectionName(section_name))
+            .custom_identity_to_id(SectionIdentity::new(SectionName(section_name), ()))
         else {
             continue;
         };
@@ -5658,10 +5659,9 @@ fn write_section_headers(out: &mut [u8], layout: &ElfLayout) -> Result {
             {
                 link = symtab_idx;
             }
-            if let Some(section_name) = output_sections.name(section_id)
-                && let Some(target_name) = section_name.0.strip_prefix(b".rela")
+            if let Some(target_name) = name.bytes().strip_prefix(b".rela")
                 && let Some(target_id) = output_sections
-                    .custom_name_to_id(crate::output_section_id::SectionName(target_name))
+                    .custom_identity_to_id(SectionIdentity::new(SectionName(target_name), ()))
                 && let Some(target_idx) = output_sections.output_index_of_section(target_id)
             {
                 info_value = target_idx;

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -3,6 +3,7 @@
 use crate::OutputSections;
 use crate::alignment;
 use crate::arch::Architecture;
+use crate::error::Context;
 use crate::error::Result;
 use crate::expression_eval::evaluate_const;
 use crate::glob_match::GlobPatternType;
@@ -16,6 +17,7 @@ use crate::linker_script;
 use crate::linker_script::ContentsCommand;
 use crate::linker_script::SectionCommand;
 use crate::output_section_id::OutputSectionId;
+use crate::output_section_id::SectionIdentity;
 use crate::output_section_id::SectionLocationInfo;
 use crate::output_section_id::SectionName;
 use crate::parsing::InternalSymDefInfo;
@@ -41,10 +43,10 @@ pub(crate) struct LayoutRulesBuilder<'data> {
     num_location_counters: usize,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum SectionKind<'data> {
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum SectionKind<'data, P: Platform> {
     /// This is the primary section.
-    Primary(SectionName<'data>),
+    Primary(SectionIdentity<'data, P>),
 
     /// This is a secondary section that will be merged into the primary. The ID of the primary is
     /// supplied.
@@ -264,8 +266,17 @@ impl<'data> LayoutRulesBuilder<'data> {
                             if !sec.phdrs.is_empty() {
                                 prev_phdrs = sec.phdrs.clone();
                             }
+                            let identity = P::section_identity_from_name(SectionName(
+                                sec.output_section_name,
+                            ))
+                            .with_context(|| {
+                                format!(
+                                    "Output section `{}` cannot be identified from the name alone",
+                                    SectionName(sec.output_section_name)
+                                )
+                            })?;
                             let primary_section_id = output_sections.add_named_section(
-                                SectionName(sec.output_section_name),
+                                identity,
                                 min_alignment,
                                 sec.region,
                                 Some(&location_info),

--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -30,6 +30,7 @@ use crate::macho_writer;
 use crate::output_section_id::OrderEvent;
 use crate::output_section_id::OutputOrderBuilder;
 use crate::output_section_id::OutputSectionId;
+use crate::output_section_id::SectionIdentity;
 use crate::output_section_id::SectionName;
 use crate::output_section_id::SectionOutputInfo;
 use crate::output_section_part_map::OutputSectionPartMap;
@@ -882,7 +883,7 @@ impl platform::ProgramSegmentDef for ProgramSegmentDef {
 }
 
 pub(crate) struct BuiltInSectionDetails {
-    pub(crate) kind: SectionKind<'static>,
+    pub(crate) kind: SectionKind<'static, MachO>,
     pub(crate) section_flags: SectionFlags,
     pub(crate) min_alignment: Alignment,
 }
@@ -890,7 +891,7 @@ pub(crate) struct BuiltInSectionDetails {
 impl platform::BuiltInSectionDetails for BuiltInSectionDetails {}
 
 const DEFAULT_DEFS: BuiltInSectionDetails = BuiltInSectionDetails {
-    kind: SectionKind::Primary(SectionName(&[])),
+    kind: SectionKind::Primary(SectionIdentity::new(SectionName(&[]), ())),
     section_flags: SectionFlags(0),
     min_alignment: alignment::MIN,
 };
@@ -1026,6 +1027,7 @@ impl platform::Platform for MachO {
     type VersionNames<'data> = ();
     type VerneedTable<'data> = VerneedTable<'data>;
     type ResolvedObjectExt<'data> = ();
+    type SectionIdentityExt = ();
 
     const HAS_NULL_SYMBOL_ENTRY: bool = true;
 
@@ -1750,6 +1752,19 @@ impl platform::Platform for MachO {
     fn is_allowed_in_archive(kind: crate::file_kind::FileKind) -> bool {
         kind == crate::file_kind::FileKind::MachOObject
     }
+
+    fn section_identity<'data>(
+        name: SectionName<'data>,
+        _section: &Self::SectionHeader,
+    ) -> SectionIdentity<'data, Self> {
+        SectionIdentity::new(name, ())
+    }
+
+    fn section_identity_from_name<'data>(
+        name: SectionName<'data>,
+    ) -> Option<SectionIdentity<'data, Self>> {
+        Some(SectionIdentity::new(name, ()))
+    }
 }
 
 pub(crate) fn install_name<'data>(
@@ -1790,44 +1805,50 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
     let mut defs = [DEFAULT_DEFS; NUM_BUILT_IN_SECTIONS];
 
     defs[crate::output_section_id::FILE_HEADER.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"FILE_HEADER")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"FILE_HEADER"), ())),
         ..DEFAULT_DEFS
     };
     defs[output_section_id::LOAD_COMMANDS.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"LOAD_COMMANDS")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"LOAD_COMMANDS"), ())),
         ..DEFAULT_DEFS
     };
     defs[output_section_id::LINK_EDIT_SEGMENT.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(SEG_LINKEDIT.as_bytes())),
+        kind: SectionKind::Primary(SectionIdentity::new(
+            SectionName(SEG_LINKEDIT.as_bytes()),
+            (),
+        )),
         ..DEFAULT_DEFS
     };
     defs[output_section_id::STRTAB.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"STRTAB")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"STRTAB"), ())),
         ..DEFAULT_DEFS
     };
     defs[output_section_id::CHAINED_FIXUP_TABLE.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"DYLD_CHAINED_FIXUPS_TABLE")),
+        kind: SectionKind::Primary(SectionIdentity::new(
+            SectionName(b"DYLD_CHAINED_FIXUPS_TABLE"),
+            (),
+        )),
         min_alignment: alignment::USIZE,
         ..DEFAULT_DEFS
     };
     defs[output_section_id::SYMTAB_GLOBAL.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"SYMTAB")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"SYMTAB"), ())),
         min_alignment: alignment::USIZE,
         ..DEFAULT_DEFS
     };
     defs[output_section_id::CODE_SIGNATURE.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"CODE_SIGNATURE")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"CODE_SIGNATURE"), ())),
         min_alignment: Alignment {
             exponent: CS_SECTION_ALIGNMENT_EXP,
         },
         ..DEFAULT_DEFS
     };
     defs[output_section_id::GOT.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"__got")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"__got"), ())),
         ..DEFAULT_DEFS
     };
     defs[output_section_id::PLT_GOT.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"__stubs")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"__stubs"), ())),
         section_flags: macho::S_SYMBOL_STUBS
             .to_flags()
             .with(macho::S_ATTR_PURE_INSTRUCTIONS)
@@ -1838,7 +1859,7 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
     // Multi-part generated sections
     // Start of regular sections
     defs[output_section_id::TEXT.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"__text")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"__text"), ())),
         section_flags: macho::S_REGULAR
             .to_flags()
             .with(macho::S_ATTR_PURE_INSTRUCTIONS)
@@ -1846,17 +1867,17 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
         ..DEFAULT_DEFS
     };
     defs[output_section_id::CSTRING.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"__cstring")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"__cstring"), ())),
         section_flags: macho::S_CSTRING_LITERALS.to_flags(),
         ..DEFAULT_DEFS
     };
     defs[output_section_id::CONST.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"__const")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"__const"), ())),
         section_flags: macho::S_REGULAR.to_flags(),
         ..DEFAULT_DEFS
     };
     defs[output_section_id::DATA.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"__data")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"__data"), ())),
         section_flags: macho::S_REGULAR.to_flags(),
         ..DEFAULT_DEFS
     };

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -39,6 +39,8 @@ use hashbrown::HashMap;
 use itertools::multizip;
 use std::fmt::Debug;
 use std::fmt::Display;
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::ops::Range;
 
 /// An ID for an output section. This is used for looking up section info. It's independent of
@@ -76,9 +78,9 @@ pub(crate) const UNMAPPED: OutputSectionId =
 pub(crate) const FILE_HEADER: OutputSectionId =
     CommonSinglePartSectionId::FileHeader.output_section_id();
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct CustomSectionDetails<'data> {
-    pub(crate) name: SectionName<'data>,
+#[derive(Debug)]
+pub(crate) struct CustomSectionDetails<'data, P: Platform> {
+    pub(crate) identity: SectionIdentity<'data, P>,
     pub(crate) index: object::SectionIndex,
     pub(crate) alignment: Alignment,
 }
@@ -103,7 +105,7 @@ pub(crate) struct OutputSections<'data, P: Platform> {
     /// being output.
     pub(crate) output_section_indexes: Vec<Option<u32>>,
 
-    custom_by_name: HashMap<SectionName<'data>, OutputSectionId>,
+    custom_by_identity: HashMap<SectionIdentity<'data, P>, OutputSectionId>,
 
     init_fini_by_priority: HashMap<(OutputSectionId, u16), OutputSectionId>,
 
@@ -500,7 +502,7 @@ impl<'data, P: Platform> OutputSections<'data, P> {
 // TODO: There's also a type with this name in layout_rules. Rename one of them to avoid confusion.
 #[derive(Debug)]
 pub(crate) struct SectionOutputInfo<'data, P: Platform> {
-    pub(crate) kind: SectionKind<'data>,
+    pub(crate) kind: SectionKind<'data, P>,
     pub(crate) section_attributes: P::SectionAttributes,
     pub(crate) min_alignment: Alignment,
     pub(crate) location_info: Option<SectionLocationInfo<'data>>,
@@ -631,6 +633,45 @@ pub(crate) enum OrderEvent<'data> {
     SetSectionAddress(linker_script::Expression<'data>),
 }
 
+/// The section's complete identity. Determines whether sections are combined into the same output
+/// section.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SectionIdentity<'data, P: Platform> {
+    name: SectionName<'data>,
+    format_specific: P::SectionIdentityExt,
+}
+
+impl<'data, P: Platform> SectionIdentity<'data, P> {
+    pub(crate) const fn new(
+        name: SectionName<'data>,
+        format_specific: P::SectionIdentityExt,
+    ) -> Self {
+        Self {
+            name,
+            format_specific,
+        }
+    }
+
+    pub(crate) fn section_name(&self) -> SectionName<'data> {
+        self.name
+    }
+}
+
+impl<'data, P: Platform> PartialEq for SectionIdentity<'data, P> {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.format_specific == other.format_specific
+    }
+}
+
+impl<'data, P: Platform> Eq for SectionIdentity<'data, P> {}
+
+impl<'data, P: Platform> Hash for SectionIdentity<'data, P> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+        self.format_specific.hash(state);
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct SectionName<'data>(pub(crate) &'data [u8]);
 
@@ -661,13 +702,13 @@ impl<'data, P: Platform> OutputSections<'data, P> {
     }
     pub(crate) fn add_sections(
         &mut self,
-        custom_sections: &[CustomSectionDetails<'data>],
+        custom_sections: &[CustomSectionDetails<'data, P>],
         section_part_ids: &mut [PartId],
         args: &P::Args,
     ) {
         for custom in custom_sections {
             let location = args
-                .start_address_for_section(custom.name)
+                .start_address_for_section(custom.identity.section_name())
                 .map(linker_script::Expression::Number);
             let location_info = location.map(|loc| SectionLocationInfo {
                 location_counters: (0, 0),
@@ -676,7 +717,7 @@ impl<'data, P: Platform> OutputSections<'data, P> {
                 is_top_level: true,
             });
             let section_id = self.add_named_section(
-                custom.name,
+                custom.identity,
                 custom.alignment,
                 None,
                 location_info.as_ref(),
@@ -724,7 +765,7 @@ impl<'data, P: Platform> OutputSections<'data, P> {
 
     pub(crate) fn add_named_section(
         &mut self,
-        name: SectionName<'data>,
+        identity: SectionIdentity<'data, P>,
         min_alignment: Alignment,
         region_name: Option<&'data [u8]>,
         location_info: Option<&SectionLocationInfo<'data>>,
@@ -735,14 +776,14 @@ impl<'data, P: Platform> OutputSections<'data, P> {
         if !self.output_kind.is_partial_object()
             && let Some(builtin_id) = (0..regular_section_base::<P>().as_usize())
                 .map(OutputSectionId::from_usize)
-                .find(|&bid| self.name(bid) == Some(name))
+                .find(|&bid| self.identity(bid) == Some(identity))
         {
             resolved_id = Some(builtin_id);
         }
 
         *self
-            .custom_by_name
-            .entry(name)
+            .custom_by_identity
+            .entry(identity)
             .and_modify(|s| {
                 let info = self.section_infos.get_mut(*s);
                 info.min_alignment = info.min_alignment.max(min_alignment);
@@ -770,7 +811,7 @@ impl<'data, P: Platform> OutputSections<'data, P> {
                     builtin_id
                 } else {
                     self.section_infos.add_new(SectionOutputInfo {
-                        kind: SectionKind::Primary(name),
+                        kind: SectionKind::Primary(identity),
                         section_attributes: Default::default(),
                         min_alignment,
                         location_info: location_info.cloned(),
@@ -812,7 +853,7 @@ impl<'data, P: Platform> OutputSections<'data, P> {
         Self {
             section_infos: OutputSectionMap::from_values(section_infos),
             base_address,
-            custom_by_name: HashMap::new(),
+            custom_by_identity: HashMap::new(),
             output_section_indexes: Default::default(),
             init_fini_by_priority: HashMap::new(),
             rosegment: true,
@@ -886,8 +927,8 @@ impl<'data, P: Platform> OutputSections<'data, P> {
                 if id == FILE_HEADER || P::CUSTOM_PHDR_EXCLUDED_SECTION_IDS.contains(&id) {
                     return;
                 } else if id.as_usize() < num_built_in_sections::<P>()
-                    && let Some(name) = self.name(id)
-                    && self.custom_name_to_id(name).is_some()
+                    && let Some(identity) = self.identity(id)
+                    && self.custom_identity_to_id(identity).is_some()
                 {
                     return;
                 }
@@ -982,18 +1023,24 @@ impl<'data, P: Platform> OutputSections<'data, P> {
         self.output_index_of_section(id).is_some()
     }
 
-    pub(crate) fn name(&self, section_id: OutputSectionId) -> Option<SectionName<'data>> {
+    pub(crate) fn identity(
+        &self,
+        section_id: OutputSectionId,
+    ) -> Option<SectionIdentity<'data, P>> {
         match self.output_info(section_id).kind {
-            SectionKind::Primary(section_name) => Some(section_name),
+            SectionKind::Primary(identity) => Some(identity),
             SectionKind::Secondary(_) => None,
         }
     }
 
+    pub(crate) fn name(&self, section_id: OutputSectionId) -> Option<SectionName<'data>> {
+        self.identity(section_id)
+            .map(|identity| identity.section_name())
+    }
+
     pub(crate) fn display_name(&self, section_id: OutputSectionId) -> String {
         match self.output_info(section_id).kind {
-            SectionKind::Primary(section_name) => {
-                format!("`{}`", String::from_utf8_lossy(section_name.0))
-            }
+            SectionKind::Primary(identity) => format!("`{identity}`"),
             SectionKind::Secondary(primary_id) => {
                 format!("{} (secondary)", self.display_name(primary_id))
             }
@@ -1018,18 +1065,24 @@ impl<'data, P: Platform> OutputSections<'data, P> {
         format!("{section_id}{merge} ({})", self.display_name(merge_target))
     }
 
-    pub(crate) fn custom_name_to_id<'a>(&self, name: SectionName<'a>) -> Option<OutputSectionId> {
-        self.custom_by_name.get(&name).copied()
+    pub(crate) fn custom_identity_to_id<'a>(
+        &self,
+        identity: SectionIdentity<'a, P>,
+    ) -> Option<OutputSectionId> {
+        self.custom_by_identity.get(&identity).copied()
     }
 
-    /// Look up a section by name across all sections — both built-in and custom.
-    pub(crate) fn section_id_by_name(&self, name: SectionName) -> Option<OutputSectionId> {
-        if let Some(id) = self.custom_by_name.get(&name).copied() {
+    /// Look up a section by name across both built-in and custom sections.
+    /// Returns None if the platform cannot construct an identity from the name alone or if no
+    /// matching section exists.
+    pub(crate) fn section_id_by_name<'a>(&self, name: SectionName<'a>) -> Option<OutputSectionId> {
+        let identity = P::section_identity_from_name(name)?;
+        if let Some(id) = self.custom_by_identity.get(&identity).copied() {
             return Some(id);
         }
         let mut found = None;
         self.section_infos.for_each(|id, _| {
-            if found.is_none() && self.name(id) == Some(name) {
+            if found.is_none() && self.identity(id) == Some(identity) {
                 found = Some(id);
             }
         });
@@ -1059,7 +1112,7 @@ impl<'data, P: Platform> OutputSections<'data, P> {
         let mut output_sections = OutputSections::<Elf64>::with_base_address(0x1000, output_kind);
         let mut add_name = |name: &'static str| {
             output_sections.add_named_section(
-                SectionName(name.as_bytes()),
+                SectionIdentity::new(SectionName(name.as_bytes()), ()),
                 crate::alignment::MIN,
                 None,
                 None,
@@ -1072,6 +1125,12 @@ impl<'data, P: Platform> OutputSections<'data, P> {
         add_name("data");
         add_name("bss");
         output_sections
+    }
+}
+
+impl<P: Platform> Display for SectionIdentity<'_, P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        P::fmt_section_identity(self.name, &self.format_specific, f)
     }
 }
 
@@ -1169,10 +1228,10 @@ impl<P: Platform> Display for OutputSections<'_, P> {
     }
 }
 
-impl Display for SectionKind<'_> {
+impl<P: Platform> Display for SectionKind<'_, P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            SectionKind::Primary(section_name) => write!(f, "{section_name}"),
+            SectionKind::Primary(identity) => write!(f, "{identity}"),
             SectionKind::Secondary(primary_id) => write!(f, "Secondary to {primary_id}"),
         }
     }

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -28,6 +28,7 @@ use crate::output_section_id::CustomSectionIds;
 use crate::output_section_id::OutputOrder;
 use crate::output_section_id::OutputSectionId;
 use crate::output_section_id::OutputSections;
+use crate::output_section_id::SectionIdentity;
 use crate::output_section_id::SectionName;
 use crate::output_section_map::OutputSectionMap;
 use crate::output_section_part_map::OutputSectionPartMap;
@@ -337,6 +338,9 @@ pub(crate) trait Platform:
     type SymtabShndxEntry: std::fmt::Debug + Default + Send + Sync + 'static;
     type ResolvedObjectExt<'data>: Default + std::fmt::Debug + Send + Sync;
     type FinaliseSizesExt<'data>: Send + Sync;
+
+    /// Format-specific fields that form part of a section's identity.
+    type SectionIdentityExt: std::fmt::Debug + Copy + Eq + Send + Sync + std::hash::Hash;
 
     /// An index into the local object's symbol versions.
     type SymbolVersionIndex: Send + Sync + Copy;
@@ -949,6 +953,29 @@ pub(crate) trait Platform:
 
     fn get_segment_flags_for_section(_section_flags: &Self::SectionFlags) -> u32 {
         0
+    }
+
+    /// Constructs the complete identity of an input section, including all format-specific fields
+    /// that distinguish sections with the same name.
+    fn section_identity<'data>(
+        name: SectionName<'data>,
+        section: &Self::SectionHeader,
+    ) -> SectionIdentity<'data, Self>;
+
+    /// Constructs a section identity with only the section name.
+    /// Returns None when the name alone cannot determine the complete section identity.
+    fn section_identity_from_name<'data>(
+        _name: SectionName<'data>,
+    ) -> Option<SectionIdentity<'data, Self>> {
+        None
+    }
+
+    fn fmt_section_identity(
+        name: SectionName<'_>,
+        _format_specific: &Self::SectionIdentityExt,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> std::fmt::Result {
+        std::fmt::Display::fmt(&name, f)
     }
 }
 

--- a/libwild/src/resolution.rs
+++ b/libwild/src/resolution.rs
@@ -772,7 +772,7 @@ pub(crate) struct ResolvedObject<'data, P: Platform> {
     pub(crate) string_merge_extras: Vec<StringMergeSectionExtra<'data>>,
 
     /// Details about each custom section that is defined in this object.
-    custom_sections: Vec<CustomSectionDetails<'data>>,
+    custom_sections: Vec<CustomSectionDetails<'data, P>>,
 
     init_fini_sections: Vec<InitFiniSectionDetail>,
 
@@ -1161,7 +1161,8 @@ fn allocate_start_stop_symbol_id<'data, P: Platform>(
         (s, false)
     };
 
-    let section_id = output_sections.custom_name_to_id(SectionName(section_name))?;
+    let identity = P::section_identity_from_name(SectionName(section_name))?;
+    let section_id = output_sections.custom_identity_to_id(identity)?;
 
     let def_info = if is_start {
         InternalSymDefInfo::new(SymbolPlacement::SectionStart(section_id), name.bytes())
@@ -1423,7 +1424,7 @@ fn resolve_section<'data, P: Platform>(
 
     if part_id == PartId::CUSTOM_PLACEHOLDER {
         let custom_section = CustomSectionDetails {
-            name: SectionName(section_name),
+            identity: P::section_identity(SectionName(section_name), input_section),
             alignment,
             index: input_section_index,
         };

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -14,6 +14,7 @@ use crate::layout_rules::SectionKind;
 use crate::layout_rules::SectionRule;
 use crate::layout_rules::SectionRuleOutcome;
 use crate::output_section_id::OutputSectionId;
+use crate::output_section_id::SectionIdentity;
 use crate::output_section_id::SectionName;
 use crate::part_id::PartId;
 use crate::platform;
@@ -1484,14 +1485,14 @@ impl platform::ProgramSegmentDef for ProgramSegmentDef {
 }
 
 pub(crate) struct BuiltInSectionDetails {
-    pub(crate) kind: SectionKind<'static>,
+    pub(crate) kind: SectionKind<'static, Wasm>,
     pub(crate) target_segment_type: Option<SegmentType>,
 }
 
 impl platform::BuiltInSectionDetails for BuiltInSectionDetails {}
 
 const DEFAULT_DEFS: BuiltInSectionDetails = BuiltInSectionDetails {
-    kind: SectionKind::Primary(SectionName(&[])),
+    kind: SectionKind::Primary(SectionIdentity::new(SectionName(&[]), ())),
     target_segment_type: None,
 };
 
@@ -1506,65 +1507,65 @@ const SECTION_DEFINITIONS: [BuiltInSectionDetails; NUM_BUILT_IN_SECTIONS] = {
 
     // The module preamble.
     defs[crate::output_section_id::FILE_HEADER.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"WASM_HEADER")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"WASM_HEADER"), ())),
         target_segment_type: Some(SegmentType::Header),
     };
 
     // Standard Wasm sections.
     defs[osid::WASM_TYPE.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"type")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"type"), ())),
         target_segment_type: Some(SegmentType::Module),
     };
     defs[osid::WASM_IMPORT.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"import")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"import"), ())),
         target_segment_type: Some(SegmentType::Module),
     };
     defs[osid::WASM_FUNCTION.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"function")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"function"), ())),
         target_segment_type: Some(SegmentType::Module),
     };
     defs[osid::WASM_TABLE.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"table")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"table"), ())),
         target_segment_type: Some(SegmentType::Module),
     };
     defs[osid::WASM_MEMORY.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"memory")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"memory"), ())),
         target_segment_type: Some(SegmentType::Module),
     };
     defs[osid::WASM_GLOBAL.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"global")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"global"), ())),
         target_segment_type: Some(SegmentType::Module),
     };
     defs[osid::WASM_EXPORT.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"export")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"export"), ())),
         target_segment_type: Some(SegmentType::Module),
     };
     defs[osid::WASM_START.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"start")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"start"), ())),
         target_segment_type: Some(SegmentType::Module),
     };
     defs[osid::WASM_ELEMENT.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"element")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"element"), ())),
         target_segment_type: Some(SegmentType::Module),
     };
     defs[osid::WASM_DATA_COUNT.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"data_count")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"data_count"), ())),
         target_segment_type: Some(SegmentType::Module),
     };
     defs[osid::WASM_CODE.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"code")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"code"), ())),
         target_segment_type: Some(SegmentType::Module),
     };
     defs[osid::WASM_DATA.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"data")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"data"), ())),
         target_segment_type: Some(SegmentType::Module),
     };
     defs[osid::WASM_NAME.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"name")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"name"), ())),
         target_segment_type: Some(SegmentType::Module),
     };
     defs[osid::WASM_TARGET_FEATURES.as_usize()] = BuiltInSectionDetails {
-        kind: SectionKind::Primary(SectionName(b"target_features")),
+        kind: SectionKind::Primary(SectionIdentity::new(SectionName(b"target_features"), ())),
         target_segment_type: Some(SegmentType::Module),
     };
 
@@ -5151,6 +5152,7 @@ impl platform::Platform for Wasm {
     type VersionNames<'data> = ();
     type VerneedTable<'data> = VerneedTable<'data>;
     type ResolvedObjectExt<'data> = WasmObjectLayout<'data>;
+    type SectionIdentityExt = ();
 
     fn write_output_file<'data, A: platform::Arch<Platform = Self>, F: FileSystem>(
         output: &crate::file_writer::Output<F>,
@@ -5634,6 +5636,19 @@ impl platform::Platform for Wasm {
 
     fn is_allowed_in_archive(kind: crate::file_kind::FileKind) -> bool {
         kind == crate::file_kind::FileKind::WasmObject
+    }
+
+    fn section_identity<'data>(
+        name: SectionName<'data>,
+        _section: &Self::SectionHeader,
+    ) -> SectionIdentity<'data, Self> {
+        SectionIdentity::new(name, ())
+    }
+
+    fn section_identity_from_name<'data>(
+        name: SectionName<'data>,
+    ) -> Option<SectionIdentity<'data, Self>> {
+        Some(SectionIdentity::new(name, ()))
     }
 }
 


### PR DESCRIPTION
Introduces `SectionIdentity`, which contains `SectionName` and a new `P::SectionIdentityExt` that provides format-specific section identification information. This replaces our previous section name-based identification and is in preparation for introducing (segment name, section name) section identification for Mach-O.

Part of #2248 