### PR TITLE
port(wasm): Synthesize GOT.func globals for `R_WASM_GLOBAL_INDEX`

### DIFF
--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -3286,13 +3286,20 @@ impl GotMem {
     }
 }
 
+/// Where a GOT.func slot's table index comes from.
+#[derive(Debug, Clone, Copy)]
+enum GotFuncTarget {
+    Object {
+        object_index: usize,
+        symbol_offset: usize,
+    },
+    LinkerDefined(WasmLinkerSymbol),
+}
+
 #[derive(Debug, Clone, Copy)]
 struct GotFuncEntry {
     def_symbol_id: SymbolId,
-    /// Layout-input object that holds the definition (or the undefined weak import).
-    object_index: usize,
-    /// Offset of that function symbol within the object's linking symbol table.
-    symbol_offset: usize,
+    target: GotFuncTarget,
 }
 
 #[derive(Debug, Default)]
@@ -3308,6 +3315,24 @@ impl GotFunc {
 
     fn len(&self) -> u32 {
         self.entries.len() as u32
+    }
+
+    fn needs_call_ctors(&self) -> bool {
+        self.entries.iter().any(|e| {
+            matches!(
+                e.target,
+                GotFuncTarget::LinkerDefined(WasmLinkerSymbol::CallCtors)
+            )
+        })
+    }
+
+    fn needs_call_dtors(&self) -> bool {
+        self.entries.iter().any(|e| {
+            matches!(
+                e.target,
+                GotFuncTarget::LinkerDefined(WasmLinkerSymbol::CallDtors)
+            )
+        })
     }
 }
 
@@ -3361,12 +3386,13 @@ fn setup_got_mem_and_indices<'data>(
         shared_imports.global_count(),
         weak_undef_stubs,
         LinkerDefinedIndexRequest {
-            has_init_funcs,
+            has_init_funcs: has_init_funcs || scan.got_func.needs_call_ctors(),
             wrap_entry,
             got_mem_count: scan.got_mem.len(),
             got_func_count: scan.got_func.len(),
             needs_memory_base: scan.needs_memory_base,
             needs_table_base: scan.needs_table_base,
+            needs_call_dtors: scan.got_func.needs_call_dtors(),
         },
     )?;
 
