### PR TITLE
api(FS): use consistently Error type

### DIFF
--- a/libwild/src/fs.rs
+++ b/libwild/src/fs.rs
@@ -273,16 +273,16 @@ pub trait FileSystem: Send + Sync + 'static {
     ) -> Result<(Self::Input, Option<Arc<File>>)>;
 
     /// Returns the type of the file at `path`.
-    fn file_type(&self, path: &Path) -> std::io::Result<FileType>;
+    fn file_type(&self, path: &Path) -> Result<FileType>;
 
     /// Resolves symbolic links and returns the canonical absolute path.
-    fn canonicalize(&self, path: &Path) -> std::io::Result<PathBuf>;
+    fn canonicalize(&self, path: &Path) -> Result<PathBuf>;
 
     /// Removes a file.
-    fn remove_file(&self, path: &Path) -> std::io::Result<()>;
+    fn remove_file(&self, path: &Path) -> Result<()>;
 
     /// Rename an existing file to a new path.
-    fn rename_file(&self, path: &Path, new_path: &Path) -> std::io::Result<()>;
+    fn rename_file(&self, path: &Path, new_path: &Path) -> Result<()>;
 
     /// Creates the sized random-access output.
     fn create_output(&self, path: Arc<Path>, options: OutputOptions) -> Result<Self::Output>;
@@ -465,7 +465,7 @@ impl FileSystem for OsFileSystem {
         ))
     }
 
