### PR TITLE
feat: implement setting section attributes in linker scripts

### DIFF
--- a/LINKER_SCRIPT_SUPPORT.md
+++ b/LINKER_SCRIPT_SUPPORT.md
@@ -49,7 +49,7 @@ end lists the features required to link the Linux kernel.
 | Per-section `ALIGN(n)` specifier | ✅ | |
 | `ASSERT(expr, "msg")` inside `SECTIONS` | ✅ | |
 | `OVERLAY { ... }` | ❌ | |
-| Output section type specifiers (`(NOLOAD)`, `(COPY)`, etc.) | 📅 | |
+| Output section type specifiers (`(NOLOAD)`, `(COPY)`, etc.) | 🧪 | Setting the section type using the `TYPE` attribute is not yet supported |
 | `FILL(value)` | 📅 | |
 | `=fillexp` | ✅ | |
 | `AT(addr)` load-address specifier on output sections | ✅ | |
@@ -117,7 +117,7 @@ see at a glance what remains before Wild can link the kernel.
 | Feature | Status | Notes |
 |---------|--------|-------|
 | `OVERLAY { ... }` sections | ❌ | |
-| Output section type specifiers (`(NOLOAD)`, `(COPY)`) | 📅 | |
+| Output section type specifiers (`(NOLOAD)`, `(COPY)`) | ✅ | The `TYPE` attribute is not used in the kernel |
 | `FILL(value)` | 📅 | |
 | `=fillexp` | ✅ | |
 | `AT(addr)` load-address specifier on output sections | ✅ | |

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -2910,7 +2910,7 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
         Some(SectionIdentity::new(name, ()))
     }
 
-    fn set_section_attributes(
+    fn apply_linker_script_attributes(
         linker_script_attributes: &linker_script::SectionAttributes,
         mut output_attributes: Self::SectionAttributes,
     ) -> Self::SectionAttributes {
@@ -2920,7 +2920,7 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
                 output_attributes.overrides.has_fixed_type = true;
             }
             linker_script::SectionAttributes::Readonly => {
-                output_attributes.overrides.avoid_progpogation = shf::WRITE | shf::EXECINSTR;
+                output_attributes.overrides.avoid_progpogation = shf::WRITE;
             }
             linker_script::SectionAttributes::Dsect
             | linker_script::SectionAttributes::Copy

--- a/libwild/src/elf.rs
+++ b/libwild/src/elf.rs
@@ -35,6 +35,7 @@ use crate::layout::objects_iter;
 use crate::layout_rules::SectionKind;
 use crate::layout_rules::SectionRule;
 use crate::layout_rules::SectionRuleOutcome;
+use crate::linker_script;
 use crate::output_kind::OutputKind;
 use crate::output_section_id::CustomSectionIds;
 use crate::output_section_id::OrderEvent;
@@ -844,6 +845,7 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
             flags: header.sh_flags(LittleEndian),
             ty: header.sh_type(LittleEndian),
             entsize: header.sh_entsize(LittleEndian).into(),
+            overrides: Default::default(),
             class: PhantomData,
         }
     }
@@ -1417,6 +1419,7 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
                     flags: d.section_flags,
                     ty: d.ty,
                     entsize: d.element_size,
+                    overrides: Default::default(),
                     class: PhantomData,
                 },
                 kind: d.kind,
@@ -2905,6 +2908,28 @@ impl<C: ElfClass> platform::Platform for Elf<C> {
         name: SectionName<'data>,
     ) -> Option<SectionIdentity<'data, Self>> {
         Some(SectionIdentity::new(name, ()))
+    }
+
+    fn set_section_attributes(
+        linker_script_attributes: &linker_script::SectionAttributes,
+        mut output_attributes: Self::SectionAttributes,
+    ) -> Self::SectionAttributes {
+        match linker_script_attributes {
+            linker_script::SectionAttributes::Noload => {
+                output_attributes.ty = sht::NOBITS;
+                output_attributes.overrides.has_fixed_type = true;
+            }
+            linker_script::SectionAttributes::Readonly => {
+                output_attributes.overrides.avoid_progpogation = shf::WRITE | shf::EXECINSTR;
+            }
+            linker_script::SectionAttributes::Dsect
+            | linker_script::SectionAttributes::Copy
+            | linker_script::SectionAttributes::Info
+            | linker_script::SectionAttributes::Overlay => {
+                output_attributes.overrides.avoid_progpogation = shf::ALLOC;
+            }
+        }
+        output_attributes
     }
 }
 
