### PR TITLE
chore: Revert string-merging change made in #2341

### DIFF
--- a/libwild/src/string_merging.rs
+++ b/libwild/src/string_merging.rs
@@ -759,18 +759,27 @@ impl ReusePool {
     /// Attempt to reserve the specified number of Vecs. Fails if there isn't at least that many
     /// already available.
     fn try_reserve(&self, num_vecs: usize) -> Result<PoolReservation, ()> {
-        self.available
-            .try_update(Ordering::Relaxed, Ordering::Relaxed, |available| {
-                if available < num_vecs {
-                    None
-                } else {
-                    Some(available - num_vecs)
-                }
-            })
-            .map(|_| PoolReservation {
-                remaining: num_vecs,
-            })
-            .map_err(|_| ())
+        let available = self.available.load(Ordering::Relaxed);
+        if available < num_vecs {
+            return Err(());
+        }
+
+        if self
+            .available
+            .compare_exchange(
+                available,
+                available - num_vecs,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            )
+            .is_err()
+        {
+            return Err(());
+        }
+
+        Ok(PoolReservation {
+            remaining: num_vecs,
+        })
     }
 
     #[allow(clippy::needless_pass_by_value)]


### PR DESCRIPTION
With the change to use `try_update`, if I run a benchmark (e.g. linking wild), I see some processes get into a bad state where they sit using heaps of CPU on all threads for extended periods of time. The processes eventually finish, but I'm seeing linking wild take between 40ms (normal) and more than a minute. This revert fixes the problem.

CC #2341