### PR TITLE
port(MachO): Emit only retained section headers

### DIFF
--- a/libwild/src/macho.rs
+++ b/libwild/src/macho.rs
@@ -1978,7 +1978,8 @@ fn count_sections_for_segment_type(
     output_sections
         .ids_with_info()
         .filter(|(section_id, _)| {
-            output_sections.should_include_in_segment(*section_id, segment_def)
+            output_sections.will_emit_section(*section_id)
+                && output_sections.should_include_in_segment(*section_id, segment_def)
         })
         .count()
 }
@@ -2011,7 +2012,9 @@ pub(crate) fn get_segment_sections<'data>(
             {
                 break;
             }
-            OrderEvent::Section(section_id) if in_matching_segment => {
+            OrderEvent::Section(section_id)
+                if in_matching_segment && layout.output_sections.will_emit_section(section_id) =>
+            {
                 let sizes = *layout.section_layouts.get(section_id);
                 sections.push((
                     sizes,
@@ -2023,7 +2026,7 @@ pub(crate) fn get_segment_sections<'data>(
         }
     }
 
-    let segment_id = segment_id.expect("must be visited in the output order");
+    let segment_id = segment_id?;
     let segment_size = layout
         .segment_layouts
         .segments

--- a/libwild/src/macho_writer.rs
+++ b/libwild/src/macho_writer.rs
@@ -1318,7 +1318,9 @@ fn macho_section_index(layout: &MachOLayout<'_>, section_id: OutputSectionId) ->
             OrderEvent::SegmentEnd(_) => {
                 in_section_segment = false;
             }
-            OrderEvent::Section(current) if in_section_segment => {
+            OrderEvent::Section(current)
+                if in_section_segment && layout.output_sections.will_emit_section(current) =>
+            {
                 if current == section_id {
                     return Ok(section_idx);
                 }

--- a/wild/tests/sources/macho/trivial/trivial.c
+++ b/wild/tests/sources/macho/trivial/trivial.c
@@ -1,5 +1,8 @@
 //#Object:runtime.c
-//#ExpectSym:_main
+//#ExpectSym:_main section="__text"
+//#ExpectSym:_exit_syscall_num section="__const"
+//#NoSection:__cstring
+//#NoSection:__stubs
 //#TestUpdateInPlace:true
 //#DiffIgnore:section.__unwind_info
 


### PR DESCRIPTION
Currently, we emit all section headers in `__TEXT`, `__DATA` and `__DATA_CONST` even when we don't retain them. This diff modifies `count_sections_for_segment_type`, `macho_section_index`, and `get_segment_sections` so that non-retained sections are filtered from emitted section headers.

**Before:**
```
running 1 test
test macho/aarch64/trivial/default ... FAILED

failures:

---- macho/aarch64/trivial/default ----
Output binary assertions failed. Binary `/Users/joannajo/wild/wild/tests/build/macho/aarch64/trivial/default/trivial.c.wild`. Relink with:
        cargo run --bin wild -- -flavor darwin -o /Users/joannajo/wild/wild/tests/build/macho/aarch64/trivial/default/trivial.c.wild /Users/joannajo/wild/wild/tests/build/macho/aarch64/trivial/default/trivial.c.o /Users/joannajo/wild/wild/tests/build/macho/aarch64/trivial/default/runtime.c.o --validate-output --write-layout --write-trace
  Caused by:
    Section `__cstring` should not exist but was found
```

**After:**
```
running 1 test
test macho/aarch64/trivial/default ... ok
```

Part of #2248