@@ -4645,7 +4670,14 @@ pub(crate) struct SectionAttributes<C: ElfClass> {
     pub(crate) flags: SectionFlags,
     pub(crate) ty: SectionType,
     pub(crate) entsize: u64,
+    pub(crate) overrides: LinkerScriptOverrides,
     class: PhantomData<C>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct LinkerScriptOverrides {
+    pub(crate) avoid_progpogation: SectionFlags,
+    pub(crate) has_fixed_type: bool,
 }
 
 /// Section flags that should not be propagated from input sections to the output section in which
@@ -4673,11 +4705,15 @@ impl<C: ElfClass> platform::SectionAttributes for SectionAttributes<C> {
     fn apply(&self, output_sections: &mut OutputSections<Elf<C>>, section_id: OutputSectionId) {
         let info = output_sections.section_infos.get_mut(section_id);
 
-        info.section_attributes.flags |= self.flags.without(SECTION_FLAGS_PROPAGATION_MASK);
+        info.section_attributes.flags |= self.flags.without(
+            SECTION_FLAGS_PROPAGATION_MASK | info.section_attributes.overrides.avoid_progpogation,
+        );
 
         info.section_attributes.entsize = self.entsize;
 
-        info.section_attributes.ty = info.section_attributes.ty.max(self.ty);
+        if !info.section_attributes.overrides.has_fixed_type {
+            info.section_attributes.ty = info.section_attributes.ty.max(self.ty);
+        }
 
         if let SectionKind::Secondary(primary_id) = info.kind
             && info.location_info.is_some()

--- a/libwild/src/layout.rs
+++ b/libwild/src/layout.rs
@@ -1648,11 +1648,21 @@ impl<'data, P: Platform> Layout<'data, P> {
                         sections: obj
                             .section_resolutions
                             .iter()
+                            .enumerate()
                             .zip(obj.object.section_iter())
                             .zip(&obj.sections)
-                            .map(|((res, section), section_slot)| {
+                            .map(|(((idx, res), section), section_slot)| {
+                                let part_id = obj.section_part_id(
+                                    object::SectionIndex(idx),
+                                    &self.symbol_db.section_part_ids,
+                                );
+                                let primary_id = self
+                                    .output_sections
+                                    .primary_output_section(part_id.output_section_id::<P>());
+                                let output_flags = self.output_sections.section_flags(primary_id);
+
                                 (matches!(section_slot, SectionSlot::Loaded(..))
-                                    && section.is_alloc()
+                                    && output_flags.is_alloc()
                                     && obj.object.section_size(section).is_ok_and(|s| s > 0))
                                 .then(|| {
                                     let address = res.address;

--- a/libwild/src/layout_rules.rs
+++ b/libwild/src/layout_rules.rs
@@ -282,6 +282,7 @@ impl<'data> LayoutRulesBuilder<'data> {
                                 Some(&location_info),
                                 fill_value,
                                 prev_phdrs.clone(),
+                                sec.attributes.as_ref(),
                             );
                             ordered_sections.push(primary_section_id);
                             current_section_id = Some(primary_section_id);

--- a/libwild/src/linker_script.rs
+++ b/libwild/src/linker_script.rs
@@ -103,6 +103,16 @@ pub(crate) struct Fill<'a> {
     pub(crate) value: Expression<'a>,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub(crate) enum SectionAttributes {
+    Noload,
+    Readonly,
+    Dsect,
+    Copy,
+    Info,
+    Overlay,
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct Section<'a> {
     pub(crate) output_section_name: &'a [u8],
@@ -113,6 +123,7 @@ pub(crate) struct Section<'a> {
     pub(crate) at_address: Option<Expression<'a>>,
     pub(crate) region: Option<&'a [u8]>,
     pub(crate) fill: Option<Fill<'a>>,
+    pub(crate) attributes: Option<SectionAttributes>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -1150,13 +1161,16 @@ fn parse_section_command<'input>(
         }));
     }
 
-    let start_address_expression = if input.starts_with(b":") {
-        None
-    } else {
-        Some(parse_expression.parse_next(input)?)
-    };
-
-    skip_comments_and_whitespace(input)?;
+    let mut start_address_expression = None;
+    let mut section_type = None;
+    while !input.starts_with(b":") {
+        if let Some(stype) = opt(parse_section_attribute).parse_next(input)? {
+            section_type = Some(stype);
+        } else {
+            start_address_expression = Some(parse_expression.parse_next(input)?);
+        }
+        skip_comments_and_whitespace(input)?;
+    }
 
     ':'.parse_next(input)?;
 
@@ -1206,7 +1220,30 @@ fn parse_section_command<'input>(
         at_address,
         region,
         fill,
+        attributes: section_type,
     }))
+}
+
+fn parse_section_attribute(input: &mut &BStr) -> winnow::Result<SectionAttributes> {
+    '('.parse_next(input)?;
+    skip_comments_and_whitespace(input)?;
+    let section_type = parse_token.parse_next(input)?;
+    skip_comments_and_whitespace(input)?;
+
+    let section_type = match section_type {
+        b"NOLOAD" => SectionAttributes::Noload,
+        b"READONLY" => SectionAttributes::Readonly,
+        b"DSECT" => SectionAttributes::Dsect,
+        b"COPY" => SectionAttributes::Copy,
+        b"INFO" => SectionAttributes::Info,
+        b"OVERLAY" => SectionAttributes::Overlay,
+        _ => {
+            return Err(ContextError::default());
+        }
+    };
+    ')'.parse_next(input)?;
+
+    Ok(section_type)
 }
 
 fn parse_fill<'input>(input: &mut &'input BStr) -> winnow::Result<Fill<'input>> {
@@ -1600,6 +1637,7 @@ mod tests {
                 at_address: None,
                 region: None,
                 fill: None,
+                attributes: None,
             }),
         );
     }
