### PR TITLE
port(wasm): Support `--initial-memory`

### DIFF
--- a/libwild/src/args/wasm.rs
+++ b/libwild/src/args/wasm.rs
@@ -35,6 +35,9 @@ pub struct WasmArgs {
     pub(crate) stack_first: bool,
     // Entry symbol name. Defaults to `DEFAULT_ENTRY`.
     pub(crate) entry: Option<String>,
+    // When set, the output `memory.initial` is raised to at least this many bytes (must be
+    // page-aligned). `None` means size is derived from data / stack layout only.
+    pub(crate) initial_memory: Option<u64>,
 }
 
 impl WasmArgs {
@@ -55,6 +58,7 @@ impl Default for WasmArgs {
             z_stack_size: DEFAULT_STACK_SIZE,
             stack_first: true,
             entry: Some(DEFAULT_ENTRY.to_owned()),
+            initial_memory: None,
         }
     }
 }
@@ -272,6 +276,15 @@ fn setup_argument_parser() -> ArgumentParser<WasmArgs> {
         .help("Place stack at the end of linear memory after data")
         .execute(|args, _modifier_stack| {
             args.stack_first = false;
+            Ok(())
+        });
+
+    parser
+        .declare_with_param()
+        .long("initial-memory")
+        .help("Initial size of the linear memory in bytes")
+        .execute(|args, _modifier_stack, value| {
+            args.initial_memory = Some(parse_number(value)?);
             Ok(())
         });
 

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -4170,10 +4170,14 @@ fn wasm_page_size() -> u64 {
     crate::args::wasm::WASM_PAGE_SIZE
 }
 
+/// Maximum linear-memory size in bytes for wasm32.
+const WASM32_MAX_MEMORY_BYTES: u64 = 1u64 << 32;
+
 fn ensure_memory_covers(
     layout: &mut WasmLayout<'_>,
     stack_size: u32,
     stack_first: bool,
+    initial_memory: Option<u64>,
 ) -> Result<u64> {
     let page = wasm_page_size();
     let mut bytes_needed = u64::from(layout.data_end.max(layout.memory_base));
@@ -4183,6 +4187,23 @@ fn ensure_memory_covers(
             stack_size,
         )?));
     }
+
+    if let Some(requested) = initial_memory {
+        ensure!(
+            requested.is_multiple_of(page),
+            "initial memory must be aligned to the page size ({page} bytes)"
+        );
+        ensure!(
+            requested <= WASM32_MAX_MEMORY_BYTES,
+            "initial memory too large, cannot be greater than {WASM32_MAX_MEMORY_BYTES}"
+        );
+        ensure!(
+            bytes_needed <= requested,
+            "initial memory too small, {bytes_needed} bytes needed"
+        );
+        bytes_needed = requested;
+    }
+
     if !layout.memories.is_empty() && bytes_needed > 0 {
         let pages_needed = bytes_needed.div_ceil(page).max(1);
         for memory in &mut layout.memories {
@@ -4492,6 +4513,7 @@ where
     let linker_memory = any_object_needs_linker_memory(&layout_inputs);
     let stack_size = symbol_db.args.z_stack_size;
     let stack_first = symbol_db.args.stack_first;
+    let initial_memory = symbol_db.args.initial_memory;
     if stack_size > 0 {
         ensure_stack_size_aligned(stack_size)?;
     }
@@ -4607,7 +4629,8 @@ where
             ensure_memory_export(&mut layout.exports);
         }
         layout.data_end = memory_cursor;
-        let initial_pages = ensure_memory_covers(&mut layout, stack_size, stack_first)?;
+        let initial_pages =
+            ensure_memory_covers(&mut layout, stack_size, stack_first, initial_memory)?;
         // wasm-ld only defines `__heap_end` when linear memory exists (end of `memory.initial`).
         let heap_end = if layout.memories.is_empty() {
             None
@@ -6069,11 +6092,11 @@ mod tests {
             ..Default::default()
         };
 
-        let pages = ensure_memory_covers(&mut layout, DEFAULT_STACK_SIZE, true).unwrap();
+        let pages = ensure_memory_covers(&mut layout, DEFAULT_STACK_SIZE, true, None).unwrap();
         assert_eq!(pages, 1);
         assert_eq!(layout.memories[0].initial, 1);
 
-        let pages = ensure_memory_covers(&mut layout, DEFAULT_STACK_SIZE, false).unwrap();
+        let pages = ensure_memory_covers(&mut layout, DEFAULT_STACK_SIZE, false, None).unwrap();
         let expected_pages = (u64::from(data_end) + u64::from(DEFAULT_STACK_SIZE))
             .div_ceil(wasm_page_size())
             .max(1);

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -4166,12 +4166,12 @@ fn emit_reserved_linker_definitions(
     }
 }
 
-fn wasm_page_size() -> u64 {
+const fn wasm_page_size() -> u64 {
     crate::args::wasm::WASM_PAGE_SIZE
 }
 
 /// Maximum linear-memory size in bytes for wasm32.
-const WASM32_MAX_MEMORY_BYTES: u64 = 1u64 << 32;
+const WASM32_MAX_MEMORY_BYTES: u64 = (1u64 << 32) - wasm_page_size();
 
 fn ensure_memory_covers(
     layout: &mut WasmLayout<'_>,

--- a/wild/tests/sources/wasm/initial-memory/initial-memory.c
+++ b/wild/tests/sources/wasm/initial-memory/initial-memory.c
@@ -16,6 +16,14 @@
 //#CompArgs: -DEXPECTED_HEAP_END=0
 //#ExpectError: initial memory must be aligned
 
+//#Config:max
+//#LinkArgs: --initial-memory=4294967296
+//#CompArgs: -DEXPECTED_HEAP_END=0
+// wasm-ld allows --initial-memory=2^32 but it makes `__heap_end` wrap around to 0, so Wild rejects
+// it
+//#ReferenceLinkers:
+//#ExpectError: initial memory too large
+
 extern char __heap_end;
 
 void _start(void) {

--- a/wild/tests/sources/wasm/initial-memory/initial-memory.c
+++ b/wild/tests/sources/wasm/initial-memory/initial-memory.c
@@ -1,0 +1,26 @@
+//#Config:default
+//#LinkArgs: --initial-memory=20971520 -z stack-size=65536 --stack-first
+//#CompArgs: -DEXPECTED_HEAP_END=20971520UL
+
+//#Config:equals-form
+//#LinkArgs: --initial-memory=131072 -z stack-size=65536 --stack-first
+//#CompArgs: -DEXPECTED_HEAP_END=131072UL
+
+//#Config:too-small
+//#LinkArgs: --initial-memory=65536 -z stack-size=1048576 --stack-first
+//#CompArgs: -DEXPECTED_HEAP_END=0
+//#ExpectError: initial memory too small
+
+//#Config:unaligned
+//#LinkArgs: --initial-memory=1000
+//#CompArgs: -DEXPECTED_HEAP_END=0
+//#ExpectError: initial memory must be aligned
+
+extern char __heap_end;
+
+void _start(void) {
+  unsigned long heap_end = (unsigned long)&__heap_end;
+  if (heap_end != EXPECTED_HEAP_END) {
+    __builtin_trap();
+  }
+}


### PR DESCRIPTION
Raise `memory.initial` to the requested page-aligned size. Reject values that are unaligned, too small for the layout, or larger than the wasm32 limit. This option is used when building CPython for WASI.

Part of #1431