@@ -3634,19 +3660,17 @@ fn scan_layout_relocations(
                             let slot = if let Some(&slot) = func_def_to_slot.get(&def_id) {
                                 slot
                             } else {
-                                let (object_index, symbol_offset) =
-                                    resolve_got_func_symbol_location(
-                                        def_id,
-                                        layout_inputs,
-                                        symbol_db,
-                                        file_id_to_index,
-                                    )?;
+                                let target = resolve_got_func_target(
+                                    def_id,
+                                    layout_inputs,
+                                    symbol_db,
+                                    file_id_to_index,
+                                )?;
                                 let slot = func_entries.len();
                                 func_def_to_slot.insert(def_id, slot);
                                 func_entries.push(GotFuncEntry {
                                     def_symbol_id: def_id,
-                                    object_index,
-                                    symbol_offset,
+                                    target,
                                 });
                                 slot
                             };
@@ -3759,45 +3783,69 @@ fn got_func_debug_name(
     entry: &GotFuncEntry,
     index: usize,
 ) -> String {
-    let sym_name = layout_inputs.get(entry.object_index).and_then(|input| {
-        input
-            .symbols
-            .get(entry.symbol_offset)
-            .and_then(|sym| wasm_symbol_name_str(input.data, sym))
-    });
-    match sym_name {
+    let name = match entry.target {
+        GotFuncTarget::Object {
+            object_index,
+            symbol_offset,
+        } => layout_inputs.get(object_index).and_then(|input| {
+            input
+                .symbols
+                .get(symbol_offset)
+                .and_then(|sym| wasm_symbol_name_str(input.data, sym))
+                .map(|s| s.to_owned())
+        }),
+        GotFuncTarget::LinkerDefined(known) => {
+            Some(String::from_utf8_lossy(known.name()).into_owned())
+        }
+    };
+    match name {
         Some(name) => format!("GOT.func.internal.{name}"),
         None => format!("GOT.func.internal.{index}"),
     }
 }
 
-fn resolve_got_func_symbol_location(
+fn resolve_got_func_target(
     def_id: SymbolId,
     layout_inputs: &[WasmObjectLayoutInput<'_>],
     symbol_db: &SymbolDb<'_, Wasm>,
     file_id_to_index: &HashMap<crate::input_data::FileId, usize>,
-) -> Result<(usize, usize)> {
+) -> Result<GotFuncTarget> {
     let def_file_id = symbol_db.file_id_for_symbol(def_id);
-    let Some(&def_obj_idx) = file_id_to_index.get(&def_file_id) else {
-        bail!(
-            "GOT.func for `{}` requires a function symbol in the link",
+    if let Some(&def_obj_idx) = file_id_to_index.get(&def_file_id) {
+        let def_input = &layout_inputs[def_obj_idx];
+        let def_off = def_id.to_offset(def_input.symbol_id_range);
+        let def_sym = def_input.symbols.get(def_off).ok_or_else(|| {
+            crate::error!(
+                "GOT.func for `{}` has out-of-range symbol offset",
+                symbol_db.symbol_name_for_display(def_id)
+            )
+        })?;
+        ensure!(
+            def_sym.kind == WasmSymbolKind::Func,
+            "GOT.func for `{}` requires a function symbol",
             symbol_db.symbol_name_for_display(def_id)
         );
-    };
-    let def_input = &layout_inputs[def_obj_idx];
-    let def_off = def_id.to_offset(def_input.symbol_id_range);
-    let def_sym = def_input.symbols.get(def_off).ok_or_else(|| {
-        crate::error!(
-            "GOT.func for `{}` has out-of-range symbol offset",
-            symbol_db.symbol_name_for_display(def_id)
+        return Ok(GotFuncTarget::Object {
+            object_index: def_obj_idx,
+            symbol_offset: def_off,
+        });
+    }
+
+    // Linker-defined functions live on the prelude file, not in `layout_inputs`.
+    if let Some(def_info) = symbol_db.prelude_symbol_def(def_id)
+        && let crate::parsing::SymbolPlacement::PlatformSpecific(known) = def_info.placement
+        && matches!(
+            known,
+            WasmLinkerSymbol::CallCtors | WasmLinkerSymbol::CallDtors
         )
-    })?;
-    ensure!(
-        def_sym.kind == WasmSymbolKind::Func,
-        "GOT.func for `{}` requires a function symbol",
+    {
+        return Ok(GotFuncTarget::LinkerDefined(known));
+    }
+
+    bail!(
+        "GOT.func for `{}` requires a function symbol in the link",
         symbol_db.symbol_name_for_display(def_id)
-    );
-    Ok((def_obj_idx, def_off))
+    )
 }
 
 fn absorb_got_mem_imports(
@@ -3983,24 +4031,36 @@ fn fill_got_func_inits(
     let defined_slot = (got_base - indices.global_import_count) as usize;
 
     for (i, entry) in got_func.entries.iter().enumerate() {
-        let input = layout_inputs.get(entry.object_index).ok_or_else(|| {
-            crate::error!("GOT.func object index {} out of range", entry.object_index)
-        })?;
-        let sym = input.symbols.get(entry.symbol_offset).ok_or_else(|| {
-            crate::error!(
-                "GOT.func symbol offset {} out of range",
-                entry.symbol_offset
-            )
-        })?;
-        ensure!(
-            sym.kind == WasmSymbolKind::Func,
-            "GOT.func definition is not a function symbol"
-        );
-        let func_out = remap_wasm_index(
-            &layout.object_index_maps[entry.object_index].function_indices,
-            sym.index,
-            "function",
-        )?;
+        let func_out = match entry.target {
+            GotFuncTarget::Object {
+                object_index,
+                symbol_offset,
+            } => {
+                let input = layout_inputs.get(object_index).ok_or_else(|| {
+                    crate::error!("GOT.func object index {object_index} out of range")
+                })?;
+                let sym = input.symbols.get(symbol_offset).ok_or_else(|| {
+                    crate::error!("GOT.func symbol offset {symbol_offset} out of range")
+                })?;
+                ensure!(
+                    sym.kind == WasmSymbolKind::Func,
+                    "GOT.func definition is not a function symbol"
+                );
+                remap_wasm_index(
+                    &layout.object_index_maps[object_index].function_indices,
+                    sym.index,
+                    "function",
+                )?
+            }
+            GotFuncTarget::LinkerDefined(known) => {
+                indices.function_index(known).ok_or_else(|| {
+                    crate::error!(
+                        "GOT.func linker-defined function `{}` was not reserved",
+                        std::str::from_utf8(known.name()).unwrap_or("?")
+                    )
+                })?
+            }
+        };
         let slot = layout
             .function_table_slots
             .get(func_out as usize)
@@ -4068,6 +4128,7 @@ struct LinkerDefinedIndexRequest {
     got_func_count: u32,
     needs_memory_base: bool,
     needs_table_base: bool,
+    needs_call_dtors: bool,
 }
 
 impl LinkerDefinedIndices {
@@ -4083,7 +4144,7 @@ impl LinkerDefinedIndices {
         let mut needs_stack_pointer = false;
         let mut needs_tls_base = false;
         let mut needs_ctors = request.has_init_funcs;
-        let mut needs_dtors = false;
+        let mut needs_dtors = request.needs_call_dtors;
 
         for resolutions in import_resolutions {
             let absorption = LinkerImportAbsorption::from_resolutions(resolutions);
@@ -5011,6 +5072,8 @@ where
             &reloc_scan.table_index_symbol_indices,
             reloc_scan.needs_table,
             &weak_undef_funcs,
+            got_func,
+            &indices,
         )?;
         // GOT.func inits need table slots assigned above.
         fill_got_func_inits(&mut layout, &indices, got_func, &layout_inputs)?;
@@ -5026,6 +5089,8 @@ fn finalize_indirect_function_table(
     table_index_symbol_indices: &[Vec<usize>],
     needs_table: bool,
     weak_undef_funcs: &HashSet<u32>,
+    got_func: &GotFunc,
+    indices: &LinkerDefinedIndices,
 ) -> Result {
     if !needs_table {
         return Ok(());
@@ -5059,13 +5124,30 @@ fn finalize_indirect_function_table(
         }
     }
 
+    for entry in &got_func.entries {
+        if let GotFuncTarget::LinkerDefined(known) = entry.target
+            && let Some(func_out) = indices.function_index(known)
+            && !weak_undef_funcs.contains(&func_out)
+            && seen.insert(func_out)
+        {
+            needed.push(func_out);
+        }
+    }
+
     // Slot 0 is unused and first function at slot 1. This matches common clang/wasm-ld layout.
-    let max_func = layout
+    let mut max_func = layout
         .object_index_maps
         .iter()
         .flat_map(|m| m.function_indices.iter().copied())
         .max()
         .unwrap_or(0);
+    for entry in &got_func.entries {
+        if let GotFuncTarget::LinkerDefined(known) = entry.target
+            && let Some(func_out) = indices.function_index(known)
+        {
+            max_func = max_func.max(func_out);
+        }
+    }
     let mut slots_by_func = vec![u32::MAX; max_func as usize + 1];
 
     for &func_out in weak_undef_funcs {

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -1612,10 +1612,12 @@ fn build_name_section<'data>(
     layout_inputs: &[WasmObjectLayoutInput<'data>],
     indices: &LinkerDefinedIndices,
     got_mem: &GotMem,
+    got_func: &GotFunc,
 ) -> Option<wasm_encoder::NameSection> {
     let mut function_names: Vec<(u32, &str)> = Vec::new();
     let mut global_names: Vec<(u32, &str)> = Vec::new();
     let mut got_mem_names: Vec<String> = Vec::new();
+    let mut got_func_names: Vec<String> = Vec::new();
 
     // Host / remaining imports.
     let mut next_func_import = 0u32;
@@ -1673,6 +1675,16 @@ fn build_name_section<'data>(
             got_mem_names.push(name);
         }
         for (i, name) in got_mem_names.iter().enumerate() {
+            let idx = got_base + i as u32;
+            global_names.push((idx, name.as_str()));
+        }
+    }
+    if let Some(got_base) = indices.got_func_global_base {
+        got_func_names.reserve(got_func.entries.len());
+        for (i, entry) in got_func.entries.iter().enumerate() {
+            got_func_names.push(got_func_debug_name(layout_inputs, entry, i));
+        }
+        for (i, name) in got_func_names.iter().enumerate() {
             let idx = got_base + i as u32;
             global_names.push((idx, name.as_str()));
         }
@@ -1849,6 +1861,7 @@ impl<'data> WasmLayout<'data> {
         layout_inputs: &[WasmObjectLayoutInput<'data>],
         indices: &LinkerDefinedIndices,
         got_mem: &GotMem,
+        got_func: &GotFunc,
     ) -> Result {
         timing_phase!("Encode Wasm metadata sections");
         let type_section = crate::wasm_writer::build_type_section(&self.output_types)?;
@@ -1893,7 +1906,9 @@ impl<'data> WasmLayout<'data> {
             self.encoded_sections.element = Some(encode_wasm_section(&element_section));
         }
 
-        if let Some(name_section) = build_name_section(self, layout_inputs, indices, got_mem) {
+        if let Some(name_section) =
+            build_name_section(self, layout_inputs, indices, got_mem, got_func)
+        {
             self.encoded_sections.name = Some(encode_wasm_section(&name_section));
         }
 
@@ -2210,6 +2225,7 @@ pub(crate) struct WasmObjectIndexMap {
     pub(crate) table_indices: Vec<u32>,
     pub(crate) data_addresses: Vec<u32>,
     pub(crate) got_mem_globals: Vec<Option<u32>>,
+    pub(crate) got_func_globals: Vec<Option<u32>>,
 }
 
 impl WasmObjectIndexMap {
@@ -2250,6 +2266,17 @@ impl WasmObjectIndexMap {
                     .ok_or_else(|| {
                         crate::error!(
                             "missing GOT.mem global for data symbol index {}",
+                            reloc.index
+                        )
+                    }),
+                WasmSymbolKind::Func => self
+                    .got_func_globals
+                    .get(reloc.index as usize)
+                    .copied()
+                    .flatten()
+                    .ok_or_else(|| {
+                        crate::error!(
+                            "missing GOT.func global for function symbol index {}",
                             reloc.index
                         )
                     }),
@@ -2585,6 +2612,7 @@ impl<'data> WasmObjectLayoutInput<'data> {
             table_indices: vec![0; self.table_imports.len()],
             data_addresses: Vec::new(),
             got_mem_globals: Vec::new(),
+            got_func_globals: Vec::new(),
         };
 
         for (i, resolution) in resolutions.function_resolutions.iter().enumerate() {
@@ -2634,7 +2662,8 @@ impl<'data> WasmObjectLayoutInput<'data> {
                 }
                 ImportResolution::ResolvedGlobal { .. }
                 | ImportResolution::DirectGlobal { .. }
-                | ImportResolution::GotMemSlot(_) => {
+                | ImportResolution::GotMemSlot(_)
+                | ImportResolution::GotFuncSlot(_) => {
                     bail!("function import resolved as global");
                 }
             }
@@ -2664,6 +2693,9 @@ impl<'data> WasmObjectLayoutInput<'data> {
                 }
                 ImportResolution::GotMemSlot(_) => {
                     bail!("GOT.mem slot was not converted to a module global index");
+                }
+                ImportResolution::GotFuncSlot(_) => {
+                    bail!("GOT.func slot was not converted to a module global index");
                 }
                 ImportResolution::ResolvedGlobal {
                     object_index,
@@ -2772,10 +2804,12 @@ enum ImportResolution {
     LinkerDefined(WasmLinkerSymbol),
     /// Undefined weak function absorbed into a shared `unreachable` stub.
     WeakUndefStub { stub_index: u32 },
-    /// Fixed module global index (GOT.mem entry).
+    /// Fixed module global index (GOT.mem / GOT.func entry).
     DirectGlobal { output_index: u32 },
     /// GOT.mem slot pending final module global index.
     GotMemSlot(usize),
+    /// GOT.func slot pending final module global index.
+    GotFuncSlot(usize),
 }
 
 #[derive(Debug, Default)]
@@ -3215,6 +3249,9 @@ struct LinkerDefinedIndices {
     /// First module global index for GOT.mem entries.
     got_mem_global_base: Option<u32>,
     got_mem_count: u32,
+    /// First module global index for GOT.func entries.
+    got_func_global_base: Option<u32>,
+    got_func_count: u32,
 }
 
 /// Where a GOT.mem slot's final linear-memory address comes from.
@@ -3249,6 +3286,40 @@ impl GotMem {
     }
 }
 
+/// Where a GOT.func slot's final table index comes from.
+#[derive(Debug, Clone, Copy)]
+enum GotFuncDef {
+    /// Defined or imported function: look up table slot via object index maps.
+    Function {
+        object_index: usize,
+        symbol_offset: usize,
+    },
+    /// Undefined weak: null function pointer (table index 0).
+    Null,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct GotFuncEntry {
+    def_symbol_id: SymbolId,
+    def: GotFuncDef,
+}
+
+#[derive(Debug, Default)]
+struct GotFunc {
+    entries: Vec<GotFuncEntry>,
+    per_object_global_indices: Vec<Vec<Option<u32>>>,
+}
+
+impl GotFunc {
+    fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    fn len(&self) -> u32 {
+        self.entries.len() as u32
+    }
+}
+
 fn layout_file_id_to_index(
     layout_inputs: &[WasmObjectLayoutInput<'_>],
 ) -> HashMap<crate::input_data::FileId, usize> {
@@ -3260,18 +3331,20 @@ fn layout_file_id_to_index(
 }
 
 /// Per-object map of linking symbol index to provisional GOT slot.
-type GotMemSlotMap = Vec<Vec<Option<usize>>>;
+type GotSlotMap = Vec<Vec<Option<usize>>>;
 
 struct LayoutRelocScan {
     got_mem: GotMem,
-    per_object_got_slots: GotMemSlotMap,
+    got_func: GotFunc,
+    per_object_got_mem_slots: GotSlotMap,
+    per_object_got_func_slots: GotSlotMap,
     needs_memory_base: bool,
     needs_table_base: bool,
     needs_table: bool,
     table_index_symbol_indices: Vec<Vec<usize>>,
 }
 
-/// Scan relocations, absorb GOT.mem / weak-undef imports, and reserve linker-defined indices.
+/// Scan relocations, absorb GOT.mem / GOT.func / weak-undef imports, and reserve indices.
 fn setup_got_mem_and_indices<'data>(
     layout_inputs: &[WasmObjectLayoutInput<'data>],
     resolutions: &mut [ObjectImportResolutions],
@@ -3288,6 +3361,15 @@ fn setup_got_mem_and_indices<'data>(
 
     absorb_got_mem_imports(&scan.got_mem, layout_inputs, resolutions, symbol_db)?;
     let weak_undef_stubs = absorb_weak_undef_function_imports(layout_inputs, resolutions)?;
+    // Weak-undef absorption must run before GOT.func def resolution (null vs table slot).
+    resolve_got_func_entry_defs(
+        &mut scan.got_func,
+        layout_inputs,
+        resolutions,
+        symbol_db,
+        file_id_to_index,
+    )?;
+    absorb_got_func_imports(&scan.got_func, layout_inputs, resolutions, symbol_db)?;
     let shared_imports = collect_shared_unresolved_imports(layout_inputs, resolutions)?;
 
     let indices = LinkerDefinedIndices::compute(
@@ -3299,6 +3381,7 @@ fn setup_got_mem_and_indices<'data>(
             has_init_funcs,
             wrap_entry,
             got_mem_count: scan.got_mem.len(),
+            got_func_count: scan.got_func.len(),
             needs_memory_base: scan.needs_memory_base,
             needs_table_base: scan.needs_table_base,
         },
@@ -3309,8 +3392,17 @@ fn setup_got_mem_and_indices<'data>(
             .got_mem_global_base
             .ok_or_else(|| crate::error!("GOT.mem entries present but no global base reserved"))?;
         scan.got_mem.per_object_global_indices =
-            assign_got_mem_global_indices(&scan.per_object_got_slots, first_got)?;
+            assign_got_slot_global_indices(&scan.per_object_got_mem_slots, first_got)?;
         finalize_got_mem_import_resolutions(resolutions, first_got)?;
+    }
+
+    if !scan.got_func.is_empty() {
+        let first_got = indices
+            .got_func_global_base
+            .ok_or_else(|| crate::error!("GOT.func entries present but no global base reserved"))?;
+        scan.got_func.per_object_global_indices =
+            assign_got_slot_global_indices(&scan.per_object_got_func_slots, first_got)?;
+        finalize_got_func_import_resolutions(resolutions, first_got)?;
     }
 
     Ok((indices, scan, shared_imports))
@@ -3472,9 +3564,12 @@ fn scan_layout_relocations(
     symbol_db: &SymbolDb<'_, Wasm>,
     file_id_to_index: &HashMap<crate::input_data::FileId, usize>,
 ) -> Result<LayoutRelocScan> {
-    let mut def_to_slot: HashMap<SymbolId, usize> = HashMap::new();
-    let mut entries = Vec::new();
-    let mut per_object_got_slots = vec![Vec::new(); layout_inputs.len()];
+    let mut mem_def_to_slot: HashMap<SymbolId, usize> = HashMap::new();
+    let mut mem_entries = Vec::new();
+    let mut per_object_got_mem_slots = vec![Vec::new(); layout_inputs.len()];
+    let mut func_def_to_slot: HashMap<SymbolId, usize> = HashMap::new();
+    let mut func_entries = Vec::new();
+    let mut per_object_got_func_slots = vec![Vec::new(); layout_inputs.len()];
     let mut needs_memory_base = false;
     let mut needs_table_base = false;
     let mut needs_table = layout_inputs
@@ -3483,7 +3578,8 @@ fn scan_layout_relocations(
     let mut table_index_symbol_indices = vec![Vec::new(); layout_inputs.len()];
 
     for (obj_idx, input) in layout_inputs.iter().enumerate() {
-        let mut got_hits: Vec<(usize, usize)> = Vec::new();
+        let mut got_mem_hits: Vec<(usize, usize)> = Vec::new();
+        let mut got_func_hits: Vec<(usize, usize)> = Vec::new();
         let mut table_syms: Vec<usize> = Vec::new();
         let mut table_sym_seen = HashSet::new();
 
@@ -3526,50 +3622,87 @@ fn scan_layout_relocations(
                             reloc.index
                         );
                     };
-                    if sym.kind != WasmSymbolKind::Data {
-                        continue;
+                    match sym.kind {
+                        WasmSymbolKind::Data => {
+                            let symbol_id = input.symbol_id_range.offset_to_id(sym_idx);
+                            let def_id = symbol_db.definition(symbol_id);
+                            let slot = if let Some(&slot) = mem_def_to_slot.get(&def_id) {
+                                slot
+                            } else {
+                                let def = resolve_got_mem_def(
+                                    def_id,
+                                    layout_inputs,
+                                    symbol_db,
+                                    file_id_to_index,
+                                )?;
+                                let slot = mem_entries.len();
+                                mem_def_to_slot.insert(def_id, slot);
+                                mem_entries.push(GotMemEntry {
+                                    def_symbol_id: def_id,
+                                    def,
+                                });
+                                slot
+                            };
+                            got_mem_hits.push((sym_idx, slot));
+                        }
+                        WasmSymbolKind::Func => {
+                            let symbol_id = input.symbol_id_range.offset_to_id(sym_idx);
+                            let def_id = symbol_db.definition(symbol_id);
+                            let slot = if let Some(&slot) = func_def_to_slot.get(&def_id) {
+                                slot
+                            } else {
+                                let slot = func_entries.len();
+                                func_def_to_slot.insert(def_id, slot);
+                                func_entries.push(GotFuncEntry {
+                                    def_symbol_id: def_id,
+                                    // Replaced by resolve_got_func_entry_defs.
+                                    def: GotFuncDef::Null,
+                                });
+                                slot
+                            };
+                            got_func_hits.push((sym_idx, slot));
+                            // Ensure the function appears in the indirect table (null weak stubs
+                            // are skipped later when assigning slots).
+                            needs_table = true;
+                            if table_sym_seen.insert(sym_idx) {
+                                table_syms.push(sym_idx);
+                            }
+                        }
+                        _ => {}
                     }
-                    let symbol_id = input.symbol_id_range.offset_to_id(sym_idx);
-                    let def_id = symbol_db.definition(symbol_id);
-                    let slot = if let Some(&slot) = def_to_slot.get(&def_id) {
-                        slot
-                    } else {
-                        let def = resolve_got_mem_def(
-                            def_id,
-                            layout_inputs,
-                            symbol_db,
-                            file_id_to_index,
-                        )?;
-                        let slot = entries.len();
-                        def_to_slot.insert(def_id, slot);
-                        entries.push(GotMemEntry {
-                            def_symbol_id: def_id,
-                            def,
-                        });
-                        slot
-                    };
-                    got_hits.push((sym_idx, slot));
                 }
                 _ => {}
             }
         }
 
-        if !got_hits.is_empty() {
+        if !got_mem_hits.is_empty() {
             let mut obj_map = vec![None; input.symbols.len()];
-            for (sym_idx, slot) in got_hits {
+            for (sym_idx, slot) in got_mem_hits {
                 obj_map[sym_idx] = Some(slot);
             }
-            per_object_got_slots[obj_idx] = obj_map;
+            per_object_got_mem_slots[obj_idx] = obj_map;
+        }
+        if !got_func_hits.is_empty() {
+            let mut obj_map = vec![None; input.symbols.len()];
+            for (sym_idx, slot) in got_func_hits {
+                obj_map[sym_idx] = Some(slot);
+            }
+            per_object_got_func_slots[obj_idx] = obj_map;
         }
         table_index_symbol_indices[obj_idx] = table_syms;
     }
 
     Ok(LayoutRelocScan {
         got_mem: GotMem {
-            entries,
+            entries: mem_entries,
             per_object_global_indices: Vec::new(),
         },
-        per_object_got_slots,
+        got_func: GotFunc {
+            entries: func_entries,
+            per_object_global_indices: Vec::new(),
+        },
+        per_object_got_mem_slots,
+        per_object_got_func_slots,
         needs_memory_base,
         needs_table_base,
         needs_table,
@@ -3577,8 +3710,8 @@ fn scan_layout_relocations(
     })
 }
 
-fn assign_got_mem_global_indices(
-    per_object_slots: &GotMemSlotMap,
+fn assign_got_slot_global_indices(
+    per_object_slots: &GotSlotMap,
     first_global_index: u32,
 ) -> Result<Vec<Vec<Option<u32>>>> {
     let mut per_object = Vec::with_capacity(per_object_slots.len());
@@ -3614,6 +3747,52 @@ fn apply_got_mem_to_index_maps(object_index_maps: &mut [WasmObjectIndexMap], got
         if !got.is_empty() {
             map.got_mem_globals = got.clone();
         }
+    }
+}
+
+fn apply_got_func_to_index_maps(object_index_maps: &mut [WasmObjectIndexMap], got_func: &GotFunc) {
+    if got_func.is_empty() {
+        return;
+    }
+    for (map, got) in object_index_maps
+        .iter_mut()
+        .zip(got_func.per_object_global_indices.iter())
+    {
+        if !got.is_empty() {
+            map.got_func_globals = got.clone();
+        }
+    }
+}
+
+fn got_func_debug_name(
+    layout_inputs: &[WasmObjectLayoutInput<'_>],
+    entry: &GotFuncEntry,
+    index: usize,
+) -> String {
+    let sym_name = match entry.def {
+        GotFuncDef::Function {
+            object_index,
+            symbol_offset,
+        } => layout_inputs.get(object_index).and_then(|input| {
+            input
+                .symbols
+                .get(symbol_offset)
+                .and_then(|sym| wasm_symbol_name_str(input.data, sym))
+        }),
+        GotFuncDef::Null => layout_inputs.iter().find_map(|input| {
+            if !input.symbol_id_range.contains(entry.def_symbol_id) {
+                return None;
+            }
+            let off = entry.def_symbol_id.to_offset(input.symbol_id_range);
+            input
+                .symbols
+                .get(off)
+                .and_then(|sym| wasm_symbol_name_str(input.data, sym))
+        }),
+    };
+    match sym_name {
+        Some(name) => format!("GOT.func.internal.{name}"),
+        None => format!("GOT.func.internal.{index}"),
     }
 }
 
@@ -3679,6 +3858,134 @@ fn finalize_got_mem_import_resolutions(
     Ok(())
 }
 
+/// Resolve GOT.func placeholders after weak-undef function imports are absorbed.
+fn resolve_got_func_entry_defs(
+    got_func: &mut GotFunc,
+    layout_inputs: &[WasmObjectLayoutInput<'_>],
+    resolutions: &[ObjectImportResolutions],
+    symbol_db: &SymbolDb<'_, Wasm>,
+    file_id_to_index: &HashMap<crate::input_data::FileId, usize>,
+) -> Result {
+    for entry in &mut got_func.entries {
+        entry.def = resolve_got_func_def(
+            entry.def_symbol_id,
+            layout_inputs,
+            resolutions,
+            symbol_db,
+            file_id_to_index,
+        )?;
+    }
+    Ok(())
+}
+
+fn resolve_got_func_def(
+    def_id: SymbolId,
+    layout_inputs: &[WasmObjectLayoutInput<'_>],
+    resolutions: &[ObjectImportResolutions],
+    symbol_db: &SymbolDb<'_, Wasm>,
+    file_id_to_index: &HashMap<crate::input_data::FileId, usize>,
+) -> Result<GotFuncDef> {
+    let def_file_id = symbol_db.file_id_for_symbol(def_id);
+    let Some(&def_obj_idx) = file_id_to_index.get(&def_file_id) else {
+        bail!(
+            "GOT.func for `{}` requires a function symbol in the link",
+            symbol_db.symbol_name_for_display(def_id)
+        );
+    };
+    let def_input = &layout_inputs[def_obj_idx];
+    let def_off = def_id.to_offset(def_input.symbol_id_range);
+    let def_sym = def_input.symbols.get(def_off).ok_or_else(|| {
+        crate::error!(
+            "GOT.func for `{}` has out-of-range symbol offset",
+            symbol_db.symbol_name_for_display(def_id)
+        )
+    })?;
+    ensure!(
+        def_sym.kind == WasmSymbolKind::Func,
+        "GOT.func for `{}` requires a function symbol",
+        symbol_db.symbol_name_for_display(def_id)
+    );
+
+    if def_sym.is_undefined() {
+        let import_idx = def_sym.index as usize;
+        if matches!(
+            resolutions
+                .get(def_obj_idx)
+                .and_then(|r| r.function_resolutions.get(import_idx)),
+            Some(ImportResolution::WeakUndefStub { .. })
+        ) {
+            return Ok(GotFuncDef::Null);
+        }
+    }
+
+    Ok(GotFuncDef::Function {
+        object_index: def_obj_idx,
+        symbol_offset: def_off,
+    })
+}
+
+fn absorb_got_func_imports(
+    got_func: &GotFunc,
+    layout_inputs: &[WasmObjectLayoutInput<'_>],
+    resolutions: &mut [ObjectImportResolutions],
+    symbol_db: &SymbolDb<'_, Wasm>,
+) -> Result {
+    if got_func.is_empty() {
+        return Ok(());
+    }
+
+    let names: Vec<UnversionedSymbolName<'_>> = got_func
+        .entries
+        .iter()
+        .map(|entry| {
+            symbol_db.symbol_name(entry.def_symbol_id).with_context(|| {
+                format!(
+                    "GOT.func entry missing symbol name for `{}`",
+                    symbol_db.symbol_name_for_display(entry.def_symbol_id)
+                )
+            })
+        })
+        .collect::<Result<_>>()?;
+
+    let mut name_to_slot: HashMap<&[u8], usize> = HashMap::new();
+    for (slot, name) in names.iter().enumerate() {
+        name_to_slot.entry(name.bytes()).or_insert(slot);
+    }
+
+    for (input, res) in layout_inputs.iter().zip(resolutions.iter_mut()) {
+        for (i, import) in input.global_imports.iter().enumerate() {
+            if import.module != "GOT.func" {
+                continue;
+            }
+            if !matches!(res.global_resolutions[i], ImportResolution::Unresolved) {
+                continue;
+            }
+            let Some(&slot) = name_to_slot.get(import.name.as_bytes()) else {
+                continue;
+            };
+            res.global_resolutions[i] = ImportResolution::GotFuncSlot(slot);
+        }
+    }
+    Ok(())
+}
+
+fn finalize_got_func_import_resolutions(
+    resolutions: &mut [ObjectImportResolutions],
+    first_got: u32,
+) -> Result {
+    for res in resolutions.iter_mut() {
+        for resolution in &mut res.global_resolutions {
+            if let ImportResolution::GotFuncSlot(slot) = *resolution {
+                let output_index = first_got
+                    .checked_add(slot as u32)
+                    .ok_or_else(|| crate::error!("Wasm global index overflow"))?;
+                *resolution = ImportResolution::DirectGlobal { output_index };
+            }
+        }
+    }
+    Ok(())
+}
+
 fn fill_got_mem_inits(
     layout: &mut WasmLayout<'_>,
     indices: &LinkerDefinedIndices,
@@ -3720,6 +4027,65 @@ fn fill_got_mem_inits(
         let addr_i32 = i32::try_from(addr)
             .map_err(|_| crate::error!("GOT.mem data address out of i32 range"))?;
         global.init_expr_body = Cow::Owned(encode_i32_const_body(addr_i32));
+    }
+    Ok(())
+}
+
+/// Fill GOT.func globals with table indices (or 0 for undefined weak). Requires the indirect
+/// function table to be finalized first.
+fn fill_got_func_inits(
+    layout: &mut WasmLayout<'_>,
+    indices: &LinkerDefinedIndices,
+    got_func: &GotFunc,
+    layout_inputs: &[WasmObjectLayoutInput<'_>],
+) -> Result {
+    let Some(got_base) = indices.got_func_global_base else {
+        return Ok(());
+    };
+    let defined_slot = (got_base - indices.global_import_count) as usize;
+
+    for (i, entry) in got_func.entries.iter().enumerate() {
+        let table_index = match entry.def {
+            GotFuncDef::Null => 0u32,
+            GotFuncDef::Function {
+                object_index,
+                symbol_offset,
+            } => {
+                let input = layout_inputs.get(object_index).ok_or_else(|| {
+                    crate::error!("GOT.func object index {object_index} out of range")
+                })?;
+                let sym = input.symbols.get(symbol_offset).ok_or_else(|| {
+                    crate::error!("GOT.func symbol offset {symbol_offset} out of range")
+                })?;
+                ensure!(
+                    sym.kind == WasmSymbolKind::Func,
+                    "GOT.func definition is not a function symbol"
+                );
+                let func_out = remap_wasm_index(
+                    &layout.object_index_maps[object_index].function_indices,
+                    sym.index,
+                    "function",
+                )?;
+                let slot = layout
+                    .function_table_slots
+                    .get(func_out as usize)
+                    .copied()
+                    .unwrap_or(u32::MAX);
+                ensure!(
+                    slot != u32::MAX,
+                    "GOT.func function {func_out} has no indirect table slot"
+                );
+                slot
+            }
+        };
+        let global_slot = defined_slot + i;
+        let global = layout
+            .globals
+            .get_mut(global_slot)
+            .ok_or_else(|| crate::error!("GOT.func global slot {global_slot} out of range"))?;
+        let table_i32 = i32::try_from(table_index)
+            .map_err(|_| crate::error!("GOT.func table index out of i32 range"))?;
+        global.init_expr_body = Cow::Owned(encode_i32_const_body(table_i32));
     }
     Ok(())
 }
@@ -3766,6 +4132,7 @@ struct LinkerDefinedIndexRequest {
     has_init_funcs: bool,
     wrap_entry: bool,
     got_mem_count: u32,
+    got_func_count: u32,
     needs_memory_base: bool,
     needs_table_base: bool,
 }
@@ -3828,6 +4195,15 @@ impl LinkerDefinedIndices {
         } else {
             None
         };
+        let got_func_global_base = if request.got_func_count > 0 {
+            let base = next_global;
+            next_global = next_global
+                .checked_add(request.got_func_count)
+                .ok_or_else(|| crate::error!("Wasm global index overflow"))?;
+            Some(base)
+        } else {
+            None
+        };
         let num_defined_globals = next_global - global_import_count;
 
         let mut next_func = function_import_count;
@@ -3869,6 +4245,8 @@ impl LinkerDefinedIndices {
             global_import_count,
             got_mem_global_base,
             got_mem_count: request.got_mem_count,
+            got_func_global_base,
+            got_func_count: request.got_func_count,
         })
     }
 
@@ -4116,6 +4494,17 @@ fn emit_reserved_linker_definitions(
     // GOT.mem placeholders. wasm-ld emits static GOT.data.internal.* as immutable i32 for
     // freestanding executables.
     for _ in 0..indices.got_mem_count {
+        linker_globals.push(OutputGlobal {
+            ty: GlobalType {
+                content_type: wasmparser::ValType::I32,
+                mutable: false,
+                shared: false,
+            },
+            init_expr_body: Cow::Borrowed(ZERO_I32_INIT_EXPR),
+        });
+    }
+    // GOT.func placeholders. Filled with table indices after the indirect table is finalized.
+    for _ in 0..indices.got_func_count {
         linker_globals.push(OutputGlobal {
             ty: GlobalType {
                 content_type: wasmparser::ValType::I32,
@@ -4489,6 +4878,7 @@ where
         wrap_entry,
     )?;
     let got_mem = &reloc_scan.got_mem;
+    let got_func = &reloc_scan.got_func;
     let index_bases = allocate_wasm_object_index_bases(&layout_inputs, &shared_imports, &indices)?;
     let mut object_layouts = {
         timing_phase!("Build per-object Wasm layouts");
@@ -4579,6 +4969,7 @@ where
                     .push(std::mem::take(&mut object_layout.index_map));
             }
             apply_got_mem_to_index_maps(&mut layout.object_index_maps, got_mem);
+            apply_got_func_to_index_maps(&mut layout.object_index_maps, got_func);
         }
         {
             for input in &layout_inputs {
@@ -4688,8 +5079,10 @@ where
             reloc_scan.needs_table,
             &weak_undef_funcs,
         )?;
+        // GOT.func inits need table slots assigned above.
+        fill_got_func_inits(&mut layout, &indices, got_func, &layout_inputs)?;
     }
-    layout.encode_metadata_sections(&layout_inputs, &indices, got_mem)?;
+    layout.encode_metadata_sections(&layout_inputs, &indices, got_mem, got_func)?;
     Ok(layout)
 }
 

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -3286,22 +3286,13 @@ impl GotMem {
     }
 }
 
-/// Where a GOT.func slot's final table index comes from.
-#[derive(Debug, Clone, Copy)]
-enum GotFuncDef {
-    /// Defined or imported function: look up table slot via object index maps.
-    Function {
-        object_index: usize,
-        symbol_offset: usize,
-    },
-    /// Undefined weak: null function pointer (table index 0).
-    Null,
-}
-
 #[derive(Debug, Clone, Copy)]
 struct GotFuncEntry {
     def_symbol_id: SymbolId,
-    def: GotFuncDef,
+    /// Layout-input object that holds the definition (or the undefined weak import).
+    object_index: usize,
+    /// Offset of that function symbol within the object's linking symbol table.
+    symbol_offset: usize,
 }
 
 #[derive(Debug, Default)]
@@ -3361,14 +3352,6 @@ fn setup_got_mem_and_indices<'data>(
 
     absorb_got_mem_imports(&scan.got_mem, layout_inputs, resolutions, symbol_db)?;
     let weak_undef_stubs = absorb_weak_undef_function_imports(layout_inputs, resolutions)?;
-    // Weak-undef absorption must run before GOT.func def resolution (null vs table slot).
-    resolve_got_func_entry_defs(
-        &mut scan.got_func,
-        layout_inputs,
-        resolutions,
-        symbol_db,
-        file_id_to_index,
-    )?;
     absorb_got_func_imports(&scan.got_func, layout_inputs, resolutions, symbol_db)?;
     let shared_imports = collect_shared_unresolved_imports(layout_inputs, resolutions)?;
 
@@ -3651,12 +3634,19 @@ fn scan_layout_relocations(
                             let slot = if let Some(&slot) = func_def_to_slot.get(&def_id) {
                                 slot
                             } else {
+                                let (object_index, symbol_offset) =
+                                    resolve_got_func_symbol_location(
+                                        def_id,
+                                        layout_inputs,
+                                        symbol_db,
+                                        file_id_to_index,
+                                    )?;
                                 let slot = func_entries.len();
                                 func_def_to_slot.insert(def_id, slot);
                                 func_entries.push(GotFuncEntry {
                                     def_symbol_id: def_id,
-                                    // Replaced by resolve_got_func_entry_defs.
-                                    def: GotFuncDef::Null,
+                                    object_index,
+                                    symbol_offset,
                                 });
                                 slot
                             };
@@ -3769,31 +3759,45 @@ fn got_func_debug_name(
     entry: &GotFuncEntry,
     index: usize,
 ) -> String {
-    let sym_name = match entry.def {
-        GotFuncDef::Function {
-            object_index,
-            symbol_offset,
-        } => layout_inputs.get(object_index).and_then(|input| {
-            input
-                .symbols
-                .get(symbol_offset)
-                .and_then(|sym| wasm_symbol_name_str(input.data, sym))
-        }),
-        GotFuncDef::Null => layout_inputs.iter().find_map(|input| {
-            if !input.symbol_id_range.contains(entry.def_symbol_id) {
-                return None;
-            }
-            let off = entry.def_symbol_id.to_offset(input.symbol_id_range);
-            input
-                .symbols
-                .get(off)
-                .and_then(|sym| wasm_symbol_name_str(input.data, sym))
-        }),
-    };
+    let sym_name = layout_inputs.get(entry.object_index).and_then(|input| {
+        input
+            .symbols
+            .get(entry.symbol_offset)
+            .and_then(|sym| wasm_symbol_name_str(input.data, sym))
+    });
     match sym_name {
         Some(name) => format!("GOT.func.internal.{name}"),
         None => format!("GOT.func.internal.{index}"),
     }
+}
+
+fn resolve_got_func_symbol_location(
+    def_id: SymbolId,
+    layout_inputs: &[WasmObjectLayoutInput<'_>],
+    symbol_db: &SymbolDb<'_, Wasm>,
+    file_id_to_index: &HashMap<crate::input_data::FileId, usize>,
+) -> Result<(usize, usize)> {
+    let def_file_id = symbol_db.file_id_for_symbol(def_id);
+    let Some(&def_obj_idx) = file_id_to_index.get(&def_file_id) else {
+        bail!(
+            "GOT.func for `{}` requires a function symbol in the link",
+            symbol_db.symbol_name_for_display(def_id)
+        );
+    };
+    let def_input = &layout_inputs[def_obj_idx];
+    let def_off = def_id.to_offset(def_input.symbol_id_range);
+    let def_sym = def_input.symbols.get(def_off).ok_or_else(|| {
+        crate::error!(
+            "GOT.func for `{}` has out-of-range symbol offset",
+            symbol_db.symbol_name_for_display(def_id)
+        )
+    })?;
+    ensure!(
+        def_sym.kind == WasmSymbolKind::Func,
+        "GOT.func for `{}` requires a function symbol",
+        symbol_db.symbol_name_for_display(def_id)
+    );
+    Ok((def_obj_idx, def_off))
 }
 
 fn absorb_got_mem_imports(
@@ -3856,72 +3860,6 @@ fn finalize_got_mem_import_resolutions(
         }
     }
     Ok(())
-}
-
-/// Resolve GOT.func placeholders after weak-undef function imports are absorbed.
-fn resolve_got_func_entry_defs(
-    got_func: &mut GotFunc,
-    layout_inputs: &[WasmObjectLayoutInput<'_>],
-    resolutions: &[ObjectImportResolutions],
-    symbol_db: &SymbolDb<'_, Wasm>,
-    file_id_to_index: &HashMap<crate::input_data::FileId, usize>,
-) -> Result {
-    for entry in &mut got_func.entries {
-        entry.def = resolve_got_func_def(
-            entry.def_symbol_id,
-            layout_inputs,
-            resolutions,
-            symbol_db,
-            file_id_to_index,
-        )?;
-    }
-    Ok(())
-}
-
-fn resolve_got_func_def(
-    def_id: SymbolId,
-    layout_inputs: &[WasmObjectLayoutInput<'_>],
-    resolutions: &[ObjectImportResolutions],
-    symbol_db: &SymbolDb<'_, Wasm>,
-    file_id_to_index: &HashMap<crate::input_data::FileId, usize>,
-) -> Result<GotFuncDef> {
-    let def_file_id = symbol_db.file_id_for_symbol(def_id);
-    let Some(&def_obj_idx) = file_id_to_index.get(&def_file_id) else {
-        bail!(
-            "GOT.func for `{}` requires a function symbol in the link",
-            symbol_db.symbol_name_for_display(def_id)
-        );
-    };
-    let def_input = &layout_inputs[def_obj_idx];
-    let def_off = def_id.to_offset(def_input.symbol_id_range);
-    let def_sym = def_input.symbols.get(def_off).ok_or_else(|| {
-        crate::error!(
-            "GOT.func for `{}` has out-of-range symbol offset",
-            symbol_db.symbol_name_for_display(def_id)
-        )
-    })?;
-    ensure!(
-        def_sym.kind == WasmSymbolKind::Func,
-        "GOT.func for `{}` requires a function symbol",
-        symbol_db.symbol_name_for_display(def_id)
-    );
-
-    if def_sym.is_undefined() {
-        let import_idx = def_sym.index as usize;
-        if matches!(
-            resolutions
-                .get(def_obj_idx)
-                .and_then(|r| r.function_resolutions.get(import_idx)),
-            Some(ImportResolution::WeakUndefStub { .. })
-        ) {
-            return Ok(GotFuncDef::Null);
-        }
-    }
-
-    Ok(GotFuncDef::Function {
-        object_index: def_obj_idx,
-        symbol_offset: def_off,
-    })
 }
 
 fn absorb_got_func_imports(
@@ -4031,8 +3969,8 @@ fn fill_got_mem_inits(
     Ok(())
 }
 
-/// Fill GOT.func globals with table indices (or 0 for undefined weak). Requires the indirect
-/// function table to be finalized first.
+/// Fill GOT.func globals with table indices. Requires the indirect function table first. Undefined
+/// weak targets resolve through `function_indices` to unreachable stubs.
 fn fill_got_func_inits(
     layout: &mut WasmLayout<'_>,
     indices: &LinkerDefinedIndices,
@@ -4045,45 +3983,40 @@ fn fill_got_func_inits(
     let defined_slot = (got_base - indices.global_import_count) as usize;
 
     for (i, entry) in got_func.entries.iter().enumerate() {
-        let table_index = match entry.def {
-            GotFuncDef::Null => 0u32,
-            GotFuncDef::Function {
-                object_index,
-                symbol_offset,
-            } => {
-                let input = layout_inputs.get(object_index).ok_or_else(|| {
-                    crate::error!("GOT.func object index {object_index} out of range")
-                })?;
-                let sym = input.symbols.get(symbol_offset).ok_or_else(|| {
-                    crate::error!("GOT.func symbol offset {symbol_offset} out of range")
-                })?;
-                ensure!(
-                    sym.kind == WasmSymbolKind::Func,
-                    "GOT.func definition is not a function symbol"
-                );
-                let func_out = remap_wasm_index(
-                    &layout.object_index_maps[object_index].function_indices,
-                    sym.index,
-                    "function",
-                )?;
-                let slot = layout
-                    .function_table_slots
-                    .get(func_out as usize)
-                    .copied()
-                    .unwrap_or(u32::MAX);
-                ensure!(
-                    slot != u32::MAX,
-                    "GOT.func function {func_out} has no indirect table slot"
-                );
-                slot
-            }
-        };
+        let input = layout_inputs.get(entry.object_index).ok_or_else(|| {
+            crate::error!("GOT.func object index {} out of range", entry.object_index)
+        })?;
+        let sym = input.symbols.get(entry.symbol_offset).ok_or_else(|| {
+            crate::error!(
+                "GOT.func symbol offset {} out of range",
+                entry.symbol_offset
+            )
+        })?;
+        ensure!(
+            sym.kind == WasmSymbolKind::Func,
+            "GOT.func definition is not a function symbol"
+        );
+        let func_out = remap_wasm_index(
+            &layout.object_index_maps[entry.object_index].function_indices,
+            sym.index,
+            "function",
+        )?;
+        let slot = layout
+            .function_table_slots
+            .get(func_out as usize)
+            .copied()
+            .unwrap_or(u32::MAX);
+        ensure!(
+            slot != u32::MAX,
+            "GOT.func function {func_out} has no indirect table slot"
+        );
+
         let global_slot = defined_slot + i;
         let global = layout
             .globals
             .get_mut(global_slot)
             .ok_or_else(|| crate::error!("GOT.func global slot {global_slot} out of range"))?;
-        let table_i32 = i32::try_from(table_index)
+        let table_i32 = i32::try_from(slot)
             .map_err(|_| crate::error!("GOT.func table index out of i32 range"))?;
         global.init_expr_body = Cow::Owned(encode_i32_const_body(table_i32));
     }

--- a/libwild/src/wasm.rs
+++ b/libwild/src/wasm.rs
@@ -3286,20 +3286,11 @@ impl GotMem {
     }
 }
 
-/// Where a GOT.func slot's table index comes from.
-#[derive(Debug, Clone, Copy)]
-enum GotFuncTarget {
-    Object {
-        object_index: usize,
-        symbol_offset: usize,
-    },
-    LinkerDefined(WasmLinkerSymbol),
-}
-
 #[derive(Debug, Clone, Copy)]
 struct GotFuncEntry {
     def_symbol_id: SymbolId,
-    target: GotFuncTarget,
+    object_index: usize,
+    symbol_offset: usize,
 }
 
 #[derive(Debug, Default)]
@@ -3315,24 +3306,6 @@ impl GotFunc {
 
     fn len(&self) -> u32 {
         self.entries.len() as u32
-    }
-
-    fn needs_call_ctors(&self) -> bool {
-        self.entries.iter().any(|e| {
-            matches!(
-                e.target,
-                GotFuncTarget::LinkerDefined(WasmLinkerSymbol::CallCtors)
-            )
-        })
-    }
-
-    fn needs_call_dtors(&self) -> bool {
-        self.entries.iter().any(|e| {
-            matches!(
-                e.target,
-                GotFuncTarget::LinkerDefined(WasmLinkerSymbol::CallDtors)
-            )
-        })
     }
 }
 
@@ -3386,13 +3359,12 @@ fn setup_got_mem_and_indices<'data>(
         shared_imports.global_count(),
         weak_undef_stubs,
         LinkerDefinedIndexRequest {
-            has_init_funcs: has_init_funcs || scan.got_func.needs_call_ctors(),
+            has_init_funcs,
             wrap_entry,
             got_mem_count: scan.got_mem.len(),
             got_func_count: scan.got_func.len(),
             needs_memory_base: scan.needs_memory_base,
             needs_table_base: scan.needs_table_base,
-            needs_call_dtors: scan.got_func.needs_call_dtors(),
         },
     )?;
 
@@ -3660,17 +3632,12 @@ fn scan_layout_relocations(
                             let slot = if let Some(&slot) = func_def_to_slot.get(&def_id) {
                                 slot
                             } else {
-                                let target = resolve_got_func_target(
-                                    def_id,
-                                    layout_inputs,
-                                    symbol_db,
-                                    file_id_to_index,
-                                )?;
                                 let slot = func_entries.len();
                                 func_def_to_slot.insert(def_id, slot);
                                 func_entries.push(GotFuncEntry {
                                     def_symbol_id: def_id,
-                                    target,
+                                    object_index: obj_idx,
+                                    symbol_offset: sym_idx,
                                 });
                                 slot
                             };
@@ -3783,69 +3750,16 @@ fn got_func_debug_name(
     entry: &GotFuncEntry,
     index: usize,
 ) -> String {
-    let name = match entry.target {
-        GotFuncTarget::Object {
-            object_index,
-            symbol_offset,
-        } => layout_inputs.get(object_index).and_then(|input| {
-            input
-                .symbols
-                .get(symbol_offset)
-                .and_then(|sym| wasm_symbol_name_str(input.data, sym))
-                .map(|s| s.to_owned())
-        }),
-        GotFuncTarget::LinkerDefined(known) => {
-            Some(String::from_utf8_lossy(known.name()).into_owned())
-        }
-    };
-    match name {
+    let sym_name = layout_inputs.get(entry.object_index).and_then(|input| {
+        input
+            .symbols
+            .get(entry.symbol_offset)
+            .and_then(|sym| wasm_symbol_name_str(input.data, sym))
+    });
+    match sym_name {
         Some(name) => format!("GOT.func.internal.{name}"),
         None => format!("GOT.func.internal.{index}"),
     }
-}
-
-fn resolve_got_func_target(
-    def_id: SymbolId,
-    layout_inputs: &[WasmObjectLayoutInput<'_>],
-    symbol_db: &SymbolDb<'_, Wasm>,
-    file_id_to_index: &HashMap<crate::input_data::FileId, usize>,
-) -> Result<GotFuncTarget> {
-    let def_file_id = symbol_db.file_id_for_symbol(def_id);
-    if let Some(&def_obj_idx) = file_id_to_index.get(&def_file_id) {
-        let def_input = &layout_inputs[def_obj_idx];
-        let def_off = def_id.to_offset(def_input.symbol_id_range);
-        let def_sym = def_input.symbols.get(def_off).ok_or_else(|| {
-            crate::error!(
-                "GOT.func for `{}` has out-of-range symbol offset",
-                symbol_db.symbol_name_for_display(def_id)
-            )
-        })?;
-        ensure!(
-            def_sym.kind == WasmSymbolKind::Func,
-            "GOT.func for `{}` requires a function symbol",
-            symbol_db.symbol_name_for_display(def_id)
-        );
-        return Ok(GotFuncTarget::Object {
-            object_index: def_obj_idx,
-            symbol_offset: def_off,
-        });
-    }
-
-    // Linker-defined functions live on the prelude file, not in `layout_inputs`.
-    if let Some(def_info) = symbol_db.prelude_symbol_def(def_id)
-        && let crate::parsing::SymbolPlacement::PlatformSpecific(known) = def_info.placement
-        && matches!(
-            known,
-            WasmLinkerSymbol::CallCtors | WasmLinkerSymbol::CallDtors
-        )
-    {
-        return Ok(GotFuncTarget::LinkerDefined(known));
-    }
-
-    bail!(
-        "GOT.func for `{}` requires a function symbol in the link",
-        symbol_db.symbol_name_for_display(def_id)
-    )
 }
 
 fn absorb_got_mem_imports(
@@ -4031,36 +3945,24 @@ fn fill_got_func_inits(
     let defined_slot = (got_base - indices.global_import_count) as usize;
 
     for (i, entry) in got_func.entries.iter().enumerate() {
-        let func_out = match entry.target {
-            GotFuncTarget::Object {
-                object_index,
-                symbol_offset,
-            } => {
-                let input = layout_inputs.get(object_index).ok_or_else(|| {
-                    crate::error!("GOT.func object index {object_index} out of range")
-                })?;
-                let sym = input.symbols.get(symbol_offset).ok_or_else(|| {
-                    crate::error!("GOT.func symbol offset {symbol_offset} out of range")
-                })?;
-                ensure!(
-                    sym.kind == WasmSymbolKind::Func,
-                    "GOT.func definition is not a function symbol"
-                );
-                remap_wasm_index(
-                    &layout.object_index_maps[object_index].function_indices,
-                    sym.index,
-                    "function",
-                )?
-            }
-            GotFuncTarget::LinkerDefined(known) => {
-                indices.function_index(known).ok_or_else(|| {
-                    crate::error!(
-                        "GOT.func linker-defined function `{}` was not reserved",
-                        std::str::from_utf8(known.name()).unwrap_or("?")
-                    )
-                })?
-            }
-        };
+        let input = layout_inputs.get(entry.object_index).ok_or_else(|| {
+            crate::error!("GOT.func object index {} out of range", entry.object_index)
+        })?;
+        let sym = input.symbols.get(entry.symbol_offset).ok_or_else(|| {
+            crate::error!(
+                "GOT.func symbol offset {} out of range",
+                entry.symbol_offset
+            )
+        })?;
+        ensure!(
+            sym.kind == WasmSymbolKind::Func,
+            "GOT.func symbol is not a function"
+        );
+        let func_out = remap_wasm_index(
+            &layout.object_index_maps[entry.object_index].function_indices,
+            sym.index,
+            "function",
+        )?;
         let slot = layout
             .function_table_slots
             .get(func_out as usize)
@@ -4128,7 +4030,6 @@ struct LinkerDefinedIndexRequest {
     got_func_count: u32,
     needs_memory_base: bool,
     needs_table_base: bool,
-    needs_call_dtors: bool,
 }
 
 impl LinkerDefinedIndices {
@@ -4144,7 +4045,7 @@ impl LinkerDefinedIndices {
         let mut needs_stack_pointer = false;
         let mut needs_tls_base = false;
         let mut needs_ctors = request.has_init_funcs;
-        let mut needs_dtors = request.needs_call_dtors;
+        let mut needs_dtors = false;
 
         for resolutions in import_resolutions {
             let absorption = LinkerImportAbsorption::from_resolutions(resolutions);
@@ -5072,8 +4973,6 @@ where
             &reloc_scan.table_index_symbol_indices,
             reloc_scan.needs_table,
             &weak_undef_funcs,
-            got_func,
-            &indices,
         )?;
         // GOT.func inits need table slots assigned above.
         fill_got_func_inits(&mut layout, &indices, got_func, &layout_inputs)?;
@@ -5089,8 +4988,6 @@ fn finalize_indirect_function_table(
     table_index_symbol_indices: &[Vec<usize>],
     needs_table: bool,
     weak_undef_funcs: &HashSet<u32>,
-    got_func: &GotFunc,
-    indices: &LinkerDefinedIndices,
 ) -> Result {
     if !needs_table {
         return Ok(());
@@ -5124,30 +5021,13 @@ fn finalize_indirect_function_table(
         }
     }
 
-    for entry in &got_func.entries {
-        if let GotFuncTarget::LinkerDefined(known) = entry.target
-            && let Some(func_out) = indices.function_index(known)
-            && !weak_undef_funcs.contains(&func_out)
-            && seen.insert(func_out)
-        {
-            needed.push(func_out);
-        }
-    }
-
     // Slot 0 is unused and first function at slot 1. This matches common clang/wasm-ld layout.
-    let mut max_func = layout
+    let max_func = layout
         .object_index_maps
         .iter()
         .flat_map(|m| m.function_indices.iter().copied())
         .max()
         .unwrap_or(0);
-    for entry in &got_func.entries {
-        if let GotFuncTarget::LinkerDefined(known) = entry.target
-            && let Some(func_out) = indices.function_index(known)
-        {
-            max_func = max_func.max(func_out);
-        }
-    }
     let mut slots_by_func = vec![u32::MAX; max_func as usize + 1];
 
     for &func_out in weak_undef_funcs {

--- a/wild/tests/sources/wasm/pic-got-ctors/pic-got-ctors.c
+++ b/wild/tests/sources/wasm/pic-got-ctors/pic-got-ctors.c
@@ -1,0 +1,18 @@
+//#CompArgs:-fPIC
+
+static int x;
+
+__attribute__((constructor(100))) static void init(void) { x = 42; }
+
+typedef void (*VoidFn)(void);
+
+extern void __wasm_call_ctors(void);
+
+static VoidFn get_ctors(void) { return __wasm_call_ctors; }
+
+void _start(void) {
+  get_ctors()();
+  if (x != 42) {
+    __builtin_trap();
+  }
+}

--- a/wild/tests/sources/wasm/pic-got-func/pic-got-func.c
+++ b/wild/tests/sources/wasm/pic-got-func/pic-got-func.c
@@ -1,0 +1,13 @@
+//#CompArgs:-fPIC
+//#Object:pic-got-func2.c
+
+typedef int (*Fn)(void);
+int foo(void);
+
+static Fn get_fp(void) { return foo; }
+
+void _start(void) {
+  if (get_fp()() != 42) {
+    __builtin_trap();
+  }
+}

--- a/wild/tests/sources/wasm/pic-got-func/pic-got-func2.c
+++ b/wild/tests/sources/wasm/pic-got-func/pic-got-func2.c
@@ -1,0 +1,1 @@
+int foo(void) { return 42; }


### PR DESCRIPTION
Similar to the earlier GOT.mem work for Data symbols, handle `R_WASM_GLOBAL_INDEX_*` relocations against Func symbols by synthesizing immutable i32 globals (`GOT.func.internal.*`) whose initializers are the function's funcref table index. Absorb `GOT.func.*` imports, place referenced functions in the indirect table, and use table index 0 for undefined weak functions.