@@ -1624,6 +1662,7 @@ mod tests {
                 at_address: None,
                 region: None,
                 fill: None,
+                attributes: None,
             }),
         );
     }
@@ -1692,6 +1731,7 @@ mod tests {
                                 at_address: None,
                                 region: None,
                                 fill: None,
+                                attributes: None,
                             }),
                         ],
                     }),
@@ -1844,6 +1884,7 @@ mod tests {
                 at_address: None,
                 region: None,
                 fill: None,
+                attributes: None,
             }),
         );
     }
@@ -1868,6 +1909,7 @@ mod tests {
                 at_address: None,
                 region: None,
                 fill: None,
+                attributes: None,
             }),
         );
     }
@@ -1892,6 +1934,7 @@ mod tests {
                 at_address: None,
                 region: None,
                 fill: None,
+                attributes: None,
             }),
         );
     }
@@ -1924,6 +1967,7 @@ mod tests {
                             at_address: None,
                             region: None,
                             fill: None,
+                            attributes: None,
                         })],
                     }),
                     Command::Assert(AssertCommand {
@@ -1967,6 +2011,7 @@ mod tests {
                             at_address: None,
                             region: None,
                             fill: None,
+                            attributes: None,
                         }),
                         SectionCommand::Assert(AssertCommand {
                             expression: Expression::LessThan(

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -723,6 +723,7 @@ impl<'data, P: Platform> OutputSections<'data, P> {
                 location_info.as_ref(),
                 None,
                 Vec::new(),
+                None,
             );
 
             let part_id = if section_id.is_regular::<P>() {
@@ -771,6 +772,7 @@ impl<'data, P: Platform> OutputSections<'data, P> {
         location_info: Option<&SectionLocationInfo<'data>>,
         fill: Option<[u8; 4]>,
         phdrs: Vec<&'data [u8]>,
+        attributes: Option<&linker_script::SectionAttributes>,
     ) -> OutputSectionId {
         let mut resolved_id = None;
         if !self.output_kind.is_partial_object()
@@ -781,47 +783,44 @@ impl<'data, P: Platform> OutputSections<'data, P> {
             resolved_id = Some(builtin_id);
         }
 
-        *self
-            .custom_by_identity
-            .entry(identity)
-            .and_modify(|s| {
-                let info = self.section_infos.get_mut(*s);
-                info.min_alignment = info.min_alignment.max(min_alignment);
-                info.region_name = region_name.or(info.region_name);
-                if location_info.is_some() {
-                    info.location_info = location_info.cloned();
-                }
-                info.fill = fill.or(info.fill);
-                if !phdrs.is_empty() {
-                    info.phdrs = phdrs.clone();
-                }
-            })
-            .or_insert_with(|| {
+        let output_id = match self.custom_by_identity.entry(identity) {
+            hashbrown::hash_map::Entry::Occupied(e) => *e.get(),
+            hashbrown::hash_map::Entry::Vacant(e) => {
                 if let Some(builtin_id) = resolved_id {
-                    let info = self.section_infos.get_mut(builtin_id);
-                    info.min_alignment = info.min_alignment.max(min_alignment);
-                    info.region_name = region_name.or(info.region_name);
-                    if location_info.is_some() {
-                        info.location_info = location_info.cloned();
-                    }
-                    info.fill = fill.or(info.fill);
-                    if !phdrs.is_empty() {
-                        info.phdrs = phdrs.clone();
-                    }
-                    builtin_id
+                    *e.insert(builtin_id)
                 } else {
-                    self.section_infos.add_new(SectionOutputInfo {
+                    let new_id = self.section_infos.add_new(SectionOutputInfo {
                         kind: SectionKind::Primary(identity),
-                        section_attributes: Default::default(),
+                        section_attributes: attributes
+                            .map(|attr| P::set_section_attributes(attr, Default::default()))
+                            .unwrap_or_default(),
                         min_alignment,
                         location_info: location_info.cloned(),
                         secondary_order: None,
                         region_name,
                         fill,
                         phdrs,
-                    })
+                    });
+                    return *e.insert(new_id);
                 }
-            })
+            }
+        };
+
+        let info = self.section_infos.get_mut(output_id);
+        info.min_alignment = info.min_alignment.max(min_alignment);
+        info.region_name = region_name.or(info.region_name);
+        if location_info.is_some() {
+            info.location_info = location_info.cloned();
+        }
+        info.fill = fill.or(info.fill);
+        if !phdrs.is_empty() {
+            info.phdrs = phdrs;
+        }
+        info.section_attributes = attributes.map_or(info.section_attributes, |attr| {
+            P::set_section_attributes(attr, info.section_attributes)
+        });
+
+        output_id
     }
 
     pub(crate) fn add_secondary_section(
@@ -1118,6 +1117,7 @@ impl<'data, P: Platform> OutputSections<'data, P> {
                 None,
                 None,
                 Vec::new(),
+                None,
             )
         };
         add_name("ro");

--- a/libwild/src/output_section_id.rs
+++ b/libwild/src/output_section_id.rs
@@ -792,7 +792,7 @@ impl<'data, P: Platform> OutputSections<'data, P> {
                     let new_id = self.section_infos.add_new(SectionOutputInfo {
                         kind: SectionKind::Primary(identity),
                         section_attributes: attributes
-                            .map(|attr| P::set_section_attributes(attr, Default::default()))
+                            .map(|attr| P::apply_linker_script_attributes(attr, Default::default()))
                             .unwrap_or_default(),
                         min_alignment,
                         location_info: location_info.cloned(),
@@ -817,7 +817,7 @@ impl<'data, P: Platform> OutputSections<'data, P> {
             info.phdrs = phdrs;
         }
         info.section_attributes = attributes.map_or(info.section_attributes, |attr| {
-            P::set_section_attributes(attr, info.section_attributes)
+            P::apply_linker_script_attributes(attr, info.section_attributes)
         });
 
         output_id

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -979,7 +979,7 @@ pub(crate) trait Platform:
         std::fmt::Display::fmt(&name, f)
     }
 
-    fn set_section_attributes(
+    fn apply_linker_script_attributes(
         _linker_script_attributes: &linker_script::SectionAttributes,
         output_attributes: Self::SectionAttributes,
     ) -> Self::SectionAttributes {

--- a/libwild/src/platform.rs
+++ b/libwild/src/platform.rs
@@ -24,6 +24,7 @@ use crate::layout_rules::LayoutRulesBuilder;
 use crate::layout_rules::SectionRule;
 use crate::layout_rules::SectionRuleOutcome;
 use crate::linker_plugins::LinkerPlugin;
+use crate::linker_script;
 use crate::output_section_id::CustomSectionIds;
 use crate::output_section_id::OutputOrder;
 use crate::output_section_id::OutputSectionId;
@@ -976,6 +977,13 @@ pub(crate) trait Platform:
         f: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result {
         std::fmt::Display::fmt(&name, f)
+    }
+
+    fn set_section_attributes(
+        _linker_script_attributes: &linker_script::SectionAttributes,
+        output_attributes: Self::SectionAttributes,
+    ) -> Self::SectionAttributes {
+        output_attributes
     }
 }
 

--- a/wild/tests/integration_tests.rs
+++ b/wild/tests/integration_tests.rs
@@ -86,6 +86,8 @@
 //! output binary. Optional properties:
 //!   max_entries=N: Asserts the section has at most N entries (uses the section's sh_entsize,
 //!   or 1 if sh_entsize is 0).
+//!   flags=WAX: Asserts the section has the specified section flags.
+//!   type=int: Asserts the section has the specified section type.
 //!
 //! RelrCount:N Checks that .relr.dyn encodes at least N total relocations (counting both address
 //! entries and bitmap-encoded relocations).
@@ -1393,6 +1395,57 @@ impl ProgramHeaderFlags {
     }
 }
 
+bitflags! {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
+    struct SectionFlags: u64 {
+        const W = object::elf::SHF_WRITE.0;
+        const A = object::elf::SHF_ALLOC.0;
+        const X = object::elf::SHF_EXECINSTR.0;
+        const M = object::elf::SHF_MERGE.0;
+        const S = object::elf::SHF_STRINGS.0;
+        const I = object::elf::SHF_INFO_LINK.0;
+        const L = object::elf::SHF_LINK_ORDER.0;
+        const O = object::elf::SHF_OS_NONCONFORMING.0;
+        const G = object::elf::SHF_GROUP.0;
+        const T = object::elf::SHF_TLS.0;
+        const C = object::elf::SHF_COMPRESSED.0;
+    }
+}
+
+impl SectionFlags {
+    fn deserialize<'de, D>(d: D) -> Result<Option<Self>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(d)?;
+
+        let mut flags = Self::empty();
+
+        for c in s.chars() {
+            match c {
+                'W' => flags |= Self::W,
+                'A' => flags |= Self::A,
+                'X' => flags |= Self::X,
+                'M' => flags |= Self::M,
+                'S' => flags |= Self::S,
+                'I' => flags |= Self::I,
+                'L' => flags |= Self::L,
+                'O' => flags |= Self::O,
+                'G' => flags |= Self::G,
+                'T' => flags |= Self::T,
+                'C' => flags |= Self::C,
+                _ => {
+                    return Err(serde::de::Error::custom(
+                        "Invalid character in SectionFlags",
+                    ));
+                }
+            }
+        }
+
+        Ok(Some(flags))
+    }
+}
+
 #[derive(Debug, Clone)]
 struct ErrorMatcher {
     regex: regex::Regex,
@@ -1764,6 +1817,12 @@ struct ExpectedSection {
 #[serde(deny_unknown_fields)]
 struct SectionAssertions {
     max_entries: Option<u64>,
+
+    #[serde(deserialize_with = "SectionFlags::deserialize", default)]
+    flags: Option<SectionFlags>,
+
+    #[serde(rename = "type")]
+    stype: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -4767,11 +4826,41 @@ impl Assertions {
 
     fn verify_expected_sections(&self, obj: &object::File) -> Result {
         for expected in &self.expected_sections {
-            ensure!(
-                obj.section_by_name(&expected.section_name).is_some(),
-                "Expected section `{}` not found",
-                expected.section_name
-            );
+            let section = obj
+                .section_by_name(&expected.section_name)
+                .with_context(|| {
+                    format!("Expected section `{}` not found", expected.section_name)
+                })?;
+
+            if let Some(expected_flags) = expected.assertions.flags {
+                let flags = match section.flags() {
+                    object::SectionFlags::Elf { sh_flags, .. } => {
+                        SectionFlags::from_bits_retain(sh_flags.0)
+                    }
+                    _ => SectionFlags::empty(),
+                };
+                ensure!(
+                    flags == expected_flags,
+                    "Section `{}` flags mismatch: expected {:?}, got {:?}",
+                    expected.section_name,
+                    expected_flags,
+                    flags
+                );
+            }
+
+            if let Some(expected_type) = expected.assertions.stype {
+                let ptype = match section.flags() {
+                    object::SectionFlags::Elf { sh_type, .. } => sh_type.0,
+                    _ => 0,
+                };
+                ensure!(
+                    ptype == expected_type,
+                    "Section `{}` type mismatch: expected {:#x}, got {:#x}",
+                    expected.section_name,
+                    expected_type,
+                    ptype
+                );
+            }
         }
         Ok(())
     }

--- a/wild/tests/sources/elf/linker-script-section-types/linker-script-section-types.c
+++ b/wild/tests/sources/elf/linker-script-section-types/linker-script-section-types.c
@@ -4,17 +4,33 @@
 //#ReferenceLinkers:bfd
 //#DiffIgnore:.dynamic.DT_FLAGS_1.NOW
 //#DiffIgnore:section.got
+//#DiffIgnore:segment.LOAD.RWX.alignment
+//#DiffIgnore:segment.LOAD.RX.alignment
 //#LinkerScript:linker-script-section-types.ld
-//#ExpectSection:.section.readonly flags=A
-//#ExpectSection:.section.noload flags=WA,type=0x8
-//#ExpectSection:.section.dsect flags=W
-//#ExpectSection:.section.copy flags=W
-//#ExpectSection:.section.info flags=W
-//#ExpectSection:.section.overlay flags=W
+//#ExpectSection:.section.readonly.wa flags=A
+//#ExpectSection:.section.noload.wa flags=WA,type=0x8
+//#ExpectSection:.section.dsect.wa flags=W
+//#ExpectSection:.section.copy.wa flags=W
+//#ExpectSection:.section.info.wa flags=W
+//#ExpectSection:.section.overlay.wa flags=W
+//#ExpectSection:.section.readonly.ax flags=AX
+//#ExpectSection:.section.noload.ax flags=AX,type=0x8
+//#ExpectSection:.section.dsect.ax flags=X
+//#ExpectSection:.section.readonly.a flags=A
+//#ExpectSection:.section.noload.a flags=A,type=0x8
+//#ExpectSection:.section.dsect.a flags=''
 
-__attribute__((section(".section.noload"))) char noload = 0;
-__attribute__((section(".section.readonly"))) char readonly = 0;
-__attribute__((section(".section.dsect"))) char dsect = 0;
-__attribute__((section(".section.copy"))) char copy = 0;
-__attribute__((section(".section.info"))) char info = 0;
-__attribute__((section(".section.overlay"))) char overlay = 0;
+__attribute__((section(".section.noload.wa"))) char noload_wa = 0;
+__attribute__((section(".section.readonly.wa"))) char readonly_wa = 0;
+__attribute__((section(".section.dsect.wa"))) char dsect_wa = 0;
+__attribute__((section(".section.copy.wa"))) char copy_wa = 0;
+__attribute__((section(".section.info.wa"))) char info_wa = 0;
+__attribute__((section(".section.overlay.wa"))) char overlay_wa = 0;
+
+__attribute__((section(".section.readonly.ax"))) char readonly_ax() { return 0; }
+__attribute__((section(".section.noload.ax"))) char noload_ax() { return 0; }
+__attribute__((section(".section.dsect.ax"))) char dsect_ax() { return 0; }
+
+const __attribute__((section(".section.noload.a"))) char noload_a = 0;
+const __attribute__((section(".section.readonly.a"))) char readonly_a = 0;
+const __attribute__((section(".section.dsect.a"))) char dsect_a = 0;

--- a/wild/tests/sources/elf/linker-script-section-types/linker-script-section-types.c
+++ b/wild/tests/sources/elf/linker-script-section-types/linker-script-section-types.c
@@ -1,0 +1,20 @@
+//#Config:default
+//#RunEnabled:false
+//#LinkArgs:-shared
+//#ReferenceLinkers:bfd
+//#DiffIgnore:.dynamic.DT_FLAGS_1.NOW
+//#DiffIgnore:section.got
+//#LinkerScript:linker-script-section-types.ld
+//#ExpectSection:.section.readonly flags=A
+//#ExpectSection:.section.noload flags=WA,type=0x8
+//#ExpectSection:.section.dsect flags=W
+//#ExpectSection:.section.copy flags=W
+//#ExpectSection:.section.info flags=W
+//#ExpectSection:.section.overlay flags=W
+
+__attribute__((section(".section.noload"))) char noload = 0;
+__attribute__((section(".section.readonly"))) char readonly = 0;
+__attribute__((section(".section.dsect"))) char dsect = 0;
+__attribute__((section(".section.copy"))) char copy = 0;
+__attribute__((section(".section.info"))) char info = 0;
+__attribute__((section(".section.overlay"))) char overlay = 0;

--- a/wild/tests/sources/elf/linker-script-section-types/linker-script-section-types.ld
+++ b/wild/tests/sources/elf/linker-script-section-types/linker-script-section-types.ld
@@ -1,8 +1,16 @@
 SECTIONS {
-	.section.readonly (READONLY) : { *(.section.readonly) }
-	.section.noload (NOLOAD) : { *(.section.noload) }
-	.section.dsect (DSECT) : { *(.section.dsect) }
-	.section.copy (COPY) : { *(.section.copy) }
-	.section.info (INFO) : { *(.section.info) }
-	.section.overlay (OVERLAY) : { *(.section.overlay) }
+    .section.readonly.wa (READONLY) : { *(.section.readonly.wa) }
+    .section.noload.wa (NOLOAD) : { *(.section.noload.wa) }
+    .section.dsect.wa (DSECT) : { *(.section.dsect.wa) }
+    .section.copy.wa (COPY) : { *(.section.copy.wa) }
+    .section.info.wa (INFO) : { *(.section.info.wa) }
+    .section.overlay.wa (OVERLAY) : { *(.section.overlay.wa) }
+
+    .section.readonly.ax (READONLY) : { *(.section.readonly.ax) }
+    .section.noload.ax (NOLOAD) : { *(.section.noload.ax) }
+    .section.dsect.ax (DSECT) : { *(.section.dsect.ax) }
+
+    .section.readonly.a (READONLY) : { *(.section.readonly.a) }
+    .section.noload.a (NOLOAD) : { *(.section.noload.a) }
+    .section.dsect.a (DSECT) : { *(.section.dsect.a) }
 }

--- a/wild/tests/sources/elf/linker-script-section-types/linker-script-section-types.ld
+++ b/wild/tests/sources/elf/linker-script-section-types/linker-script-section-types.ld
@@ -1,0 +1,8 @@
+SECTIONS {
+	.section.readonly (READONLY) : { *(.section.readonly) }
+	.section.noload (NOLOAD) : { *(.section.noload) }
+	.section.dsect (DSECT) : { *(.section.dsect) }
+	.section.copy (COPY) : { *(.section.copy) }
+	.section.info (INFO) : { *(.section.info) }
+	.section.overlay (OVERLAY) : { *(.section.overlay) }
+}


### PR DESCRIPTION
Adds support for section attributes in a section output definition in a linker script.

Support for the `TYPE = type` command is not included in this PR, as we do not have any way currently to define an input section without an implicit type of it's own (for example, using the `LONG` command).