### PR TITLE
port(wasm): warn on -mllvm option values

### DIFF
--- a/libwild/src/args/wasm.rs
+++ b/libwild/src/args/wasm.rs
@@ -246,6 +246,12 @@ fn setup_argument_parser() -> ArgumentParser<WasmArgs> {
 
     parser
         .declare_with_param()
+        .short("mllvm")
+        .help("Pass an LLVM option")
+        .execute(|args, _modifier_stack, value| args.warn_unsupported(&format!("-mllvm {value}")));
+
+    parser
+        .declare_with_param()
         .prefix("m")
         .help("Set target architecture")
         .sub_option("wasm32", "Wasm32 target", |_args, _| Ok(()))

--- a/libwild/src/args/wasm.rs
+++ b/libwild/src/args/wasm.rs
@@ -246,7 +246,7 @@ fn setup_argument_parser() -> ArgumentParser<WasmArgs> {
 
     parser
         .declare_with_param()
-        .short("mllvm")
+        .long("mllvm")
         .help("Pass an LLVM option")
         .execute(|args, _modifier_stack, value| args.warn_unsupported(&format!("-mllvm {value}")));
 


### PR DESCRIPTION
Similarly to Mach-O port, let's warn on these options for now. If someone links without the LTO, then the options have no impact on the final binary.

Issue: #1431