### PR TITLE
port(wasm): report unrecognized options

### DIFF
--- a/libwild/src/args.rs
+++ b/libwild/src/args.rs
@@ -337,6 +337,15 @@ fn default_warning_callback(warning: Warning) {
 }
 
 impl CommonArgs {
+    pub(crate) fn report_unrecognized(&self) -> Result {
+        if !self.unrecognized_options.is_empty() {
+            let options_list = self.unrecognized_options.join(", ");
+            bail!("unrecognized option(s): {}", options_list);
+        }
+
+        Ok(())
+    }
+
     pub(crate) fn trace_span_for_file(
         &self,
         file_id: FileId,

--- a/libwild/src/args/elf.rs
+++ b/libwild/src/args/elf.rs
@@ -415,10 +415,7 @@ pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(
         args.rpath = Some(std::mem::take(&mut args.rpath_set).into_iter().join(":"));
     }
 
-    if !args.common.unrecognized_options.is_empty() {
-        let options_list = args.common.unrecognized_options.join(", ");
-        bail!("unrecognized option(s): {}", options_list);
-    }
+    args.common.report_unrecognized()?;
 
     if !args.auxiliary.is_empty() && args.should_output_executable {
         bail!("-f may not be used without -shared");

--- a/libwild/src/args/macho.rs
+++ b/libwild/src/args/macho.rs
@@ -173,10 +173,7 @@ pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(
         arg_parser.handle_argument(args, &mut modifier_stack, arg, &mut input)?;
     }
 
-    if !args.common.unrecognized_options.is_empty() {
-        let options_list = args.common.unrecognized_options.join(", ");
-        bail!("unrecognized option(s): {}", options_list);
-    }
+    args.common.report_unrecognized()?;
 
     Ok(())
 }

--- a/libwild/src/args/wasm.rs
+++ b/libwild/src/args/wasm.rs
@@ -152,6 +152,8 @@ pub(crate) fn parse<S: AsRef<str>, I: Iterator<Item = S>>(
         arg_parser.handle_argument(args, &mut modifier_stack, arg, &mut input)?;
     }
 
+    args.common.report_unrecognized()?;
+
     Ok(())
 }
 
@@ -196,6 +198,15 @@ fn setup_argument_parser() -> ArgumentParser<WasmArgs> {
                 search_first: None,
                 modifiers,
             });
+            Ok(())
+        });
+
+    parser
+        .declare()
+        .long("gc-sections")
+        .help("Enable removal of unused sections")
+        .execute(|_args, _modifier_stack| {
+            // TODO
             Ok(())
         });
 
@@ -270,6 +281,22 @@ fn setup_argument_parser() -> ArgumentParser<WasmArgs> {
         .help("Place stack at the end of linear memory after data")
         .execute(|args, _modifier_stack| {
             args.stack_first = false;
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .prefix("O")
+        .execute(|_args, _modifier_stack, _value|
+        // We don't use opt-level for now.
+        Ok(()));
+
+    parser
+        .declare()
+        .long("no-demangle")
+        .help("Disable symbol demangling")
+        .execute(|args, _modifier_stack| {
+            args.common_mut().demangle = false;
             Ok(())
         });
 


### PR DESCRIPTION
The PR factors out a code into `CommonArgs` so that we can handle unrecognized options for all supported ports. On top of that, I added handling of a couple of options necessary for `rustc-println` test-case:
```
    ---- wasm/wasm32/rust-println/default ----
    Test failed: `rust-println.rs` with linker `wild` config `default`
      Caused by:
        Linker failed:
    wild: error: unrecognized option(s): --no-demangle, --gc-sections, -O0
```

Issue: #1431