-    fn file_type(&self, path: &Path) -> std::io::Result<FileType> {
+    fn file_type(&self, path: &Path) -> Result<FileType> {
         let ty = std::fs::metadata(path)?.file_type();
         Ok(if ty.is_file() {
             FileType::File
@@ -476,15 +476,15 @@ impl FileSystem for OsFileSystem {
         })
     }
 
-    fn canonicalize(&self, path: &Path) -> std::io::Result<PathBuf> {
+    fn canonicalize(&self, path: &Path) -> Result<PathBuf> {
         std::fs::canonicalize(path)
     }
 
-    fn remove_file(&self, path: &Path) -> std::io::Result<()> {
+    fn remove_file(&self, path: &Path) -> Result<()> {
         std::fs::remove_file(path)
     }
 
-    fn rename_file(&self, path: &Path, new_path: &Path) -> std::io::Result<()> {
+    fn rename_file(&self, path: &Path, new_path: &Path) -> Result<()> {
         std::fs::rename(path, new_path)
     }
 

--- a/libwild/src/fs.rs
+++ b/libwild/src/fs.rs
@@ -123,7 +123,10 @@ pub trait OutputFileData: Send {
 ///
 ///     fn finish(mut self) -> libwild::error::Result {
 ///         let data = mem::take(&mut self.bytes);
-///         self.files.lock().unwrap().insert(self.path.clone(), data);
+///         self.files
+///             .lock()
+///             .expect("cannot lock in-memory FS")
+///             .insert(self.path.clone(), data);
 ///         Ok(())
 ///     }
 /// }
@@ -140,50 +143,58 @@ pub trait OutputFileData: Send {
 ///         let bytes = self
 ///             .files
 ///             .lock()
-///             .unwrap()
+///             .expect("cannot lock in-memory FS")
 ///             .get(&path.to_path_buf())
 ///             .cloned()
 ///             .ok_or_else(|| libwild::error!("No such in-memory file: {}", path.display()))?;
 ///         Ok((Input(bytes), None))
 ///     }
 ///
-///     fn file_type(&self, path: &Path) -> std::io::Result<FileType> {
-///         if self.files.lock().unwrap().contains_key(&path.to_path_buf()) {
+///     fn file_type(&self, path: &Path) -> libwild::error::Result<FileType> {
+///         if self
+///             .files
+///             .lock()
+///             .expect("cannot lock in-memory FS")
+///             .contains_key(&path.to_path_buf())
+///         {
 ///             Ok(FileType::File)
 ///         } else {
 ///             Err(std::io::Error::new(
 ///                 std::io::ErrorKind::NotFound,
 ///                 "no such in-memory file",
-///             ))
+///             )
+///             .into())
 ///         }
 ///     }
 ///
-///     fn canonicalize(&self, path: &Path) -> std::io::Result<PathBuf> {
+///     fn canonicalize(&self, path: &Path) -> libwild::error::Result<PathBuf> {
 ///         Ok(path.to_path_buf())
 ///     }
 ///
-///     fn rename_file(&self, path: &Path, new_path: &Path) -> std::io::Result<()> {
-///         let mut guard = self.files.lock().unwrap();
+///     fn rename_file(&self, path: &Path, new_path: &Path) -> libwild::error::Result<()> {
+///         let mut guard = self.files.lock().expect("cannot lock in-memory FS");
 ///         let Some(data) = guard.remove(&path.to_path_buf()) else {
 ///             return Err(std::io::Error::new(
 ///                 std::io::ErrorKind::NotFound,
 ///                 "no such in-memory file",
-///             ));
+///             )
+///             .into());
 ///         };
 ///         guard.insert(new_path.to_path_buf(), data);
 ///
 ///         Ok(())
 ///     }
 ///
-///     fn remove_file(&self, path: &Path) -> std::io::Result<()> {
-///         self.files
+///     fn remove_file(&self, path: &Path) -> libwild::error::Result<()> {
+///         Ok(self
+///             .files
 ///             .lock()
-///             .unwrap()
+///             .expect("cannot lock in-memory FS")
 ///             .remove(&path.to_path_buf())
 ///             .map(|_| ())
 ///             .ok_or_else(|| {
 ///                 std::io::Error::new(std::io::ErrorKind::NotFound, "no such in-memory file")
-///             })
+///             })?)
 ///     }
 ///
 ///     fn create_output(
@@ -203,7 +214,7 @@ pub trait OutputFileData: Send {
 ///     fn write_auxiliary(&self, path: &Path, bytes: &[u8]) -> libwild::error::Result {
 ///         self.files
 ///             .lock()
-///             .unwrap()
+///             .expect("cannot lock in-memory FS")
 ///             .insert(path.to_path_buf(), bytes.to_vec());
 ///         Ok(())
 ///     }
@@ -231,7 +242,7 @@ pub trait OutputFileData: Send {
 ///
 ///     fs.files
 ///         .lock()
-///         .unwrap()
+///         .expect("cannot lock in-memory FS")
 ///         .insert(PathBuf::from("main.o"), create_main_object()?);
 ///
 ///     let arguments = [
@@ -253,7 +264,7 @@ pub trait OutputFileData: Send {
 ///     let output = fs
 ///         .files
 ///         .lock()
-///         .unwrap()
+///         .expect("cannot lock in-memory FS")
 ///         .get(Path::new("libx.so"))
 ///         .cloned()
 ///         .ok_or_else(|| libwild::error!("linker did not create libx.so"))?;
@@ -477,15 +488,15 @@ impl FileSystem for OsFileSystem {
     }
 
     fn canonicalize(&self, path: &Path) -> Result<PathBuf> {
-        std::fs::canonicalize(path)
+        Ok(std::fs::canonicalize(path)?)
     }
 
     fn remove_file(&self, path: &Path) -> Result<()> {
-        std::fs::remove_file(path)
+        Ok(std::fs::remove_file(path)?)
     }
 
     fn rename_file(&self, path: &Path, new_path: &Path) -> Result<()> {
-        std::fs::rename(path, new_path)
+        Ok(std::fs::rename(path, new_path)?)
     }
 
     fn create_output(&self, path: Arc<Path>, options: OutputOptions) -> Result<Self::Output> {

--- a/libwild/src/fs.rs
+++ b/libwild/src/fs.rs
@@ -125,7 +125,7 @@ pub trait OutputFileData: Send {
 ///         let data = mem::take(&mut self.bytes);
 ///         self.files
 ///             .lock()
-///             .expect("cannot lock in-memory FS")
+///             .unwrap()
 ///             .insert(self.path.clone(), data);
 ///         Ok(())
 ///     }
@@ -143,7 +143,7 @@ pub trait OutputFileData: Send {
 ///         let bytes = self
 ///             .files
 ///             .lock()
-///             .expect("cannot lock in-memory FS")
+///             .unwrap()
 ///             .get(&path.to_path_buf())
 ///             .cloned()
 ///             .ok_or_else(|| libwild::error!("No such in-memory file: {}", path.display()))?;
@@ -154,7 +154,7 @@ pub trait OutputFileData: Send {
 ///         if self
 ///             .files
 ///             .lock()
-///             .expect("cannot lock in-memory FS")
+///             .unwrap()
 ///             .contains_key(&path.to_path_buf())
 ///         {
 ///             Ok(FileType::File)
@@ -172,7 +172,7 @@ pub trait OutputFileData: Send {
 ///     }
 ///
 ///     fn rename_file(&self, path: &Path, new_path: &Path) -> libwild::error::Result<()> {
-///         let mut guard = self.files.lock().expect("cannot lock in-memory FS");
+///         let mut guard = self.files.lock().unwrap();
 ///         let Some(data) = guard.remove(&path.to_path_buf()) else {
 ///             return Err(std::io::Error::new(
 ///                 std::io::ErrorKind::NotFound,
@@ -189,7 +189,7 @@ pub trait OutputFileData: Send {
 ///         Ok(self
 ///             .files
 ///             .lock()
-///             .expect("cannot lock in-memory FS")
+///             .unwrap()
 ///             .remove(&path.to_path_buf())
 ///             .map(|_| ())
 ///             .ok_or_else(|| {
@@ -214,7 +214,7 @@ pub trait OutputFileData: Send {
 ///     fn write_auxiliary(&self, path: &Path, bytes: &[u8]) -> libwild::error::Result {
 ///         self.files
 ///             .lock()
-///             .expect("cannot lock in-memory FS")
+///             .unwrap()
 ///             .insert(path.to_path_buf(), bytes.to_vec());
 ///         Ok(())
 ///     }
@@ -242,7 +242,7 @@ pub trait OutputFileData: Send {
 ///
 ///     fs.files
 ///         .lock()
-///         .expect("cannot lock in-memory FS")
+///         .unwrap()
 ///         .insert(PathBuf::from("main.o"), create_main_object()?);
 ///
 ///     let arguments = [
@@ -264,7 +264,7 @@ pub trait OutputFileData: Send {
 ///     let output = fs
 ///         .files
 ///         .lock()
-///         .expect("cannot lock in-memory FS")
+///         .unwrap()
 ///         .get(Path::new("libx.so"))
 ///         .cloned()
 ///         .ok_or_else(|| libwild::error!("linker did not create libx.so"))?;


### PR DESCRIPTION
I feel it would be better having a unified `Error` type in the FS abstraction. It shows nicely in the provided example, where the nature of an error is not tightly connected to a `std::io` Error type, but can be e.g. `Mutex::lock` error.